### PR TITLE
feat(redis): redis/mongo资源池的调整,存储集群、机器规格 #152

### DIFF
--- a/dbm-ui/backend/db_meta/api/cluster/mongocluster/create.py
+++ b/dbm-ui/backend/db_meta/api/cluster/mongocluster/create.py
@@ -55,6 +55,7 @@ def create_mongo_cluster(
     creator: str = "",
     bk_cloud_id: int = DEFAULT_BK_CLOUD_ID,
     region: str = "",
+    deploy_plan_id: int = 0,
     cluster_type=ClusterType.MongoShardedCluster.value,
 ):
     """创建副本集 MongoSet 实例
@@ -95,6 +96,7 @@ def create_mongo_cluster(
             updater=creator,
             cluster_type=cluster_type,
             bk_cloud_id=bk_cloud_id,
+            deploy_plan_id=deploy_plan_id,  # 这里存储当时选择的部署方案ID
             region=region,
         )
         cluster.proxyinstance_set.add(*mongos_objs)
@@ -150,6 +152,8 @@ def pkg_create_mongo_cluster(
     creator: str = "",
     bk_cloud_id: int = DEFAULT_BK_CLOUD_ID,
     region: str = "",
+    deploy_plan_id: int = 0,
+    machine_specs: Optional[Dict] = None,
     cluster_type=ClusterType.MongoShardedCluster.value,
 ):
     """创建副本集 MongoSet 实例
@@ -161,6 +165,7 @@ def pkg_create_mongo_cluster(
         proxies: [{},{}]
         configes: [{},{},{}]
         storages: [{"shard":"S1","nodes":[{"ip":,"port":,"role":},{},{}]},]
+        machine_specs:{"mongos":{"spec_id":0,"spec_config":""},"mongo_config":{"spec_id":0,"spec_config":""}}
     """
 
     bk_biz_id = request_validator.validated_integer(bk_biz_id)
@@ -179,10 +184,25 @@ def pkg_create_mongo_cluster(
     before_create_storage_precheck(all_instances)
 
     # 实例创建，关系创建
-    create_proxies(bk_biz_id, bk_cloud_id, MachineType.MONGOS.value, proxies)
-    create_mongo_instances(bk_biz_id, bk_cloud_id, MachineType.MONOG_CONFIG.value, configs)
+    spec_id, spec_config = 0, ""
+    if machine_specs.get(MachineType.MONGOS.value):
+        spec_id = machine_specs[MachineType.MONGOS.value]["spec_id"]
+        spec_config = machine_specs[MachineType.MONGOS.value]["spec_config"]
+    create_proxies(bk_biz_id, bk_cloud_id, MachineType.MONGOS.value, proxies, spec_id, spec_config)
+
+    spec_id, spec_config = 0, ""
+    if machine_specs.get(MachineType.MONOG_CONFIG.value):
+        spec_id = machine_specs[MachineType.MONOG_CONFIG.value]["spec_id"]
+        spec_config = machine_specs[MachineType.MONOG_CONFIG.value]["spec_config"]
+    create_mongo_instances(bk_biz_id, bk_cloud_id, MachineType.MONOG_CONFIG.value, configs, spec_id, spec_config)
     for shard_pair in storages:
-        create_mongo_instances(bk_biz_id, bk_cloud_id, MachineType.MONGODB.value, shard_pair["nodes"])
+        spec_id, spec_config = 0, ""
+        if machine_specs.get(MachineType.MONGODB.value):
+            spec_id = machine_specs[MachineType.MONGODB.value]["spec_id"]
+            spec_config = machine_specs[MachineType.MONGODB.value]["spec_config"]
+        create_mongo_instances(
+            bk_biz_id, bk_cloud_id, MachineType.MONGODB.value, shard_pair["nodes"], spec_id, spec_config
+        )
 
     create_mongo_cluster(
         bk_biz_id=bk_biz_id,
@@ -198,4 +218,5 @@ def pkg_create_mongo_cluster(
         bk_cloud_id=bk_cloud_id,
         region=region,
         cluster_type=cluster_type,
+        deploy_plan_id=deploy_plan_id,  # 这里存储当时选择的部署方案ID
     )

--- a/dbm-ui/backend/db_meta/api/cluster/mongocluster/create.py
+++ b/dbm-ui/backend/db_meta/api/cluster/mongocluster/create.py
@@ -184,6 +184,7 @@ def pkg_create_mongo_cluster(
     before_create_storage_precheck(all_instances)
 
     # 实例创建，关系创建
+    machine_specs = machine_specs or {}
     spec_id, spec_config = 0, ""
     if machine_specs.get(MachineType.MONGOS.value):
         spec_id = machine_specs[MachineType.MONGOS.value]["spec_id"]

--- a/dbm-ui/backend/db_meta/api/cluster/mongorepset/create.py
+++ b/dbm-ui/backend/db_meta/api/cluster/mongorepset/create.py
@@ -51,6 +51,9 @@ def pkg_create_mongoset(
     creator: str = "",
     bk_cloud_id: int = DEFAULT_BK_CLOUD_ID,
     region: str = "",
+    spec_id: int = 0,
+    spec_config: str = "",
+    deploy_plan_id: int = 0,
     cluster_type=ClusterType.MongoReplicaSet.value,
 ):
     """
@@ -74,7 +77,7 @@ def pkg_create_mongoset(
     before_create_domain_precheck(domains)
     before_create_storage_precheck(storages)
 
-    create_mongo_instances(bk_biz_id, bk_cloud_id, MachineType.MONGODB.value, storages)
+    create_mongo_instances(bk_biz_id, bk_cloud_id, MachineType.MONGODB.value, storages, spec_id, spec_config)
     create_mongoset(
         bk_biz_id=bk_biz_id,
         name=name,
@@ -87,6 +90,7 @@ def pkg_create_mongoset(
         bk_cloud_id=bk_cloud_id,
         region=region,
         cluster_type=cluster_type,
+        deploy_plan_id=deploy_plan_id,
     )
 
 
@@ -102,6 +106,7 @@ def create_mongoset(
     creator: str = "",
     bk_cloud_id: int = DEFAULT_BK_CLOUD_ID,
     region: str = "",
+    deploy_plan_id: int = 0,
     cluster_type=ClusterType.MongoReplicaSet.value,
 ):
     """创建副本集 MongoSet 实例
@@ -144,6 +149,7 @@ def create_mongoset(
             updater=creator,
             cluster_type=cluster_type,
             bk_cloud_id=bk_cloud_id,
+            deploy_plan_id=deploy_plan_id,
             region=region,
         )
         cluster.storageinstance_set.add(*storage_objs)

--- a/dbm-ui/backend/db_meta/api/cluster/nosqlcomm/create_cluster.py
+++ b/dbm-ui/backend/db_meta/api/cluster/nosqlcomm/create_cluster.py
@@ -189,19 +189,19 @@ def pkg_create_twemproxy_cluster(
     before_create_domain_precheck([immute_domain])
     before_create_proxy_precheck(proxies)
     before_create_storage_precheck(all_instances)
+
+    machine_specs = machine_specs or {}
+    spec_id, spec_config = 0, ""
     if machine_specs.get("proxy"):
-        create_proxies(
-            bk_biz_id=bk_biz_id,
-            bk_cloud_id=bk_cloud_id,
-            machine_type=MachineType.TWEMPROXY.value,
-            proxies=proxies,
-            spec_id=machine_specs["proxy"]["spec_id"],
-            spec_config=machine_specs["proxy"]["spec_config"],
-        )
-    else:
-        create_proxies(
-            bk_biz_id=bk_biz_id, bk_cloud_id=bk_cloud_id, machine_type=MachineType.TWEMPROXY.value, proxies=proxies
-        )
+        spec_id, spec_config = machine_specs["proxy"]["spec_id"], machine_specs["proxy"]["spec_config"]
+    create_proxies(
+        bk_biz_id=bk_biz_id,
+        bk_cloud_id=bk_cloud_id,
+        machine_type=MachineType.TWEMPROXY.value,
+        proxies=proxies,
+        spec_id=spec_id,
+        spec_config=spec_config,
+    )
 
     spec_id, spec_config = 0, ""
     if machine_specs.get("redis"):

--- a/dbm-ui/backend/db_meta/api/cluster/nosqlcomm/create_instances.py
+++ b/dbm-ui/backend/db_meta/api/cluster/nosqlcomm/create_instances.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("flow")
 
 
 @transaction.atomic
-def create_mongo_instances(bk_biz_id, bk_cloud_id, machine_type, storages):
+def create_mongo_instances(bk_biz_id, bk_cloud_id, machine_type, storages, spec_id: int = 0, spec_config: str = ""):
     """打包创建 MongoShard/MongoConfig 类型实例， 一主N从
 
     Args:
@@ -37,6 +37,8 @@ def create_mongo_instances(bk_biz_id, bk_cloud_id, machine_type, storages):
                 "bk_biz_id": bk_biz_id,
                 "bk_cloud_id": bk_cloud_id,
                 "machine_type": machine_type,
+                "spec_id": spec_id,
+                "spec_config": spec_config,
             }
             instances.append({"ip": storage["ip"], "port": storage["port"], "instance_role": storage["role"]})
             if storage["role"] == InstanceRole.MONGO_M1:
@@ -58,7 +60,7 @@ def create_mongo_instances(bk_biz_id, bk_cloud_id, machine_type, storages):
 
 
 @transaction.atomic
-def create_proxies(bk_biz_id, bk_cloud_id, machine_type, proxies):
+def create_proxies(bk_biz_id, bk_cloud_id, machine_type, proxies, spec_id: int = 0, spec_config: str = ""):
     """打包创建 Proxy 类型实例
         proxy 部署类型为单机单实例部署！！！
     Args:
@@ -73,6 +75,8 @@ def create_proxies(bk_biz_id, bk_cloud_id, machine_type, proxies):
                 "bk_biz_id": bk_biz_id,
                 "bk_cloud_id": bk_cloud_id,
                 "machine_type": machine_type,
+                "spec_id": spec_id,
+                "spec_config": spec_config,
             }
             for proxy in proxies
         ]
@@ -84,7 +88,7 @@ def create_proxies(bk_biz_id, bk_cloud_id, machine_type, proxies):
 
 
 @transaction.atomic
-def create_tendis_instances(bk_biz_id, bk_cloud_id, machine_type, storages):
+def create_tendis_instances(bk_biz_id, bk_cloud_id, machine_type, storages, spec_id: int = 0, spec_config: str = ""):
     """打包创建 TendisCache/TendisSSD/TendisSingle 类型实例， 一主N从
 
     Args:
@@ -101,12 +105,16 @@ def create_tendis_instances(bk_biz_id, bk_cloud_id, machine_type, storages):
                 "bk_biz_id": bk_biz_id,
                 "bk_cloud_id": bk_cloud_id,
                 "machine_type": machine_type,
+                "spec_id": spec_id,
+                "spec_config": spec_config,
             }
             machines[slave["ip"]] = {
                 "ip": slave["ip"],
                 "bk_biz_id": bk_biz_id,
                 "bk_cloud_id": bk_cloud_id,
                 "machine_type": machine_type,
+                "spec_id": spec_id,
+                "spec_config": spec_config,
             }
             instances.append(
                 {"ip": master["ip"], "port": master["port"], "instance_role": InstanceRole.REDIS_MASTER.value}

--- a/dbm-ui/backend/db_meta/api/cluster/tendispluscluster/create.py
+++ b/dbm-ui/backend/db_meta/api/cluster/tendispluscluster/create.py
@@ -40,6 +40,7 @@ def create(
     creator: str = "",
     bk_cloud_id: int = DEFAULT_BK_CLOUD_ID,
     region: str = "",
+    deploy_plan_id: int = 0,
 ):
     """
     注册 TendisplusCluster 集群
@@ -72,6 +73,7 @@ def create(
             immute_domain=immute_domain,
             creator=creator,
             bk_cloud_id=bk_cloud_id,
+            deploy_plan_id=deploy_plan_id,  # 这里存储当时选择的部署方案ID
             region=region,
         )
         cluster.proxyinstance_set.add(*proxy_objs)


### PR DESCRIPTION
redis/mongo资源池的调整,存储集群、机器规格 #152
增加
cluster:
    deploy_plan_id = models.BigIntegerField(default=0, help_text=_("部署方法ID"))


machine :
    spec_id = models.PositiveBigIntegerField(default=0, help_text=_("虚拟规格ID"))
    spec_config = models.TextField(default="", help_text=_("当前的虚拟规格配置"))
