### PR TITLE
fix(redis): 整机替换proxy重载 #607

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_master_rep.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_master_rep.py
@@ -147,6 +147,4 @@ def RedisClusterMasterReplaceJob(root_id, ticket_data, sub_kwargs: ActKwargs, ma
     redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
     # #### 下架旧实例 ###################################################################### 完毕 ###
 
-    return redis_pipeline.build_sub_process(
-        sub_name=_("Redis-{}-Master替换").format(act_kwargs.cluster["immute_domain"])
-    )
+    return redis_pipeline.build_sub_process(sub_name=_("{}-Master替换").format(act_kwargs.cluster["immute_domain"]))

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_slave_rep.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_slave_rep.py
@@ -130,4 +130,4 @@ def RedisClusterSlaveReplaceJob(root_id, ticket_data, sub_kwargs: ActKwargs, sla
         sub_pipelines.append(sub_builder)
     redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
     # #### 下架旧实例 ###################################################################### 完毕 ###
-    return redis_pipeline.build_sub_process(sub_name=_("Redis-{}-Slave替换").format(act_kwargs.cluster["immute_domain"]))
+    return redis_pipeline.build_sub_process(sub_name=_("{}-Slave替换").format(act_kwargs.cluster["immute_domain"]))

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_switch.py
@@ -76,11 +76,11 @@ def RedisClusterSwitchAtomJob(root_id, data, act_kwargs: ActKwargs, sync_params:
         )
 
     # 人工确认
-    # if (
-    #     act_kwargs.cluster.get("switch_option", SwitchType.SWITCH_WITH_CONFIRM.value)
-    #     == SwitchType.SWITCH_WITH_CONFIRM.value
-    # ):
-    sub_pipeline.add_act(act_name=_("Redis-人工确认"), act_component_code=PauseComponent.code, kwargs={})
+    if (
+        act_kwargs.cluster.get("switch_option", SwitchType.SWITCH_WITH_CONFIRM.value)
+        == SwitchType.SWITCH_WITH_CONFIRM.value
+    ):
+        sub_pipeline.add_act(act_name=_("Redis-人工确认"), act_component_code=PauseComponent.code, kwargs={})
 
     # 下发介质包
     act_kwargs.exec_ip = exec_ip

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_switch.py
@@ -75,12 +75,12 @@ def RedisClusterSwitchAtomJob(root_id, data, act_kwargs: ActKwargs, sync_params:
             act_name=_("Redis-元数据加入集群"), act_component_code=RedisDBMetaComponent.code, kwargs=asdict(act_kwargs)
         )
 
-    # # 人工确认
+    # 人工确认
     # if (
     #     act_kwargs.cluster.get("switch_option", SwitchType.SWITCH_WITH_CONFIRM.value)
     #     == SwitchType.SWITCH_WITH_CONFIRM.value
     # ):
-    #     sub_pipeline.add_act(act_name=_("Redis-人工确认"), act_component_code=PauseComponent.code, kwargs={})
+    sub_pipeline.add_act(act_name=_("Redis-人工确认"), act_component_code=PauseComponent.code, kwargs={})
 
     # 下发介质包
     act_kwargs.exec_ip = exec_ip
@@ -111,9 +111,6 @@ def RedisClusterSwitchAtomJob(root_id, data, act_kwargs: ActKwargs, sync_params:
             )
     act_kwargs.cluster["domain_name"] = act_kwargs.cluster["immute_domain"]
     act_kwargs.cluster["switch_condition"] = act_kwargs.cluster["switch_condition"]
-    act_kwargs.cluster["cluster_meta"] = nosqlcomm.other.get_cluster_detail(
-        cluster_id=act_kwargs.cluster["cluster_id"]
-    )[0]
     act_kwargs.get_redis_payload_func = RedisActPayload.redis_twemproxy_arch_switch_4_scene.__name__
     sub_pipeline.add_act(
         act_name=_("Redis-{}-实例切换").format(exec_ip),

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_backend_scale.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_backend_scale.py
@@ -79,6 +79,7 @@ class RedisBackendScaleFlow(object):
             master_slave_map[master_obj.machine.ip] = slave_obj.machine.ip
         version = version or cluster.major_version
         return {
+            "cluster_id": cluster.id,
             "immute_domain": cluster.immute_domain,
             "cluster_name": cluster.name,
             "bk_biz_id": cluster.bk_biz_id,

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
@@ -267,7 +267,7 @@ class RedisClusterCMRSceneFlow(object):
             )
             sub_pipeline.add_sub_pipeline(master_replace_pipe)
 
-        return sub_pipeline.build_sub_process(sub_name=_("Redis-{}-整机替换").format(act_kwargs.cluster["immute_domain"]))
+        return sub_pipeline.build_sub_process(sub_name=_("整机替换-{}").format(act_kwargs.cluster["immute_domain"]))
 
     def proxy_replacement(self, sub_pipeline, act_kwargs, proxy_replace_info):
         old_proxies, new_proxies = [], []

--- a/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
@@ -18,6 +18,7 @@ from backend.configuration.constants import DBType
 from backend.configuration.models.system import SystemSettings
 from backend.constants import BACKUP_SYS_STATUS, IP_PORT_DIVIDER
 from backend.db_meta import api as metaApi
+from backend.db_meta.api.cluster import nosqlcomm
 from backend.db_meta.enums.cluster_type import ClusterType
 from backend.db_meta.models import Cluster
 from backend.db_package.models import Package
@@ -835,13 +836,14 @@ class RedisActPayload(object):
     # twemproxy 架构-实例切换
     def redis_twemproxy_arch_switch_4_scene(self, **kwargs) -> dict:
         """{
-            "cluster_meta":{},
+            "cluster_id":0,
+            "immute_domain":"",
+            "cluster_type":"",
             "switch_info":{},
             "switch_condition":{},
         }
         """
-        params = kwargs["params"]
-        cluster_meta, proxy_version = params["cluster_meta"], ""
+        params, proxy_version = kwargs["params"], ""
         self.namespace = params["cluster_type"]
         if self.namespace in [
             ClusterType.TendisTwemproxyRedisInstance.value,
@@ -850,9 +852,8 @@ class RedisActPayload(object):
             proxy_version = ConfigFileEnum.Twemproxy
         elif self.namespace == ClusterType.TendisPredixyTendisplusCluster.value:
             proxy_version = ConfigFileEnum.Predixy
-        proxy_config = self.__get_cluster_config(
-            cluster_meta["immute_domain"], proxy_version, ConfigTypeEnum.ProxyConf
-        )
+        proxy_config = self.__get_cluster_config(params["immute_domain"], proxy_version, ConfigTypeEnum.ProxyConf)
+        cluster_meta = nosqlcomm.other.get_cluster_detail(cluster_id=params["cluster_id"])[0]
         cluster_meta["proxy_pass"] = proxy_config["password"]
         cluster_meta["storage_pass"] = proxy_config["redis_password"]
 


### PR DESCRIPTION
修复整机替换时，把集群所有proxy节点替换掉后， 在替换master时动态获取最新proxy节点