### PR TITLE
fix(mysql): flashback单据库表打开检查挪到flow里面

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/rollback/flashback.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/rollback/flashback.go
@@ -131,9 +131,9 @@ func (f *Flashback) PreCheck() error {
 	if err = f.checkDBRole(); err != nil {
 		return err
 	}
-	if err = f.checkDBTableInUse(); err != nil {
-		return err
-	}
+	//if err = f.checkDBTableInUse(); err != nil {
+	//	return err
+	//}
 	if f.BinlogDir == "" { // 没有指定 binlog 目录，目前是自动从 实例 binlog 目录本地找，并做软链
 		if totalSize, err := f.getBinlogFiles(""); err != nil {
 			return err

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_flashback_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_flashback_flow.py
@@ -16,13 +16,19 @@ from typing import Dict, Optional
 from django.utils.translation import ugettext as _
 
 from backend.configuration.constants import DBType
+from backend.flow.consts import TruncateDataTypeEnum
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
+from backend.flow.plugins.components.collections.mysql.filter_database_table_by_flashback_input import (
+    FilterDatabaseTableFromFlashbackInputComponent,
+)
+from backend.flow.plugins.components.collections.mysql.general_check_db_in_using import GeneralCheckDBInUsingComponent
 from backend.flow.plugins.components.collections.mysql.trans_flies import TransFileComponent
 from backend.flow.utils.mysql.common.mysql_cluster_info import get_cluster_info
-from backend.flow.utils.mysql.mysql_act_dataclass import DownloadMediaKwargs, ExecActuatorKwargs
+from backend.flow.utils.mysql.mysql_act_dataclass import BKCloudIdKwargs, DownloadMediaKwargs, ExecActuatorKwargs
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
+from backend.flow.utils.mysql.mysql_context_dataclass import MySQLFlashBackContext
 
 logger = logging.getLogger("flow")
 
@@ -48,11 +54,33 @@ class MysqlFlashbackFlow(object):
         mysql_restore_slave_pipeline = Builder(root_id=self.root_id, data=copy.deepcopy(self.data))
         sub_pipeline_list = []
         for info in self.data["infos"]:
-            ticket_data = copy.deepcopy(self.data)
-            sub_pipeline = SubBuilder(root_id=self.root_id, data=copy.deepcopy(ticket_data))
             one_cluster = get_cluster_info(info["cluster_id"])
             one_cluster.update(info)
             one_cluster["work_dir"] = f"/data/dbbak/{self.root_id}"
+
+            ticket_data = {
+                **copy.deepcopy(self.data),
+                "uid": self.data["uid"],
+                "created_by": self.data["created_by"],
+                "bk_biz_id": self.data["bk_biz_id"],
+                "ip": one_cluster["master_ip"],
+                "port": one_cluster["master_port"],
+                "truncate_data_type": TruncateDataTypeEnum.TRUNCATE_TABLE.value,  # 不是真的要删表, 只是复用打开检查必须
+            }
+            sub_pipeline = SubBuilder(root_id=self.root_id, data=copy.deepcopy(ticket_data))
+
+            sub_pipeline.add_act(
+                act_name=_("获取回档库表"),
+                act_component_code=FilterDatabaseTableFromFlashbackInputComponent.code,
+                kwargs=asdict(BKCloudIdKwargs(bk_cloud_id=one_cluster["bk_cloud_id"])),
+            )
+
+            if not self.data["force"]:
+                sub_pipeline.add_act(
+                    act_name=_("检查库表是否在用"),
+                    act_component_code=GeneralCheckDBInUsingComponent.code,
+                    kwargs=asdict(BKCloudIdKwargs(bk_cloud_id=one_cluster["bk_cloud_id"])),
+                )
 
             sub_pipeline.add_act(
                 act_name=_("下发db-actor到集群主节点{}").format(one_cluster["master_ip"]),
@@ -81,4 +109,4 @@ class MysqlFlashbackFlow(object):
             sub_pipeline_list.append(sub_pipeline.build_sub_process(sub_name=_("flash开始恢复数据")))
 
         mysql_restore_slave_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipeline_list)
-        mysql_restore_slave_pipeline.run_pipeline()
+        mysql_restore_slave_pipeline.run_pipeline(init_trans_data_class=MySQLFlashBackContext())

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/filter_database_table_by_flashback_input.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/filter_database_table_by_flashback_input.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from collections import defaultdict
+
+from pipeline.component_framework.component import Component
+
+from backend.components.db_remote_service.client import DRSApi
+from backend.constants import IP_PORT_DIVIDER
+from backend.flow.consts import SYSTEM_DBS
+from backend.flow.plugins.components.collections.common.base_service import BaseService
+
+
+class FilterDatabaseTableFromFlashbackInputService(BaseService):
+    def _execute(self, data, parent_data) -> bool:
+        kwargs = data.get_one_of_inputs("kwargs")
+        trans_data = data.get_one_of_inputs("trans_data")
+        global_data = data.get_one_of_inputs("global_data")
+
+        ip = global_data["ip"]
+        port = global_data["port"]
+
+        databases = global_data["databases"]
+        databases_ignore = global_data["databases_ignore"]
+        tables = global_data["tables"]
+        tables_ignore = global_data["tables_ignore"]
+
+        db_filter_sql = "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE ({}) AND ({})".format(
+            " OR ".join(["SCHEMA_NAME LIKE '{}'".format(ele) for ele in databases]),
+            " AND ".join(["SCHEMA_NAME NOT LIKE '{}'".format(ele) for ele in databases_ignore + SYSTEM_DBS]),
+        )
+        self.log_info("[{}] db_filter_sql: {}".format(kwargs["node_name"], db_filter_sql))
+        db_filter_res = DRSApi.rpc(
+            {
+                "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
+                "cmds": [db_filter_sql],
+                "force": False,
+                "bk_cloud_id": kwargs["bk_cloud_id"],
+            }
+        )
+        self.log_info("[{}] filter database response: {}".format(kwargs["node_name"], db_filter_res))
+        if db_filter_res[0]["error_msg"]:
+            self.log_error(
+                "[{}] filter databases on {}{}{} failed: {}".format(
+                    kwargs["node_name"], ip, IP_PORT_DIVIDER, port, db_filter_res[0]["error_msg"]
+                )
+            )
+            return False
+
+        databases_filtered = [ele["SCHEMA_NAME"] for ele in db_filter_res[0]["cmd_results"][0]["table_data"]]
+
+        # tables 和 tables_ignore 使用三元操作符返回一个恒真表达式, 简化代码
+        table_filter_sql = (
+            "SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.TABLES "
+            "WHERE TABLE_TYPE='BASE TABLE' AND {} AND ({}) AND ({})"
+        ).format(
+            "TABLE_SCHEMA IN ({})".format(",".join(["'{}'".format(ele) for ele in databases_filtered])),
+            " OR ".join(["TABLE_NAME LIKE '{}'".format(ele) for ele in tables]) if tables else "1=1",
+            " AND ".join(["TABLE_NAME NOT LIKE '{}'".format(ele) for ele in tables_ignore])
+            if tables_ignore
+            else "1=1",
+        )
+        self.log_info("[{}] table_filter_sql: {}".format(kwargs["node_name"], table_filter_sql))
+        table_filter_res = DRSApi.rpc(
+            {
+                "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
+                "cmds": [table_filter_sql],
+                "force": False,
+                "bk_cloud_id": kwargs["bk_cloud_id"],
+            }
+        )
+        self.log_info("[{}] filter table response: {}".format(kwargs["node_name"], table_filter_res))
+        if table_filter_res[0]["error_msg"]:
+            self.log_error(
+                "[{}] filter table on {}{}{} failed: {}".format(
+                    kwargs["node_name"], ip, IP_PORT_DIVIDER, port, table_filter_res[0]["error_msg"]
+                )
+            )
+            return False
+
+        targets = defaultdict(dict)
+        for row in table_filter_res[0]["cmd_results"][0]["table_data"]:
+            db = row["TABLE_SCHEMA"]
+            tbl = row["TABLE_NAME"]
+            targets[db][tbl] = False
+
+        self.log_info("[{}] filtered table: {}".format(kwargs["node_name"], targets))
+
+        if not targets:
+            self.log_error("[{}] match nothing".format(kwargs["node_name"]))
+            return False
+
+        trans_data.targets = dict(targets)
+        data.outputs["trans_data"] = trans_data
+        return True
+
+
+class FilterDatabaseTableFromFlashbackInputComponent(Component):
+    name = __name__
+    code = "filter_database_table_from_flashback_input"
+    bound_service = FilterDatabaseTableFromFlashbackInputService

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/filter_database_table_from_regex.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/filter_database_table_from_regex.py
@@ -91,7 +91,7 @@ class FilterDatabaseTableFromRegexService(BaseService):
         self.log_info(_("[{}] 过滤所得库表: {}").format(kwargs["node_name"], targets))
 
         if not targets:
-            self.log_error(_("[{}] 未匹配到任何库"))
+            self.log_error(_("[{}] 未匹配到任何库".format(kwargs["node_name"])))
             return False
 
         trans_data.targets = dict(targets)

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/general_check_db_in_using.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/general_check_db_in_using.py
@@ -36,100 +36,90 @@ class GeneralCheckDBInUsingService(BaseService):
     """
 
     __need_schedule__ = True
-    interval = StaticIntervalGenerator(60)
+    interval = StaticIntervalGenerator(10)
 
     def _execute(self, data, parent_data) -> bool:
         """
         bk_cloud_id 统一由私有变量kwargs传入
         """
-        kwargs = data.get_one_of_inputs("kwargs")
-        trans_data = data.get_one_of_inputs("trans_data")
-        global_data = data.get_one_of_inputs("global_data")
-
-        ip = global_data["ip"]
-        port = global_data["port"]
-
-        flush_table_res = DRSApi.rpc(
-            {
-                "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
-                "cmds": ["flush tables"],
-                "force": False,
-                "bk_cloud_id": kwargs["bk_cloud_id"],
-            }
-        )
-
-        self.log_info("[{}] flush tables response: {}".format(kwargs["node_name"], flush_table_res))
-        if flush_table_res[0]["error_msg"]:
-            self.log_error(
-                "[{}] flush tables on {}{}{} failed: {}".format(
-                    kwargs["node_name"], ip, IP_PORT_DIVIDER, port, flush_table_res[0]["error_msg"]
-                )
-            )
-            return False
-
-        trans_data.show_open_fence = True
-        data.outputs["trans_data"] = trans_data
+        data.outputs.counter = 6
         return True
 
     def _schedule(self, data, parent_data, callback_data=None):
+        counter = data.get_one_of_outputs("counter")
         kwargs = data.get_one_of_inputs("kwargs")
         trans_data = data.get_one_of_inputs("trans_data")
         global_data = data.get_one_of_inputs("global_data")
-
-        # schedule 模式马上会被调度, 这个栅栏立即返回
-        # 达到 sleep 60 后才真的做检查的目的
-        if trans_data.show_open_fence:
-            self.log_info("[{}] close fence will be sleep 60s".format(kwargs["node_name"]))
-            trans_data.show_open_fence = False
-            return True
 
         ip = global_data["ip"]
         port = global_data["port"]
         targets = trans_data.targets
         truncate_data_type = global_data["truncate_data_type"]
 
-        show_open_table_res = DRSApi.rpc(
-            {
-                "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
-                "cmds": ["show open tables"],
-                "force": False,
-                "bk_cloud_id": kwargs["bk_cloud_id"],
-            }
-        )
-        self.log_info("[{}] show open tables response: {}".format(kwargs["node_name"], show_open_table_res))
-        if show_open_table_res[0]["error_msg"]:
-            self.log_error(
-                "[{}] show open tables on {}{}{} failed: {}".format(
-                    kwargs["node_name"], ip, IP_PORT_DIVIDER, port, show_open_table_res[0]["error_msg"]
-                )
+        if counter > 0:
+            counter -= 1
+            self.log_info("[{}] {} round flush tables left".format(kwargs["node_name"], counter))
+
+            flush_table_res = DRSApi.rpc(
+                {
+                    "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
+                    "cmds": ["flush tables"],
+                    "force": False,
+                    "bk_cloud_id": kwargs["bk_cloud_id"],
+                }
             )
-            data.outputs.ext_result = False
-            self.finish_schedule()
-            return False
+            self.log_info("[{}] flush tables response: {}".format(kwargs["node_name"], flush_table_res))
+            if flush_table_res[0]["error_msg"]:
+                self.log_error(
+                    "[{}] flush tables on {}{}{} failed: {}".format(
+                        kwargs["node_name"], ip, IP_PORT_DIVIDER, port, flush_table_res[0]["error_msg"]
+                    )
+                )
+                self.finish_schedule()
+                return False
 
-        # 检查 targets dbs 是否在 open tables 中
-        reopened_targets = []
-        for row in show_open_table_res[0]["cmd_results"][0]["table_data"]:
-            db = row["Database"]
-            tbl = row["Table"]
-            # 如果是删库需求, 就不检查表了
-            if truncate_data_type == TruncateDataTypeEnum.DROP_DATABASE.value:
-                if db in targets:
-                    reopened_targets.append(db)
-            else:
-                if db in targets and tbl in targets[db]:
-                    reopened_targets.append("{}.{}".format(db, tbl))
-
-        data.outputs["trans_data"] = trans_data
-
-        if reopened_targets:
-            self.log_info("[{}] check db using failed: {}".format(kwargs["node_name"], reopened_targets))
-            self.finish_schedule()
-            return False
-        else:
-            self.log_info("[{}] check db using pass".format(kwargs["node_name"]))
-            self.finish_schedule()
+            data.outputs.counter = counter
             return True
+        else:
+            show_open_table_res = DRSApi.rpc(
+                {
+                    "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
+                    "cmds": ["show open tables"],
+                    "force": False,
+                    "bk_cloud_id": kwargs["bk_cloud_id"],
+                }
+            )
+            self.log_info("[{}] show open tables response: {}".format(kwargs["node_name"], show_open_table_res))
+            if show_open_table_res[0]["error_msg"]:
+                self.log_error(
+                    "[{}] show open tables on {}{}{} failed: {}".format(
+                        kwargs["node_name"], ip, IP_PORT_DIVIDER, port, show_open_table_res[0]["error_msg"]
+                    )
+                )
+                data.outputs.ext_result = False
+                self.finish_schedule()
+                return False
+
+            reopened_targets = []
+            for row in show_open_table_res[0]["cmd_results"][0]["table_data"]:
+                db = row["Database"]
+                tbl = row["Table"]
+
+                if truncate_data_type == TruncateDataTypeEnum.DROP_DATABASE.value:
+                    if db in targets:
+                        reopened_targets.append(db)
+                else:
+                    if db in targets and tbl in targets[db]:
+                        reopened_targets.append("{}.{}".format(db, tbl))
+
+            if reopened_targets:
+                self.log_info("[{}] check db/table using failed: {}".format(kwargs["node_name"], reopened_targets))
+                self.finish_schedule()
+                return False
+            else:
+                self.log_info("[{}] check db/table using pass".format(kwargs["node_name"]))
+                self.finish_schedule()
+                return True
 
 
 class GeneralCheckDBInUsingComponent(Component):

--- a/dbm-ui/backend/flow/utils/mysql/mysql_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_context_dataclass.py
@@ -149,7 +149,7 @@ class MySQLTruncateDataContext:
     ip: str = None
     port: int = None
     targets: Dict = None
-    show_open_fence: bool = None
+    # show_open_fence: bool = None
     old_new_map: dict = None
     db_table_filter_regex: str = None
     db_filter_regex: str = None
@@ -306,3 +306,8 @@ class MySQLBackupDemandContext:
     @staticmethod
     def get_backup_ip_var_name() -> str:
         return "ip"
+
+
+@dataclass()
+class MySQLFlashBackContext:
+    targets: Dict = None


### PR DESCRIPTION
1. tendb/tendbcluster flashback 库表是否在用检查移动到 flow
2. 库表是否在用检查从 flush tables 1次, sleep 60s 修改为 flush tables 6次, 间隔 10s
3. 两个 flashback 单据新增单据级别参数 "force": bool
4. dbactuator 中不再检查库表是否在用
5. 修复 flow 中没有正确展开通配参数的问题