### PR TITLE
fix: 集群单据记录改造

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_full_backup.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_full_backup.py
@@ -56,7 +56,7 @@ class TenDBClusterFullBackupFlow(object):
             "file_tag": enum of backend.flow.consts.MySQLBackupFileTagEnum
             “clusters": [
               {
-                "id": int,
+                "cluster_id": int,
                 "backup_local": enum TenDBBackupLocation::[REMOTE, SPIDER_MNT],
                 "spider_mnt_address": "x.x.x.x:y" # 如果 backup_local 是 spider_mnt
               },
@@ -79,13 +79,13 @@ class TenDBClusterFullBackupFlow(object):
 
             try:
                 cluster_obj = Cluster.objects.get(
-                    pk=cluster["id"],
+                    pk=cluster["cluster_id"],
                     bk_biz_id=self.data["bk_biz_id"],
                     cluster_type=ClusterType.TenDBCluster.value,
                 )
             except ObjectDoesNotExist:
                 raise ClusterNotExistException(
-                    cluster_type=ClusterType.TenDBCluster.value, cluster_id=cluster["id"], immute_domain=""
+                    cluster_type=ClusterType.TenDBCluster.value, cluster_id=cluster["cluster_id"], immute_domain=""
                 )
 
             backup_id = uuid.uuid1()

--- a/dbm-ui/backend/ticket/builders/tendbcluster/tendb_fixpoint_rollback.py
+++ b/dbm-ui/backend/ticket/builders/tendbcluster/tendb_fixpoint_rollback.py
@@ -65,7 +65,7 @@ class TendbFixPointRollbackFlowParamBuilder(builders.FlowParamBuilder):
         rollback_flow = self.ticket.current_flow()
         ticket_data = rollback_flow.details["ticket_data"]
 
-        # # 为定点构造的flow填充临时集群信息
+        # 为定点构造的flow填充临时集群信息
         source_cluster_id = ticket_data.pop("cluster_id")
         # 对同一个集群同一天回档26^4才有可能重名, 暂时无需担心
         target_cluster = Cluster.objects.get(name=ticket_data["apply_details"]["cluster_name"])
@@ -73,12 +73,6 @@ class TendbFixPointRollbackFlowParamBuilder(builders.FlowParamBuilder):
         rollback_flow.save(update_fields=["details"])
 
         # 对临时集群记录变更
-        ClusterOperateRecord.objects.create(
-            cluster_id=target_cluster.id,
-            ticket_id=self.ticket.id,
-            flow_id=rollback_flow.id,
-            creator=self.ticket.creator,
-        )
         target_cluster.status = ClusterStatus.TEMPORARY.value
         target_cluster.save(update_fields=["status"])
 

--- a/dbm-ui/backend/ticket/builders/tendbcluster/tendb_full_backup.py
+++ b/dbm-ui/backend/ticket/builders/tendbcluster/tendb_full_backup.py
@@ -22,7 +22,7 @@ from backend.ticket.constants import TicketType
 class TendbFullBackUpDetailSerializer(TendbBaseOperateDetailSerializer):
     class FullBackUpItemSerializer(serializers.Serializer):
         class FullBackUpClusterItemSerializer(serializers.Serializer):
-            id = serializers.IntegerField(help_text=_("集群ID"))
+            cluster_id = serializers.IntegerField(help_text=_("集群ID"))
             backup_local = serializers.CharField(help_text=_("备份位置信息"))
 
         backup_type = serializers.ChoiceField(help_text=_("备份选项"), choices=MySQLBackupTypeEnum.get_choices())

--- a/dbm-ui/backend/ticket/flow_manager/base.py
+++ b/dbm-ui/backend/ticket/flow_manager/base.py
@@ -9,14 +9,18 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import logging
+import operator
 from abc import ABC, abstractmethod
+from functools import reduce
 from typing import Any, Optional, Union
 
+from django.db.models import Q
 from django.utils.translation import gettext as _
 
 from backend.ticket import constants
 from backend.ticket.constants import FLOW_FINISHED_STATUS, FLOW_NOT_EXECUTE_STATUS, FlowErrCode, TicketFlowStatus
-from backend.ticket.models import Flow
+from backend.ticket.models import ClusterOperateRecord, Flow, InstanceOperateRecord
+from backend.utils.basic import get_target_items_from_details
 
 logger = logging.getLogger("root")
 
@@ -135,6 +139,47 @@ class BaseTicketFlow(ABC):
         self.ticket.status = constants.TicketStatus.RUNNING
         self.ticket.save(update_fields=["status", "update_at"])
 
+    def create_operate_records(self, object_key, record_model):
+        """
+        写入操作记录的通用方法
+        每一轮flow在running时，需要更新当前集群的record.flow为当前flow，为新出现的集群增加record(如定点回档包含了新出现的集群)
+        """
+        object_ids = set(
+            get_target_items_from_details(self.flow_obj.details, match_keys=[object_key, f"{object_key}s"])
+            + get_target_items_from_details(self.ticket.details, match_keys=[object_key, f"{object_key}s"])
+        )
+        if not object_ids:
+            return
+
+        record_filter = reduce(
+            operator.or_, [Q(**{object_key: obj_id, "ticket": self.ticket}) for obj_id in object_ids]
+        )
+
+        # 修改当前的flow引用，并批量更新
+        to_update_records = record_model.objects.filter(record_filter)
+        for record in to_update_records:
+            record.flow = self.flow_obj
+        record_model.objects.bulk_update(to_update_records, fields=["flow"])
+
+        # 创建新加入的record，并批量创建
+        object_ticket_tuples = list(to_update_records.values_list(object_key, "ticket"))
+        to_create_records = [
+            record_model(
+                **{object_key: obj_id, "flow": self.flow_obj, "ticket": self.ticket, "creator": self.ticket.creator}
+            )
+            for obj_id in object_ids
+            if (obj_id, self.ticket.id) not in object_ticket_tuples
+        ]
+        record_model.objects.bulk_create(to_create_records)
+
+    def create_cluster_operate_records(self):
+        """写入集群操作记录"""
+        self.create_operate_records(object_key="cluster_id", record_model=ClusterOperateRecord)
+
+    def create_instance_operate_records(self):
+        """写入示例的操作记录"""
+        self.create_operate_records(object_key="instance_id", record_model=InstanceOperateRecord)
+
     def run(self):
         """执行流程并记录流程对象ID"""
         try:
@@ -142,6 +187,9 @@ class BaseTicketFlow(ABC):
         except Exception as err:  # pylint: disable=broad-except
             self.run_error_status_handler(err)
             return
+        else:
+            self.create_cluster_operate_records()
+            self.create_instance_operate_records()
 
         self.run_status_handler(flow_obj_id)
 

--- a/dbm-ui/backend/ticket/flow_manager/inner.py
+++ b/dbm-ui/backend/ticket/flow_manager/inner.py
@@ -96,43 +96,6 @@ class InnerFlow(BaseTicketFlow):
     def _url(self) -> str:
         return f"/database/{self.ticket.bk_biz_id}/mission-details/{self.root_id}/"
 
-    def create_cluster_operate_records(self):
-        """
-        写入集群操作记录
-        """
-        cluster_ids = get_target_items_from_details(self.flow_obj.details, match_keys=["cluster_id", "cluster_ids"])
-        records = [
-            ClusterOperateRecord(
-                cluster_id=cluster_id, flow=self.flow_obj, ticket=self.ticket, creator=self.ticket.creator
-            )
-            for cluster_id in cluster_ids
-        ]
-
-        # 如果当前记录已经被创建过了，则不重复创建(这里主要是防止重试inner节点造成重复的记录)
-        if records and ClusterOperateRecord.objects.filter(**model_to_dict(records[0])).exists():
-            return
-
-        ClusterOperateRecord.objects.bulk_create(records)
-
-    def create_instance_operate_records(self):
-        """
-        写入实例的操作记录
-        """
-        # TODO 这个函数暂时只考虑StorageInstance，后续应该会将StorageInstance和ProxyInstance合并
-        instance_ids = get_target_items_from_details(self.flow_obj.details, match_keys=["instance_id", "instance_ids"])
-        records = [
-            InstanceOperateRecord(
-                instance_id=instance_id, flow=self.flow_obj, ticket=self.ticket, creator=self.ticket.creator
-            )
-            for instance_id in instance_ids
-        ]
-
-        # 如果当前已经被创建过了，则不重复创建
-        if records and InstanceOperateRecord.objects.filter(**model_to_dict(records[0])).exists():
-            return
-
-        InstanceOperateRecord.objects.bulk_create(records)
-
     def check_exclusive_operations(self):
         """判断执行互斥"""
         # TODO: 目前来说，执行互斥对于同时提单或者同时重试的操作是防不住的。


### PR DESCRIPTION
目前设计如下：
1. 在集群提单阶段就进行record的记录
2. 每个flow running阶段会进行对record的flow更新
3. 执行互斥通过判断inner flow是否running来决策