### PR TITLE
fix(mysql): mysql-monitor modify immute-domain

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/install_checksum.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/install_checksum.go
@@ -36,6 +36,7 @@ type InstanceInfo struct {
 	ClusterId    int    `json:"cluster_id"`
 	ImmuteDomain string `json:"immute_domain"`
 	BkInstanceId int64  `json:"bk_instance_id,omitempty"` // 0 被视为空, 不序列化
+	DBModuleId   int    `json:"db_module_id"`
 }
 
 // InstallMySQLChecksumParam 输入参数

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/install_monitor.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/install_monitor.go
@@ -73,6 +73,7 @@ type monitorConfig struct {
 	MachineType     string        `yaml:"machine_type"`
 	Role            *string       `yaml:"role"`
 	BkCloudId       *int          `yaml:"bk_cloud_id" validate:"required,gte=0"`
+	DBModuleID      *int          `yaml:"db_module_id" validate:"required"`
 	Log             *_logConfig   `yaml:"log"`
 	ItemsConfigFile string        `yaml:"items_config_file" validate:"required"`
 	ApiUrl          string        `yaml:"api_url" validate:"required"`
@@ -174,6 +175,7 @@ func (c *InstallMySQLMonitorComp) GenerateBinaryConfig() (err error) {
 			Role:         &instance.Role,
 			BkBizId:      instance.BkBizId,
 			BkCloudId:    &c.Params.BkCloudId,
+			DBModuleID:   &instance.DBModuleId,
 			MachineType:  c.Params.MachineType,
 			Log: &_logConfig{
 				Console:    false,

--- a/dbm-services/mysql/db-tools/mysql-monitor/cmd/init.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/cmd/init.go
@@ -41,7 +41,10 @@ func initLogger(cfg *config.LogConfig) {
 
 		// ToDo 修改目录宿主
 
-		logFile := filepath.Join(*cfg.LogFileDir, fmt.Sprintf("%s.log", executableName))
+		logFile := filepath.Join(
+			*cfg.LogFileDir,
+			fmt.Sprintf("%s.%d.log", executableName, config.MonitorConfig.Port),
+		)
 		_, err = os.Stat(logFile)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/config/monitor_config.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/config/monitor_config.go
@@ -25,6 +25,7 @@ type monitorConfig struct {
 	MachineType     string        `yaml:"machine_type"`
 	Role            *string       `yaml:"role"`
 	BkCloudID       *int          `yaml:"bk_cloud_id" validate:"required,gte=0"`
+	DBModuleID      *int          `yaml:"db_module_id" validate:"required"`
 	Log             *LogConfig    `yaml:"log"`
 	ItemsConfigFile string        `yaml:"items_config_file" validate:"required"`
 	ApiUrl          string        `yaml:"api_url" validate:"required"`

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/mysqlconnlog/init.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/mysqlconnlog/init.go
@@ -44,8 +44,13 @@ func (c *Checker) Run() (msg string, err error) {
 		slog.Error("select @@init_connect", slog.String("error", err.Error()))
 		return "", err
 	}
+	slog.Info(
+		"select @@init_connect",
+		slog.String("init_connect", initConnLog.String),
+		slog.Bool("initConnLog valid", initConnLog.Valid),
+	)
 
-	if !initConnLog.Valid {
+	if !initConnLog.Valid || initConnLog.String == "" {
 		slog.Info("init_connect disabled")
 		return "", nil
 	}

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_event.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_event.go
@@ -13,7 +13,8 @@ func SendMonitorEvent(name string, msg string) {
 	crondManager := ma.NewManager(config.MonitorConfig.ApiUrl)
 
 	additionDimension := map[string]interface{}{
-		"immute_domain":                 config.MonitorConfig.ImmuteDomain,
+		"cluster_domain":                config.MonitorConfig.ImmuteDomain,
+		"db_module":                     *config.MonitorConfig.DBModuleID,
 		"machine_type":                  config.MonitorConfig.MachineType,
 		"bk_cloud_id":                   *config.MonitorConfig.BkCloudID,
 		"port":                          config.MonitorConfig.Port,

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_metrics.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_metrics.go
@@ -14,7 +14,8 @@ func SendMonitorMetrics(name string, value int64, customDimension map[string]int
 	crondManager := ma.NewManager(config.MonitorConfig.ApiUrl)
 
 	additionDimension := map[string]interface{}{
-		"immute_domain":                 config.MonitorConfig.ImmuteDomain,
+		"cluster_domain":                config.MonitorConfig.ImmuteDomain,
+		"db_module":                     *config.MonitorConfig.DBModuleID,
 		"machine_type":                  config.MonitorConfig.MachineType,
 		"bk_cloud_id":                   strconv.Itoa(*config.MonitorConfig.BkCloudID),
 		"port":                          strconv.Itoa(config.MonitorConfig.Port),

--- a/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
@@ -1225,6 +1225,7 @@ class MysqlActPayload(PayloadHandler, TBinlogDumperActPayload):
                     "role": instance.instance_inner_role,
                     "cluster_id": cluster.id,
                     "immute_domain": cluster.immute_domain,
+                    "db_module_id": instance.db_module_id,
                 }
             )
 
@@ -1452,6 +1453,7 @@ class MysqlActPayload(PayloadHandler, TBinlogDumperActPayload):
                         "cluster_id": cluster.id,
                         "immute_domain": cluster.immute_domain,
                         "bk_instance_id": instance.bk_instance_id,
+                        "db_module_id": instance.db_module_id,
                     }
                 )
         # 增加对安装spider监控的适配
@@ -1467,6 +1469,7 @@ class MysqlActPayload(PayloadHandler, TBinlogDumperActPayload):
                         "cluster_id": cluster.id,
                         "immute_domain": cluster.immute_domain,
                         "bk_instance_id": instance.bk_instance_id,
+                        "db_module_id": instance.db_module_id,
                     }
                 )
 
@@ -1483,6 +1486,7 @@ class MysqlActPayload(PayloadHandler, TBinlogDumperActPayload):
                         "cluster_id": cluster.id,
                         "immute_domain": cluster.immute_domain,
                         "bk_instance_id": instance.bk_instance_id,
+                        "db_module_id": instance.db_module_id,
                     }
                 )
         else:


### PR DESCRIPTION
1. mysql monitor 上报维度 immute_domain 更名为 cluster_domain
2. mysql monitor 上报增加 db_module 维度
3. 修复了 connlog 表不存在时 mysql monitor异常报错的问题
4. 修复了 mysql monitor 错误判断 connlog 是否启用的问题
5. mysql monitor 现在会给每一个实例生成一个独立的日志文件