### PR TITLE
fix redis  data structure argument list too long

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/cmd/root.go
+++ b/dbm-services/redis/db-tools/dbactuator/cmd/root.go
@@ -45,6 +45,17 @@ var RootCmd = &cobra.Command{
 		var err error
 		dir, _ := util.GetCurrentDirectory()
 
+		// payLoadFile 数据构造的时候使用的
+		// 解决命令行参数超限问题:./dbactuator_redis: Argument list too long 问题
+		if payLoad == "" && payLoadFile != "" {
+			if o, err := os.ReadFile(payLoadFile); err == nil {
+				payLoad = base64.StdEncoding.EncodeToString(o)
+				log.Printf("using payload file %s", payLoadFile)
+			} else {
+				log.Printf("using payload file %s err %v", payLoadFile, err)
+			}
+		}
+
 		manager, err := jobmanager.NewJobGenericManager(uid, rootID, nodeID, versionID,
 			payLoad, payLoadFormat, atomJobList, dir, multiProcessConcurrency)
 		if err != nil {
@@ -56,15 +67,6 @@ var RootCmd = &cobra.Command{
 			return
 		}
 
-		// 优先使用payLoad。 payLoadFile 个人测试的时候使用的.
-		if payLoad == "" && payLoadFile != "" {
-			if o, err := os.ReadFile(payLoadFile); err == nil {
-				payLoad = base64.StdEncoding.EncodeToString(o)
-				log.Printf("using payload file %s", payLoadFile)
-			} else {
-				log.Printf("using payload file %s err %v", payLoadFile, err)
-			}
-		}
 		err = consts.SetRedisDataDir(dataDir)
 		if err != nil {
 			log.Println(err.Error())

--- a/dbm-ui/backend/flow/utils/redis/redis_script_template.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_script_template.py
@@ -24,3 +24,17 @@ chmod +x dbactuator_redis
 ./dbactuator_redis --uid {{uid}} --root_id {{root_id}} --node_id {{node_id}} \
 --version_id {{version_id}} --payload {{payload}} --atom-job-list {{action}}
 """
+
+
+redis_data_structure_payload_template = """
+{{payload}}
+"""
+
+redis_data_structure_actuator_template = """
+mkdir -p {{data_dir}}/install/dbactuator-{{uid}}/logs
+cp {{data_dir}}/install/dbactuator_redis {{data_dir}}/install/dbactuator-{{uid}}
+cd {{data_dir}}/install/dbactuator-{{uid}}
+chmod +x dbactuator_redis
+./dbactuator_redis --uid {{uid}} --root_id {{root_id}} --node_id {{node_id}} \
+--version_id {{version_id}} --payload_file={{data_dir}}/install/{{file_name}} --atom-job-list {{action}}
+"""


### PR DESCRIPTION
1、解决数据构造时命令行参数超限问题 ./dbactuator_redis: Argument list too long
2、修复dbactuator_redis 使用payLoadFile传入参数时为空的问题