### PR TITLE
fix(mysql): 全库备份增加位置选择

### DIFF
--- a/dbm-ui/backend/components/constants.py
+++ b/dbm-ui/backend/components/constants.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 SSL_KEY = "DBM_SSL"
 CLIENT_CRT_PATH = "backend/components/conf/ssl"

--- a/dbm-ui/backend/components/dbconfig/constants.py
+++ b/dbm-ui/backend/components/dbconfig/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 DEPLOY_FILE_NAME = "deploy_info"
 

--- a/dbm-ui/backend/components/itsm/constants.py
+++ b/dbm-ui/backend/components/itsm/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ItsmTicketStatus(str, StructuredEnum):

--- a/dbm-ui/backend/core/encrypt/constants.py
+++ b/dbm-ui/backend/core/encrypt/constants.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 # 默认编码
 ENCODING = "utf-8"

--- a/dbm-ui/backend/core/storages/constants.py
+++ b/dbm-ui/backend/core/storages/constants.py
@@ -11,10 +11,10 @@ specific language governing permissions and limitations under the License.
 from enum import Enum
 from typing import Any, Dict, List
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext as _
 
 from backend.utils.cache import class_member_cache
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class CosBucketEnum(StructuredEnum):

--- a/dbm-ui/backend/db_meta/api/cluster/base/graph.py
+++ b/dbm-ui/backend/db_meta/api/cluster/base/graph.py
@@ -14,13 +14,13 @@ from dataclasses import asdict, dataclass, field
 from functools import reduce
 from typing import Dict, List, Optional, Tuple, Union
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from backend import env
 from backend.db_meta.enums import ClusterEntryType, ClusterType, InstanceRole, MachineType, TenDBClusterSpiderRole
 from backend.db_meta.models import Cluster, ClusterEntry, ProxyInstance, StorageInstance
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 @dataclass

--- a/dbm-ui/backend/db_meta/enums/access_layer.py
+++ b/dbm-ui/backend/db_meta/enums/access_layer.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class AccessLayer(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/cluster_entry_role.py
+++ b/dbm-ui/backend/db_meta/enums/cluster_entry_role.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ClusterEntryRole(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/cluster_entry_type.py
+++ b/dbm-ui/backend/db_meta/enums/cluster_entry_type.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ClusterEntryType(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/cluster_phase.py
+++ b/dbm-ui/backend/db_meta/enums/cluster_phase.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ClusterPhase(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/cluster_status.py
+++ b/dbm-ui/backend/db_meta/enums/cluster_status.py
@@ -11,8 +11,9 @@ specific language governing permissions and limitations under the License.
 from enum import IntFlag, auto
 from typing import List
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ClusterStatus(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/cluster_type.py
+++ b/dbm-ui/backend/db_meta/enums/cluster_type.py
@@ -8,10 +8,10 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
 
 from backend.configuration.constants import DBType
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ClusterType(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/comm.py
+++ b/dbm-ui/backend/db_meta/enums/comm.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class SyncType(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/dumper.py
+++ b/dbm-ui/backend/db_meta/enums/dumper.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class DumperReceiverType(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/extra_process_type.py
+++ b/dbm-ui/backend/db_meta/enums/extra_process_type.py
@@ -8,8 +8,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ExtraProcessType(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/instance_inner_role.py
+++ b/dbm-ui/backend/db_meta/enums/instance_inner_role.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class InstanceInnerRole(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/instance_phase.py
+++ b/dbm-ui/backend/db_meta/enums/instance_phase.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class InstancePhase(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/instance_role.py
+++ b/dbm-ui/backend/db_meta/enums/instance_role.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class InstanceRole(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/instance_status.py
+++ b/dbm-ui/backend/db_meta/enums/instance_status.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class InstanceStatus(str, StructuredEnum):

--- a/dbm-ui/backend/db_meta/enums/machine_type.py
+++ b/dbm-ui/backend/db_meta/enums/machine_type.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class MachineType(str, StructuredEnum):

--- a/dbm-ui/backend/db_monitor/constants.py
+++ b/dbm-ui/backend/db_monitor/constants.py
@@ -10,9 +10,10 @@ specific language governing permissions and limitations under the License.
 """
 import os
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.conf import settings
 from django.utils.translation import ugettext as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 DB_MONITOR_TPLS_DIR = os.path.join(settings.BASE_DIR, "backend/db_monitor/tpls")
 TPLS_COLLECT_DIR = os.path.join(DB_MONITOR_TPLS_DIR, "collect")

--- a/dbm-ui/backend/db_package/constants.py
+++ b/dbm-ui/backend/db_package/constants.py
@@ -8,10 +8,10 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
 
 from backend.flow.consts import MediumEnum
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class PackageMode(str, StructuredEnum):

--- a/dbm-ui/backend/db_periodic_task/constants.py
+++ b/dbm-ui/backend/db_periodic_task/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 # 任务状态轮询最大次数
 MAX_QUERY_TASK_STATUS_TIMES = 5

--- a/dbm-ui/backend/db_proxy/constants.py
+++ b/dbm-ui/backend/db_proxy/constants.py
@@ -8,10 +8,10 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
 
 from backend.configuration.constants import DBType
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 SWAGGER_TAG = _("透传服务")
 

--- a/dbm-ui/backend/db_report/enums/__init__.py
+++ b/dbm-ui/backend/db_report/enums/__init__.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 from .dbmon_heartbeat_report_sub_type import DbmonHeartbeatReportSubType
 from .meta_check_sub_type import MetaCheckSubType

--- a/dbm-ui/backend/db_report/enums/dbmon_heartbeat_report_sub_type.py
+++ b/dbm-ui/backend/db_report/enums/dbmon_heartbeat_report_sub_type.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class DbmonHeartbeatReportSubType(str, StructuredEnum):

--- a/dbm-ui/backend/db_report/enums/meta_check_sub_type.py
+++ b/dbm-ui/backend/db_report/enums/meta_check_sub_type.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class MetaCheckSubType(str, StructuredEnum):

--- a/dbm-ui/backend/db_report/enums/mysqlbackup_check_sub_type.py
+++ b/dbm-ui/backend/db_report/enums/mysqlbackup_check_sub_type.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class MysqlBackupCheckSubType(str, StructuredEnum):

--- a/dbm-ui/backend/db_report/enums/redisbackup_check_sub_type.py
+++ b/dbm-ui/backend/db_report/enums/redisbackup_check_sub_type.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class RedisBackupCheckSubType(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/dbbase/constants.py
+++ b/dbm-ui/backend/db_services/dbbase/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 ES_DEFAULT_PORT = 9200
 

--- a/dbm-ui/backend/db_services/dbbase/resources/constants.py
+++ b/dbm-ui/backend/db_services/dbbase/resources/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 RESOURCE_TAG = "db_services/resources"
 

--- a/dbm-ui/backend/db_services/dbresource/constants.py
+++ b/dbm-ui/backend/db_services/dbresource/constants.py
@@ -9,7 +9,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
 
 from backend.db_meta.enums import ClusterType
@@ -19,6 +18,7 @@ from backend.db_services.dbresource.handlers import (
     TendisPlusSpecFilter,
     TendisSSDSpecFilter,
 )
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 SWAGGER_TAG = _("资源池")
 

--- a/dbm-ui/backend/db_services/infras/constants.py
+++ b/dbm-ui/backend/db_services/infras/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class InventoryTag(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/meta_import/constants.py
+++ b/dbm-ui/backend/db_services/meta_import/constants.py
@@ -8,7 +8,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 SWAGGER_TAG = _("元数据迁移")

--- a/dbm-ui/backend/db_services/mysql/permission/constants.py
+++ b/dbm-ui/backend/db_services/mysql/permission/constants.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class PrivilegeType:

--- a/dbm-ui/backend/db_services/mysql/sql_import/constants.py
+++ b/dbm-ui/backend/db_services/mysql/sql_import/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 BKREPO_SQLFILE_PATH = "mysql/sqlfile"
 

--- a/dbm-ui/backend/db_services/partition/constants.py
+++ b/dbm-ui/backend/db_services/partition/constants.py
@@ -8,8 +8,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 SWAGGER_TAG = _("分区管理")
 

--- a/dbm-ui/backend/db_services/quick_search/constants.py
+++ b/dbm-ui/backend/db_services/quick_search/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class ResourceType(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/redis/autofix/enums.py
+++ b/dbm-ui/backend/db_services/redis/autofix/enums.py
@@ -10,8 +10,9 @@ specific language governing permissions and limitations under the License.
 """
 from dataclasses import dataclass, field
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class DBHASwitchResult(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/redis/autofix/models.py
+++ b/dbm-ui/backend/db_services/redis/autofix/models.py
@@ -11,13 +11,13 @@ specific language governing permissions and limitations under the License.
 
 import logging
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from backend.bk_web.constants import LEN_LONG, LEN_NORMAL, LEN_XX_LONG
 from backend.bk_web.models import AuditedModel
 from backend.db_meta.enums import ClusterType
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 from .enums import AutofixStatus
 

--- a/dbm-ui/backend/db_services/redis/constants.py
+++ b/dbm-ui/backend/db_services/redis/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class KeyDeleteType(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/redis/redis_dts/constants.py
+++ b/dbm-ui/backend/db_services/redis/redis_dts/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class DtsTaskType(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/redis/redis_dts/enums/type_enums.py
+++ b/dbm-ui/backend/db_services/redis/redis_dts/enums/type_enums.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 class DtsBillType(str, StructuredEnum):

--- a/dbm-ui/backend/db_services/version/constants.py
+++ b/dbm-ui/backend/db_services/version/constants.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 # 部分场景的版本无需特定，保持最新即可
 LATEST = "latest"

--- a/dbm-ui/backend/dbm_init/medium/handlers.py
+++ b/dbm-ui/backend/dbm_init/medium/handlers.py
@@ -20,7 +20,6 @@ from datetime import datetime
 import yaml
 from bkstorages.backends.bkrepo import TIMEOUT_THRESHOLD, BKGenericRepoClient, BKRepoStorage, urljoin
 
-
 logger = logging.getLogger("root")
 
 

--- a/dbm-ui/backend/flow/consts.py
+++ b/dbm-ui/backend/flow/consts.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 GenerateAndPublish = "GenerateAndPublish"
 HOST = "host"

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_ha_full_backup_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_ha_full_backup_flow.py
@@ -23,6 +23,7 @@ from backend.db_meta.models import Cluster
 from backend.flow.consts import DBA_SYSTEM_USER
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
+from backend.flow.engine.exceptions import MySQLBackupLocalException
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.plugins.components.collections.mysql.mysql_link_backup_id_bill_id import (
     MySQLLinkBackupIdBillIdComponent,
@@ -57,6 +58,7 @@ class MySQLHAFullBackupFlow(object):
             "backup_type": enum of backend.flow.consts.MySQLBackupTypeEnum
             "file_tag": enum of backend.flow.consts.MySQLBackupFileTagEnum
             "cluster_ids": List[int],
+            "backup_local": enum of backend.db_meta.enum.InstanceInnerRole
         }
         }
         """
@@ -75,12 +77,17 @@ class MySQLHAFullBackupFlow(object):
                     cluster_type=ClusterType.TenDBHA.value, cluster_id=cluster_id, immute_domain=""
                 )
 
-            try:
-                slave_obj = cluster_obj.storageinstance_set.get(
-                    instance_inner_role=InstanceInnerRole.SLAVE.value, is_stand_by=True
-                )
-            except ObjectDoesNotExist:
-                raise DBMetaBaseException(message=_("{} standby slave 不存在".format(cluster_obj.immute_domain)))
+            if self.data["infos"]["backup_local"] == InstanceInnerRole.MASTER.value:
+                backend_obj = cluster_obj.storageinstance_set.get(instance_inner_role=InstanceInnerRole.MASTER.value)
+            elif self.data["infos"]["backup_local"] == InstanceInnerRole.SLAVE.value:
+                try:
+                    backend_obj = cluster_obj.storageinstance_set.get(
+                        instance_inner_role=InstanceInnerRole.SLAVE.value, is_stand_by=True
+                    )
+                except ObjectDoesNotExist:
+                    raise DBMetaBaseException(message=_("{} standby slave 不存在".format(cluster_obj.immute_domain)))
+            else:
+                raise MySQLBackupLocalException(msg=_("不支持的备份位置 {}".format(self.data["infos"]["backup_local"])))
 
             sub_pipe = SubBuilder(
                 root_id=self.root_id,
@@ -89,13 +96,13 @@ class MySQLHAFullBackupFlow(object):
                     "created_by": self.data["created_by"],
                     "bk_biz_id": self.data["bk_biz_id"],
                     "ticket_type": self.data["ticket_type"],
-                    "ip": slave_obj.machine.ip,
-                    "port": slave_obj.port,
+                    "ip": backend_obj.machine.ip,
+                    "port": backend_obj.port,
                     "file_tag": self.data["infos"]["file_tag"],
                     "backup_type": self.data["infos"]["backup_type"],
                     "backup_id": uuid.uuid1(),
                     "backup_gsd": ["schema", "data"],
-                    "role": slave_obj.instance_role,
+                    "role": backend_obj.instance_role,
                 },
             )
 
@@ -105,7 +112,7 @@ class MySQLHAFullBackupFlow(object):
                 kwargs=asdict(
                     DownloadMediaKwargs(
                         bk_cloud_id=cluster_obj.bk_cloud_id,
-                        exec_ip=slave_obj.machine.ip,
+                        exec_ip=backend_obj.machine.ip,
                         file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
                     )
                 ),
@@ -118,7 +125,7 @@ class MySQLHAFullBackupFlow(object):
                     ExecActuatorKwargs(
                         bk_cloud_id=cluster_obj.bk_cloud_id,
                         run_as_system_user=DBA_SYSTEM_USER,
-                        exec_ip=slave_obj.machine.ip,
+                        exec_ip=backend_obj.machine.ip,
                         get_mysql_payload_func=MysqlActPayload.mysql_backup_demand_payload.__name__,
                     )
                 ),

--- a/dbm-ui/backend/flow/utils/hdfs/hdfs_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/hdfs/hdfs_context_dataclass.py
@@ -11,9 +11,8 @@ specific language governing permissions and limitations under the License.
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
-
 from backend.flow.consts import HdfsRoleEnum
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
 @dataclass()

--- a/dbm-ui/backend/flow/utils/pulsar/consts.py
+++ b/dbm-ui/backend/flow/utils/pulsar/consts.py
@@ -8,8 +8,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 PULSAR_KEY_PATH_LIST_ZOOKEEPER = ["/data/pulsarenv/zookeeper/my-secret.key"]
 PULSAR_KEY_PATH_LIST_BROKER = ["/data/pulsarenv/broker/my-secret.key"]

--- a/dbm-ui/backend/tests/mock_data/utils.py
+++ b/dbm-ui/backend/tests/mock_data/utils.py
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 from typing import Any, Callable, Optional, Union
 
 import wrapt
+
 from blue_krill.data_types.enum import StructuredEnum
 
 

--- a/dbm-ui/backend/ticket/builders/common/constants.py
+++ b/dbm-ui/backend/ticket/builders/common/constants.py
@@ -9,8 +9,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import gettext_lazy as _
+
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 ES_MASTER_NEED = 3
 

--- a/dbm-ui/backend/ticket/todos/__init__.py
+++ b/dbm-ui/backend/ticket/todos/__init__.py
@@ -14,10 +14,10 @@ import os
 from dataclasses import asdict, dataclass
 from typing import Callable
 
-from blue_krill.data_types.enum import EnumField, StructuredEnum
 from django.utils.translation import ugettext_lazy as _
 
 from backend.ticket.models import Todo
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 logger = logging.getLogger("root")
 


### PR DESCRIPTION
dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_ha_full_backup_flow.py  
infos 中增加 backup_local 参数, 可选值是 InstanceInnerRole.Master, InstanceInnerRole.Slave

dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_full_backup.py
backup_local 参数的可选值 从原来的 [remote, spider_mnt] 调整为 [InstanceInnerRole.Master, InstanceInnerRole.Slave, spider_mnt]

两个全备流程都已添加在 master 上备份的支持