### PR TITLE
fix(mysql): 重建slave没有正确继承is_stand_by状态

### DIFF
--- a/dbm-ui/backend/db_meta/api/cluster/tendbha/switch_storage.py
+++ b/dbm-ui/backend/db_meta/api/cluster/tendbha/switch_storage.py
@@ -40,8 +40,9 @@ def switch_storage(cluster_id: int, target_storage_ip: str, origin_storage_ip: s
     # target实例需要继承source实例的is_standby特性
     target_storage.is_stand_by = origin_storage.is_stand_by
     target_storage.save()
-    origin_storage.is_stand_by = False
-    origin_storage.save()
+    # 这两行目前看来有点多余, 而且似乎不做更好
+    # origin_storage.is_stand_by = False
+    # origin_storage.save()
 
 
 def change_proxy_storage_entry(cluster_id: int, master_ip: str, new_master_ip: str):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/slave_recover_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/slave_recover_switch.py
@@ -116,7 +116,7 @@ def slave_migrate_switch_sub_flow(
     )
 
     sub_pipeline.add_act(
-        act_name=_("再删除旧从库域名{}").format(new_slave_ip),
+        act_name=_("再删除旧从库域名{}").format(old_slave_ip),
         act_component_code=MySQLDnsManageComponent.code,
         kwargs=asdict(
             RecycleDnsRecordKwargs(


### PR DESCRIPTION
1. 主备迁移流程中断时可能导致is stand by丢失: 不再清理老机器的 is stand by 位
2. 调整重建slave流程减少告警: 提前清理实例服务实例, 实例下架流程修改为 删除元数据->关闭周边->关闭实例 
3. 修正一处日志错误