### PR TITLE
fix(redis): redis迁移相关问题修复 #2796

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/proxy_install.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/proxy_install.py
@@ -94,8 +94,8 @@ def ProxyBatchInstallAtomJob(root_id, ticket_data, act_kwargs: ActKwargs, param:
         ),
     )
 
-    # proxy扩容是，config从参数传过来
-    if ticket_data["ticket_type"] == TicketType.PROXY_SCALE_UP.value:
+    # proxy扩容/替换/自愈，config从参数传过来
+    if "conf_configs" in param:
         act_kwargs.cluster["conf_configs"] = param["conf_configs"]
         act_kwargs.cluster["dbconfig"] = param["conf_configs"]
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_migrate_load.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_migrate_load.py
@@ -366,6 +366,15 @@ class RedisClusterMigrateLoadFlow(object):
                 act_name=_("建立集群 元数据"), act_component_code=RedisDBMetaComponent.code, kwargs=asdict(act_kwargs)
             )
 
+            db_admin = {"db_type": DBType.Redis.value, "users": str.split(self.data["nosqldbas"], ",")}
+            act_kwargs.cluster = {
+                "db_admins": [db_admin],
+                "meta_func_name": RedisDBMeta.update_nosql_dba.__name__,
+            }
+            sub_pipeline.add_act(
+                act_name=_("更新业务NOSQL DBA"), act_component_code=RedisDBMetaComponent.code, kwargs=asdict(act_kwargs)
+            )
+
             # clb、北极星需要写元数据
             if len(params["entry"]["clb"]) != 0:
                 act_kwargs.cluster = params["entry"]["clb"]
@@ -399,8 +408,6 @@ class RedisClusterMigrateLoadFlow(object):
                 redis_password = params["proxy_config"].pop("redis_password")
             if "password" in params["proxy_config"]:
                 proxy_pwd = params["proxy_config"].pop("password")
-            if "hash_tag" in params["proxy_config"] and params["proxy_config"]["hash_tag"] == "":
-                del params["proxy_config"]["hash_tag"]
             params["proxy_config"]["port"] = str(cluster["proxy_port"])
 
             act_kwargs.cluster = {

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_auotfix.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_auotfix.py
@@ -256,6 +256,7 @@ class RedisClusterAutoFixSceneFlow(object):
                 "ip": proxy_ip,
                 "redis_pwd": config_info["redis_password"],
                 "proxy_pwd": config_info["password"],
+                "conf_configs": config_info,
                 "proxy_port": int(config_info["port"]),
                 "servers": replace_kwargs.cluster["backend_servers"],
                 "spec_id": proxy_fix_info["proxy_spec"].get("id", 0),

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
@@ -314,6 +314,7 @@ class RedisClusterCMRSceneFlow(object):
                 "ip": proxy_ip,
                 "redis_pwd": config_info["redis_password"],
                 "proxy_pwd": config_info["password"],
+                "conf_configs": config_info,
                 "proxy_admin_pwd": config_info["redis_proxy_admin_password"],
                 "proxy_port": int(config_info["port"]),
                 "servers": replace_kwargs.cluster["backend_servers"],

--- a/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
@@ -80,6 +80,13 @@ predixy_cluster_type_list = [
     ClusterType.TendisPredixyTendisplusCluster.value,
     ClusterType.TendisPredixyRedisCluster.value,
 ]
+cache_cluster_type_list = [
+    ClusterType.RedisCluster.value,
+    ClusterType.TendisPredixyRedisCluster.value,
+    ClusterType.TendisTwemproxyRedisInstance.value,
+    ClusterType.TendisRedisInstance.value,
+    ClusterType.TendisRedisCluster.value,
+]
 
 
 class RedisActPayload(object):
@@ -172,15 +179,16 @@ class RedisActPayload(object):
                 "level_value": cluster_map["domain_name"],
             }
         )
-        # 备份相关的配置，需要单独写进去
-        if "backup_config" in cluster_map:
-            if "cache_backup_mode" in cluster_map["backup_config"]:
-                set_backup_mode(
-                    cluster_map["domain_name"],
-                    self.bk_biz_id,
-                    self.namespace,
-                    cluster_map["backup_config"]["cache_backup_mode"],
-                )
+        # 备份相关的配置，需要单独写进去。只有cache类型的的集群，才会去修改fullbackup的参数
+        if self.namespace in cache_cluster_type_list:
+            if "backup_config" in cluster_map:
+                if "cache_backup_mode" in cluster_map["backup_config"]:
+                    set_backup_mode(
+                        cluster_map["domain_name"],
+                        self.bk_biz_id,
+                        self.namespace,
+                        cluster_map["backup_config"]["cache_backup_mode"],
+                    )
 
         return data
 

--- a/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
@@ -19,6 +19,7 @@ from django.utils.translation import ugettext as _
 
 from backend.components import DBConfigApi
 from backend.components.dbconfig.constants import FormatType, LevelName
+from backend.configuration.models import DBAdministrator
 from backend.db_meta import api
 from backend.db_meta.api.cluster.nosqlcomm.create_cluster import update_cluster_type
 from backend.db_meta.api.cluster.tendiscache.handler import TendisCacheClusterHandler
@@ -987,3 +988,9 @@ class RedisDBMeta(object):
             shutdown_master_slave_pair=self.cluster["shutdown_master_slave_pair"],
         )
         record.save()
+
+    def update_nosql_dba(self):
+        """
+        更新dba
+        """
+        DBAdministrator.upsert_biz_admins(self.ticket_data["bk_biz_id"], self.cluster["db_admins"])


### PR DESCRIPTION
1、dbconfig 写 fullbackup 时，需要做判断。只有cache类集群才需要。
2、hashtag不做特殊处理，前面传什么，就传什么。（这里默认值与gcs不同）
3、往configuration_dbadministrator表中插入DBA数据
4、扩缩容、集群替换的时候proxy参数，需要从集群配置中拿