### PR TITLE
fix(other): 更新大数据仪表盘

### DIFF
--- a/dbm-ui/backend/bk_dataview/dashboards/json/es.json
+++ b/dbm-ui/backend/bk_dataview/dashboards/json/es.json
@@ -6,7 +6,7 @@
       "description": "",
       "type": "datasource",
       "pluginId": "bkmonitor-timeseries-datasource",
-      "pluginName": "蓝鲸监控-时序数据"
+      "pluginName": "BlueKing Monitor TimeSeries"
     }
   ],
   "__elements": {},
@@ -14,7 +14,7 @@
     {
       "type": "datasource",
       "id": "bkmonitor-timeseries-datasource",
-      "name": "蓝鲸监控-时序数据",
+      "name": "BlueKing Monitor TimeSeries",
       "version": "3.6.0"
     },
     {
@@ -468,10 +468,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -510,19 +506,20 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "code",
+          "mode": "ui",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": "auto",
+              "interval": 60,
               "interval_unit": "s",
               "method": "COUNT",
               "metric_field": "elasticsearch_indices_docs_primary",
@@ -532,18 +529,18 @@
               "time_field": "",
               "where": [
                 {
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
                   "key": "app",
                   "method": "eq",
                   "value": [
                     "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
                   ]
                 }
               ]
@@ -1090,7 +1087,7 @@
             }
           ],
           "refId": "A",
-          "source": "count(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{name=~\"hot-.*|dn-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "source": "count(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{__name=~\"hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -1163,7 +1160,7 @@
           "promqlAlias": "",
           "query_configs": [],
           "refId": "A",
-          "source": "count(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{name=~\"cold-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "source": "count(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{__name=~\"cold-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -1656,25 +1653,26 @@
             {
               "active": true,
               "alias": "",
-              "expression": "a * 1 + b * 2 + c * 3",
+              "expression": "a*1+b*2+c*3",
               "functions": []
             }
           ],
           "format": "time_series",
           "host": [],
-          "mode": "code",
+          "mode": "ui",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
-              "display": true,
+              "display": false,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": 60,
+              "interval": "auto",
               "interval_unit": "s",
               "method": "max_without_time",
               "metric_field": "elasticsearch_cluster_health_status",
@@ -1710,19 +1708,21 @@
             },
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
+              "display": false,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": 60,
+              "interval": "auto",
               "interval_unit": "s",
               "method": "max_without_time",
               "metric_field": "elasticsearch_cluster_health_status",
               "refId": "b",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -1751,19 +1751,21 @@
             },
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
+              "display": false,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": 60,
+              "interval": "auto",
               "interval_unit": "s",
               "method": "max_without_time",
               "metric_field": "elasticsearch_cluster_health_status",
               "refId": "c",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -1792,7 +1794,7 @@
             }
           ],
           "refId": "A",
-          "source": "max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\",color=\"green\"}) * 1 + max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\",color=\"yellow\"}) * 2 + max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\",color=\"red\"}) * 3",
+          "source": "elasticsearch_cluster_health_status",
           "step": "",
           "type": "range"
         }
@@ -2258,7 +2260,7 @@
         "type": "bkmonitor-timeseries-datasource",
         "uid": "bkmonitor_timeseries"
       },
-      "description": "1: green\n2: yellow\n3: red",
+      "description": "0: red\n1: green\n2: yellow",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2294,7 +2296,28 @@
               "mode": "off"
             }
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "red"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "green"
+                },
+                "2": {
+                  "color": "yellow",
+                  "index": 2,
+                  "text": "yellow"
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -2335,18 +2358,26 @@
             "type": "bkmonitor-timeseries-datasource",
             "uid": "bkmonitor_timeseries"
           },
-          "expressionList": [],
+          "expressionList": [
+            {
+              "active": true,
+              "alias": "状态",
+              "expression": "a*1+b*2+c*3",
+              "functions": []
+            }
+          ],
           "format": "time_series",
           "host": [],
-          "mode": "code",
+          "mode": "ui",
           "module": [],
           "promqlAlias": "状态",
           "query_configs": [
             {
               "alias": "状态",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
-              "display": true,
+              "display": false,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
@@ -2373,12 +2404,106 @@
                   "value": [
                     "$cluster_domain"
                   ]
+                },
+                {
+                  "condition": "and",
+                  "key": "color",
+                  "method": "eq",
+                  "value": [
+                    "green"
+                  ]
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": false,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "elasticsearch_cluster_health_status",
+              "refId": "b",
+              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "color",
+                  "method": "eq",
+                  "value": [
+                    "yellow"
+                  ]
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": false,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "elasticsearch_cluster_health_status",
+              "refId": "c",
+              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "color",
+                  "method": "eq",
+                  "value": [
+                    "red"
+                  ]
                 }
               ]
             }
           ],
           "refId": "A",
-          "source": "max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\",color=\"green\"}) * 1 + max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\",color=\"yellow\"}) * 2 + max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\",color=\"red\"}) * 3",
+          "source": "max(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_cluster_health_status{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -2461,8 +2586,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -2980,8 +3105,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -3215,7 +3340,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -3237,8 +3362,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -3248,7 +3373,14 @@
             "type": "bkmonitor-timeseries-datasource",
             "uid": "bkmonitor_timeseries"
           },
-          "expressionList": [],
+          "expressionList": [
+            {
+              "active": true,
+              "alias": "",
+              "expression": "a/b",
+              "functions": []
+            }
+          ],
           "format": "time_series",
           "host": [],
           "mode": "code",
@@ -3257,23 +3389,103 @@
           "query_configs": [
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
               "filter_dict": {},
-              "functions": [],
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "3m"
+                    }
+                  ]
+                }
+              ],
               "group_by": [],
-              "interval": 60,
+              "interval": 90,
               "interval_unit": "s",
               "method": "AVG",
-              "metric_field": "elasticsearch_indices_indexing_index_total",
+              "metric_field": "elasticsearch_indices_indexing_index_time_seconds_total",
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "__name",
+                  "method": "reg",
+                  "value": [
+                    "hot-.*|dn-.*"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "3m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [],
+              "interval": 90,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "elasticsearch_indices_indexing_index_total",
+              "refId": "b",
+              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "name",
                   "method": "eq",
                   "value": []
                 }
@@ -3281,7 +3493,7 @@
             }
           ],
           "refId": "A",
-          "source": "avg(irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_indices_indexing_index_time_seconds_total{name=~\"hot-.*|dn-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"}[3m]))/avg(irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_indices_indexing_index_total{app=\"$app\", cluster_domain=\"$cluster_domain\",name=~\"hot-.*|dn-.*\"}[3m]))",
+          "source": "avg(irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_indices_indexing_index_time_seconds_total{name=~\"hot-.*|dn-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"}[3m])) / avg(irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_indices_indexing_index_total{name=~\"hot-.*|dn-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"}[3m]))",
           "step": "",
           "type": "range"
         },
@@ -3308,6 +3520,7 @@
           "query_configs": [
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -3331,7 +3544,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "__name",
@@ -3360,6 +3573,7 @@
             },
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -3383,7 +3597,7 @@
               "refId": "b",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -3432,6 +3646,7 @@
           "query_configs": [
             {
               "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -3445,7 +3660,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": []
             }
           ],
@@ -3671,8 +3886,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -3753,6 +3968,7 @@
           "query_configs": [
             {
               "alias": "数据节点",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "filter_dict": {},
@@ -3765,7 +3981,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -3814,6 +4030,7 @@
           "query_configs": [
             {
               "alias": "数据节点",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "filter_dict": {},
@@ -3826,7 +4043,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -3875,6 +4092,7 @@
           "query_configs": [
             {
               "alias": "数据节点",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "filter_dict": {},
@@ -3887,7 +4105,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -4115,7 +4333,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -4165,7 +4383,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4173,2935 +4391,3078 @@
         "y": 50
       },
       "id": 41,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 43,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [
+                {
+                  "active": true,
+                  "alias": "",
+                  "expression": "",
+                  "functions": []
+                }
+              ],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_index",
+              "query_configs": [
+                {
+                  "alias": "$tag_index",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "rate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "topk",
+                      "params": [
+                        {
+                          "id": "k",
+                          "value": "20"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "index"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "sum_without_time",
+                  "metric_field": "elasticsearch_index_stats_indexing_index_total",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "topk(20, sum by(index) (rate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_index_stats_indexing_index_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m])))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "每秒indexing请求（top20）",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 46,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_index",
+              "query_configs": [
+                {
+                  "alias": "$tag_index",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "topk",
+                      "params": [
+                        {
+                          "id": "k",
+                          "value": "20"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "rate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "index"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "SUM",
+                  "metric_field": "elasticsearch_index_stats_search_query_total",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "topk(20, sum by(index) (rate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_index_stats_search_query_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m])))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "每秒search请求（top20）",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "ui",
+              "module": [],
+              "promqlAlias": "",
+              "query_configs": [
+                {
+                  "alias": "$tag_index",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "topk",
+                      "params": [
+                        {
+                          "id": "k",
+                          "value": "20"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "index"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_indices_store_size_bytes_total",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "indices数据量（top20）",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 45,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_index-$tag_shard",
+              "query_configs": [
+                {
+                  "alias": "$tag_index-$tag__shard",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "topk",
+                      "params": [
+                        {
+                          "id": "k",
+                          "value": "20"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "index",
+                    "_shard"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "avg_without_time",
+                  "metric_field": "elasticsearch_indices_shards_docs",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "topk(20, avg by (index, shard) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_indices_shards_docs{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "shard docs（top20）",
+          "type": "timeseries"
+        }
+      ],
       "title": "indices信息",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 51
-      },
-      "id": 43,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Last",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [
-            {
-              "active": true,
-              "alias": "",
-              "expression": "",
-              "functions": []
-            }
-          ],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_index",
-          "query_configs": [
-            {
-              "alias": "$tag_index",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "rate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "2m"
-                    }
-                  ]
-                },
-                {
-                  "id": "topk",
-                  "params": [
-                    {
-                      "id": "k",
-                      "value": "20"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "index"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "sum_without_time",
-              "metric_field": "elasticsearch_index_stats_indexing_index_total",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "topk(20, sum by(index) (rate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_index_stats_indexing_index_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m])))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "每秒indexing请求（top20）",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 51
-      },
-      "id": 46,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_index",
-          "query_configs": [
-            {
-              "alias": "$tag_index",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "topk",
-                  "params": [
-                    {
-                      "id": "k",
-                      "value": "20"
-                    }
-                  ]
-                },
-                {
-                  "id": "rate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "2m"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "index"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "SUM",
-              "metric_field": "elasticsearch_index_stats_search_query_total",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "topk(20, sum by(index) (rate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_index_stats_search_query_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m])))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "每秒search请求（top20）",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 59
-      },
-      "id": 44,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Last",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "ui",
-          "module": [],
-          "promqlAlias": "",
-          "query_configs": [
-            {
-              "alias": "$tag_index",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "topk",
-                  "params": [
-                    {
-                      "id": "k",
-                      "value": "20"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "index"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "max_without_time",
-              "metric_field": "elasticsearch_indices_store_size_bytes_total",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "indices数据量（top20）",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 59
-      },
-      "id": 45,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Last",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_index-$tag_shard",
-          "query_configs": [
-            {
-              "alias": "$tag_index-$tag__shard",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "topk",
-                  "params": [
-                    {
-                      "id": "k",
-                      "value": "20"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "index",
-                "_shard"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "avg_without_time",
-              "metric_field": "elasticsearch_indices_shards_docs",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "topk(20, avg by (index, shard) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_indices_shards_docs{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "shard docs（top20）",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 51
       },
       "id": 48,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 50,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [
+                {
+                  "active": true,
+                  "alias": "",
+                  "expression": "a / b",
+                  "functions": []
+                }
+              ],
+              "format": "time_series",
+              "hide": false,
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag_name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": false,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_jvm_memory_used_bytes",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_master_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "alias": "$tag_name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_jvm_memory_max_bytes",
+                  "refId": "b",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_master_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_memory_used_bytes{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\"}) / max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_memory_max_bytes{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "jvm heap使用率",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 54,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [
+                {
+                  "active": true,
+                  "alias": "",
+                  "expression": "a*60",
+                  "functions": []
+                }
+              ],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "young-$tag_name",
+              "query_configs": [
+                {
+                  "alias": "young-$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_jvm_gc_collection_seconds_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_master_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "gc",
+                      "method": "eq",
+                      "value": [
+                        "young"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by(name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\",gc=\"young\"}[2m])) * 60",
+              "step": "",
+              "type": "range"
+            },
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [
+                {
+                  "active": true,
+                  "alias": "old-$tag___name",
+                  "expression": "a * 60",
+                  "functions": []
+                }
+              ],
+              "format": "time_series",
+              "hide": false,
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "old-$tag_name",
+              "query_configs": [
+                {
+                  "alias": "old-$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_jvm_gc_collection_seconds_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_master_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "gc",
+                      "method": "eq",
+                      "value": [
+                        "old"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "B",
+              "source": "avg by(name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\",gc=\"old\"}[2m])) * 60",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "jvm gc次数（1m）",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 53,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [
+                {
+                  "active": true,
+                  "alias": "",
+                  "expression": "a + b",
+                  "functions": []
+                }
+              ],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "3m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": 90,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_jvm_gc_collection_seconds_sum",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "__name",
+                      "method": "reg",
+                      "value": [
+                        "master-.*|Master-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "gc",
+                      "method": "eq",
+                      "value": [
+                        "old"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "3m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": 90,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_jvm_gc_collection_seconds_sum",
+                  "refId": "b",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "__name",
+                      "method": "reg",
+                      "value": [
+                        "master-.*|Master-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "gc",
+                      "method": "eq",
+                      "value": [
+                        "young"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"master-.*|Master-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"old\"}[3m])) + avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"master-.*|Master-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"young\"}[3m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "jvm gc时间占比",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "dtdurations"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 51,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_jvm_uptime_seconds",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_master_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "节点uptime",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 52,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "avg_without_time",
+                  "metric_field": "usage",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.cpu_summary",
+                  "result_table_label": "os",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "CPU使用率",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 55,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "avg_without_time",
+                  "metric_field": "load1",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.load",
+                  "result_table_label": "os",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "系统负载(1m)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 57,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "avg_without_time",
+                  "metric_field": "speed_recv",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.net",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluser_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})*8",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "入流量(单位：bits/s)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 59,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "avg_without_time",
+                  "metric_field": "speed_sent",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.net",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})*8",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "出流量(单位：bits/s)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 60,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "cur_tcp_estab",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.netstat",
+                  "result_table_label": "os",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by(bk_target_ip) (bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "连接数",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 62,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [
+                    "bk_target_ip"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "avg_without_time",
+                  "metric_field": "cur_tcp_estab",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.netstat",
+                  "result_table_label": "os",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by(bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"}[2m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "新建连接数",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 61,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "title": "打开fd数",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 63,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip$tag_mount_point",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip$tag_mount_point",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip",
+                    "mount_point"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "in_use",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.disk",
+                  "result_table_label": "os",
+                  "time_field": "",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "mount_point",
+                      "method": "neq",
+                      "value": [
+                        "/"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "mount_point",
+                      "method": "neq",
+                      "value": [
+                        "/usr/local"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "分区使用率",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "KBs"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 64,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip  $tag_device_name",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip  $tag_device_name",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "device_name",
+                    "bk_target_ip"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "rkb_s",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.io",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{device_name!~\"nbd*|ram*|loop*\",app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"}[1m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "磁盘读取",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "KBs"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 65,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip $tag_device_name",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip",
+                    "device_name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "wkb_s",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.io",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (bk_target_ip, device_name) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{device_name!~\"nbd*|ram*|loop*\",app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"}[1m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "磁盘写入",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 149,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip $tag_device_name",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "bk_target_ip",
+                    "device_name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "wkb_s",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.io",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_master"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:util{app=\"$app\",cluster_domain=\"$cluster_domain\",device_name!~\"nbd*|ram*|loop*\",instance_role=\"es_master\"}[1m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "磁盘ioutil",
+          "type": "timeseries"
+        }
+      ],
       "title": "master",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 68
-      },
-      "id": 50,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [
-            {
-              "active": true,
-              "alias": "$tag___name",
-              "expression": "a  / b",
-              "functions": []
-            }
-          ],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_name",
-          "query_configs": [
-            {
-              "alias": "",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": false,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "max_without_time",
-              "metric_field": "elasticsearch_jvm_memory_used_bytes",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "es_master_node",
-                  "method": "eq",
-                  "value": [
-                    "true"
-                  ]
-                }
-              ]
-            },
-            {
-              "alias": "",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "max_without_time",
-              "metric_field": "elasticsearch_jvm_memory_max_bytes",
-              "refId": "b",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "es_master_node",
-                  "method": "eq",
-                  "value": [
-                    "true"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_memory_used_bytes{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\"}) / max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_memory_max_bytes{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\"})",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "jvm heap使用率",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 68
-      },
-      "id": 54,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [
-            {
-              "active": true,
-              "alias": "",
-              "expression": "a*60",
-              "functions": []
-            }
-          ],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "young-$tag_name",
-          "query_configs": [
-            {
-              "alias": "young-$tag___name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "irate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "2m"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "elasticsearch_jvm_gc_collection_seconds_count",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "es_master_node",
-                  "method": "eq",
-                  "value": [
-                    "true"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "gc",
-                  "method": "eq",
-                  "value": [
-                    "young"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\",gc=\"young\"}[2m])) * 60",
-          "step": "",
-          "type": "range"
-        },
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [
-            {
-              "active": true,
-              "alias": "old-$tag___name",
-              "expression": "a * 60",
-              "functions": []
-            }
-          ],
-          "format": "time_series",
-          "hide": false,
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "old-$tag_name",
-          "query_configs": [
-            {
-              "alias": "old-$tag___name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "irate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "2m"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "elasticsearch_jvm_gc_collection_seconds_count",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "es_master_node",
-                  "method": "eq",
-                  "value": [
-                    "true"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "gc",
-                  "method": "eq",
-                  "value": [
-                    "old"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "B",
-          "source": "avg by(name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\",gc=\"old\"}[2m])) * 60",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "jvm gc次数（1m）",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 76
-      },
-      "id": 53,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [
-            {
-              "active": true,
-              "alias": "$tag___name",
-              "expression": "a + b",
-              "functions": []
-            }
-          ],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_name",
-          "query_configs": [
-            {
-              "alias": "$tag___name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "irate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "3m"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 90,
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "elasticsearch_jvm_gc_collection_seconds_sum",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "__name",
-                  "method": "reg",
-                  "value": [
-                    "master-.*|Master-.*"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "gc",
-                  "method": "eq",
-                  "value": [
-                    "old"
-                  ]
-                }
-              ]
-            },
-            {
-              "alias": "$tag___name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "irate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "3m"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 90,
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "elasticsearch_jvm_gc_collection_seconds_sum",
-              "refId": "b",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "__name",
-                  "method": "reg",
-                  "value": [
-                    "master-.*|Master-.*"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "gc",
-                  "method": "eq",
-                  "value": [
-                    "young"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"master-.*|Master-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"old\"}[3m])) + avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"master-.*|Master-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"young\"}[3m]))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "jvm gc时间占比",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "dtdurations"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 76
-      },
-      "id": 51,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_name",
-          "query_configs": [
-            {
-              "alias": "$tag___name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "__name"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "max_without_time",
-              "metric_field": "elasticsearch_jvm_uptime_seconds",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "es_master_node",
-                  "method": "eq",
-                  "value": [
-                    "true"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{app=\"$app\",cluster_domain=\"$cluster_domain\",es_master_node=\"true\"})",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "节点uptime",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 84
-      },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip",
-          "query_configs": [
-            {
-              "alias": "",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "avg_without_time",
-              "metric_field": "usage",
-              "refId": "a",
-              "result_table_id": "dbm_system.cpu_summary",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "CPU使用率",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 84
-      },
-      "id": 55,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip",
-          "query_configs": [
-            {
-              "alias": "",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "avg_without_time",
-              "metric_field": "load1",
-              "refId": "a",
-              "result_table_id": "dbm_system.load",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "系统负载(1m)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 92
-      },
-      "id": 57,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip",
-          "query_configs": [
-            {
-              "alias": "",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "avg_without_time",
-              "metric_field": "speed_recv",
-              "refId": "a",
-              "result_table_id": "dbm_system.net",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluser_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})*8",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "入流量",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 92
-      },
-      "id": 59,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip",
-          "query_configs": [
-            {
-              "alias": "",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "avg_without_time",
-              "metric_field": "speed_sent",
-              "refId": "a",
-              "result_table_id": "dbm_system.net",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})*8",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "出流量",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 100
-      },
-      "id": 60,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip",
-          "query_configs": [
-            {
-              "alias": "$tag_bk_target_ip",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "max_without_time",
-              "metric_field": "cur_tcp_estab",
-              "refId": "a",
-              "result_table_id": "dbm_system.netstat",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "max by(bk_target_ip) (bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"})",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "连接数",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 100
-      },
-      "id": 62,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip",
-          "query_configs": [
-            {
-              "alias": "$tag_bk_target_ip",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [
-                {
-                  "id": "irate",
-                  "params": [
-                    {
-                      "id": "window",
-                      "value": "2m"
-                    }
-                  ]
-                }
-              ],
-              "group_by": [
-                "bk_target_ip"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "avg_without_time",
-              "metric_field": "cur_tcp_estab",
-              "refId": "a",
-              "result_table_id": "dbm_system.netstat",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"}[2m]))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "新建连接数",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 108
-      },
-      "id": 61,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "title": "打开fd数",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 108
-      },
-      "id": 63,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip$tag_mount_point",
-          "query_configs": [
-            {
-              "alias": "$tag_bk_target_ip$tag_mount_point",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip",
-                "mount_point"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "in_use",
-              "refId": "a",
-              "result_table_id": "dbm_system.disk",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "mount_point",
-                  "method": "neq",
-                  "value": [
-                    "/usr/local"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "mount_point",
-                  "method": "neq",
-                  "value": [
-                    "/"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "分区使用率",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "KBs"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 116
-      },
-      "id": 64,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_bk_target_ip  $tag_device_name",
-          "query_configs": [
-            {
-              "alias": "$tag_bk_target_ip  $tag_device_name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "device_name",
-                "bk_target_ip"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "rkb_s",
-              "refId": "a",
-              "result_table_id": "dbm_system.io",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "avg by(device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_master\"}[1m]))",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "磁盘读取",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "KBs"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 116
-      },
-      "id": 65,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "ui",
-          "module": [],
-          "promqlAlias": "",
-          "query_configs": [
-            {
-              "alias": "$tag_bk_target_ip $tag_device_name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "bk_target_ip",
-                "device_name"
-              ],
-              "interval": "auto",
-              "interval_unit": "s",
-              "method": "AVG",
-              "metric_field": "wkb_s",
-              "refId": "a",
-              "result_table_id": "dbm_system.io",
-              "result_table_label": "os",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "instance_role",
-                  "method": "eq",
-                  "value": [
-                    "es_master"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "磁盘写入",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 124
+        "y": 52
       },
       "id": 67,
       "panels": [],
@@ -7169,7 +7530,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 125
+        "y": 53
       },
       "id": 69,
       "options": {
@@ -7185,8 +7546,8 @@
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -7205,6 +7566,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -7230,7 +7592,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -7336,7 +7698,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 53
       },
       "id": 99,
       "options": {
@@ -7350,8 +7712,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -7370,6 +7732,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -7395,7 +7758,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -7493,9 +7856,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 133
+        "y": 61
       },
-      "id": 96,
+      "id": 150,
       "options": {
         "legend": {
           "calcs": [
@@ -7507,8 +7870,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -7527,6 +7890,335 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "name"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "elasticsearch_thread_pool_queue_count",
+              "refId": "a",
+              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "name",
+                  "method": "reg",
+                  "value": [
+                    "dn-.*|hot-.*"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "es_data_node",
+                  "method": "eq",
+                  "value": [
+                    "true"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "type",
+                  "method": "eq",
+                  "value": [
+                    "search"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_active_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"dn-.*|hot-.*\",type=~\"write|bulk\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Write Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "id": 151,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_name",
+          "query_configs": [
+            {
+              "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "name"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "elasticsearch_thread_pool_queue_count",
+              "refId": "a",
+              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "name",
+                  "method": "reg",
+                  "value": [
+                    "dn-.*|hot-.*"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "es_data_node",
+                  "method": "eq",
+                  "value": [
+                    "true"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "type",
+                  "method": "eq",
+                  "value": [
+                    "search"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_active_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"dn-.*|hot-.*\",type=\"search\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Search Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 96,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_name",
+          "query_configs": [
+            {
+              "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -7542,7 +8234,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -7587,7 +8279,7 @@
             }
           ],
           "refId": "A",
-          "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_queue_count{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",type=\"write\"})",
+          "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_queue_count{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",type=~\"write|bulk\"})",
           "step": "",
           "type": "range"
         }
@@ -7656,169 +8348,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 133
-      },
-      "id": 95,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "cluster": [],
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "expressionList": [],
-          "format": "time_series",
-          "host": [],
-          "mode": "code",
-          "module": [],
-          "promqlAlias": "$tag_name",
-          "query_configs": [
-            {
-              "alias": "$tag___name",
-              "data_source_label": "bk_monitor",
-              "data_type_label": "time_series",
-              "display": true,
-              "filter_dict": {},
-              "functions": [],
-              "group_by": [
-                "__name"
-              ],
-              "interval": 60,
-              "interval_unit": "s",
-              "method": "max_without_time",
-              "metric_field": "elasticsearch_thread_pool_rejected_count",
-              "refId": "a",
-              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
-              "result_table_label": "component",
-              "time_field": "",
-              "where": [
-                {
-                  "key": "__name",
-                  "method": "reg",
-                  "value": [
-                    "dn-.*|DN-.*"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "app",
-                  "method": "eq",
-                  "value": [
-                    "$app"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "cluster_domain",
-                  "method": "eq",
-                  "value": [
-                    "$cluster_domain"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "es_data_node",
-                  "method": "eq",
-                  "value": [
-                    "true"
-                  ]
-                },
-                {
-                  "condition": "and",
-                  "key": "type",
-                  "method": "eq",
-                  "value": [
-                    "write"
-                  ]
-                }
-              ]
-            }
-          ],
-          "refId": "A",
-          "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_rejected_count{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",type=\"write\"})",
-          "step": "",
-          "type": "range"
-        }
-      ],
-      "title": "Write Rejected",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "bkmonitor-timeseries-datasource",
-        "uid": "bkmonitor_timeseries"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 141
+        "y": 69
       },
       "id": 94,
       "options": {
@@ -7832,8 +8362,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -7852,6 +8382,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -7867,7 +8398,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "__name",
@@ -7965,7 +8496,180 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      },
+      "id": 95,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_name",
+          "query_configs": [
+            {
+              "alias": "",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "elasticsearch_thread_pool_rejected_count",
+              "refId": "a",
+              "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "es_data_node",
+                  "method": "eq",
+                  "value": [
+                    "true"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "name",
+                  "method": "reg",
+                  "value": [
+                    "dn-.*|hot-.*"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "type",
+                  "method": "eq",
+                  "value": [
+                    "write"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_rejected_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"dn-.*|hot-.*\",type=~\"write|bulk\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Write Rejected",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -7980,7 +8684,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 141
+        "y": 77
       },
       "id": 93,
       "options": {
@@ -7994,8 +8698,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -8014,6 +8718,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -8029,7 +8734,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "__name",
@@ -8074,7 +8779,7 @@
             }
           ],
           "refId": "A",
-          "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_rejected_count{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",type=\"search\"})",
+          "source": "irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_rejected_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"dn-.*|hot-.*\",type=\"search\"}[2m])",
           "step": "",
           "type": "range"
         }
@@ -8127,7 +8832,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8143,7 +8849,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 149
+        "y": 85
       },
       "id": 92,
       "options": {
@@ -8157,8 +8863,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -8229,7 +8935,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8244,7 +8951,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 149
+        "y": 85
       },
       "id": 91,
       "options": {
@@ -8258,8 +8965,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -8286,6 +8993,7 @@
           "query_configs": [
             {
               "alias": "young-$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": false,
@@ -8311,7 +9019,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -8383,6 +9091,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": false,
@@ -8408,7 +9117,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -8506,7 +9215,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8522,7 +9232,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 157
+        "y": 93
       },
       "id": 90,
       "options": {
@@ -8536,8 +9246,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -8551,7 +9261,7 @@
             {
               "active": true,
               "alias": "$tag___name",
-              "expression": "a/180/1000 + b/180/1000",
+              "expression": "a / 180 / 1000 + b / 180 / 1000",
               "functions": []
             }
           ],
@@ -8562,7 +9272,8 @@
           "promqlAlias": "$tag_name",
           "query_configs": [
             {
-              "alias": "",
+              "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "filter_dict": {},
@@ -8587,9 +9298,17 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
+                  "key": "__name",
+                  "method": "reg",
+                  "value": [
+                    "dn-.*|hot-.*"
+                  ]
+                },
+                {
+                  "condition": "and",
                   "key": "app",
                   "method": "eq",
                   "value": [
@@ -8606,14 +9325,6 @@
                 },
                 {
                   "condition": "and",
-                  "key": "__name",
-                  "method": "reg",
-                  "value": [
-                    "dn-.*|hot-.*"
-                  ]
-                },
-                {
-                  "condition": "and",
                   "key": "gc",
                   "method": "eq",
                   "value": [
@@ -8623,7 +9334,8 @@
               ]
             },
             {
-              "alias": "",
+              "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "filter_dict": {},
@@ -8648,9 +9360,17 @@
               "refId": "b",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
+                  "key": "__name",
+                  "method": "reg",
+                  "value": [
+                    "dn-.*|hot-.*"
+                  ]
+                },
+                {
+                  "condition": "and",
                   "key": "app",
                   "method": "eq",
                   "value": [
@@ -8667,14 +9387,6 @@
                 },
                 {
                   "condition": "and",
-                  "key": "__name",
-                  "method": "reg",
-                  "value": [
-                    "dn-.*|hot-.*"
-                  ]
-                },
-                {
-                  "condition": "and",
                   "key": "gc",
                   "method": "eq",
                   "value": [
@@ -8685,7 +9397,7 @@
             }
           ],
           "refId": "A",
-          "source": "avg by (name) (increase(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"old\"}[3m])) / 180 / 1000 + avg by (name) (increase(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"young\"}[3m])) / 180 / 1000",
+          "source": "avg by (name) (increase(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"old\"}[3m])) / 180 / 1000 + avg by (name) (increase(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_gc_collection_seconds_sum{name=~\"dn-.*|hot-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"young\"}[3m])) / 180 / 1000",
           "step": "",
           "type": "range"
         }
@@ -8738,7 +9450,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -8754,7 +9467,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 157
+        "y": 93
       },
       "id": 89,
       "options": {
@@ -8768,8 +9481,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -8788,6 +9501,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -8803,7 +9517,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -8909,7 +9623,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 165
+        "y": 101
       },
       "id": 88,
       "options": {
@@ -8923,8 +9637,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -8945,6 +9659,7 @@
               "alias": "$tag_bk_target_ip",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
+              "display": true,
               "filter_dict": {},
               "functions": [],
               "group_by": [
@@ -8957,7 +9672,7 @@
               "refId": "a",
               "result_table_id": "dbm_system.cpu_summary",
               "result_table_label": "os",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -9046,7 +9761,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
@@ -9054,7 +9770,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 165
+        "y": 101
       },
       "id": 87,
       "options": {
@@ -9068,8 +9784,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -9200,7 +9916,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 173
+        "y": 109
       },
       "id": 84,
       "options": {
@@ -9214,8 +9930,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -9248,7 +9964,7 @@
               "refId": "a",
               "result_table_id": "dbm_system.net",
               "result_table_label": "os",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -9262,7 +9978,7 @@
                   "key": "cluster_domain",
                   "method": "eq",
                   "value": [
-                    "$cluser_domain"
+                    "$cluster_domain"
                   ]
                 },
                 {
@@ -9282,7 +9998,7 @@
           "type": "range"
         }
       ],
-      "title": "入流量",
+      "title": "入流量(单位：bits/s)",
       "type": "timeseries"
     },
     {
@@ -9346,7 +10062,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 173
+        "y": 109
       },
       "id": 83,
       "options": {
@@ -9360,8 +10076,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -9394,7 +10110,7 @@
               "refId": "a",
               "result_table_id": "dbm_system.net",
               "result_table_label": "os",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -9491,7 +10207,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 181
+        "y": 117
       },
       "id": 82,
       "options": {
@@ -9505,8 +10221,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -9636,7 +10352,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 181
+        "y": 117
       },
       "id": 81,
       "options": {
@@ -9650,8 +10366,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -9791,7 +10507,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 189
+        "y": 125
       },
       "id": 80,
       "options": {
@@ -9870,7 +10586,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 189
+        "y": 125
       },
       "id": 79,
       "options": {
@@ -10094,7 +10810,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 197
+        "y": 133
       },
       "id": 78,
       "options": {
@@ -10108,8 +10824,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -10301,7 +11017,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 197
+        "y": 133
       },
       "id": 77,
       "options": {
@@ -10315,8 +11031,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -10464,7 +11180,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 205
+        "y": 141
       },
       "id": 76,
       "options": {
@@ -10478,8 +11194,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -10513,7 +11229,7 @@
               "refId": "a",
               "result_table_id": "dbm_system.io",
               "result_table_label": "os",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -10542,7 +11258,7 @@
             }
           ],
           "refId": "A",
-          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_hot\"}[1m]))",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{device_name!~\"nbd*|ram*|loop*\",app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_hot\"}[1m]))",
           "step": "",
           "type": "range"
         }
@@ -10611,7 +11327,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 205
+        "y": 141
       },
       "id": 75,
       "options": {
@@ -10625,8 +11341,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -10660,7 +11376,7 @@
               "refId": "a",
               "result_table_id": "dbm_system.io",
               "result_table_label": "os",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -10689,7 +11405,7 @@
             }
           ],
           "refId": "A",
-          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_hot\"}[1m]))",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{device_name!~\"nbd*|ram*|loop*\",app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_hot\"}[1m]))",
           "step": "",
           "type": "range"
         }
@@ -10758,7 +11474,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 213
+        "y": 149
       },
       "id": 72,
       "options": {
@@ -10772,8 +11488,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -10792,6 +11508,7 @@
           "query_configs": [
             {
               "alias": "$tag___name",
+              "data_label": "exporter_dbm_elasticsearch_exporter",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -10807,7 +11524,7 @@
               "refId": "a",
               "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -10851,12 +11568,159 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 149
+      },
+      "id": 152,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_device_name",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "device_name",
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "wkb_s",
+              "refId": "a",
+              "result_table_id": "dbm_system.io",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "es_datanode_hot"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:util{device_name!~\"nbd*|ram*|loop*\",app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_hot\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘ioutil",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 221
+        "y": 157
       },
       "id": 101,
       "panels": [
@@ -10920,7 +11784,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 101
+            "y": 5
           },
           "id": 103,
           "options": {
@@ -10934,8 +11798,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -10954,6 +11818,7 @@
               "query_configs": [
                 {
                   "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -10978,7 +11843,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -11083,7 +11948,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 101
+            "y": 5
           },
           "id": 129,
           "options": {
@@ -11097,8 +11962,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -11185,7 +12050,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 109
+            "y": 13
           },
           "id": 122,
           "options": {
@@ -11199,8 +12064,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -11286,7 +12151,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 109
+            "y": 13
           },
           "id": 121,
           "options": {
@@ -11300,8 +12165,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -11327,6 +12192,7 @@
               "query_configs": [
                 {
                   "alias": "young-$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -11351,7 +12217,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -11396,7 +12262,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{name=~\"cold-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",gc=\"young\"}[2m])) * 60",
+              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_gc_collection_seconds_count{name=~\"cold-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",gc=\"young\"}[2m])) * 60",
               "step": "",
               "type": "range"
             },
@@ -11423,6 +12289,7 @@
               "query_configs": [
                 {
                   "alias": "old-$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -11447,7 +12314,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -11492,7 +12359,7 @@
                 }
               ],
               "refId": "B",
-              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{name=~\"cold-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",gc=\"old\"}[2m])) * 60",
+              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_gc_collection_seconds_count{name=~\"cold-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",gc=\"old\"}[2m])) * 60",
               "step": "",
               "type": "range"
             }
@@ -11561,7 +12428,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 117
+            "y": 21
           },
           "id": 120,
           "options": {
@@ -11575,8 +12442,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -11602,6 +12469,7 @@
               "query_configs": [
                 {
                   "alias": "",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -11626,7 +12494,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -11663,6 +12531,7 @@
                 },
                 {
                   "alias": "",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -11687,7 +12556,7 @@
                   "refId": "b",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -11793,7 +12662,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 117
+            "y": 21
           },
           "id": 119,
           "options": {
@@ -11807,8 +12676,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -11827,6 +12696,7 @@
               "query_configs": [
                 {
                   "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -11841,7 +12711,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -11947,7 +12817,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 125
+            "y": 29
           },
           "id": 118,
           "options": {
@@ -11961,8 +12831,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12092,7 +12962,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 125
+            "y": 29
           },
           "id": 117,
           "options": {
@@ -12106,8 +12976,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12229,6 +13099,1000 @@
                     "value": 80
                   }
                 ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 153,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "search"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_active_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"cold-.*\",type=~\"write|bulk\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Write Active",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 156,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "search"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_active_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"cold-.*\",type=~\"search\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Search Active",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 154,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "__name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|DN-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_queue_count{name=~\"cold-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",type=~\"write|bulk\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Write Queue",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 157,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "__name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|DN-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_queue_count{name=~\"cold-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",type=~\"search\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Search Queue",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 155,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_thread_pool_rejected_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_rejected_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"cold-.*\",type=~\"write|bulk\"}[2m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Write Rejected",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 158,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_thread_pool_rejected_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_rejected_count{app=\"$app\",cluster_domain=\"$cluster_domain\",es_data_node=\"true\",name=~\"cold-.*\",type=~\"search\"}[2m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Search Rejected",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
               },
               "unit": "bps"
             },
@@ -12238,7 +14102,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 133
+            "y": 61
           },
           "id": 114,
           "options": {
@@ -12252,8 +14116,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12286,7 +14150,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.net",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -12320,7 +14184,7 @@
               "type": "range"
             }
           ],
-          "title": "入流量",
+          "title": "入流量(单位：bits/s)",
           "type": "timeseries"
         },
         {
@@ -12384,7 +14248,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 133
+            "y": 61
           },
           "id": 113,
           "options": {
@@ -12398,8 +14262,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12432,7 +14296,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.net",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -12466,7 +14330,7 @@
               "type": "range"
             }
           ],
-          "title": "出流量",
+          "title": "出流量(单位：bits/s)",
           "type": "timeseries"
         },
         {
@@ -12529,7 +14393,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 141
+            "y": 69
           },
           "id": 112,
           "options": {
@@ -12543,8 +14407,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12674,7 +14538,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 141
+            "y": 69
           },
           "id": 111,
           "options": {
@@ -12688,8 +14552,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12830,7 +14694,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 149
+            "y": 77
           },
           "id": 108,
           "options": {
@@ -12844,8 +14708,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -12866,6 +14730,7 @@
                   "alias": "总容量",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
+                  "display": true,
                   "filter_dict": {},
                   "functions": [],
                   "group_by": [],
@@ -12876,7 +14741,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.disk",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -12927,6 +14792,7 @@
                   "alias": "已使用容量",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
+                  "display": true,
                   "filter_dict": {},
                   "functions": [],
                   "group_by": [],
@@ -12937,7 +14803,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.disk",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -12959,14 +14825,14 @@
                       "key": "instance_role",
                       "method": "eq",
                       "value": [
-                        "es_datanode_hot"
+                        "es_datanode_cold"
                       ]
                     }
                   ]
                 }
               ],
               "refId": "B",
-              "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_hot\"})",
+              "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_cold\"})",
               "step": "",
               "type": "range"
             }
@@ -13035,7 +14901,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 149
+            "y": 77
           },
           "id": 109,
           "options": {
@@ -13049,8 +14915,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -13072,7 +14938,7 @@
               "host": [],
               "mode": "code",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "总磁盘使用率",
               "query_configs": [
                 {
                   "alias": "",
@@ -13088,7 +14954,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.disk",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -13145,7 +15011,7 @@
                   "refId": "b",
                   "result_table_id": "dbm_system.disk",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -13259,7 +15125,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 157
+            "y": 85
           },
           "id": 106,
           "options": {
@@ -13273,8 +15139,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -13308,7 +15174,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.io",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -13337,7 +15203,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_cold\"}[1m]))",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_cold\",device_name!~\"nbd*|ram*|loop*\"}[1m]))",
               "step": "",
               "type": "range"
             }
@@ -13406,7 +15272,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 157
+            "y": 85
           },
           "id": 105,
           "options": {
@@ -13420,8 +15286,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -13455,7 +15321,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.io",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -13484,7 +15350,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_cold\"}[1m]))",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_cold\",device_name!~\"nbd*|ram*|loop*\"}[1m]))",
               "step": "",
               "type": "range"
             }
@@ -13553,7 +15419,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 165
+            "y": 93
           },
           "id": 104,
           "options": {
@@ -13567,8 +15433,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -13586,7 +15452,8 @@
               "promqlAlias": "$tag_name",
               "query_configs": [
                 {
-                  "alias": "$tag___name",
+                  "alias": "$tag_name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -13602,7 +15469,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -13631,7 +15498,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_uptime_seconds{name=~\"cold-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_uptime_seconds{name=~\"cold-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\"})",
               "step": "",
               "type": "range"
             }
@@ -13700,7 +15567,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 165
+            "y": 93
           },
           "id": 107,
           "options": {
@@ -13714,8 +15581,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -13749,7 +15616,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.disk",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -13801,6 +15668,153 @@
           ],
           "title": "分区使用率",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 101
+          },
+          "id": 159,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip $tag_device_name",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "device_name",
+                    "bk_target_ip"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "wkb_s",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.io",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "es_datanode_hot"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:util{device_name!~\"nbd*|ram*|loop*\",app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"es_datanode_cold\"}[1m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "磁盘ioutil",
+          "type": "timeseries"
         }
       ],
       "title": "冷节点",
@@ -13812,7 +15826,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 222
+        "y": 158
       },
       "id": 131,
       "panels": [
@@ -13877,7 +15891,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 174
+            "y": 6
           },
           "id": 133,
           "options": {
@@ -13891,8 +15905,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -13978,7 +15992,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 174
+            "y": 6
           },
           "id": 148,
           "options": {
@@ -13992,8 +16006,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14019,6 +16033,7 @@
               "query_configs": [
                 {
                   "alias": "young-$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -14043,7 +16058,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -14080,7 +16095,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{name=~\"client-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"young\"}[2m])) * 60",
+              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_gc_collection_seconds_count{name=~\"client-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"young\"}[2m])) * 60",
               "step": "",
               "type": "range"
             },
@@ -14107,6 +16122,7 @@
               "query_configs": [
                 {
                   "alias": "old-$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -14131,7 +16147,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -14168,7 +16184,7 @@
                 }
               ],
               "refId": "B",
-              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_jvm_gc_collection_seconds_count{name=~\"client-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"old\"}[2m])) * 60",
+              "source": "avg by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_jvm_gc_collection_seconds_count{name=~\"client-*\",app=\"$app\",cluster_domain=\"$cluster_domain\",gc=\"old\"}[2m])) * 60",
               "step": "",
               "type": "range"
             }
@@ -14237,7 +16253,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 182
+            "y": 14
           },
           "id": 147,
           "options": {
@@ -14251,8 +16267,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14339,7 +16355,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 182
+            "y": 14
           },
           "id": 146,
           "options": {
@@ -14353,8 +16369,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14373,6 +16389,7 @@
               "query_configs": [
                 {
                   "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "filter_dict": {},
@@ -14387,7 +16404,7 @@
                   "refId": "a",
                   "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "__name",
@@ -14485,7 +16502,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 190
+            "y": 22
           },
           "id": 145,
           "options": {
@@ -14499,8 +16516,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14630,7 +16647,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 190
+            "y": 22
           },
           "id": 144,
           "options": {
@@ -14644,8 +16661,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14776,7 +16793,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 198
+            "y": 30
           },
           "id": 141,
           "options": {
@@ -14790,8 +16807,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14824,7 +16841,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.net",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -14858,7 +16875,7 @@
               "type": "range"
             }
           ],
-          "title": "入流量",
+          "title": "入流量(单位：bits/s)",
           "type": "timeseries"
         },
         {
@@ -14922,7 +16939,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 198
+            "y": 30
           },
           "id": 140,
           "options": {
@@ -14936,8 +16953,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -14970,7 +16987,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.net",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -15004,7 +17021,7 @@
               "type": "range"
             }
           ],
-          "title": "出流量",
+          "title": "出流量(单位：bits/s)",
           "type": "timeseries"
         },
         {
@@ -15067,7 +17084,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 206
+            "y": 38
           },
           "id": 139,
           "options": {
@@ -15081,8 +17098,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -15212,7 +17229,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 206
+            "y": 38
           },
           "id": 138,
           "options": {
@@ -15226,8 +17243,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -15306,6 +17323,1000 @@
           ],
           "title": "新建连接数",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 160,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "search"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_active_count{app=\"$app\",cluster_domain=\"$cluster_domain\",name=~\"client-.*\",type=~\"write|bulk\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Write Active",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 161,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "name"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "search"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_active_count{app=\"$app\",cluster_domain=\"$cluster_domain\",name=~\"client-.*\",type=~\"search\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Search Active",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 54
+          },
+          "id": 162,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "__name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|DN-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_queue_count{name=~\"client-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",type=~\"write|bulk\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Write Queue",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 54
+          },
+          "id": 163,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "$tag___name",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "__name"
+                  ],
+                  "interval": "auto",
+                  "interval_unit": "s",
+                  "method": "max_without_time",
+                  "metric_field": "elasticsearch_thread_pool_queue_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "__name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|DN-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by(name) (bkmonitor:exporter_dbm_elasticsearch_exporter:__default__:elasticsearch_thread_pool_queue_count{name=~\"client-.*\",app=\"$app\",cluster_domain=\"$cluster_domain\",type=~\"search\"})",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Search Queue",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "id": 164,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_thread_pool_rejected_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_rejected_count{app=\"$app\",cluster_domain=\"$cluster_domain\",name=~\"client-.*\",type=~\"write|bulk\"}[2m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Write Rejected",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 62
+          },
+          "id": 165,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_name",
+              "query_configs": [
+                {
+                  "alias": "",
+                  "data_label": "exporter_dbm_elasticsearch_exporter",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [
+                    {
+                      "id": "irate",
+                      "params": [
+                        {
+                          "id": "window",
+                          "value": "2m"
+                        }
+                      ]
+                    }
+                  ],
+                  "group_by": [],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "elasticsearch_thread_pool_rejected_count",
+                  "refId": "a",
+                  "result_table_id": "exporter_dbm_elasticsearch_exporter.__default__",
+                  "result_table_label": "component",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "es_data_node",
+                      "method": "eq",
+                      "value": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "name",
+                      "method": "reg",
+                      "value": [
+                        "dn-.*|hot-.*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "type",
+                      "method": "eq",
+                      "value": [
+                        "write"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "max by (name) (irate(bkmonitor:exporter_dbm_elasticsearch_exporter:elasticsearch_thread_pool_rejected_count{app=\"$app\",cluster_domain=\"$cluster_domain\",name=~\"client-.*\",type=~\"search\"}[2m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "Search Rejected",
+          "type": "timeseries"
         }
       ],
       "title": "client",
@@ -15315,9 +18326,7 @@
   "refresh": false,
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [
-    "es"
-  ],
+  "tags": ["es"],
   "templating": {
     "list": [
       {
@@ -15327,7 +18336,7 @@
           "uid": "bkmonitor_timeseries"
         },
         "definition": "- Blueking Monitor - 维度",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "app",
         "multi": false,
@@ -15367,7 +18376,7 @@
           "uid": "bkmonitor_timeseries"
         },
         "definition": "- Blueking Monitor - 维度",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "cluster_domain",
         "multi": false,
@@ -15417,7 +18426,7 @@
   "timepicker": {},
   "timezone": "default",
   "title": "ES",
-  "uid": "9-LtL0h4z",
-  "version": 71,
+  "uid": "aVri53FIk",
+  "version": 67,
   "weekStart": ""
 }

--- a/dbm-ui/backend/bk_dataview/dashboards/json/kafka.json
+++ b/dbm-ui/backend/bk_dataview/dashboards/json/kafka.json
@@ -6,7 +6,7 @@
       "description": "",
       "type": "datasource",
       "pluginId": "bkmonitor-timeseries-datasource",
-      "pluginName": "Blueing Monitor TimeSeries"
+      "pluginName": "BlueKing Monitor TimeSeries"
     }
   ],
   "__elements": {},
@@ -14,7 +14,7 @@
     {
       "type": "datasource",
       "id": "bkmonitor-timeseries-datasource",
-      "name": "Blueing Monitor TimeSeries",
+      "name": "BlueKing Monitor TimeSeries",
       "version": "3.6.0"
     },
     {
@@ -257,8 +257,9 @@
           },
           "expressionList": [],
           "format": "time_series",
+          "hide": true,
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
@@ -266,7 +267,7 @@
               "alias": "brokers",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
-              "display": true,
+              "display": false,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
@@ -277,7 +278,7 @@
               "refId": "a",
               "result_table_id": "dbm_system.cpu_summary",
               "result_table_label": "os",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -306,7 +307,60 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "count(bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"})",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "",
+          "query_configs": [
+            {
+              "alias": "",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "COUNT",
+              "metric_field": "kafka_server_kafkaserver_brokerstate",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "B",
+          "source": "sum(count_over_time(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_kafkaserver_brokerstate{app=\"$app\",cluster_domain=\"$cluster_domain\"}[1m]))",
           "step": "",
           "type": "range"
         }
@@ -331,10 +385,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -391,7 +441,7 @@
               "method": "count_without_time",
               "metric_field": "kafka_cluster_partition_replicascount",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -422,7 +472,7 @@
             }
           ],
           "refId": "A",
-          "source": "count(count by (topic) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_cluster_partition_replicascount{app=\"$app\",cluster_domain=\"$cluster_domain\",partition=\"0\"}))",
+          "source": "count(count by (topic) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_cluster_partition_replicascount{app=\"$app\",cluster_domain=\"$cluster_domain\",partition=\"0\"}))",
           "step": "",
           "type": "range"
         }
@@ -485,26 +535,27 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
-          "promqlAlias": "",
+          "promqlAlias": "partitions",
           "query_configs": [
             {
               "alias": "partitions",
+              "data_label": "pushgateway_dbm_kafka_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": "auto",
+              "interval": 60,
               "interval_unit": "s",
               "method": "count_without_time",
               "metric_field": "kafka_cluster_partition_replicascount",
               "refId": "a",
               "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -525,7 +576,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "count(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_cluster_partition_replicascount{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -588,7 +639,7 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
@@ -605,7 +656,7 @@
               "method": "sum_without_time",
               "metric_field": "kafka_controller_kafkacontroller_activecontrollercount",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -628,7 +679,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "sum(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_controller_kafkacontroller_activecontrollercount{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -711,8 +762,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -725,7 +776,7 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "生产",
           "query_configs": [
@@ -749,10 +800,10 @@
               "group_by": [],
               "interval": "auto",
               "interval_unit": "s",
-              "method": "MAX",
+              "method": "sum_without_time",
               "metric_field": "kafka_server_brokertopicmetrics_messagesin_total",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -770,12 +821,18 @@
                   "value": [
                     "$cluster_domain"
                   ]
+                },
+                {
+                  "condition": "and",
+                  "key": "topic",
+                  "method": "neq",
+                  "value": []
                 }
               ]
             }
           ],
           "refId": "A",
-          "source": "max(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluser_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -816,7 +873,7 @@
               "method": "SUM",
               "metric_field": "kafka_server_brokertopicmetrics_fetchmessageconversions_total",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -839,7 +896,7 @@
             }
           ],
           "refId": "B",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_fetchmessageconversions_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:group1:kafka_server_brokertopicmetrics_fetchmessageconversions_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         }
@@ -922,8 +979,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -986,7 +1043,7 @@
             }
           ],
           "refId": "A",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_totalproducerequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_totalproducerequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -1050,7 +1107,7 @@
             }
           ],
           "refId": "B",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_totalfetchrequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_totalfetchrequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -1114,7 +1171,7 @@
             }
           ],
           "refId": "C",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_failedproducerequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_failedproducerequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -1178,7 +1235,7 @@
             }
           ],
           "refId": "D",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_failedfetchrequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_failedfetchrequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         }
@@ -1240,7 +1297,7 @@
               }
             ]
           },
-          "unit": "binBps"
+          "unit": "bps"
         },
         "overrides": []
       },
@@ -1262,8 +1319,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1276,7 +1333,7 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "生产",
           "query_configs": [
@@ -1303,7 +1360,7 @@
               "method": "SUM",
               "metric_field": "kafka_server_brokertopicmetrics_replicationbytesin_total",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -1326,7 +1383,7 @@
             }
           ],
           "refId": "A",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_replicationbytesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "8*sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_bytesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -1367,7 +1424,7 @@
               "method": "SUM",
               "metric_field": "kafka_server_brokertopicmetrics_bytesout_total",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -1390,7 +1447,7 @@
             }
           ],
           "refId": "B",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_bytesout_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "8*sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_bytesout_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -1431,7 +1488,7 @@
               "method": "SUM",
               "metric_field": "kafka_server_brokertopicmetrics_bytesrejected_total",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -1454,12 +1511,12 @@
             }
           ],
           "refId": "C",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_bytesrejected_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "8*sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_bytesrejected_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         }
       ],
-      "title": "集群流量",
+      "title": "集群流量(bits/s)",
       "type": "timeseries"
     },
     {
@@ -1538,8 +1595,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1608,7 +1665,7 @@
             }
           ],
           "refId": "A",
-          "source": "avg(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"Produce\"})",
+          "source": "avg(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"Produce\"})",
           "step": "",
           "type": "range"
         },
@@ -1678,7 +1735,7 @@
             }
           ],
           "refId": "B",
-          "source": "avg(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchConsumer\"})",
+          "source": "avg(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchConsumer\"})",
           "step": "",
           "type": "range"
         },
@@ -1748,7 +1805,7 @@
             }
           ],
           "refId": "C",
-          "source": "avg(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchFollower\"})",
+          "source": "avg(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchFollower\"})",
           "step": "",
           "type": "range"
         }
@@ -1831,8 +1888,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -1895,7 +1952,7 @@
             }
           ],
           "refId": "A",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_replicamanager_isrshrinks_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_replicamanager_isrshrinks_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         },
@@ -1936,7 +1993,7 @@
               "method": "SUM",
               "metric_field": "kafka_server_replicamanager_isrexpands_total",
               "refId": "a",
-              "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
               "result_table_label": "component",
               "time_field": "",
               "where": [
@@ -1959,7 +2016,7 @@
             }
           ],
           "refId": "B",
-          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_replicamanager_isrexpands_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_replicamanager_isrexpands_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
           "step": "",
           "type": "range"
         }
@@ -1968,7 +2025,7 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1976,730 +2033,1245 @@
         "y": 30
       },
       "id": 16,
-      "panels": [
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
+      "panels": [],
+      "title": "topic信息",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 2
-          },
-          "id": 18,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
             },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_topic",
-              "query_configs": [
-                {
-                  "alias": "$tag_topic",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "topk",
-                      "params": [
-                        {
-                          "id": "k",
-                          "value": "20"
-                        }
-                      ]
-                    },
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "topic"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "SUM",
-                  "metric_field": "kafka_server_brokertopicmetrics_messagesin_total",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_kafka_bkpull_metrics.group1",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_name",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_name"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "topk(20, sum by (topic) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m])))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "topic每秒消息数（top20）",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 2
-          },
-          "id": 22,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_topic",
-              "query_configs": [
-                {
-                  "alias": "$tag_topic",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "topk",
-                      "params": [
-                        {
-                          "id": "k",
-                          "value": "20"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "topic"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "kafka_log_log_size",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_kafka_bkpull_metrics.group3",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_name",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_name"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_log_log_size{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "topic数据量（含副本，top20）",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 10
-          },
-          "id": 21,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "topic数量",
-              "query_configs": [
-                {
-                  "alias": "topic数量",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "count_without_time",
-                  "metric_field": "kafka_topic_partitions",
-                  "refId": "a",
-                  "result_table_id": "exporter_dbm_kafka_exporter.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_name",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_name"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "count(count by (topic) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_cluster_partition_replicascount{app=\"$app\",cluster_domain=\"$cluster_domain\",partition=\"0\"}))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "topic数量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 10
-          },
-          "id": 20,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "last"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "sortBy": "Last",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_consumergroup",
-              "query_configs": [
-                {
-                  "alias": "$tag_consumergroup",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "topk",
-                      "params": [
-                        {
-                          "id": "k",
-                          "value": "20"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "consumergroup"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "kafka_consumergroup_lag_sum",
-                  "refId": "a",
-                  "result_table_id": "exporter_dbm_kafka_exporter.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_name",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_name"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "topk(20, max by (consumergroup) (bkmonitor:exporter_dbm_kafka_exporter:__default__:kafka_consumergroup_lag_sum{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "消费Lag（top20，消费者组下不同分区lag的最大值）",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "displayMode": "auto",
-                "filterable": false,
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 18
-          },
-          "id": 19,
-          "options": {
-            "footer": {
-              "enablePagination": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true,
-            "sortBy": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "desc": false,
-                "displayName": "Time"
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_topic",
+          "query_configs": [
+            {
+              "alias": "$tag_topic",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "topk",
+                  "params": [
+                    {
+                      "id": "k",
+                      "value": "20"
+                    }
+                  ]
+                },
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "topic"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "kafka_server_brokertopicmetrics_messagesin_total",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "topk(20, sum by (topic) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}[2m])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "topic每秒消息数（top20）",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "pluginVersion": "9.1.0",
-          "targets": [
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_topic",
+          "query_configs": [
             {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "table",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_topic",
-              "query_configs": [
+              "alias": "$tag_topic",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
                 {
-                  "alias": "$tag_topic",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
+                  "id": "topk",
+                  "params": [
                     {
-                      "id": "increase",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "topic"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "kafka_server_brokertopicmetrics_messagesin_total",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_kafka_bkpull_metrics.group1",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_name",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_name"
-                      ]
+                      "id": "k",
+                      "value": "20"
                     }
                   ]
                 }
               ],
-              "refId": "A",
-              "source": "sum(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}  - (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}  offset $__range)) by ( topic )",
-              "step": "",
-              "type": "instant"
+              "group_by": [
+                "topic"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "kafka_log_log_size",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull_metrics.group3",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_name",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_name"
+                  ]
+                }
+              ]
             }
           ],
-          "title": "累计生产消息数（对应右上角的时间范围）",
-          "type": "table"
+          "refId": "A",
+          "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_log_log_size{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
+          "step": "",
+          "type": "range"
         }
       ],
-      "title": "topic信息",
-      "type": "row"
+      "title": "topic数据量（含副本，top20）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_topic",
+          "query_configs": [
+            {
+              "alias": "$tag_topic",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "topk",
+                  "params": [
+                    {
+                      "id": "k",
+                      "value": "20"
+                    }
+                  ]
+                },
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "topic"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "kafka_server_brokertopicmetrics_bytesin_total",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "topic",
+                  "method": "neq",
+                  "value": [
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "topk(20, sum by (topic) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_bytesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}[2m])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "topic生产流量（top20）",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_topic",
+          "query_configs": [
+            {
+              "alias": "$tag_topic",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "topk",
+                  "params": [
+                    {
+                      "id": "k",
+                      "value": "20"
+                    }
+                  ]
+                },
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "topic"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "kafka_server_brokertopicmetrics_bytesout_total",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "topic",
+                  "method": "neq",
+                  "value": [
+                    ""
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "topk(20, sum by (topic) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_bytesout_total{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}[2m])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "topic消费流量（top20）",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "topic数量",
+          "query_configs": [
+            {
+              "alias": "topic数量",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "count_without_time",
+              "metric_field": "kafka_topic_partitions",
+              "refId": "a",
+              "result_table_id": "exporter_dbm_kafka_exporter.group4",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_name",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_name"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "count(count by (topic) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_cluster_partition_replicascount{app=\"$app\",cluster_domain=\"$cluster_domain\",partition=\"0\"}))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "topic数量",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "[$tag_consumergroup/$tag_topic]",
+          "query_configs": [
+            {
+              "alias": "$tag_consumergroup",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "topk",
+                  "params": [
+                    {
+                      "id": "k",
+                      "value": "20"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "consumergroup"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "kafka_consumergroup_lag_sum",
+              "refId": "a",
+              "result_table_id": "exporter_dbm_kafka_exporter.group1",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_name",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_name"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "topk(20, max by (consumergroup,topic) (bkmonitor:exporter_dbm_kafka_exporter:kafka_consumergroup_lag_sum{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "消费Lag（top20，消费者组下不同分区lag的最大值）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 19,
+      "options": {
+        "footer": {
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "消息数"
+          }
+        ]
+      },
+      "pluginVersion": "9.1.0",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "table",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_topic",
+          "query_configs": [
+            {
+              "alias": "$tag_topic",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "increase",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "topic"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "kafka_server_brokertopicmetrics_messagesin_total",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_kafka_bkpull_metrics.group1",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_name",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_name"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\", topic!=\"\"}  - (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_messagesin_total{app=\"$app\",cluster_domain=\"$cluster_domain\", topic!=\"\"}  offset $__range)) by ( topic )",
+          "step": "",
+          "type": "instant"
+        }
+      ],
+      "title": "累计生产消息数（对应右上角的时间范围）",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "消息数"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "[$tag_consumergroup/$tag_topic]",
+          "query_configs": [
+            {
+              "alias": "$tag_consumergroup",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "topk",
+                  "params": [
+                    {
+                      "id": "k",
+                      "value": "20"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "consumergroup"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "kafka_consumergroup_lag_sum",
+              "refId": "a",
+              "result_table_id": "exporter_dbm_kafka_exporter.group1",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_name",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_name"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max(rate(bkmonitor:exporter_dbm_kafka_exporter:kafka_consumergroup_current_offset_sum{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m])) by (consumergroup, topic)\n",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "每秒消费消息数",
+      "type": "timeseries"
     },
     {
       "collapsed": true,
@@ -2707,7 +3279,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 63
       },
       "id": 24,
       "panels": [
@@ -2782,11 +3354,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -2818,7 +3392,7 @@
                   "method": "max_without_time",
                   "metric_field": "kafka_server_replicamanager_partitioncount",
                   "refId": "a",
-                  "result_table_id": "pushgateway_dbm_kafka_bkpull.__default__",
+                  "result_table_id": "pushgateway_dbm_kafka_bkpull.group1",
                   "result_table_label": "component",
                   "time_field": "",
                   "where": [
@@ -2841,7 +3415,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_replicamanager_partitioncount{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+              "source": "max by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_replicamanager_partitioncount{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
               "step": "",
               "type": "range"
             }
@@ -2923,8 +3497,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -2979,7 +3553,7 @@
                 }
               ],
               "refId": "A",
-              "source": "min by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_replicamanager_underreplicatedpartitions{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+              "source": "min by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_replicamanager_underreplicatedpartitions{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
               "step": "",
               "type": "range"
             }
@@ -3061,8 +3635,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -3127,7 +3701,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by (instance) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_totalproducerequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+              "source": "max by (instance) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_totalproducerequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
               "step": "",
               "type": "range"
             }
@@ -3209,8 +3783,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -3275,7 +3849,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by (instance) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_server_brokertopicmetrics_totalfetchrequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+              "source": "max by (instance) (irate(bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_server_brokertopicmetrics_totalfetchrequests_total{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
               "step": "",
               "type": "range"
             }
@@ -3358,8 +3932,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -3430,7 +4004,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by(instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"Produce\"})",
+              "source": "max by(instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"Produce\"})",
               "step": "",
               "type": "range"
             }
@@ -3513,8 +4087,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -3586,7 +4160,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchConsumer\"})",
+              "source": "max by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchConsumer\"})",
               "step": "",
               "type": "range"
             }
@@ -3649,7 +4223,32 @@
               },
               "unit": "ms"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "172.27.129.217-9092"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -3669,8 +4268,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -3741,7 +4340,7 @@
                 }
               ],
               "refId": "A",
-              "source": "max by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:__default__:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchFollower\"})",
+              "source": "max by (instance) (bkmonitor:pushgateway_dbm_kafka_bkpull:kafka_network_requestmetrics_totaltimems{app=\"$app\",cluster_domain=\"$cluster_domain\",quantile=\"0.99\",request=\"FetchFollower\"})",
               "step": "",
               "type": "range"
             }
@@ -3823,8 +4422,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -3947,9 +4546,35 @@
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "percent"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "172.27.128.218"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -3966,11 +4591,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -4093,7 +4720,7 @@
                   }
                 ]
               },
-              "unit": "binBps"
+              "unit": "bps"
             },
             "overrides": []
           },
@@ -4112,11 +4739,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -4178,7 +4807,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"})",
+              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_sent_bit{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"})",
               "step": "",
               "type": "range"
             }
@@ -4239,7 +4868,7 @@
                   }
                 ]
               },
-              "unit": "binBps"
+              "unit": "bps"
             },
             "overrides": []
           },
@@ -4258,11 +4887,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -4324,7 +4955,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"})",
+              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_recv_bit{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"})",
               "step": "",
               "type": "range"
             }
@@ -4561,8 +5192,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -4931,8 +5562,8 @@
               "showLegend": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -5133,11 +5764,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -5158,6 +5791,7 @@
                   "alias": "$tag_bk_target_ip $tag_device_name",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
+                  "display": true,
                   "filter_dict": {},
                   "functions": [],
                   "group_by": [
@@ -5171,7 +5805,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.io",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -5195,12 +5829,20 @@
                       "value": [
                         "broker"
                       ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "device_name",
+                      "method": "nreg",
+                      "value": [
+                        "nbd*|ram*|loop*"
+                      ]
                     }
                   ]
                 }
               ],
               "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"}[1m]))",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",device_name!~\"nbd*|ram*|loop*\",instance_role=\"broker\"}[1m]))",
               "step": "",
               "type": "range"
             }
@@ -5261,7 +5903,7 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "percent"
             },
             "overrides": []
           },
@@ -5280,11 +5922,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -5296,6 +5940,7 @@
               },
               "expressionList": [],
               "format": "time_series",
+              "hide": false,
               "host": [],
               "mode": "code",
               "module": [],
@@ -5313,7 +5958,7 @@
                   ],
                   "interval": 60,
                   "interval_unit": "s",
-                  "method": "AVG",
+                  "method": "max_without_time",
                   "metric_field": "in_use",
                   "refId": "a",
                   "result_table_id": "dbm_system.disk",
@@ -5333,6 +5978,14 @@
                       "method": "eq",
                       "value": [
                         "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "device_type",
+                      "method": "reg",
+                      "value": [
+                        "ext|xfs"
                       ]
                     },
                     {
@@ -5363,7 +6016,7 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
+              "source": "max by (bk_target_ip, mount_point) (bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",device_type=~\"ext|xfs\",instance_role=\"broker\",mount_point!=\"/\",mount_point!=\"/usr/local\"})",
               "step": "",
               "type": "range"
             }
@@ -5443,11 +6096,13 @@
               ],
               "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
-              "mode": "single",
-              "sort": "none"
+              "mode": "multi",
+              "sort": "desc"
             }
           },
           "targets": [
@@ -5481,7 +6136,7 @@
                   "refId": "a",
                   "result_table_id": "dbm_system.io",
                   "result_table_label": "os",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -5510,12 +6165,170 @@
                 }
               ],
               "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"broker\"}[1m]))",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",device_name!~\"nbd*|ram*|loop*\",instance_role=\"broker\"}[1m]))",
               "step": "",
               "type": "range"
             }
           ],
           "title": "磁盘读取",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 104
+          },
+          "id": 49,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "cluster": [],
+              "datasource": {
+                "type": "bkmonitor-timeseries-datasource",
+                "uid": "bkmonitor_timeseries"
+              },
+              "expressionList": [],
+              "format": "time_series",
+              "host": [],
+              "mode": "code",
+              "module": [],
+              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+              "query_configs": [
+                {
+                  "alias": "$tag_bk_target_ip $tag_device_name",
+                  "data_source_label": "bk_monitor",
+                  "data_type_label": "time_series",
+                  "display": true,
+                  "filter_dict": {},
+                  "functions": [],
+                  "group_by": [
+                    "device_name",
+                    "bk_target_ip"
+                  ],
+                  "interval": 60,
+                  "interval_unit": "s",
+                  "method": "AVG",
+                  "metric_field": "util",
+                  "refId": "a",
+                  "result_table_id": "dbm_system.io",
+                  "result_table_label": "os",
+                  "time_field": "time",
+                  "where": [
+                    {
+                      "key": "app",
+                      "method": "eq",
+                      "value": [
+                        "$app"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "cluster_domain",
+                      "method": "eq",
+                      "value": [
+                        "$cluster_domain"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "device_name",
+                      "method": "nreg",
+                      "value": [
+                        "nbd*|ram*|loop*"
+                      ]
+                    },
+                    {
+                      "condition": "and",
+                      "key": "instance_role",
+                      "method": "eq",
+                      "value": [
+                        "broker"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "refId": "A",
+              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:util{app=\"$app\",cluster_domain=\"$cluster_domain\",device_name!~\"nbd*|ram*|loop*\",instance_role=\"broker\"}[1m]))",
+              "step": "",
+              "type": "range"
+            }
+          ],
+          "title": "磁盘ioutil",
           "type": "timeseries"
         }
       ],
@@ -5535,7 +6348,7 @@
           "uid": "bkmonitor_timeseries"
         },
         "definition": "- Blueking Monitor - 维度",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "app",
         "multi": false,
@@ -5575,7 +6388,7 @@
           "uid": "bkmonitor_timeseries"
         },
         "definition": "- Blueking Monitor - 维度",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "cluster_domain",
         "multi": false,
@@ -5617,7 +6430,7 @@
   "timepicker": {},
   "timezone": "default",
   "title": "Kafka",
-  "uid": "VNJZyZA4k",
-  "version": 23,
+  "uid": "W-5DfcKSk",
+  "version": 7,
   "weekStart": ""
 }

--- a/dbm-ui/backend/bk_dataview/dashboards/json/pulsar.json
+++ b/dbm-ui/backend/bk_dataview/dashboards/json/pulsar.json
@@ -6,7 +6,7 @@
       "description": "",
       "type": "datasource",
       "pluginId": "bkmonitor-timeseries-datasource",
-      "pluginName": "Blueing Monitor TimeSeries"
+      "pluginName": "BlueKing Monitor TimeSeries"
     }
   ],
   "__elements": {},
@@ -14,7 +14,7 @@
     {
       "type": "datasource",
       "id": "bkmonitor-timeseries-datasource",
-      "name": "Blueing Monitor TimeSeries",
+      "name": "BlueKing Monitor TimeSeries",
       "version": "3.6.0"
     },
     {
@@ -137,12 +137,13 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -156,7 +157,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -177,7 +178,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "count(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:process_start_time_seconds{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -244,26 +245,27 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "code",
+          "mode": "ui",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": "auto",
+              "interval": 60,
               "interval_unit": "s",
               "method": "count_without_time",
               "metric_field": "process_start_time_seconds",
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -284,7 +286,7 @@
             }
           ],
           "refId": "A",
-          "source": "count(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:__default__:process_start_time_seconds{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "source": "count(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:process_start_time_seconds{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -357,20 +359,21 @@
           "query_configs": [
             {
               "alias": "",
+              "data_label": "pushgateway_dbm_pulsarzookeeper_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
               "filter_dict": {},
               "functions": [],
               "group_by": [],
-              "interval": "auto",
+              "interval": 60,
               "interval_unit": "s",
               "method": "count_without_time",
               "metric_field": "jvm_info",
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -391,7 +394,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "count(bkmonitor:pushgateway_dbm_pulsarzookeeper_bkpull:jvm_info{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -454,12 +457,13 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -473,7 +477,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -494,7 +498,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "sum(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_producers_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -557,12 +561,13 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -576,7 +581,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -597,7 +602,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "sum(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_consumers_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -660,12 +665,13 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
           "promqlAlias": "",
           "query_configs": [
             {
               "alias": "",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -679,7 +685,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -700,7 +706,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "sum(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_topics_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -851,12 +857,13 @@
           "format": "time_series",
           "hide": false,
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
-          "promqlAlias": "",
+          "promqlAlias": "delivery rate",
           "query_configs": [
             {
               "alias": "delivery rate",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -870,7 +877,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -891,7 +898,7 @@
             }
           ],
           "refId": "B",
-          "source": "",
+          "source": "avg(avg_over_time(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_rate_out{app=\"$app\",cluster_domain=\"$cluster_domain\"}[1m]))",
           "step": "",
           "type": "range"
         }
@@ -1026,12 +1033,13 @@
           "format": "time_series",
           "hide": false,
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
-          "promqlAlias": "",
+          "promqlAlias": "delivery throughput",
           "query_configs": [
             {
               "alias": "delivery throughput",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -1045,7 +1053,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -1066,7 +1074,7 @@
             }
           ],
           "refId": "B",
-          "source": "",
+          "source": "avg(avg_over_time(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_throughput_out{app=\"$app\",cluster_domain=\"$cluster_domain\"}[1m]))",
           "step": "",
           "type": "range"
         }
@@ -1164,12 +1172,13 @@
           "expressionList": [],
           "format": "time_series",
           "host": [],
-          "mode": "ui",
+          "mode": "code",
           "module": [],
-          "promqlAlias": "",
+          "promqlAlias": "存储量",
           "query_configs": [
             {
               "alias": "存储量",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
               "data_source_label": "bk_monitor",
               "data_type_label": "time_series",
               "display": true,
@@ -1183,7 +1192,7 @@
               "refId": "a",
               "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
               "result_table_label": "component",
-              "time_field": "",
+              "time_field": "time",
               "where": [
                 {
                   "key": "app",
@@ -1204,7 +1213,7 @@
             }
           ],
           "refId": "A",
-          "source": "",
+          "source": "sum(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_storage_size{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
           "step": "",
           "type": "range"
         }
@@ -1267,8 +1276,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1283,7 +1291,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 21
           },
           "id": 17,
           "options": {
@@ -1317,6 +1325,7 @@
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -1335,14 +1344,14 @@
                   "group_by": [
                     "topic"
                   ],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "sum_without_time",
                   "metric_field": "pulsar_rate_in",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -1363,13 +1372,15 @@
                       "condition": "and",
                       "key": "topic",
                       "method": "neq",
-                      "value": []
+                      "value": [
+                        ""
+                      ]
                     }
                   ]
                 }
               ],
               "refId": "A",
-              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:__default__:pulsar_rate_in{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}))",
+              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_rate_in{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}))",
               "step": "",
               "type": "range"
             }
@@ -1422,8 +1433,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1438,7 +1448,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 21
           },
           "id": 23,
           "options": {
@@ -1472,6 +1482,7 @@
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -1490,14 +1501,14 @@
                   "group_by": [
                     "topic"
                   ],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "sum_without_time",
                   "metric_field": "pulsar_subscription_msg_rate_out",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -1518,7 +1529,7 @@
                 }
               ],
               "refId": "A",
-              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:__default__:pulsar_subscription_msg_rate_out{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
+              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_subscription_msg_rate_out{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
               "step": "",
               "type": "range"
             }
@@ -1571,8 +1582,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1588,7 +1598,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 29
           },
           "id": 22,
           "options": {
@@ -1616,12 +1626,13 @@
               "expressionList": [],
               "format": "time_series",
               "host": [],
-              "mode": "ui",
+              "mode": "code",
               "module": [],
               "promqlAlias": "$tag_topic",
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -1647,7 +1658,7 @@
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -1676,7 +1687,7 @@
                 }
               ],
               "refId": "A",
-              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:__default__:pulsar_throughput_in{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
+              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_throughput_in{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"}))",
               "step": "",
               "type": "range"
             }
@@ -1729,8 +1740,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1746,7 +1756,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 29
           },
           "id": 18,
           "options": {
@@ -1782,6 +1792,7 @@
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -1800,14 +1811,14 @@
                   "group_by": [
                     "topic"
                   ],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "sum_without_time",
                   "metric_field": "pulsar_subscription_msg_throughput_out",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -1828,7 +1839,7 @@
                 }
               ],
               "refId": "A",
-              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:__default__:pulsar_subscription_msg_throughput_out{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
+              "source": "topk(20, sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_subscription_msg_throughput_out{app=\"$app\",cluster_domain=\"$cluster_domain\"}))",
               "step": "",
               "type": "range"
             }
@@ -1881,8 +1892,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1897,7 +1907,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 37
           },
           "id": 21,
           "options": {
@@ -1924,10 +1934,11 @@
               "host": [],
               "mode": "ui",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "$tag_topic",
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -1936,14 +1947,14 @@
                   "group_by": [
                     "topic"
                   ],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "sum_without_time",
                   "metric_field": "pulsar_producers_count",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -1972,7 +1983,7 @@
                 }
               ],
               "refId": "A",
-              "source": "",
+              "source": "sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_producers_count{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"})",
               "step": "",
               "type": "range"
             }
@@ -2025,8 +2036,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2041,7 +2051,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 37
           },
           "id": 20,
           "options": {
@@ -2071,10 +2081,11 @@
               "host": [],
               "mode": "ui",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "$tag_topic",
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -2083,14 +2094,14 @@
                   "group_by": [
                     "topic"
                   ],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "sum_without_time",
                   "metric_field": "pulsar_subscriptions_count",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -2119,7 +2130,7 @@
                 }
               ],
               "refId": "A",
-              "source": "",
+              "source": "sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_subscriptions_count{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"})",
               "step": "",
               "type": "range"
             }
@@ -2172,8 +2183,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2188,7 +2198,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 45
           },
           "id": 19,
           "options": {
@@ -2216,12 +2226,13 @@
               "expressionList": [],
               "format": "time_series",
               "host": [],
-              "mode": "ui",
+              "mode": "code",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "$tag_topic",
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -2237,7 +2248,7 @@
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -2266,7 +2277,7 @@
                 }
               ],
               "refId": "A",
-              "source": "",
+              "source": "sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_consumers_count{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"})",
               "step": "",
               "type": "range"
             }
@@ -2319,8 +2330,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2335,7 +2345,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 45
           },
           "id": 24,
           "options": {
@@ -2365,17 +2375,19 @@
               "host": [],
               "mode": "code",
               "module": [],
-              "promqlAlias": "$tag_topic-$tag__subscription",
+              "promqlAlias": "$tag_topic-$tag_subscription",
               "query_configs": [
                 {
                   "alias": "$tag_topic-$tag_subscription",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
                   "filter_dict": {},
                   "functions": [],
                   "group_by": [
-                    "topic"
+                    "topic",
+                    "_subscription"
                   ],
                   "interval": 60,
                   "interval_unit": "s",
@@ -2384,7 +2396,7 @@
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -2405,7 +2417,7 @@
                 }
               ],
               "refId": "A",
-              "source": "sum by (topic,_subscription) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:__default__:pulsar_subscription_back_log{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+              "source": "sum by (topic, _subscription) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_subscription_back_log{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
               "step": "",
               "type": "range"
             }
@@ -2458,8 +2470,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2475,7 +2486,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 53
           },
           "id": 27,
           "options": {
@@ -2507,10 +2518,11 @@
               "host": [],
               "mode": "ui",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "$tag_topic",
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -2519,14 +2531,14 @@
                   "group_by": [
                     "topic"
                   ],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "avg_without_time",
                   "metric_field": "pulsar_storage_backlog_size",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -2547,7 +2559,7 @@
                 }
               ],
               "refId": "A",
-              "source": "",
+              "source": "avg by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_storage_backlog_size{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
               "step": "",
               "type": "range"
             }
@@ -2600,8 +2612,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2616,7 +2627,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 53
           },
           "id": 26,
           "options": {
@@ -2646,24 +2657,25 @@
               "host": [],
               "mode": "ui",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "Topic数量",
               "query_configs": [
                 {
                   "alias": "Topic数量",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
                   "filter_dict": {},
                   "functions": [],
                   "group_by": [],
-                  "interval": "auto",
+                  "interval": 60,
                   "interval_unit": "s",
                   "method": "sum_without_time",
                   "metric_field": "pulsar_topics_count",
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -2692,7 +2704,7 @@
                 }
               ],
               "refId": "A",
-              "source": "",
+              "source": "sum(bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_topics_count{app=\"$app\",cluster_domain=\"$cluster_domain\",namespace!=\"\\\"\\\"\"})",
               "step": "",
               "type": "range"
             }
@@ -2745,8 +2757,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2762,7 +2773,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 61
           },
           "id": 25,
           "options": {
@@ -2792,12 +2803,13 @@
               "expressionList": [],
               "format": "time_series",
               "host": [],
-              "mode": "ui",
+              "mode": "code",
               "module": [],
-              "promqlAlias": "",
+              "promqlAlias": "$tag_topic",
               "query_configs": [
                 {
                   "alias": "$tag_topic",
+                  "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
                   "data_source_label": "bk_monitor",
                   "data_type_label": "time_series",
                   "display": true,
@@ -2813,7 +2825,7 @@
                   "refId": "a",
                   "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
                   "result_table_label": "component",
-                  "time_field": "",
+                  "time_field": "time",
                   "where": [
                     {
                       "key": "app",
@@ -2842,7 +2854,7 @@
                 }
               ],
               "refId": "A",
-              "source": "",
+              "source": "sum by (topic) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_storage_size{app=\"$app\",cluster_domain=\"$cluster_domain\",topic!=\"\"})",
               "step": "",
               "type": "range"
             }
@@ -2855,7 +2867,7 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2863,8759 +2875,8783 @@
         "y": 21
       },
       "id": 29,
-      "panels": [
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 3
-          },
-          "id": 31,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_rate_in",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Publish rate (msg/s)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 3
-          },
-          "id": 43,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_rate_out",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Dispatch rate (msg / s)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 11
-          },
-          "id": 42,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_throughput_in",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Publish throughput (MB/s)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 11
-          },
-          "id": 41,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_throughput_out",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Dispatch throughput (MB/s)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 19
-          },
-          "id": 40,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_topics_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Topics count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 19
-          },
-          "id": 39,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_msg_backlog",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Messages Backlog",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 27
-          },
-          "id": 38,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_producers_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Producers count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 27
-          },
-          "id": 37,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "pulsar_consumers_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Consumers count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 35
-          },
-          "id": 36,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "usage",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.cpu_summary",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "CPU使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 35
-          },
-          "id": 35,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "load1",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.load",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "系统负载（1m）",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 43
-          },
-          "id": 34,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "speed_recv",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.net",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "入流量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 43
-          },
-          "id": 33,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "speed_sent",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.net",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "出流量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 51
-          },
-          "id": 32,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "cur_tcp_estab",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.netstat",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "连接数",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 51
-          },
-          "id": 108,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "cur_tcp_estab",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.netstat",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_broker"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "新建连接数",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "Broker",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_rate_in",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_rate_in{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Publish rate (msg/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_rate_out",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_rate_out{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Dispatch rate (msg / s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_throughput_in",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_throughput_in{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Publish throughput (MB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_throughput_out",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_throughput_out{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Dispatch throughput (MB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_topics_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_topics_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Topics count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_msg_backlog",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_msg_backlog{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Messages Backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_producers_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_producers_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Producers count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "pulsar_consumers_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbroker_bkpull:pulsar_consumers_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Consumers count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "usage",
+              "refId": "a",
+              "result_table_id": "dbm_system.cpu_summary",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "CPU使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "load1",
+              "refId": "a",
+              "result_table_id": "dbm_system.load",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (avg_over_time(bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "系统负载（1m）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "speed_recv",
+              "refId": "a",
+              "result_table_id": "dbm_system.net",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (avg_over_time(bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"}[1m]))*8",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "入流量(单位：bits/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "speed_sent",
+              "refId": "a",
+              "result_table_id": "dbm_system.net",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (avg_over_time(bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"}[1m]))*8",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "出流量(单位：bits/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "cur_tcp_estab",
+              "refId": "a",
+              "result_table_id": "dbm_system.netstat",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (avg_over_time(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "连接数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 70
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "cur_tcp_estab",
+              "refId": "a",
+              "result_table_id": "dbm_system.netstat",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_broker"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_broker\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "新建连接数",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 78
       },
       "id": 52,
-      "panels": [
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 4
-          },
-          "id": 54,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "add entry",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "rate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_WRITE_BYTES",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            },
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "hide": false,
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "read entry",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "rate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_READ_BYTES",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "B",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Throughput (MB / s)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 4
-          },
-          "id": 55,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "read entry",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookkeeper_server_READ_ENTRY_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "success",
-                      "method": "eq",
-                      "value": [
-                        "true"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            },
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "hide": false,
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "add entry",
-              "query_configs": [
-                {
-                  "alias": "add entry",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookkeeper_server_ADD_ENTRY_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "success",
-                      "method": "eq",
-                      "value": [
-                        "true"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "B",
-              "source": "sum(irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:__default__:bookkeeper_server_ADD_ENTRY_count{app=\"$app\",cluster_domain=\"$cluster_domain\",success=\"true\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Entry Rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 12
-          },
-          "id": 86,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_WRITE_BYTES",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Write Bytes",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "Bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 12
-          },
-          "id": 85,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_READ_BYTES",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Read Bytes (bytes/s)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 20
-          },
-          "id": 84,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_instance_host",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookkeeper_server_ADD_ENTRY_REQUEST_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:__default__:bookkeeper_server_ADD_ENTRY_REQUEST_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Add Entry Rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 20
-          },
-          "id": 83,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_instance_host",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookkeeper_server_READ_ENTRY_REQUEST_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:__default__:bookkeeper_server_READ_ENTRY_REQUEST_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Read Entry Rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 28
-          },
-          "id": 82,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_instance_host",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_journal_JOURNAL_SYNC_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:__default__:bookie_journal_JOURNAL_SYNC_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Journal Sync Rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 28
-          },
-          "id": 81,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_instance_host",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_journal_JOURNAL_SYNC_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:__default__:bookie_journal_JOURNAL_SYNC_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Journal Add Rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 36
-          },
-          "id": 80,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_journal_JOURNAL_QUEUE_SIZE",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Journal Queue length",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 36
-          },
-          "id": 79,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_journal_JOURNAL_FORCE_WRITE_QUEUE_SIZE",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Journal Force Write Queue length",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 44
-          },
-          "id": 78,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_journal_JOURNAL_CB_QUEUE_SIZE",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Journal Callback Queue length",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 44
-          },
-          "id": 77,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_ledgers_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Ledgers count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 52
-          },
-          "id": 76,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_entries_count",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Entries count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 52
-          },
-          "id": 75,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_write_cache_size",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Write Cache Size",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 60
-          },
-          "id": 74,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_read_cache_size",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Read Cache Size",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 60
-          },
-          "id": 73,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_DELETED_LEDGER_COUNT",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Deleted Ledger Count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 68
-          },
-          "id": 72,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "bookie_ledger_writable_dirs",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "Writable Ledger Directory Count",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 68
-          },
-          "id": 70,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "last"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "系统负载（1m）",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 76
-          },
-          "id": 71,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "usage",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.cpu_summary",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "CPU使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 76
-          },
-          "id": 66,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "speed_sent",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.net",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "出流量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 84
-          },
-          "id": 67,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "last"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "speed_recv",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.net",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluser_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "入流量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 84
-          },
-          "id": 64,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "last"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "cur_tcp_estab",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.netstat",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "新建连接数",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 92
-          },
-          "id": 65,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "cur_tcp_estab",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.netstat",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "max by (bk_target_ip) (bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "连接数",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 92
-          },
-          "id": 60,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "last"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip $tag_device_name",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "device_name",
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "wkb_s",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.io",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"}[1m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "磁盘写入",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 100
-          },
-          "id": 61,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip $tag_device_name",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "device_name",
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "rkb_s",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.io",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"}[1m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "磁盘读取",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 100
-          },
-          "id": 59,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip $tag_mount_point",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip $tag_mount_point",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip",
-                    "mount_point"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "in_use",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/usr/local"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "分区使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 108
-          },
-          "id": 62,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [
-                {
-                  "active": true,
-                  "alias": "总磁盘使用率",
-                  "expression": "a / b",
-                  "functions": []
-                }
-              ],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "used",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/usr/local"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "alias": "",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "total",
-                  "refId": "b",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/usr/local"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}) / sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"})\n",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "总磁盘使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 108
-          },
-          "id": 110,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "已用容量",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "used",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            },
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "hide": false,
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "总容量",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "total",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_bookkeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "B",
-              "source": "sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "磁盘容量",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "BookKeeper",
       "type": "row"
     },
     {
-      "collapsed": true,
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "add entry",
+          "query_configs": [
+            {
+              "alias": "add entry",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "rate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "bookie_WRITE_BYTES",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(rate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_WRITE_BYTES{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "",
+          "query_configs": [
+            {
+              "alias": "read entry",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "rate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_READ_BYTES",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "B",
+          "source": "",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Throughput (MB / s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "read entry",
+          "query_configs": [
+            {
+              "alias": "read entry",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookkeeper_server_READ_ENTRY_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "success",
+                  "method": "eq",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookkeeper_server_READ_ENTRY_count{app=\"$app\",cluster_domain=\"$cluster_domain\",success=\"true\"}[2m]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "add entry",
+          "query_configs": [
+            {
+              "alias": "add entry",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookkeeper_server_ADD_ENTRY_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "success",
+                  "method": "eq",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "B",
+          "source": "sum(irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookkeeper_server_ADD_ENTRY_count{app=\"$app\",cluster_domain=\"$cluster_domain\",success=\"true\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Entry Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "id": 86,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "bookie_WRITE_BYTES",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_WRITE_BYTES{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Write Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 85,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_READ_BYTES",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_READ_BYTES{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Read Bytes (bytes/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 95
+      },
+      "id": 84,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "bookkeeper_server_ADD_ENTRY_REQUEST_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookkeeper_server_ADD_ENTRY_REQUEST_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Add Entry Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 95
+      },
+      "id": 83,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "bookkeeper_server_READ_ENTRY_REQUEST_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookkeeper_server_READ_ENTRY_REQUEST_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Read Entry Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 103
+      },
+      "id": 82,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "bookie_journal_JOURNAL_SYNC_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_journal_JOURNAL_SYNC_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Journal Sync Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 103
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "SUM",
+              "metric_field": "bookie_journal_JOURNAL_SYNC_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (irate(bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_journal_JOURNAL_SYNC_count{app=\"$app\",cluster_domain=\"$cluster_domain\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Journal Add Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 111
+      },
+      "id": 80,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_journal_JOURNAL_QUEUE_SIZE",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_journal_JOURNAL_QUEUE_SIZE{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Journal Queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 111
+      },
+      "id": 79,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_journal_JOURNAL_FORCE_WRITE_QUEUE_SIZE",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_journal_JOURNAL_FORCE_WRITE_QUEUE_SIZE{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Journal Force Write Queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 119
+      },
+      "id": 78,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_journal_JOURNAL_CB_QUEUE_SIZE",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_journal_JOURNAL_CB_QUEUE_SIZE{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Journal Callback Queue length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 119
+      },
+      "id": 77,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_ledgers_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_ledgers_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Ledgers count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 127
+      },
+      "id": 76,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_entries_count",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_entries_count{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Entries count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 127
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_write_cache_size",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_write_cache_size{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Write Cache Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 135
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_read_cache_size",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_read_cache_size{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Read Cache Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 135
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_DELETED_LEDGER_COUNT",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_DELETED_LEDGER_COUNT{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Deleted Ledger Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 143
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_label": "pushgateway_dbm_pulsarbookkeeper_bkpull",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "bookie_ledger_writable_dirs",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarbookkeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum by (instance_host) (bkmonitor:pushgateway_dbm_pulsarbookkeeper_bkpull:bookie_ledger_writable_dirs{app=\"$app\",cluster_domain=\"$cluster_domain\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Writable Ledger Directory Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 143
+      },
+      "id": 70,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "load1",
+              "refId": "a",
+              "result_table_id": "dbm_system.load",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "系统负载（1m）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 151
+      },
+      "id": 71,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "usage",
+              "refId": "a",
+              "result_table_id": "dbm_system.cpu_summary",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "CPU使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 151
+      },
+      "id": 66,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "speed_sent",
+              "refId": "a",
+              "result_table_id": "dbm_system.net",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})*8",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "出流量(单位：bits/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 159
+      },
+      "id": 67,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "speed_recv",
+              "refId": "a",
+              "result_table_id": "dbm_system.net",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})*8",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "入流量(单位：bits/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 159
+      },
+      "id": 64,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "cur_tcp_estab",
+              "refId": "a",
+              "result_table_id": "dbm_system.netstat",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "新建连接数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 167
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "cur_tcp_estab",
+              "refId": "a",
+              "result_table_id": "dbm_system.netstat",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (bk_target_ip) (bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "连接数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 167
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_device_name",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "device_name",
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "wkb_s",
+              "refId": "a",
+              "result_table_id": "dbm_system.io",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",device_name!~\"nbd*|ram*|loop*\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘写入",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 175
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_device_name",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "device_name",
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "rkb_s",
+              "refId": "a",
+              "result_table_id": "dbm_system.io",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",device_name!~\"nbd*|ram*|loop*\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘读取",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 175
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_mount_point",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_mount_point",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip",
+                "mount_point"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "in_use",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/usr/local"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "分区使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 183
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [
+            {
+              "active": true,
+              "alias": "",
+              "expression": "a / b",
+              "functions": []
+            }
+          ],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "总磁盘使用率",
+          "query_configs": [
+            {
+              "alias": "",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "used",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/usr/local"
+                  ]
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "total",
+              "refId": "b",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/usr/local"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}) / sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "总磁盘使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 183
+      },
+      "id": 110,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "已用容量",
+          "query_configs": [
+            {
+              "alias": "已用容量",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "used",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "总容量",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "total",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "time",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_bookkeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "B",
+          "source": "sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_bookkeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘容量",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 191
       },
       "id": 88,
-      "panels": [
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 128
-          },
-          "id": 90,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_instance_host : $tag__key",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host:$tag__key",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host",
-                    "_key"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "write_per_namespace_sum",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "max by (instance_host, _key) (bkmonitor:pushgateway_dbm_pulsarzookeeper_bkpull:__default__:write_per_namespace_sum{app=\"$app\",cluster_domain=\"$cluster_domain\",_key!=\"\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "write_per_namespace",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "bytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 128
-          },
-          "id": 106,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "last"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_instance_host:$tag__key",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host:$tag__key",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host",
-                    "_key"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "read_per_namespace_sum",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "max by (instance_host, _key) (bkmonitor:pushgateway_dbm_pulsarzookeeper_bkpull:__default__:read_per_namespace_sum{app=\"$app\",cluster_domain=\"$cluster_domain\",_key!=\"\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "read_per_namespace",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 136
-          },
-          "id": 105,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true,
-              "sortBy": "Max",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "uptime",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "ZK启动时间",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 136
-          },
-          "id": 104,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "ui",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "$tag_instance_host",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "display": true,
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "rate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "instance_host"
-                  ],
-                  "interval": "auto",
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "jvm_pause_time_ms_sum",
-                  "refId": "a",
-                  "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
-                  "result_table_label": "component",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "jvm_pause_time_ms",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 144
-          },
-          "id": 103,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "usage",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.cpu_summary",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "CPU使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 144
-          },
-          "id": 102,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "load1",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.load",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "系统负载（1m）",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 152
-          },
-          "id": 99,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "speed_recv",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.net",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluser_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "入流量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 152
-          },
-          "id": 98,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "avg_without_time",
-                  "metric_field": "speed_sent",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.net",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "出流量",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 160
-          },
-          "id": 97,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "max_without_time",
-                  "metric_field": "cur_tcp_estab",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.netstat",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "max by (bk_target_ip) (bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "连接数",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 160
-          },
-          "id": 96,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [
-                    {
-                      "id": "irate",
-                      "params": [
-                        {
-                          "id": "window",
-                          "value": "2m"
-                        }
-                      ]
-                    }
-                  ],
-                  "group_by": [
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "cur_tcp_estab",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.netstat",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"}[2m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "新建连接数",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 168
-          },
-          "id": 93,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip $tag_device_name",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "device_name",
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "rkb_s",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.io",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"}[1m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "磁盘读取",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 168
-          },
-          "id": 92,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip $tag_device_name",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip $tag_device_name",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "device_name",
-                    "bk_target_ip"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "wkb_s",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.io",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"}[1m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "磁盘写入",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 176
-          },
-          "id": 111,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [
-                {
-                  "active": true,
-                  "alias": "总磁盘使用率",
-                  "expression": "a / b",
-                  "functions": []
-                }
-              ],
-              "format": "time_series",
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "",
-              "query_configs": [
-                {
-                  "alias": "",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "used",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/usr/local"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "alias": "",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "total",
-                  "refId": "b",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/usr/local"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}) / sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "总磁盘使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 176
-          },
-          "id": 94,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "hide": false,
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "$tag_bk_target_ip $tag_mount_point",
-              "query_configs": [
-                {
-                  "alias": "$tag_bk_target_ip $tag_mount_point",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [
-                    "bk_target_ip",
-                    "mount_point"
-                  ],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "AVG",
-                  "metric_field": "in_use",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "mount_point",
-                      "method": "neq",
-                      "value": [
-                        "/usr/local"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "avg by (bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "分区磁盘使用率",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "bkmonitor-timeseries-datasource",
-            "uid": "bkmonitor_timeseries"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 184
-          },
-          "id": 112,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "lastNotNull"
-              ],
-              "displayMode": "table",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "hide": false,
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "已用容量",
-              "query_configs": [
-                {
-                  "alias": "已用容量",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "used",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "A",
-              "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            },
-            {
-              "cluster": [],
-              "datasource": {
-                "type": "bkmonitor-timeseries-datasource",
-                "uid": "bkmonitor_timeseries"
-              },
-              "expressionList": [],
-              "format": "time_series",
-              "hide": false,
-              "host": [],
-              "mode": "code",
-              "module": [],
-              "promqlAlias": "总容量",
-              "query_configs": [
-                {
-                  "alias": "总容量",
-                  "data_source_label": "bk_monitor",
-                  "data_type_label": "time_series",
-                  "filter_dict": {},
-                  "functions": [],
-                  "group_by": [],
-                  "interval": 60,
-                  "interval_unit": "s",
-                  "method": "sum_without_time",
-                  "metric_field": "total",
-                  "refId": "a",
-                  "result_table_id": "dbm_system.disk",
-                  "result_table_label": "os",
-                  "time_field": "",
-                  "where": [
-                    {
-                      "key": "app",
-                      "method": "eq",
-                      "value": [
-                        "$app"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "cluster_domain",
-                      "method": "eq",
-                      "value": [
-                        "$cluster_domain"
-                      ]
-                    },
-                    {
-                      "condition": "and",
-                      "key": "instance_role",
-                      "method": "eq",
-                      "value": [
-                        "pulsar_zookeeper"
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "refId": "B",
-              "source": "sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
-              "step": "",
-              "type": "range"
-            }
-          ],
-          "title": "磁盘容量",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "Zookeeper",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 192
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host : $tag__key",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host:$tag__key",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host",
+                "_key"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "write_per_namespace_sum",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (instance_host, _key) (bkmonitor:pushgateway_dbm_pulsarzookeeper_bkpull:write_per_namespace_sum{app=\"$app\",cluster_domain=\"$cluster_domain\",_key!=\"\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "write_per_namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 192
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_instance_host:$tag__key",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host:$tag__key",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host",
+                "_key"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "read_per_namespace_sum",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (instance_host, _key) (bkmonitor:pushgateway_dbm_pulsarzookeeper_bkpull:read_per_namespace_sum{app=\"$app\",cluster_domain=\"$cluster_domain\",_key!=\"\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "read_per_namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 200
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "uptime",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "ZK启动时间",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 200
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "ui",
+          "module": [],
+          "promqlAlias": "",
+          "query_configs": [
+            {
+              "alias": "$tag_instance_host",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "display": true,
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "rate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "instance_host"
+              ],
+              "interval": "auto",
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "jvm_pause_time_ms_sum",
+              "refId": "a",
+              "result_table_id": "pushgateway_dbm_pulsarzookeeper_bkpull.__default__",
+              "result_table_label": "component",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "jvm_pause_time_ms",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 208
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "usage",
+              "refId": "a",
+              "result_table_id": "dbm_system.cpu_summary",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:cpu_summary:usage{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "CPU使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 208
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "load1",
+              "refId": "a",
+              "result_table_id": "dbm_system.load",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:load:load1{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "系统负载（1m）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 216
+      },
+      "id": 99,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "speed_recv",
+              "refId": "a",
+              "result_table_id": "dbm_system.net",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluser_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_recv{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "入流量",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 216
+      },
+      "id": 98,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "avg_without_time",
+              "metric_field": "speed_sent",
+              "refId": "a",
+              "result_table_id": "dbm_system.net",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (bkmonitor:dbm_system:net:speed_sent{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "出流量",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 224
+      },
+      "id": 97,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "max_without_time",
+              "metric_field": "cur_tcp_estab",
+              "refId": "a",
+              "result_table_id": "dbm_system.netstat",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "max by (bk_target_ip) (bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "连接数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 224
+      },
+      "id": 96,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [
+                {
+                  "id": "irate",
+                  "params": [
+                    {
+                      "id": "window",
+                      "value": "2m"
+                    }
+                  ]
+                }
+              ],
+              "group_by": [
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "cur_tcp_estab",
+              "refId": "a",
+              "result_table_id": "dbm_system.netstat",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip) (irate(bkmonitor:dbm_system:netstat:cur_tcp_estab{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"}[2m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "新建连接数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 232
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_device_name",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "device_name",
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "rkb_s",
+              "refId": "a",
+              "result_table_id": "dbm_system.io",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:rkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘读取",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 232
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_device_name",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_device_name",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "device_name",
+                "bk_target_ip"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "wkb_s",
+              "refId": "a",
+              "result_table_id": "dbm_system.io",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (device_name, bk_target_ip) (avg_over_time(bkmonitor:dbm_system:io:wkb_s{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘写入",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 240
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [
+            {
+              "active": true,
+              "alias": "总磁盘使用率",
+              "expression": "a / b",
+              "functions": []
+            }
+          ],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "",
+          "query_configs": [
+            {
+              "alias": "",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "used",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/usr/local"
+                  ]
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "total",
+              "refId": "b",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/usr/local"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}) / sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "总磁盘使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 240
+      },
+      "id": 94,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_bk_target_ip $tag_mount_point",
+          "query_configs": [
+            {
+              "alias": "$tag_bk_target_ip $tag_mount_point",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [
+                "bk_target_ip",
+                "mount_point"
+              ],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "AVG",
+              "metric_field": "in_use",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "mount_point",
+                  "method": "neq",
+                  "value": [
+                    "/usr/local"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "avg by (bk_target_ip, mount_point) (avg_over_time(bkmonitor:dbm_system:disk:in_use{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\",mount_point!=\"/\",mount_point!=\"/usr/local\"}[1m]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "分区磁盘使用率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "bkmonitor_timeseries"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 248
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "已用容量",
+          "query_configs": [
+            {
+              "alias": "已用容量",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "used",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "A",
+          "source": "sum(bkmonitor:dbm_system:disk:used{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "bkmonitor_timeseries"
+          },
+          "expressionList": [],
+          "format": "time_series",
+          "hide": false,
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "总容量",
+          "query_configs": [
+            {
+              "alias": "总容量",
+              "data_source_label": "bk_monitor",
+              "data_type_label": "time_series",
+              "filter_dict": {},
+              "functions": [],
+              "group_by": [],
+              "interval": 60,
+              "interval_unit": "s",
+              "method": "sum_without_time",
+              "metric_field": "total",
+              "refId": "a",
+              "result_table_id": "dbm_system.disk",
+              "result_table_label": "os",
+              "time_field": "",
+              "where": [
+                {
+                  "key": "app",
+                  "method": "eq",
+                  "value": [
+                    "$app"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "cluster_domain",
+                  "method": "eq",
+                  "value": [
+                    "$cluster_domain"
+                  ]
+                },
+                {
+                  "condition": "and",
+                  "key": "instance_role",
+                  "method": "eq",
+                  "value": [
+                    "pulsar_zookeeper"
+                  ]
+                }
+              ]
+            }
+          ],
+          "refId": "B",
+          "source": "sum(bkmonitor:dbm_system:disk:total{app=\"$app\",cluster_domain=\"$cluster_domain\",instance_role=\"pulsar_zookeeper\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "磁盘容量",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 37,
   "style": "dark",
-  "tags": ["pulsar"],
+  "tags": [
+    "pulsar"
+  ],
   "templating": {
     "list": [
       {
@@ -11625,7 +11661,7 @@
           "uid": "bkmonitor_timeseries"
         },
         "definition": "- Blueking Monitor - 维度",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "app",
         "multi": false,
@@ -11633,12 +11669,13 @@
         "options": [],
         "query": {
           "metricConfig": {
+            "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
             "data_source_label": "bk_monitor",
             "data_type_label": "time_series",
             "group_by": "app",
-            "metric_field": "usage",
-            "result_table_id": "dbm_system.cpu_summary",
-            "result_table_label": "os",
+            "metric_field": "jvm_info",
+            "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+            "result_table_label": "component",
             "where": []
           },
           "queryType": "dimension",
@@ -11657,7 +11694,7 @@
           "uid": "bkmonitor_timeseries"
         },
         "definition": "- Blueking Monitor - 维度",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "cluster_domain",
         "multi": false,
@@ -11665,26 +11702,19 @@
         "options": [],
         "query": {
           "metricConfig": {
+            "data_label": "pushgateway_dbm_pulsarbroker_bkpull",
             "data_source_label": "bk_monitor",
             "data_type_label": "time_series",
             "group_by": "cluster_domain",
-            "metric_field": "usage",
-            "result_table_id": "dbm_system.cpu_summary",
-            "result_table_label": "os",
+            "metric_field": "jvm_info",
+            "result_table_id": "pushgateway_dbm_pulsarbroker_bkpull.__default__",
+            "result_table_label": "component",
             "where": [
               {
                 "key": "app",
                 "method": "eq",
                 "value": [
                   "$app"
-                ]
-              },
-              {
-                "condition": "and",
-                "key": "instance_role",
-                "method": "eq",
-                "value": [
-                  "pulsar_zookeeper"
                 ]
               }
             ]
@@ -11707,7 +11737,7 @@
   "timepicker": {},
   "timezone": "default",
   "title": "Pulsar",
-  "uid": "ajbvKs1Vk",
-  "version": 17,
+  "uid": "3gEBGz5Ik",
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
- ES仪表盘更新
1. 修正search rejetcted/write rejetcted的计算规则
2. 入流量、出流量显示单为改为bits/s
3. 增加磁盘ioutil面板
4. write active/queue/rejectd面板兼容5.4版本

- Kafka仪表盘更新
1. 增加消费速度面板
2. 消费lag面板粒度改为topic

- Pulsar仪表盘更新
1. 入流量、出流量显示单位改为bits/s
2. 修正CPU使用率显示
3. 修正磁盘使用率显示