### PR TITLE
feat(redis): drs 新增命令支持 close #3258

### DIFF
--- a/dbm-services/mysql/db-remote-service/pkg/redis_rpc/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/redis_rpc/init.go
@@ -74,6 +74,8 @@ func init() {
 			KeyStep: 0}
 		RedisCommandTable["get"] = &RedisCmdMeta{Name: "get", Arity: 2, Sflags: readOnlyFlag, FirstKey: 1, LastKey: 1,
 			KeyStep: 1}
+		RedisCommandTable["getserver"] = &RedisCmdMeta{Name: "getserver", Arity: 2, Sflags: readOnlyFlag,
+			FirstKey: 1, LastKey: 1, KeyStep: 1}
 		RedisCommandTable["getex"] = &RedisCmdMeta{Name: "getex", Arity: -2, Sflags: writeFlag, FirstKey: 1, LastKey: 1,
 			KeyStep: 1}
 		RedisCommandTable["getdel"] = &RedisCmdMeta{Name: "getdel", Arity: 2, Sflags: writeFlag, FirstKey: 1, LastKey: 1,

--- a/dbm-services/mysql/db-remote-service/pkg/redis_rpc/redis_rpc.go
+++ b/dbm-services/mysql/db-remote-service/pkg/redis_rpc/redis_rpc.go
@@ -34,6 +34,18 @@ func (r *RedisRPCEmbed) IsQueryCommand(cmdArgs []string) bool {
 		if cmdArgs[0] == "cluster" && cmdArgs[1] == "slots" {
 			return true
 		}
+		if cmdArgs[0] == "cluster" && cmdArgs[1] == "keyslot" {
+			return true
+		}
+		if cmdArgs[0] == "cluster" && cmdArgs[1] == "getkeysinslot" {
+			return true
+		}
+		if cmdArgs[0] == "cluster" && cmdArgs[1] == "countkeysinslot" {
+			return true
+		}
+		if cmdArgs[0] == "getserver" {
+			return true
+		}
 		if (cmdArgs[0] == "confxx" || cmdArgs[0] == "config") && cmdArgs[1] == "get" {
 			return true
 		}


### PR DESCRIPTION
1、twemproxy新增获取key所属segment支持: getserver
2、tendisplus新增关于keyslot 信息的支持: cluster keyslot,getkeysinslot,countkeysinslot 