### PR TITLE
fix(mysql): mysql monitor优化快照删除逻辑

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/scenesnapshot/engineinnodbstatus.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/scenesnapshot/engineinnodbstatus.go
@@ -19,7 +19,7 @@ type engineInnodbStatus struct {
 var engineInnodbStatusName = "engine-innodb-status"
 
 func engineInnodbStatusScene(db *sqlx.DB) error {
-	err := tarball.DeleteOld(engineInnodbStatusName, sceneBase, 2)
+	err := tarball.DeleteOld(engineInnodbStatusName, sceneBase, 1)
 	if err != nil {
 		return err
 	}

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/scenesnapshot/internal/tarball/init.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/scenesnapshot/internal/tarball/init.go
@@ -4,28 +4,46 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"dbm-services/mysql/db-tools/mysql-monitor/pkg/config"
 )
 
 func DeleteOld(name string, basePath string, days int) error {
-	oldFile := filepath.Join(
-		basePath,
-		fmt.Sprintf(
-			"%s.%d.%s.tar",
-			name,
-			config.MonitorConfig.Port,
-			time.Now().Add(time.Hour*time.Duration(-days*24)).Format("20060102")))
-
-	err := os.RemoveAll(oldFile)
+	oldFiles, err := findBefore(name, basePath, days)
 	if err != nil {
 		return err
 	}
 
+	for _, oldFile := range oldFiles {
+		err := os.RemoveAll(oldFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func findBefore(name string, basePath string, days int) (oldFiles []string, err error) {
+	t := time.Now().Add(time.Hour * time.Duration((1-days)*24))
+	d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+
+	err = filepath.Walk(basePath, func(p string, i fs.FileInfo, e error) error {
+		if e != nil {
+			return e
+		}
+		if !i.IsDir() && strings.HasPrefix(i.Name(), name) && i.ModTime().Before(d) {
+			oldFiles = append(oldFiles, p)
+		}
+		return nil
+	})
+
+	return
 }
 
 func Write(name string, basePath string, content []byte) error {

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/scenesnapshot/processlist.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/scenesnapshot/processlist.go
@@ -45,7 +45,7 @@ func queryProcesslist(db *sqlx.DB) (res []*mysqlProcess, err error) {
 }
 
 func processListScene(db *sqlx.DB) error {
-	err := tarball.DeleteOld(processListName, sceneBase, 2)
+	err := tarball.DeleteOld(processListName, sceneBase, 1)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. mysql processlist 和 innodb engine status 快照改为保留当天
2. 优化旧文件删除逻辑