### PR TITLE
fix(mysql): 导入元数据不检查slave规格,优化清档重建 #3748

### DIFF
--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/truncate_data_recreate_table.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/truncate_data_recreate_table.py
@@ -35,7 +35,9 @@ class TruncateDataReCreateTableService(BaseService):
             tables = trans_data.targets[db]
             for table in tables:
 
-                recreate_table_cmd = "create table `{}`.`{}` like `{}`.`{}`".format(db, table, old_new_map[db], table)
+                recreate_table_cmd = "create table if not exists `{}`.`{}` like `{}`.`{}`".format(
+                    db, table, old_new_map[db], table
+                )
                 sql_cmds.append(recreate_table_cmd)
 
         recreate_table_res = DRSApi.rpc(

--- a/dbm-ui/backend/ticket/builders/mysql/mysql_ha_metadata_import.py
+++ b/dbm-ui/backend/ticket/builders/mysql/mysql_ha_metadata_import.py
@@ -163,9 +163,9 @@ class TenDBHAMetadataImportDetailSerializer(MySQLBaseOperateDetailSerializer):
             self.__validate_machine_spec_match(machine_json=mj[0], spec_obj=self.__proxy_spec)
 
     def __validate_storage_spec_match(self, cluster_json):
-        slaves = cluster_json["slaves"]
-        ips = list(set([ele["ip"] for ele in slaves]))
-        ips.append(cluster_json["master"]["ip"])
+        # slaves = cluster_json["slaves"]
+        # ips = list(set([ele["ip"] for ele in slaves]))
+        ips = [cluster_json["master"]["ip"]]
         for ip in ips:
             mj = list(filter(lambda e: e["IP"] == ip, cluster_json["machines"]))
             if not mj:

--- a/dbm-ui/backend/ticket/builders/spider/metadata_import.py
+++ b/dbm-ui/backend/ticket/builders/spider/metadata_import.py
@@ -158,7 +158,7 @@ class TenDBClusterMetadataImportDetailSerializer(MySQLBaseOperateDetailSerialize
         remotes = []
         for s in cluster_json["sets"]:
             remotes.append(s["master"])
-            remotes.append(s["slave"])
+            # remotes.append(s["slave"])
 
         ips = list(set([ele["ip"] for ele in remotes]))
 


### PR DESCRIPTION
1. tendbcluster/tendbha 元数据导入不再检查 slave storage 规格
2. 清档重建空表改成 create if not exists