### PR TITLE
fix(mysql): pt-table-checksum分块逻辑bug #3768

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pt-table-checksum
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pt-table-checksum
@@ -6569,7 +6569,7 @@ sub _nibble_params {
          . " /*explain $comments->{nibble}*/";
       PTDEBUG && _d('Explain nibble statement:', $explain_nibble_sql);
 
-      my $limit = $chunk_size - 1;
+      my $limit = 999;
       PTDEBUG && _d('Initial chunk size (LIMIT):', $limit);
 
       my $params = {
@@ -6795,7 +6795,7 @@ sub can_nibble {
 
    my $chunk_size_limit = $o->get('chunk-size-limit') || 1;
    my $one_nibble = !defined $args{one_nibble} || $args{one_nibble}
-                  ? $row_est <= $chunk_size * $chunk_size_limit
+                  ? $row_est <= 999 * $chunk_size_limit
                   : 0;
    PTDEBUG && _d('One nibble:', $one_nibble ? 'yes' : 'no');
 


### PR DESCRIPTION
错误的判断是否需要分块
假设校验顺序是 small_table, big_table , 同时 --chunk-size-limit=5
其中 small_table 因为非常小, 1000 行耗时 0.01s
在开始校验 big_table 时的 chunk_size = 10w , 如果 big_table 有 30w 行, 就会因为 30w < 10w*5 不再分块校验

大表块过大
还是上面的场景造成了统计的 chunk_size 虚高, 导致大表即使分块校验, 第一个块也会过大