### PR TITLE
fix(mysql): 修复pt-table-checksum无唯一约束时过慢的问题 #3812

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pt-table-checksum
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pt-table-checksum
@@ -6482,7 +6482,7 @@ sub _nibble_params {
       my ($nibble_params, $tbl, $args, $cols, $chunk_size, $where, $comments, $q) = @_;
       my $index      = $nibble_params->{index}; # brevity
       my $index_cols = $tbl->{tbl_struct}->{keys}->{$index}->{cols};
-
+      
       my $asc = $args->{TableNibbler}->generate_asc_stmt(
          %$args,
          tbl_struct   => $tbl->{tbl_struct},
@@ -6806,9 +6806,19 @@ sub can_nibble {
       $one_nibble = 1;
    }
 
-   my $index = _find_best_index(%args, mysql_index => $mysql_index);
+   my ($index, $is_unique) = _find_best_index(%args, mysql_index => $mysql_index);
    if ( !$index && !$one_nibble ) {
-      die "There is no good index and the table is oversized.";
+            # $tbl->{checksum_results}->{n_chunks} = 1;
+            # $tbl->{checksum_results}->{skipped} = 1;
+            # $tbl->{checksum_results}->{msg} = "NO INDEX";
+            # print_checksum_results(tbl => $tbl);
+         die "There is no good index and the table is oversized.";   
+   }
+
+   my $skip_this = 0;
+   if ( $o->get('skip-no-unique') && !$is_unique ) {
+      PTDEBUG && _d($tbl->{tbl}, " has 0 unique/primary indexes, will be skipped.");
+      $skip_this = 1;
    }
 
    my $pause_file = ($o->has('pause-file') && $o->get('pause-file')) || undef;
@@ -6818,6 +6828,7 @@ sub can_nibble {
       index       => $index,        # using this index
       one_nibble  => $one_nibble,   # if the table fits in one nibble/chunk
       pause_file  => $pause_file,
+      skip_this   => $skip_this,
    };
 }
 
@@ -6871,9 +6882,13 @@ sub _find_best_index {
       }
    }
 
+   my $is_unique = 1;
    if ( !$best_index && @possible_indexes ) {
       PTDEBUG && _d('No PRIMARY or unique indexes;',
          'will use index with highest cardinality');
+      
+      $is_unique = 0;
+      
       foreach my $index ( @possible_indexes ) {
          $indexes->{$index}->{cardinality} = _get_index_cardinality(
             %args,
@@ -6893,7 +6908,7 @@ sub _find_best_index {
    }
 
    PTDEBUG && _d('Best index:', $best_index);
-   return $best_index;
+   return $best_index, $is_unique;
 }
 
 sub _get_index_cardinality {
@@ -10977,6 +10992,19 @@ sub main {
          my $statements  = $nibble_iter->statements();
          my $oktonibble  = 1;
 
+         if ( $nibble_iter->{nibble_params}->{skip_this} ) {
+            PTDEBUG && _d("Skip checksum table: ", $tbl->{tbl});
+            $exit_status |= $PTC_EXIT_STATUS{SKIP_TABLE};
+            $oktonibble = 0;
+
+            $tbl->{checksum_results}->{n_chunks} = 1;
+            $tbl->{checksum_results}->{skipped} = 1;
+            if ( !$tbl->{checksum_results}->{msg} ) {
+               $tbl->{checksum_results}->{msg} = "NO UNIQUE INDEX";
+            }
+            print_checksum_results(tbl => $tbl);
+         }
+
          if ( $last_chunk ) { # resuming
             if ( have_more_chunks(%args, last_chunk => $last_chunk) ) {
                $nibble_iter->set_nibble_number($last_chunk->{chunk});
@@ -11467,6 +11495,10 @@ sub main {
             print_checksum_results(tbl => $tbl);
          }
 
+         # if ( !$o->get('quiet') || $o->get('quiet')< 2 && $tbl->{skip_this} ) {
+         #    print_checksum_results(tbl => $tbl);            
+         # }
+
          return;
       },
    };
@@ -11906,7 +11938,8 @@ sub exec_nibble {
 
 {
 my $line_fmt = "%14s %6s %6s %8s % 10s %7s %7s %7s %-s\n";
-my @headers  =  qw(TS ERRORS DIFFS ROWS DIFF_ROWS CHUNKS SKIPPED TIME TABLE);
+# my $line_fmt = "%14s %6s %6s %8s % 10s %7s %7s %7s %-20s %-s\n";
+my @headers  =  qw(TS ERRORS DIFFS ROWS DIFF_ROWS CHUNKS SKIPPED TIME MSG TABLE);
 
 sub print_checksum_results {
    my (%args) = @_;
@@ -11931,6 +11964,7 @@ sub print_checksum_results {
       $res->{n_chunks} || 0,
       $res->{skipped}  || 0,
       sprintf('%.3f', $res->{start_time} ? time - $res->{start_time} : 0),
+      # sprintf('%.20s', $res->{msg} ? $res->{msg} : ""),
       "$tbl->{db}.$tbl->{tbl}";
 
    return;
@@ -13135,6 +13169,12 @@ See L<"--replicate">.
 type: time; default: 1; group: Throttle
 
 Sleep time between checks for L<"--max-lag">.
+
+=item --[no]skip-no-unique
+
+default: yes
+
+Skip checksum tables without unique/primary index.
 
 =item --[no]check-plan
 


### PR DESCRIPTION
1. pt-table-checksum 添加 --[no]-skip-no-unique , default yes 参数 跳过没有唯一约束的表
2. 跳过的表在报告摘要中会显示为 1 chunks, 1 skipped
3. 完全没有索引的表维持原 die 逻辑
4. mysql-table-checksum 可以兼容上述情况