### PR TITLE
fix(mysql): 集群标准化不再校验bkbizid #4051

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_full_backup.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_full_backup.py
@@ -118,7 +118,9 @@ class TenDBClusterFullBackupFlow(object):
                     sub_flow_list=self.backup_on_remote_slave(backup_id=backup_id, cluster_obj=cluster_obj)
                 )
             elif cluster["backup_local"] == InstanceInnerRole.MASTER.value:
-                pass
+                cluster_pipe.add_parallel_sub_pipeline(
+                    sub_flow_list=self.backup_on_remote_master(backup_id=backup_id, cluster_obj=cluster_obj)
+                )
             elif cluster["backup_local"] == TenDBClusterSpiderRole.SPIDER_MNT.value:
                 cluster_pipe.add_sub_pipeline(
                     sub_flow=self.backup_on_spider_mnt(

--- a/dbm-ui/backend/ticket/builders/mysql/mysql_ha_standardize.py
+++ b/dbm-ui/backend/ticket/builders/mysql/mysql_ha_standardize.py
@@ -33,14 +33,9 @@ class TenDBHAStandardizeDetailSerializer(MySQLBaseOperateDetailSerializer):
         return attrs
 
     def __validate_clusters(self, attrs):
-        app_obj = AppCache.objects.get(bk_biz_id=attrs["bk_biz_id"])
+        AppCache.objects.get(bk_biz_id=attrs["bk_biz_id"])
 
         for cluster_obj in Cluster.objects.filter(pk__in=attrs["infos"]["cluster_ids"]).all():
-            if cluster_obj.bk_biz_id != attrs["bk_biz_id"]:
-                raise serializers.ValidationError(
-                    _("{} 不是 [{}]{} 的集群".format(cluster_obj.immute_domain, app_obj.bk_biz_id, app_obj.db_app_abbr))
-                )
-
             if cluster_obj.cluster_type != ClusterType.TenDBHA.value:
                 raise serializers.ValidationError(
                     _("{} 不是 {} 集群".format(cluster_obj.immute_domain, ClusterType.TenDBHA.value))

--- a/dbm-ui/backend/ticket/builders/spider/mysql_spider_standardize.py
+++ b/dbm-ui/backend/ticket/builders/spider/mysql_spider_standardize.py
@@ -33,22 +33,15 @@ class TenDBClusterStandardizeDetailSerializer(MySQLBaseOperateDetailSerializer):
         return attrs
 
     def __validate_clusters(self, attrs):
-        app_obj = AppCache.objects.get(bk_biz_id=attrs["bk_biz_id"])
+        AppCache.objects.get(bk_biz_id=attrs["bk_biz_id"])
 
         for cluster_obj in Cluster.objects.filter(pk__in=attrs["infos"]["cluster_ids"]).all():
-            if cluster_obj.bk_biz_id != attrs["bk_biz_id"]:
-                raise serializers.ValidationError(
-                    _("{} 不是 [{}]{} 的集群".format(cluster_obj.immute_domain, app_obj.bk_biz_id, app_obj.db_app_abbr))
-                )
-
             if cluster_obj.cluster_type != ClusterType.TenDBCluster.value:
                 raise serializers.ValidationError(
                     _("{} 不是 {} 集群".format(cluster_obj.immute_domain, ClusterType.TenDBCluster.value))
                 )
 
             self.__validate_cluster_proxy(cluster_obj=cluster_obj, attrs=attrs)
-            # self.__validate_cluster_master_storage(cluster_obj=cluster_obj, attrs=attrs)
-            # self.__validate_cluster_slave_storage(cluster_obj=cluster_obj, attrs=attrs)
 
     @staticmethod
     def __validate_cluster_proxy(cluster_obj: Cluster, attrs):

--- a/dbm-ui/backend/ticket/builders/tendbsingle/standardize.py
+++ b/dbm-ui/backend/ticket/builders/tendbsingle/standardize.py
@@ -32,14 +32,9 @@ class TenDBSingleStandardizeDetailSerializer(MySQLBaseOperateDetailSerializer):
 
     @staticmethod
     def __validate_clusters(attrs):
-        app_obj = AppCache.objects.get(bk_biz_id=attrs["bk_biz_id"])
+        AppCache.objects.get(bk_biz_id=attrs["bk_biz_id"])
 
         for cluster_obj in Cluster.objects.filter(pk__in=attrs["infos"]["cluster_ids"]).all():
-            if cluster_obj.bk_biz_id != attrs["bk_biz_id"]:
-                raise serializers.ValidationError(
-                    _("{} 不是 [{}]{} 的集群".format(cluster_obj.immute_domain, app_obj.bk_biz_id, app_obj.db_app_abbr))
-                )
-
             if cluster_obj.cluster_type != ClusterType.TenDBSingle.value:
                 raise serializers.ValidationError(
                     _("{} 不是 {} 集群".format(cluster_obj.immute_domain, ClusterType.TenDBSingle.value))


### PR DESCRIPTION
1. tendbsingle, tendbha, tendbcluster 标准化不再校验bkbizid
2. tendbcluster修复全备单据选择在master备份时没有正确构建流程树的问题