### PR TITLE
fix(kafka): 优化kafka缩容场景 #4519

### DIFF
--- a/dbm-services/bigdata/db-tools/dbactuator/internal/subcmd/kafkacmd/check_broker_empty.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/internal/subcmd/kafkacmd/check_broker_empty.go
@@ -1,0 +1,95 @@
+package kafkacmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"dbm-services/bigdata/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka"
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/rollback"
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+
+	"github.com/spf13/cobra"
+)
+
+// CheckBrokerEmptyAct 结构体定义了检查Kafka Broker是否为空的操作
+type CheckBrokerEmptyAct struct {
+	*subcmd.BaseOptions                       // 嵌入基础选项
+	Service             kafka.DecomBrokerComp // Kafka服务组件
+}
+
+// CheckBrokerEmptyCommand 创建并返回一个cobra命令，用于检查Kafka Broker是否为空
+func CheckBrokerEmptyCommand() *cobra.Command {
+	act := CheckBrokerEmptyAct{
+		BaseOptions: subcmd.GBaseOptions, // 初始化基础选项
+	}
+	cmd := &cobra.Command{
+		Use:     "check_broker_empty",
+		Short:   "检查Broker为空",
+		Example: fmt.Sprintf(`dbactuator kafka check_broker_empty %s`, subcmd.CmdBaseExapmleStr),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate()) // 验证参数
+			if act.RollBack {
+				util.CheckErr(act.Rollback()) // 执行回滚操作
+				return
+			}
+			util.CheckErr(act.Init()) // 初始化操作
+			util.CheckErr(act.Run())  // 执行检查操作
+		},
+	}
+	return cmd
+}
+
+// Validate 验证CheckBrokerEmptyAct结构体的参数
+func (d *CheckBrokerEmptyAct) Validate() (err error) {
+	return d.BaseOptions.Validate() // 调用基础选项的验证方法
+}
+
+// Init 初始化CheckBrokerEmptyAct结构体
+func (d *CheckBrokerEmptyAct) Init() (err error) {
+	logger.Info("CheckBrokerEmptyAct Init")
+	if err = d.Deserialize(&d.Service.Params); err != nil {
+		logger.Error("DeserializeAndValidate failed, %v", err)
+		return err
+	}
+	d.Service.GeneralParam = subcmd.GeneralRuntimeParam // 设置通用运行时参数
+	return d.Service.Init()                             // 初始化服务组件
+}
+
+// Rollback 执行回滚操作
+func (d *CheckBrokerEmptyAct) Rollback() (err error) {
+	var r rollback.RollBackObjects
+	if err = d.DeserializeAndValidate(&r); err != nil {
+		logger.Error("DeserializeAndValidate failed, %v", err)
+		return err
+	}
+	err = r.RollBack() // 调用回滚对象的回滚方法
+	if err != nil {
+		logger.Error("roll back failed %s", err.Error())
+	}
+	return
+}
+
+// Run 执行检查Kafka Broker是否为空的操作
+func (d *CheckBrokerEmptyAct) Run() (err error) {
+	steps := subcmd.Steps{
+		{
+			FunName: "检查Broker为空",
+			Func:    d.Service.DoEmptyCheck, // 指定执行的函数
+		},
+	}
+
+	if err := steps.Run(); err != nil {
+		rollbackCtxb, rerr := json.Marshal(d.Service.RollBackContext) // 序列化回滚上下文
+		if rerr != nil {
+			logger.Error("json Marshal %s", err.Error())
+			fmt.Printf("<ctx>Can't RollBack<ctx>\n")
+		}
+		fmt.Printf("<ctx>%s<ctx>\n", string(rollbackCtxb)) // 打印回滚上下文
+		return err
+	}
+
+	logger.Info("check_broker_empty successfully") // 打印成功信息
+	return nil
+}

--- a/dbm-services/bigdata/db-tools/dbactuator/internal/subcmd/kafkacmd/cmd.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/internal/subcmd/kafkacmd/cmd.go
@@ -1,25 +1,29 @@
 package kafkacmd
 
-// Todo
 import (
+	// 导入内部子命令包和模板工具包
 	. "dbm-services/bigdata/db-tools/dbactuator/internal/subcmd"
 	"dbm-services/bigdata/db-tools/dbactuator/pkg/util/templates"
 
 	"github.com/spf13/cobra"
 )
 
-// NewKafkaCommand TODO
-// Todo
+// NewKafkaCommand 创建一个新的Kafka命令集
+// 这个函数返回一个*cobra.Command对象，它是Kafka相关操作的根命令
 func NewKafkaCommand() *cobra.Command {
+	// 创建根命令"kafka"，它将包含一系列子命令
 	cmds := &cobra.Command{
-		Use:   "kafka [kafka operation]",
-		Short: "Kafka Operation Command Line Interface",
-		RunE:  ValidateSubCommand(),
+		Use:   "kafka [kafka operation]",                // 使用说明
+		Short: "Kafka Operation Command Line Interface", // 简短描述
+		RunE:  ValidateSubCommand(),                     // 当运行无子命令时，验证是否提供了子命令
 	}
+
+	// 定义一组子命令
 	groups := templates.CommandGroups{
 		{
-			Message: "kafka operation sets",
+			Message: "kafka operation sets", // 组描述
 			Commands: []*cobra.Command{
+				// 添加Kafka相关的子命令
 				InitCommand(),
 				DecompressKafkaPkgCommand(),
 				InstallSupervisorCommand(),
@@ -37,9 +41,14 @@ func NewKafkaCommand() *cobra.Command {
 				ReconfigRemoveCommand(),
 				RestartBrokerCommand(),
 				ReplaceBrokerCommand(),
+				CheckBrokerEmptyCommand(),
 			},
 		},
 	}
+
+	// 将命令组添加到根命令
 	groups.Add(cmds)
+
+	// 返回根命令对象
 	return cmds
 }

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/core/cst/kafka.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/core/cst/kafka.go
@@ -1,38 +1,44 @@
 package cst
 
 const (
-	// DefaultKafkaDataDir TODO
+	// DefaultKafkaDataDir Kafka默认数据目录
 	DefaultKafkaDataDir = "/data/kafkadata"
-	// DefaultKafkaPort TODO
-	DefaultKafkaPort = 9092 // 默认端口
-	// DefaultKafkaEnv TODO
-	DefaultKafkaEnv = "/data/kafkaenv" // kafka安装包存放目录
-	// DefaultKafkaLogDir TODO
+	// DefaultKafkaPort Kafka默认端口
+	DefaultKafkaPort = 9092
+	// DefaultKafkaEnv Kafka默认环境目录
+	DefaultKafkaEnv = "/data/kafkaenv"
+	// DefaultKafkaLogDir Kafka默认日志目录
 	DefaultKafkaLogDir = "/data/kafkalog"
-	// DefaultZookeeperLogDir TODO
+	// DefaultZookeeperLogDir zk默认日志目录
 	DefaultZookeeperLogDir = "/data/zklog"
-	// DefaultKafkaDir TODO
+	// DefaultKafkaDir kafka程序目录
 	DefaultKafkaDir = DefaultKafkaEnv + "/kafka"
-	// DefaultZookeeperDir TODO
+	// DefaultZookeeperDir zk程序目录
 	DefaultZookeeperDir = DefaultKafkaEnv + "/zk"
-	// DefaultZookeeperLogsDir TODO
+	// DefaultZookeeperLogsDir zk写入日志目录
 	DefaultZookeeperLogsDir = DefaultKafkaEnv + "/zookeeper/logs"
-	// DefaultZookeeperDataDir TODO
+	// DefaultZookeeperDataDir zk数据目录
 	DefaultZookeeperDataDir = DefaultKafkaEnv + "/zookeeper/data"
-	// DefaultZookeeperConfDir TODO
+	// DefaultZookeeperConfDir zk配置文件目录
 	DefaultZookeeperConfDir = DefaultKafkaEnv + "/zookeeper/conf"
-	// DefaultZookeeperDynamicConf TODO
+	// DefaultZookeeperDynamicConf zk配置文件路径
 	DefaultZookeeperDynamicConf = DefaultZookeeperConfDir + "/zoo.cfg.dynamic"
-	// DefaultKafkaSupervisorConf TODO
+	// DefaultKafkaSupervisorConf supervisor配置目录
 	DefaultKafkaSupervisorConf = DefaultKafkaEnv + "/supervisor/conf"
-	// DefaultZookeeperVersion TODO
+	// DefaultZookeeperVersion zk版本
 	DefaultZookeeperVersion = "3.6.3"
-	// DefaultZookeeperShell TODO
+	// DefaultZookeeperShell  zookeeper-shell.sh路径
 	DefaultZookeeperShell = DefaultKafkaDir + "/bin/zookeeper-shell.sh"
-	// DefaultTopicBin TODO
+	// DefaultTopicBin kafka-topics.sh路径
 	DefaultTopicBin = DefaultKafkaDir + "/bin/kafka-topics.sh"
-	// DefaultReassignPartitionsBin TODO
+	// DefaultReassignPartitionsBin kafka-reassign-partitions.sh路径
 	DefaultReassignPartitionsBin = DefaultKafkaDir + "/bin/kafka-reassign-partitions.sh"
-	// Kafka0102 TODO
+	// Kafka0102 kafka 0.10.2
 	Kafka0102 = "0.10.2"
+	// PlanJSONFile kafka均衡计划路径
+	PlanJSONFile = DefaultKafkaEnv + "/plan.json"
+	// RollbackFile kafka均衡回退路径
+	RollbackFile = DefaultKafkaEnv + "/rollback.json"
+	// KafkaConfigFile kafka broker配置文件
+	KafkaConfigFile = DefaultKafkaDir + "/config/server.properties"
 )


### PR DESCRIPTION
增强kafka的缩容场景：
当前下线前都需要先做均衡，在以下场景存在不必要的开销。
1. 故障机器，这种希望直接从dbm下线的，下线前无需做均衡。
2. 对于已经均衡过，上面已经没有数据的broker，也无需先做均衡，直接下线。