### PR TITLE
fix(redis): rediscluster协议扩缩容bug#4836

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_master_rep.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_master_rep.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext as _
 
 from backend.constants import IP_PORT_DIVIDER
 from backend.db_meta.enums import ClusterType, InstanceRole
+from backend.db_services.redis.util import is_redis_cluster_protocal
 from backend.flow.consts import (
     DEFAULT_LAST_IO_SECOND_AGO,
     DEFAULT_MASTER_DIFF_TIME,
@@ -45,7 +46,7 @@ def RedisClusterMasterReplaceJob(root_id, ticket_data, sub_kwargs: ActKwargs, ma
     ]:
         return TwemproxyClusterMasterReplaceJob(root_id, ticket_data, sub_kwargs, master_replace_info)
 
-    elif sub_kwargs.cluster["cluster_type"] == ClusterType.TendisPredixyTendisplusCluster:
+    elif is_redis_cluster_protocal(sub_kwargs.cluster["cluster_type"]):
         return TendisClusterMasterReplaceJob(root_id, ticket_data, sub_kwargs, master_replace_info)
 
     else:

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_makesync.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_makesync.py
@@ -53,7 +53,9 @@ def RedisMakeSyncAtomJob(root_id, ticket_data, sub_kwargs: ActKwargs, params: Di
 
     # 下发介质包
     exec_ip = [params["origin_1"], params["sync_dst1"]]
-    if ins_sync_type in [SyncType.SYNC_MMS, SyncType.SYNC_SMS]:
+    if ins_sync_type in [SyncType.SYNC_MMS, SyncType.SYNC_SMS] and not is_redis_cluster_protocal(
+        act_kwargs.cluster["cluster_type"]
+    ):
         exec_ip.append(params["sync_dst2"])
     act_kwargs.exec_ip = exec_ip
     act_kwargs.file_list = GetFileList(db_type=DBType.Redis).redis_actuator()
@@ -303,7 +305,7 @@ def RedisClusterMakeSyncAtomJob(sub_pipeline: SubBuilder, sub_kwargs: ActKwargs,
     # 第一步 新节点加入集群
     act_kwargs.exec_ip = params[data_to]
     act_kwargs.cluster["meet_instances"] = [
-        {"master_ip": params[data_to], "master_port": int(portlink[data_from])} for portlink in params["ins_link"]
+        {"master_ip": params[data_to], "master_port": int(portlink[data_to])} for portlink in params["ins_link"]
     ]
     act_kwargs.get_redis_payload_func = RedisActPayload.redis_cluster_meet_4_scene.__name__
     sub_pipeline.add_act(

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_shutdown.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_shutdown.py
@@ -16,7 +16,7 @@ from typing import Dict, Optional
 from django.utils.translation import ugettext as _
 
 from backend.configuration.constants import DBType
-from backend.db_meta.enums import InstanceRole
+from backend.db_meta.enums import ClusterEntryRole, InstanceRole
 from backend.db_meta.models import AppCache, Cluster
 from backend.flow.consts import (
     DEFAULT_MONITOR_TIME,
@@ -100,7 +100,7 @@ class RedisClusterShutdownFlow(object):
         act_kwargs.is_update_trans_data = True
         act_kwargs.cluster = {
             **cluster_info,
-            "backup_type": RedisBackupEnum.NORMAL_BACKUP.value,
+            "backup_type": RedisBackupEnum.FOREVER_BACKUP.value,
             **cluster_info["redis_map"],
             **cluster_info["proxy_map"],
             "monitor_time_ms": DEFAULT_MONITOR_TIME,
@@ -153,6 +153,7 @@ class RedisClusterShutdownFlow(object):
         params = {
             "cluster_id": self.data["cluster_id"],
             "op_type": DnsOpType.CLUSTER_DELETE,
+            "role": [ClusterEntryRole.NODE_ENTRY.value, ClusterEntryRole.PROXY_ENTRY.value],
         }
         access_sub_builder = AccessManagerAtomJob(self.root_id, self.data, act_kwargs, params)
         redis_pipeline.add_sub_pipeline(sub_flow=access_sub_builder)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_ins_shutdown.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_ins_shutdown.py
@@ -16,7 +16,7 @@ from typing import Dict, Optional
 from django.utils.translation import ugettext as _
 
 from backend.configuration.constants import DBType
-from backend.db_meta.enums import InstanceRole
+from backend.db_meta.enums import ClusterEntryRole, InstanceRole
 from backend.db_meta.models import Cluster
 from backend.flow.consts import DEFAULT_MONITOR_TIME, DEFAULT_REDIS_SYSTEM_CMDS, DnsOpType, RedisBackupEnum
 from backend.flow.engine.bamboo.scene.common.builder import Builder
@@ -124,7 +124,7 @@ class RedisInsShutdownFlow(object):
         act_kwargs.cluster = {
             **all_ins_info,
             **ip_ports,
-            "backup_type": RedisBackupEnum.NORMAL_BACKUP.value,
+            "backup_type": RedisBackupEnum.FOREVER_BACKUP.value,
             "monitor_time_ms": DEFAULT_MONITOR_TIME,
             "ignore_req": True,
             "ignore_keys": DEFAULT_REDIS_SYSTEM_CMDS,
@@ -183,6 +183,7 @@ class RedisInsShutdownFlow(object):
             params = {
                 "cluster_id": cluster_id,
                 "op_type": DnsOpType.CLUSTER_DELETE,
+                "role": [ClusterEntryRole.NODE_ENTRY.value, ClusterEntryRole.PROXY_ENTRY.value],
             }
             access_sub_builder = AccessManagerAtomJob(self.root_id, self.data, act_kwargs, params)
             sub_pipeline_list.append(access_sub_builder)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_open_close.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_open_close.py
@@ -128,7 +128,7 @@ class RedisClusterOpenCloseFlow(object):
         sub_pipelines = []
         status = (
             InstanceStatus.UNAVAILABLE.value
-            if self.data["ticket_type"] == TicketType.REDIS_PROXY_OPEN
+            if self.data["ticket_type"] == TicketType.REDIS_PROXY_CLOSE
             else InstanceStatus.RUNNING.value
         )
         for ip in proxy_ips:

--- a/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
@@ -1348,3 +1348,43 @@ class RedisDBMeta(object):
             )
             api.proxy_instance.create(proxies=proxies, creator=self.cluster["created_by"], status=ins_status)
         return True
+
+    def update_cluster_entry(self) -> bool:
+        """
+        更新nodes cluster_entry记录
+        cluster_id
+        bk_biz_id
+        nodes_domain
+        """
+        nodes_domain = self.cluster["nodes_domain"]
+        cluster = Cluster.objects.get(id=self.cluster["cluster_id"], bk_biz_id=self.cluster["bk_biz_id"])
+        cluster_entry = cluster.clusterentry_set.filter(role=ClusterEntryRole.NODE_ENTRY.value).first()
+        storageinstances = cluster.storageinstance_set.all()
+
+        if is_redis_cluster_protocal(cluster.cluster_type):
+            if not cluster_entry:
+                cluster_entry = ClusterEntry.objects.create(
+                    cluster=cluster,
+                    cluster_entry_type=ClusterEntryType.DNS,
+                    entry=nodes_domain,
+                    creator=cluster.creator,
+                    role=ClusterEntryRole.NODE_ENTRY,
+                )
+                cluster_entry.storageinstance_set.add(*storageinstances)
+                cluster_entry.save()
+                logger.info(
+                    _("redis集群:%s cluster_type:%s 新增 %s cluster_entry").format(
+                        cluster.immute_domain, cluster.cluster_type, nodes_domain
+                    )
+                )
+            else:
+                # 应该存在的,确实存在,则更新
+                cluster_entry.storageinstance_set.clear()
+                cluster_entry.storageinstance_set.add(*storageinstances)
+                cluster_entry.save()
+                logger.info(
+                    _("redis集群:%s cluster_type:%s 更新 cluster_entry:%s").format(
+                        cluster.immute_domain, cluster.cluster_type, cluster_entry.entry
+                    )
+                )
+        return True


### PR DESCRIPTION
修复以下问题：
1、同步端口不一致时，目标端口不正确
2、slave 没meet进集群 
3、new_master/new_slave 主从关系没建立 
4、predixy 配置没重写
5、predixy扩容时多写一个node域名
6、rediscluster容量变更完后，api获取集群信息获取不到set内容
7、下架备份类型错误
8、关闭/开启集群，元数据状态错误
