### PR TITLE
fix(es): 优化es扩容流程，减少不必要dbactuator下发 #6079

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/es/es_scale_up_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/es/es_scale_up_flow.py
@@ -92,9 +92,9 @@ class EsScaleUpFlow(EsFlow):
 
         # 原有机器下发dbactuator
         act_kwargs.file_list = trans_files.es_disable()
-        act_kwargs.exec_ip = self.get_all_node_ips_in_dbmeta()
+        act_kwargs.exec_ip = self.master_ips
         es_pipeline.add_act(
-            act_name=_("下发dbactuator"), act_component_code=TransFileComponent.code, kwargs=asdict(act_kwargs)
+            act_name=_("原有机器下发dbactuator"), act_component_code=TransFileComponent.code, kwargs=asdict(act_kwargs)
         )
 
         # 打包证书


### PR DESCRIPTION
原先会往所有节点下发dbactuator，在规模比较大的集群，会使得扩容周期长。
改为只下发到3台master。