### PR TITLE
feat(redis): cache、ssd本地扩容实现 #5889

### DIFF
--- a/dbm-ui/backend/dbm_init/json_files/bklog/dbm_win_dbactuator.json
+++ b/dbm-ui/backend/dbm_init/json_files/bklog/dbm_win_dbactuator.json
@@ -11,6 +11,7 @@
     "target_object_type": "HOST",
     "target_node_type": "TOPO",
     "target_nodes": [],
+    "environment": "windows",
     "params": {
         "paths": [
             "d:\\install\\dbactuator*\\logs\\*.log"

--- a/dbm-ui/backend/dbm_init/json_files/format.py
+++ b/dbm-ui/backend/dbm_init/json_files/format.py
@@ -90,7 +90,7 @@ class JsonConfigFormat:
         internal_set_info = CCApi.get_biz_internal_module({"bk_biz_id": env.DBA_APP_BK_BIZ_ID}, use_admin=True)
         target_nodes.append(
             {
-                "bk_biz_id": internal_set_info["bk_biz_id"],
+                "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
                 "bk_inst_id": internal_set_info["bk_set_id"],
                 "bk_obj_id": "set",
             }

--- a/dbm-ui/backend/tests/mock_data/components/cc.py
+++ b/dbm-ui/backend/tests/mock_data/components/cc.py
@@ -32,7 +32,6 @@ MOCK_FIND_HOST_BIZ_RELATIONS_RETURN = [
 ]
 
 MOCK_GET_BIZ_INTERNAL_MODULE_RETURN = {
-    "bk_biz_id": constant.BK_BIZ_ID,
     "bk_set_id": constant.BK_SET_ID,
     "bk_set_name": "空闲机池",
     "module": [


### PR DESCRIPTION
<img width="1356" alt="企业微信截图_b6a65005-c57f-4806-bac5-4ef9603c25d0" src="https://github.com/user-attachments/assets/c8c08414-e49c-4d32-98a3-0978ec85ef53">
复用老机器模式的本地扩容功能实现。


已验证场景：
1、 刚好能整除场景                  2->4 8分片  [4,4] ->[2 2 2 2]         pass
2、 部分老实例需要多几个实例场景       3->4 9分片  [3,3,3] ->[3 2 2 2]       场景5已覆盖
3、 全部老实例需要多几个实例场景       2->4 10分片  [5,5] -> [3 3 2 2]       pass+场景5已覆盖
4、 部分新实例需要多几个实例场景       3->5 9分片   [3,3,3] -> [2,2,2,2,1]   pass
5、 老实例数不规整情况
5.1 扩容后老机器多几个实例+扩容前老实例不规整场景         2->3->4 8分片    [4,4] -> [3,3,2] -> [2,2,2,2]  pass
5.2 扩容后部分老机器多几个实例+扩容前老机器实例不规整场景  2->3->4 10分片   [5,5] -> [4,3,3] -> [3,3,2,2]   pass
6、整体扩缩容场景review                                         pass+场景7覆盖
7、多集群/模式扩缩容同时提单          1->2 4分片 替换+本地 扩容提一个单 pass
8、部分老机器不需要迁移实例场景        3->4 6分片 [2,2,2] -> [2,2,1,1]   pass

存在问题，已反馈，待其他pr中修复：
1、切换子流程中，切换后db_meta_storageinstance表的cluster_type字段不正确，待修复
2、切换子流程中，切换后新机器的dbmon配置文件未更新，待修复

