### PR TITLE
fix(frontend): 修复redis webconsole交互问题 #6492

### DIFF
--- a/dbm-ui/frontend/src/services/source/dbbase.ts
+++ b/dbm-ui/frontend/src/services/source/dbbase.ts
@@ -82,7 +82,7 @@ export function queryResourceAdministrationAttrs(params: { resource_type: string
  */
 export function queryWebconsole(params: { cluster_id: number; cmd: string }) {
   return http.post<{
-    query: Array<Record<string, string>>;
+    query: string | Record<string, string>[];
     error_msg?: string;
   }>(`${path}/webconsole/`, params);
 }


### PR DESCRIPTION
# Reviewed, transaction id: 16635
![image](https://github.com/user-attachments/assets/8275dc67-6ac1-4852-bd98-51f65a440d8a)

1、修复因textarea聚焦时无法选择内容复制问题，需要先将textarea冻结；
2、所选数据库索引应该当query=“OK"时set，并更新之前输入过的命令行；
3、格式化字符串输出