### PR TITLE
feat(frontend): 修复kafka安全认证复制值不对问题 #6159

### DIFF
--- a/dbm-ui/frontend/src/components/cluster-common/RenderPassword.vue
+++ b/dbm-ui/frontend/src/components/cluster-common/RenderPassword.vue
@@ -169,7 +169,7 @@
     let content = `${t('集群名称')}: ${cluster_name}\n${t('域名')}: ${domainPort}\n${t('账号')}: ${username}\n${t('密码')}: ${passwordToken}`;
     let securityInfo = '';
     if (props.dbType) {
-      securityInfo = `security.protocol=SASL_PLAINTEXT\nsasl.mechanism=PLAIN\nsasl.jaas.config=org.apache.${props.dbType}.common.security.plain.PlainLoginModule required username="${username}" password="${password}";`;
+      securityInfo = `security.protocol=SASL_PLAINTEXT\nsasl.mechanism=SCRAM-SHA-512\nsasl.jaas.config=org.apache.${props.dbType}.common.security.plain.PlainLoginModule required username="${username}" password="${password}";`;
       content = `${content}\n${t('安全认证')}: ${securityInfo}`;
     }
     switch (type) {


### PR DESCRIPTION
<img width="653" alt="企业微信截图_17249033885309" src="https://github.com/user-attachments/assets/567c915b-e58b-4d84-a3bd-ff5e19afc938">

复制结果与展示不符修复