### PR TITLE
feat(frontend): 业务下增加单据流程设置 #6346

### DIFF
--- a/dbm-ui/frontend/src/services/model/ticket-flow-describe/TicketFlowDescribe.ts
+++ b/dbm-ui/frontend/src/services/model/ticket-flow-describe/TicketFlowDescribe.ts
@@ -45,8 +45,14 @@ export default class TicketFlowDescribe {
     return utcDisplayTime(this.update_at);
   }
 
+  // 是否自定义目标
   get isCustomTarget() {
     return this.bk_biz_id !== 0;
+  }
+
+  // 是否集群目标
+  get isClusterTarget() {
+    return this.cluster_ids.length > 0;
   }
 
   get clusterDomainList() {

--- a/dbm-ui/frontend/src/services/source/ticket.tsx
+++ b/dbm-ui/frontend/src/services/source/ticket.tsx
@@ -274,10 +274,6 @@ export function queryTicketFlowDescribe(params: {
   offset?: number;
   bk_biz_id?: number;
 }) {
-  // 组件 db-table 传值问题，临时解决 bk_biz_id 多余传值
-  // eslint-disable-next-line no-param-reassign
-  delete params.bk_biz_id;
-
   return http.get<TicketFlowDescribeModel[]>(`${path}/query_ticket_flow_describe/`, params).then((data) => ({
     count: data.length || 0,
     results: data.map((item) => new TicketFlowDescribeModel(item)) || [],

--- a/dbm-ui/frontend/src/views/ticket-flow-setting-global/components/List.vue
+++ b/dbm-ui/frontend/src/views/ticket-flow-setting-global/components/List.vue
@@ -233,6 +233,8 @@
   const fetchData = () => {
     tableRef.value.fetchData({ ...reqParams.value }, {
       db_type: props.dbType,
+      // 全局配置下单据流程列表不传bk_biz_id,覆盖db-table组件传入的bk_biz_id,请求时会过滤掉值为undefined的字段
+      bk_biz_id: undefined,
     });
   };
 


### PR DESCRIPTION
# Reviewed, transaction id: 16866
![image](https://github.com/user-attachments/assets/925685f7-994d-4644-8410-efbb59b5f6f9)

业务下、全局下列表请求参数修正

业务下单据列表
1、人工审批列只读；
2、是否审批列只对自定义目标可修改
3、聚合多行时隐藏内置目标