### PR TITLE
fix(mysql): db重命名和清档中的触发器 #6662

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/rename_dbs/pkg/trans_db_tables.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/rename_dbs/pkg/trans_db_tables.go
@@ -9,17 +9,35 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TransDBTables(conn *sqlx.Conn, from, to string, tables []string) error {
-	for _, table := range tables {
-		err := transDBTable(conn, from, to, table)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+type createTriggerRow struct {
+	Trigger             string `db:"Trigger"`
+	SqlMode             string `db:"sql_mode"`
+	Sql                 string `db:"SQL Original Statement"`
+	CharsetClient       string `db:"character_set_client"`
+	CollationConnection string `db:"collation_connection"`
+	Collation           string `db:"Database Collation"`
+	Created             string `db:"Created"`
 }
 
-func transDBTable(conn *sqlx.Conn, from, to, tableName string) error {
+// TransDBTables
+// 一个表如果有触发器, 必须要 drop 触发器才能 drop/rename
+// 如果是 rename db 单据, 源触发器可以不用保留
+// 如果是 truncate db, 当清档类型是 truncate table 时, 源触发器需要保留
+// 实际是 rename table 前先把触发器删掉, 完事了再看需求重建
+// 但是又不能在这个函数重建, 因为表还不在, 所以只能把需求重建的 trigger 返回
+func TransDBTables(conn *sqlx.Conn, from, to string, tables []string) ([]string, error) {
+	var res []string
+	for _, table := range tables {
+		createTriggers, err := transDBTable(conn, from, to, table)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, createTriggers...)
+	}
+	return res, nil
+}
+
+func transDBTable(conn *sqlx.Conn, from, to, tableName string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -29,7 +47,40 @@ func transDBTable(conn *sqlx.Conn, from, to, tableName string) error {
 		fmt.Sprintf("DROP TABLE IF EXISTS `%s`.`%s`;", to, tableName),
 	)
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	// 源触发器
+	var triggers []string
+	err = conn.SelectContext(
+		ctx,
+		&triggers,
+		`SELECT TRIGGER_NAME FROM INFORMATION_SCHEMA.TRIGGERS WHERE EVENT_OBJECT_SCHEMA = ? AND EVENT_OBJECT_TABLE = ?`,
+		from, tableName,
+	)
+	if err != nil {
+		logger.Error("query trigger for %s.%s failed: %s", from, tableName, err)
+		return nil, err
+	}
+	logger.Info("query trigger for %s.%s succeeded: %v", from, tableName, triggers)
+
+	var createTriggers []string
+	for _, trigger := range triggers {
+		createTrigger := createTriggerRow{}
+		err = conn.GetContext(ctx, &createTrigger, fmt.Sprintf("SHOW CREATE TRIGGER `%s`.`%s`", from, trigger))
+		if err != nil {
+			logger.Error("show create trigger for %s.%s failed: %s", from, trigger, err)
+			return nil, err
+		}
+		createTriggers = append(createTriggers, createTrigger.Sql)
+		logger.Info("stage create trigger for %s.%s: %s", from, trigger, createTrigger.Sql)
+
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP TRIGGER `%s`.`%s`", from, trigger))
+		if err != nil {
+			logger.Error("drop trigger for %s.%s failed: %s", from, trigger, err)
+			return nil, err
+		}
+		logger.Info("drop trigger for %s.%s succeeded", from, trigger)
 	}
 
 	_, err = conn.ExecContext(
@@ -40,9 +91,9 @@ func transDBTable(conn *sqlx.Conn, from, to, tableName string) error {
 		),
 	)
 	if err != nil {
-		logger.Info("rename %s from %s to %s failed: %s", tableName, from, to, err.Error())
-		return err
+		logger.Error("rename %s from %s to %s failed: %s", tableName, from, to, err.Error())
+		return nil, err
 	}
 	logger.Info("rename %s from %s to %s success", tableName, from, to)
-	return nil
+	return createTriggers, nil
 }

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/truncate/pkg/safe_drop_tables.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/truncate/pkg/safe_drop_tables.go
@@ -32,6 +32,37 @@ func safeDropSourceTable(conn *sqlx.Conn, dbName, stageDBName, tableName string)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// 留着这里, drop table 不需要预处理触发器
+	//var triggers []string
+	//err = conn.SelectContext(
+	//	ctx,
+	//	&triggers,
+	//	`SELECT TRIGGER_NAME FROM INFORMATION_SCHEMA.TRIGGERS WHERE EVENT_OBJECT_SCHEMA = ? AND EVENT_OBJECT_TABLE = ?`,
+	//	dbName, tableName,
+	//)
+	//if err != nil {
+	//	logger.Error("query trigger for %s.%s failed: %s", dbName, tableName, err)
+	//	return err
+	//}
+	//logger.Info("query trigger for %s.%s succeeded: %v", dbName, tableName, triggers)
+	//
+	//for _, trigger := range triggers {
+	//	_, err = conn.ExecContext(ctx, fmt.Sprintf("USE `%s`", dbName))
+	//	if err != nil {
+	//		logger.Error("change db to %s failed: %s", dbName, err)
+	//		return err
+	//	}
+	//	logger.Info("change db to %s succeeded", dbName)
+	//
+	//	// 中控要 change db 再 drop trigger
+	//	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP TRIGGER `%s`", trigger))
+	//	if err != nil {
+	//		logger.Error("drop trigger for %s.%s failed: %s", dbName, trigger, err)
+	//		return err
+	//	}
+	//	logger.Info("drop trigger for %s.%s succeeded", dbName, trigger)
+	//}
+
 	_, err = conn.ExecContext(
 		ctx,
 		fmt.Sprintf(

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/mysqlconfigdiff/mysql_config_diff.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/mysqlconfigdiff/mysql_config_diff.go
@@ -80,7 +80,10 @@ type Checker struct {
 func (c *Checker) Run() (msg string, err error) {
 	var cnfFile string
 	if config.MonitorConfig.Port == 3306 {
-		cnfFile = "/etc/my.cnf"
+		cnfFile = "etc/my.cnf.3306"
+		if _, err := os.Stat(cnfFile); os.IsNotExist(err) {
+			cnfFile = "/etc/my.cnf"
+		}
 	} else {
 		cnfFile = fmt.Sprintf("/etc/my.cnf.%d", config.MonitorConfig.Port)
 	}


### PR DESCRIPTION
1. 修复了监控端口为3306的实例配置文件路径错误的问题
2. 清档和db重命名现在能正确处理触发器
3. 都在开发环境提单实际测试过了