### PR TITLE
fix(mysql): 补充修复mysql备份单据参数问题 #6911

### DIFF
--- a/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
@@ -1862,9 +1862,9 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
                     "shard_id": self.ticket_data.get("shard_id", 0),
                     "backup_file_tag": self.ticket_data.get("file_tag", ""),
                     "db_patterns": self.ticket_data.get("db_patterns", ["*"]),
-                    "ignore_dbs": self.ticket_data.get("ignore_dbs", ""),
+                    "ignore_dbs": self.ticket_data.get("ignore_dbs", []),
                     "table_patterns": self.ticket_data.get("table_patterns", ["*"]),
-                    "ignore_tables": self.ticket_data.get("ignore_tables", ""),
+                    "ignore_tables": self.ticket_data.get("ignore_tables", []),
                 },
             },
         }


### PR DESCRIPTION
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/64f9042b-0cbe-43b7-b1dc-c05d20e26d53">
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/a98f1c5b-99c2-4503-8847-6f3c8c097f4d">
已验证能正确生成全备和库表备份的配置文件