### PR TITLE
fix(mysql): mysql-monitor-missing-machine-type #6919

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/example.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/example.go
@@ -23,25 +23,23 @@ func (c *MySQLMonitorComp) Example() interface{} {
 			SystemDbs: native.DBSys,
 			ExecUser:  "whoru",
 			ApiUrl:    `http://x.x.x.x:yyyy`,
-			InstancesInfo: []*instanceInfo{
+			ItemsConfig: map[string]*config.MonitorItem{
+				"character-consistency": {
+					Name:        "",
+					Enable:      nil,
+					Schedule:    nil,
+					MachineType: nil,
+					Role:        nil,
+				},
+			},
+			InstancesInfo: []*internal.InstanceInfo{
 				{
-					internal.InstanceInfo{
-						BkBizId:      1,
-						Ip:           "127.0.0.1",
-						Port:         123,
-						Role:         "master",
-						ClusterId:    12,
-						ImmuteDomain: "aaa.bbb.com",
-					},
-					map[string]*config.MonitorItem{
-						"character-consistency": {
-							Name:        "",
-							Enable:      nil,
-							Schedule:    nil,
-							MachineType: nil,
-							Role:        nil,
-						},
-					},
+					BkBizId:      1,
+					Ip:           "127.0.0.1",
+					Port:         123,
+					Role:         "master",
+					ClusterId:    12,
+					ImmuteDomain: "aaa.bbb.com",
 				},
 			},
 			MachineType: "backend",

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/exporter_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/exporter_config.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"dbm-services/common/go-pubpkg/logger"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/internal"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/native"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil"
@@ -21,7 +22,7 @@ func (c *MySQLMonitorComp) GenerateExporterConfig() (err error) {
 	return nil
 }
 
-func generateExporterConfigIns(mmp *MySQLMonitorParam, instance *instanceInfo, rtap *components.RuntimeAccountParam) (err error) {
+func generateExporterConfigIns(mmp *MySQLMonitorParam, instance *internal.InstanceInfo, rtap *components.RuntimeAccountParam) (err error) {
 	exporterConfigPath := filepath.Join(
 		"/etc",
 		fmt.Sprintf("exporter_%d.cnf", instance.Port),

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/init.go
@@ -27,15 +27,11 @@ func (c *MySQLMonitorComp) Init() (err error) {
 
 type MySQLMonitorParam struct {
 	components.Medium
-	SystemDbs     []string        `json:"system_dbs"`
-	ExecUser      string          `json:"exec_user"`
-	ApiUrl        string          `json:"api_url"`
-	InstancesInfo []*instanceInfo `json:"instances_info"`
-	MachineType   string          `json:"machine_type"`
-	BkCloudId     int             `json:"bk_cloud_id"`
-}
-
-type instanceInfo struct {
-	internal.InstanceInfo
-	ItemsConfig map[string]*config.MonitorItem `json:"items_config" yaml:"items_config"`
+	SystemDbs     []string                       `json:"system_dbs"`
+	ExecUser      string                         `json:"exec_user"`
+	ApiUrl        string                         `json:"api_url"`
+	InstancesInfo []*internal.InstanceInfo       `json:"instances_info"`
+	MachineType   string                         `json:"machine_type"`
+	BkCloudId     int                            `json:"bk_cloud_id"`
+	ItemsConfig   map[string]*config.MonitorItem `json:"items_config" yaml:"items_config"`
 }

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/items_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/items_config.go
@@ -4,8 +4,11 @@ import (
 	"dbm-services/common/go-pubpkg/logger"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/internal"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
+	"dbm-services/mysql/db-tools/mysql-monitor/pkg/config"
 	"fmt"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v2"
@@ -13,7 +16,7 @@ import (
 
 func (c *MySQLMonitorComp) GenerateItemsConfig() (err error) {
 	for _, inst := range c.Params.InstancesInfo {
-		err = generateItemsConfigIns(inst)
+		err = generateItemsConfigIns(inst, c.Params.ItemsConfig)
 		if err != nil {
 			return err
 		}
@@ -21,8 +24,13 @@ func (c *MySQLMonitorComp) GenerateItemsConfig() (err error) {
 	return nil
 }
 
-func generateItemsConfigIns(instance *instanceInfo) (err error) {
-	b, err := yaml.Marshal(maps.Values(instance.ItemsConfig))
+func generateItemsConfigIns(instance *internal.InstanceInfo, itemsConfig map[string]*config.MonitorItem) (err error) {
+	itemList := maps.Values(itemsConfig)
+	slices.SortFunc(itemList, func(a, b *config.MonitorItem) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	b, err := yaml.Marshal(itemList)
 	if err != nil {
 		logger.Error(err.Error())
 		return err

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/runtime_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/monitor/runtime_config.go
@@ -25,7 +25,7 @@ func (c *MySQLMonitorComp) GenerateRuntimeConfig() (err error) {
 	return nil
 }
 
-func generateRuntimeConfigIns(mmp *MySQLMonitorParam, instance *instanceInfo, rtap *components.RuntimeAccountParam) (err error) {
+func generateRuntimeConfigIns(mmp *MySQLMonitorParam, instance *internal.InstanceInfo, rtap *components.RuntimeAccountParam) (err error) {
 	if instance.BkInstanceId <= 0 {
 		err = errors.Errorf(
 			"%s:%d invalid bk_instance_id: %d",

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/config/items_config.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/config/items_config.go
@@ -4,11 +4,11 @@ import "slices"
 
 // MonitorItem 监控项
 type MonitorItem struct {
-	Name        string   `yaml:"name" validate:"required"`
-	Enable      *bool    `yaml:"enable" validate:"required"`
-	Schedule    *string  `yaml:"schedule"`
-	MachineType []string `yaml:"machine_type"`
-	Role        []string `yaml:"role"`
+	Name        string   `json:"name" yaml:"name" validate:"required"`
+	Enable      *bool    `json:"enable" yaml:"enable" validate:"required"`
+	Schedule    *string  `json:"schedule" yaml:"schedule"`
+	MachineType []string `json:"machine_type" yaml:"machine_type"`
+	Role        []string `json:"role" yaml:"role"`
 }
 
 // IsEnable 监控项启用

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_ha_standardize_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_ha_standardize_flow.py
@@ -243,6 +243,7 @@ class MySQLHAStandardizeFlow(object):
                         exec_ip=ip,
                         bk_cloud_id=bk_cloud_id,
                         get_mysql_payload_func=MysqlActPayload.get_deploy_mysql_monitor_payload.__name__,
+                        cluster={"cluster_ids": self.data["infos"]["cluster_ids"]},
                         cluster_type=ClusterType.TenDBHA.value,
                     )
                 ),
@@ -308,6 +309,7 @@ class MySQLHAStandardizeFlow(object):
                         exec_ip=ip,
                         bk_cloud_id=bk_cloud_id,
                         get_mysql_payload_func=MysqlActPayload.get_deploy_mysql_monitor_payload.__name__,
+                        cluster={"cluster_ids": self.data["infos"]["cluster_ids"]},
                         cluster_type=ClusterType.TenDBHA.value,
                     )
                 ),

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_standardize_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/spider_cluster_standardize_flow.py
@@ -311,6 +311,7 @@ class SpiderClusterStandardizeFlow(object):
                     exec_ip=ip,
                     bk_cloud_id=bk_cloud_id,
                     get_mysql_payload_func=MysqlActPayload.get_deploy_mysql_monitor_payload.__name__,
+                    cluster={"cluster_ids": self.data["infos"]["cluster_ids"]},
                     cluster_type=ClusterType.TenDBCluster.value,
                 )
             ),

--- a/dbm-ui/backend/flow/engine/bamboo/scene/tendbsingle/standardize.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/tendbsingle/standardize.py
@@ -230,6 +230,7 @@ class TenDBSingleStandardizeFlow(object):
                         exec_ip=ip,
                         bk_cloud_id=bk_cloud_id,
                         get_mysql_payload_func=MysqlActPayload.get_deploy_mysql_monitor_payload.__name__,
+                        cluster={"cluster_ids": self.data["infos"]["cluster_ids"]},
                         cluster_type=ClusterType.TenDBSingle.value,
                     )
                 ),


### PR DESCRIPTION
<img width="314" alt="image" src="https://github.com/user-attachments/assets/6fbad7c7-4f7f-41bc-90dd-6a8cde7d3174">

1. 修复了无法正确渲染 machine_type 的问题
2. 集群标准化不再强制要求填入同机器所有集群
3. 解决了单机多实例同时部署监控时参数过大导致执行失败的问题