### PR TITLE
feat(backend): 反向查询接口 #7173

### DIFF
--- a/dbm-ui/backend/db_services/reverse_api/__init__.py
+++ b/dbm-ui/backend/db_services/reverse_api/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/db_services/reverse_api/base_reverse_api_view.py
+++ b/dbm-ui/backend/db_services/reverse_api/base_reverse_api_view.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+from types import FunctionType
+from typing import Tuple
+
+from django.utils.translation import ugettext as _
+from rest_framework import permissions
+
+from backend.bk_web.viewsets import SystemViewSet
+from backend.db_meta.models import Machine
+from backend.db_services.reverse_api.get_ip_from_request import get_bk_cloud_id, get_client_ip, get_nginx_ip
+from backend.db_services.reverse_api.serializers import ReverseApiParamSerializer
+
+logger = logging.getLogger("root")
+
+
+class IPHasRegisteredPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        try:
+            nginx_ip = get_nginx_ip(request)
+            logger.debug(f"nginx_ip: {nginx_ip}")
+
+            bk_cloud_id = get_bk_cloud_id(request)
+            logger.debug(f"bk_cloud_id: {bk_cloud_id}")
+
+            client_ip = get_client_ip(request)
+            Machine.objects.get(ip=client_ip, bk_cloud_id=bk_cloud_id)
+
+            logger.debug(f"client_ip: {client_ip}")
+        except Exception as e:  # noqa
+            # if not found:
+            raise Exception(_("访问受限，不存在于DBM平台 {}".format(e)))
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
+class BaseReverseApiView(SystemViewSet):
+    serializer_class = ReverseApiParamSerializer
+
+    @classmethod
+    def _get_login_exempt_view_func(cls):
+        return {
+            "get": [
+                x
+                for x, y in cls.__dict__.items()
+                if isinstance(y, FunctionType) and getattr(y, "is_reverse_api", False)
+            ]
+        }
+
+    def get_permissions(self):
+        return [IPHasRegisteredPermission()]
+
+    def get_api_params(self) -> Tuple[int, str, int]:
+        """
+        return request bk_cloud_id, ip, port param
+        """
+        data = self.params_validate(self.get_serializer_class())
+
+        ip = data.get("ip")
+        bk_cloud_id = data.get("bk_cloud_id")
+        port = data.get("port")
+
+        return bk_cloud_id, ip, port

--- a/dbm-ui/backend/db_services/reverse_api/decorators.py
+++ b/dbm-ui/backend/db_services/reverse_api/decorators.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import logging
+from functools import wraps
+
+from django.http import HttpRequest
+from rest_framework.decorators import action
+
+from backend.db_services.reverse_api.get_ip_from_request import get_bk_cloud_id, get_client_ip
+
+logger = logging.getLogger("root")
+
+
+# def reverse_api(func):
+#     @wraps(func)
+#     @action(
+#         methods=["GET"],
+#         detail=False,
+#     )
+#     def wrapped_func(obj, request: HttpRequest, *args, **kwargs):
+#         if not request.GET._mutable:
+#             request.GET._mutable = True
+#
+#         bk_cloud_id = get_bk_cloud_id(request)
+#         client_ip = get_client_ip(request)
+#
+#         for k, v in list(request.GET.items()):
+#             if k != "port":
+#                 request.GET.pop(key=k)
+#
+#         request.GET["bk_cloud_id"] = bk_cloud_id
+#         request.GET["ip"] = client_ip
+#         request.GET._mutable = False
+#
+#         return func(obj, request, *args, **kwargs)
+#
+#     return wrapped_func
+
+
+def reverse_api(url_path):
+    def actual_decorator(func):
+        setattr(func, "is_reverse_api", True)
+
+        @action(url_path=url_path, detail=False, methods=["GET"])
+        @wraps(func)
+        def wrapped_func(obj, request: HttpRequest, *args, **kwargs):
+            if not request.GET._mutable:
+                request.GET._mutable = True
+
+            bk_cloud_id = get_bk_cloud_id(request)
+            client_ip = get_client_ip(request)
+
+            for k, v in list(request.GET.items()):
+                if k != "port":
+                    request.GET.pop(key=k)
+
+            request.GET["bk_cloud_id"] = bk_cloud_id
+            request.GET["ip"] = client_ip
+            request.GET._mutable = False
+            return func(obj, request, *args, **kwargs)
+
+        return wrapped_func
+
+    return actual_decorator

--- a/dbm-ui/backend/db_services/reverse_api/get_ip_from_request.py
+++ b/dbm-ui/backend/db_services/reverse_api/get_ip_from_request.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.db.models import Q
+
+from backend.db_proxy.models import DBCloudProxy
+
+
+def get_client_ip(request):
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(",")[0]
+        return ip
+    else:
+        raise Exception("client ip in HTTP_X_FORWARDED_FOR not found")
+
+
+def get_nginx_ip(request):
+    ip = request.META.get("REMOTE_ADDR")
+    if ip:
+        return ip
+    else:
+        raise Exception("nginx ip in REMOTE_ADDR not found")
+
+
+def get_bk_cloud_id(request):
+    nginx_ip = get_nginx_ip(request)
+
+    p = DBCloudProxy.objects.get(Q(internal_address=nginx_ip) | Q(external_address=nginx_ip))
+    return p.bk_cloud_id

--- a/dbm-ui/backend/db_services/reverse_api/mysql/__init__.py
+++ b/dbm-ui/backend/db_services/reverse_api/mysql/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from .views import MySQLReverseApiView

--- a/dbm-ui/backend/db_services/reverse_api/mysql/views.py
+++ b/dbm-ui/backend/db_services/reverse_api/mysql/views.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import logging
+
+from django.db.models import Q
+from django.http import JsonResponse
+from django.utils.translation import ugettext_lazy as _
+
+from backend.bk_web.swagger import common_swagger_auto_schema
+from backend.db_meta.enums import AccessLayer
+from backend.db_meta.models import Machine, ProxyInstance, StorageInstance
+from backend.db_services.reverse_api.base_reverse_api_view import BaseReverseApiView
+from backend.db_services.reverse_api.decorators import reverse_api
+
+logger = logging.getLogger("root")
+
+
+class MySQLReverseApiView(BaseReverseApiView):
+    @common_swagger_auto_schema(operation_summary=_("获取实例基本信息"))
+    @reverse_api(url_path="list_instance_info")
+    def list_instance_info(self, request, *args, **kwargs):
+        bk_cloud_id, ip, port_list = self.get_api_params()
+        logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
+
+        m = Machine.objects.get(ip=ip, bk_cloud_id=bk_cloud_id)
+        q = Q()
+        q |= Q(**{"machine": m})
+
+        if port_list:
+            q &= Q(**{"port__in": port_list})
+
+        res = []
+        if m.access_layer == AccessLayer.PROXY:
+            for i in ProxyInstance.objects.filter(q):
+                res.append({"ip": i.machine.ip, "port": i.port, "phase": i.phase, "status": i.status})
+        else:
+            for i in StorageInstance.objects.filter(q):
+                res.append({"ip": i.machine.ip, "port": i.port, "phase": i.phase, "status": i.status})
+
+        logger.info(f"instance info: {res}")
+        return JsonResponse(
+            {
+                "result": True,
+                "code": 0,
+                "data": res,
+                "message": "",
+                "errors": None,
+            }
+        )

--- a/dbm-ui/backend/db_services/reverse_api/readme.md
+++ b/dbm-ui/backend/db_services/reverse_api/readme.md
@@ -1,0 +1,69 @@
+# 用途
+* _dbm_ 提供只读 _api_
+* _db_ 机器调用 _api_ 查询必要的信息
+
+# 限制
+1. 只提供查询功能
+2. _http method_ 必须为 _GET_
+3. _api_ 只有一个可选参数 _port: int | [int]_
+
+# 实现
+
+```python
+class MySQLReverseApiView(BaseReverseApiView):
+    @common_swagger_auto_schema(operation_summary=_("获取实例基本信息"))
+    @reverse_api(url_path="list_instance_info")
+    def list_instance_info(self, request, *args, **kwargs):
+        bk_cloud_id, ip, port_list = self.get_api_params()
+        logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
+
+        m = Machine.objects.get(ip=ip, bk_cloud_id=bk_cloud_id)
+        q = Q()
+        q |= Q(**{"machine": m})
+
+        if port_list:
+            q &= Q(**{"port__in": port_list})
+
+        res = []
+        if m.access_layer == AccessLayer.PROXY:
+            for i in ProxyInstance.objects.filter(q):
+                res.append({"ip": i.machine.ip, "port": i.port, "phase": i.phase, "status": i.status})
+        else:
+            for i in StorageInstance.objects.filter(q):
+                res.append({"ip": i.machine.ip, "port": i.port, "phase": i.phase, "status": i.status})
+
+        logger.info(f"instance info: {res}")
+        return JsonResponse(
+            {
+                "result": True,
+                "code": 0,
+                "data": res,
+                "message": "",
+                "errors": None,
+            }
+        )
+```
+
+1. 继承 `BaseReverseApiView`
+2. 使用装饰器 `reverse_api` 实现服务方法
+3. 注册 _urls_: `routers.register("mysql", MySQLReverseApiView, basename="")`
+
+## 参数
+会的到这样一个 _api_
+
+`/mysql/list_instance_info/?port=10000&port=20000`
+
+* _port_ 可以多次输入, 也可以不输入
+* _api_ 并不阻止传入如 `ip=127.1.1.1&role=slave` 这样的参数, 但毫无作用
+* 调用框架会传递 `bk_cloud_id, ip, port` 三个参数给服务方法, 其中 `bk_cloud_id, ip` 是框架自动合成的
+
+# 安全
+## 框架限制
+1. _api_ 服务方法的 `bk_cloud_id, ip` 参数由框架自动生成
+2. _ip_ 必须已注册在 _dbm_ 中才允许调用
+3. 只开发 _http GET_
+
+## 开发规则
+1. 不要在代码中提供写能力
+2. 不要故意违反 `bk_cloud_id, ip` 的数据可见性限制
+3. 尽可能减少每一个 _api_ 返回的数据, 多实现专用 _api_

--- a/dbm-ui/backend/db_services/reverse_api/serializers.py
+++ b/dbm-ui/backend/db_services/reverse_api/serializers.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from rest_framework import serializers
+
+
+class ReverseApiParamSerializer(serializers.Serializer):
+    port = serializers.ListField(child=serializers.IntegerField(), required=False)
+    bk_cloud_id = serializers.IntegerField()
+    ip = serializers.IPAddressField()

--- a/dbm-ui/backend/db_services/reverse_api/urls.py
+++ b/dbm-ui/backend/db_services/reverse_api/urls.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from rest_framework.routers import DefaultRouter
+
+from backend.db_services.reverse_api.mysql import MySQLReverseApiView
+from backend.db_services.reverse_api.views import CommonReverseApiView
+
+routers = DefaultRouter(trailing_slash=True)
+routers.register("mysql", MySQLReverseApiView, basename="")
+routers.register("", CommonReverseApiView, basename="")
+
+urlpatterns = routers.urls

--- a/dbm-ui/backend/db_services/reverse_api/views.py
+++ b/dbm-ui/backend/db_services/reverse_api/views.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.http import JsonResponse
+from django.utils.translation import ugettext_lazy as _
+
+from backend.bk_web.swagger import common_swagger_auto_schema
+from backend.db_proxy.models import DBCloudProxy
+from backend.db_services.reverse_api.base_reverse_api_view import BaseReverseApiView
+from backend.db_services.reverse_api.decorators import reverse_api
+
+
+class CommonReverseApiView(BaseReverseApiView):
+    @common_swagger_auto_schema(operation_summary=_("云区域NGINX列表"))
+    @reverse_api(url_path="list_cloud_nginx")
+    def list_cloud_nginx(self, request):
+        bk_cloud_id, ip, port = self.get_api_params()
+
+        res = []
+        for ele in DBCloudProxy.objects.filter(bk_cloud_id=bk_cloud_id):
+            res.append(
+                {
+                    "internal-address": ele.internal_address,
+                    "external-address": ele.external_address,
+                }
+            )
+
+        return JsonResponse({"result": True, "code": 0, "data": res, "message": "", "errors": None})

--- a/dbm-ui/backend/urls.py
+++ b/dbm-ui/backend/urls.py
@@ -62,6 +62,7 @@ api_patterns = [
     path("dbbase/", include("backend.db_services.dbbase.urls")),
     path("quick_search/", include("backend.db_services.quick_search.urls")),
     path("plugin/", include("backend.db_services.plugin.urls")),
+    path("reverse_api/", include("backend.db_services.reverse_api.urls")),
 ]
 
 urlpatterns = [

--- a/dbm-ui/config/default.py
+++ b/dbm-ui/config/default.py
@@ -586,3 +586,5 @@ GRAFANA = {
 # 开启DEBUG_TOOL_BAR，需要内联IP
 if env.DEBUG_TOOL_BAR:
     INTERNAL_IPS = ["127.0.0.1", "localhost"]
+
+


### PR DESCRIPTION
1. 实现了公共 api GET /apis/reverse_api/list_cloud_nginx, 查询云区域各自的 NGINX ip. 用于后续的高可用
2. 实现了 GET /apis/reverse_api/mysql/list_instance_info, 查询实例基础信息, 以后给监控判断是否能自动拉起进程
3. 增加了反向查询接口框架的安全验证
4. 简化了反向查询接口框架的使用