### PR TITLE
fix(redis): proxy无密码时相关flow和act问题修复 #7484

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_auotfix.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_auotfix.py
@@ -178,12 +178,9 @@ class RedisClusterAutoFixSceneFlow(object):
         )
 
         passwd_ret = PayloadHandler.redis_get_password_by_domain(domain_name)
-        if passwd_ret.get("redis_password"):
-            data["content"]["redis_password"] = passwd_ret.get("redis_password")
-        if passwd_ret.get("redis_proxy_password"):
-            data["content"]["password"] = passwd_ret.get("redis_proxy_password")
-        if passwd_ret.get("redis_proxy_admin_password"):
-            data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
+        data["content"]["redis_password"] = passwd_ret.get("redis_password")
+        data["content"]["password"] = passwd_ret.get("redis_proxy_password")
+        data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
 
         return data["content"]
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
@@ -197,12 +197,9 @@ class RedisClusterCMRSceneFlow(object):
             }
         )
 
-        if passwd_ret.get("redis_password"):
-            data["content"]["redis_password"] = passwd_ret.get("redis_password")
-        if passwd_ret.get("redis_proxy_password"):
-            data["content"]["password"] = passwd_ret.get("redis_proxy_password")
-        if passwd_ret.get("redis_proxy_admin_password"):
-            data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
+        data["content"]["redis_password"] = passwd_ret.get("redis_password")
+        data["content"]["password"] = passwd_ret.get("redis_proxy_password")
+        data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
 
         return data["content"]
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_proxy_scale.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_proxy_scale.py
@@ -106,12 +106,11 @@ class RedisProxyScaleFlow(object):
                 "format": FormatType.MAP,
             }
         )
-        if passwd_ret.get("redis_password"):
-            data["content"]["redis_password"] = passwd_ret.get("redis_password")
-        if passwd_ret.get("redis_proxy_password"):
-            data["content"]["password"] = passwd_ret.get("redis_proxy_password")
-        if passwd_ret.get("redis_proxy_admin_password"):
-            data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
+
+        # 密码相关信息以密码服务为准，直接覆盖
+        data["content"]["redis_password"] = passwd_ret.get("redis_password")
+        data["content"]["password"] = passwd_ret.get("redis_proxy_password")
+        data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
         return data["content"]
 
     def redis_proxy_scale_up_flow(self):

--- a/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
@@ -480,15 +480,11 @@ class RedisActPayload(object):
             }
         )
         if conf_type == ConfigTypeEnum.ProxyConf.value:
-            if passwd_ret.get("redis_password"):
-                data["content"]["redis_password"] = passwd_ret.get("redis_password")
-            if passwd_ret.get("redis_proxy_password"):
-                data["content"]["password"] = passwd_ret.get("redis_proxy_password")
-            if passwd_ret.get("redis_proxy_admin_password"):
-                data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
+            data["content"]["redis_password"] = passwd_ret.get("redis_password")
+            data["content"]["password"] = passwd_ret.get("redis_proxy_password")
+            data["content"]["redis_proxy_admin_password"] = passwd_ret.get("redis_proxy_admin_password")
         elif conf_type == ConfigTypeEnum.DBConf.value:
-            if passwd_ret.get("redis_password"):
-                data["content"]["requirepass"] = passwd_ret.get("redis_password")
+            data["content"]["requirepass"] = passwd_ret.get("redis_password")
 
         return data["content"]
 


### PR DESCRIPTION
密码相关信息以密码服务为准，直接覆盖配置中心默认值
涉及单据：
- proxy扩容
- 自愈
- 裁撤
![image](https://github.com/user-attachments/assets/867fabd2-9b50-421d-8973-d621d93d640d)
![image](https://github.com/user-attachments/assets/a469cd3e-a520-4175-bbd2-e0667124ad4c)
![image](https://github.com/user-attachments/assets/872af8ea-d2fb-4e15-8d18-2d34348d97d4)
