### PR TITLE
fix(mysql): 标准化流程优化, crontab 安装保留业务自定义任务 #7509

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/standardize_mysql.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/standardize_mysql.go
@@ -98,9 +98,10 @@ func (c *StandardizeMySQLComp) Init() error {
 }
 
 func (c *StandardizeMySQLComp) ClearOldCrontab() error {
-	err := osutil.RemoveUserCrontab("mysql")
+	err := osutil.CleanLocalCrontab()
 	if err != nil {
 		logger.Error("clear mysql crontab failed: %s", err.Error())
+		return err
 	} else {
 		logger.Info("clear mysql crontab success")
 	}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/standardize_proxy.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/standardize_proxy.go
@@ -11,9 +11,10 @@ type StandardizeProxyComp struct {
 }
 
 func (c *StandardizeProxyComp) ClearOldCrontab() error {
-	err := osutil.RemoveUserCrontab("mysql")
+	err := osutil.CleanLocalCrontab()
 	if err != nil {
 		logger.Error("clear mysql crontab failed: %s", err.Error())
+		return err
 	} else {
 		logger.Info("clear mysql crontab success")
 	}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil/crontab.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil/crontab.go
@@ -202,16 +202,18 @@ func CleanLocalCrontab() error {
 		slaveSync          = "/home/mysql/monitor/master_slave_sync_check.pl"
 		tbinlodumperStatus = "tbinlogdumper_status.pl"
 		prometheus         = "prometheus"
+		filebeatWatcher    = "/home/mysql/filebeat-deploy/monitor_filebeat_watcher"
 	)
 	cleanCrontabs := []string{
 		getStatusPL, dbBackupOld, dbBackupNew, dbBackupMulti, dbBackupXtrabackup, rotateLog,
-		proxyStatus, slaveSync, tbinlodumperStatus, prometheus, rotateLogGo, dbBackupMultiGo,
+		proxyStatus, slaveSync, tbinlodumperStatus, prometheus, rotateLogGo, dbBackupMultiGo, filebeatWatcher,
 	}
 
 	existCrontabs, err := CrontabsExist(cleanCrontabs)
 	if err != nil {
 		return err
 	}
+	logger.Info("find crontabs %s", existCrontabs)
 	// 如果不存在需要清理的crontab 直接返回成功
 	if len(existCrontabs) <= 0 {
 		return nil

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/cluster_standardize_trans_module.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/cluster_standardize_trans_module.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import ugettext as _
 from pipeline.component_framework.component import Component
 
+from backend.db_meta.enums import TenDBClusterSpiderRole
 from backend.db_meta.models import Cluster
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils.mysql.mysql_module_operate import MysqlCCTopoOperator
@@ -28,8 +29,15 @@ class ClusterStandardizeTransModuleService(BaseService):
             cluster_obj.storageinstance_set.all(), is_increment=True
         )
         MysqlCCTopoOperator(cluster_obj).transfer_instances_to_cluster_module(
-            cluster_obj.proxyinstance_set.all(), is_increment=True
+            cluster_obj.proxyinstance_set.exclude(
+                tendbclusterspiderext__spider_role__in=[
+                    TenDBClusterSpiderRole.SPIDER_MNT,
+                    TenDBClusterSpiderRole.SPIDER_SLAVE_MNT,
+                ]
+            ),
+            is_increment=True,
         )
+
         self.log_info(_("[{}] CC 模块标准化完成".format(kwargs["node_name"])))
         return True
 

--- a/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
@@ -1607,7 +1607,9 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
                 )
         # 增加对安装spider监控的适配
         elif machine.machine_type == MachineType.SPIDER.value:
-            for instance in ProxyInstance.objects.filter(machine__ip=kwargs["ip"], cluster__id__in=cluster_ids):
+            for instance in ProxyInstance.objects.filter(
+                machine__ip=kwargs["ip"], cluster__id__in=cluster_ids
+            ).prefetch_related("tendbclusterspiderext"):
                 cluster = instance.cluster.get()
                 instances_info.append(
                     {


### PR DESCRIPTION
1. 优化标准化流程的 prefetch_relate
2. 调整cc标准化在流程中的位置到 exporter 配置生成之后
3. 标准化流程现在会保留自定义的crontab条目
4. TenDBCluster的运维节点排除在cc标准化之外