### PR TITLE
fix(redis): redis删除key是空格字符异常问题 #7815

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
@@ -649,7 +649,8 @@ func (task *RedisInsKeyPatternTask) getTargetKeysByPartten(db int) {
 	if grepPattern != "" && grepPattern != ".*" {
 		grepExtra = fmt.Sprintf(` %s | { grep -vE %q || true; }`, grepExtra, grepPattern)
 	}
-	grepCmd := fmt.Sprintf(`awk '{ print $3}' %s %s > %s`, task.KeysFile, grepExtra, task.ResultFile)
+	grepCmd := fmt.Sprintf(`awk '{for(i=3;i<=NF-3;++i) printf "%%s ", $i; print ""}' %s %s > %s`,
+		task.KeysFile, grepExtra, task.ResultFile)
 	_, err := util.RunLocalCmd("bash", []string{"-c", grepCmd}, "", nil, 48*time.Hour)
 	if err != nil {
 		task.Err = fmt.Errorf("grepCmd:%s err:%v", grepCmd, err)


### PR DESCRIPTION
解决tendisplus在删除包含空格key的时候，awk过滤key的时候空格被截断问题
文件格式：
![image](https://github.com/user-attachments/assets/451cc06f-437a-442a-8f39-34ac819a9342)
![image](https://github.com/user-attachments/assets/91bc410f-acb5-4fca-b15d-c5098cf1c44b)



修复验证：
![image](https://github.com/user-attachments/assets/524c6e75-518c-42a1-b99a-1a83d7f5d9ed)
![image](https://github.com/user-attachments/assets/d408e64b-086d-4ccc-a343-e72faabc9591)
