### PR TITLE
fix(kafka): kafka manager不展示消费组信息 #7975

### DIFF
--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/install_kafka.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/install_kafka.go
@@ -983,8 +983,9 @@ func configCluster(cmak CmakConfig, noSecurity int) (err error) {
 
 	zookeeperIPList := strings.Split(cmak.ZookeeperIP, ",")
 	zkHosts := fmt.Sprintf("%s:2181,%s:2181,%s:2181/", zookeeperIPList[0], zookeeperIPList[1], zookeeperIPList[2])
-	jaasConfig := fmt.Sprintf("%s required username=%s  password=%s ;",
-		"org.apache.kafka.common.security.scram.ScramLoginModule", cmak.Username, cmak.Password)
+	jaasConfig := fmt.Sprintf(
+		`org.apache.kafka.common.security.scram.ScramLoginModule required username="%s" password="%s" ;`, cmak.Username,
+		cmak.Password)
 	postData := url.Values{}
 	postData.Add("name", cmak.ClusterName)
 	postData.Add("zkHosts", zkHosts)


### PR DESCRIPTION
kafka manager
jassconfig配置里，如果帐号密码是数字开头的，需要用双引号括起来，否则无法正常显示消费组等信息。