### PR TITLE
fix(dbm-services): DBHA multi-GM may cause repeated switch

### DIFF
--- a/dbm-services/common/dbha/ha-module/client/hadb.go
+++ b/dbm-services/common/dbha/ha-module/client/hadb.go
@@ -239,7 +239,7 @@ func (c *HaDBClient) ReportDBStatus(app, agentIp, ip string, port int, dbType, s
 	return nil
 }
 
-// ReportHaLogRough report ha logs
+// ReportHaLogRough report ha logs without return
 func (c *HaDBClient) ReportHaLogRough(monIP, app, ip string, port int, module, comment string) {
 	_, _ = c.ReportHaLog(monIP, app, ip, port, module, comment)
 }

--- a/dbm-services/common/dbha/ha-module/dbmodule/dbmysql/MySQL_common_switch.go
+++ b/dbm-services/common/dbha/ha-module/dbmodule/dbmysql/MySQL_common_switch.go
@@ -359,7 +359,7 @@ func (ins *MySQLCommonSwitch) CheckSlaveStatus() error {
 		slaveDelay, gmConf.GCM.AllowedSlaveDelayMax))
 
 	if timeDelay >= gmConf.GCM.AllowedTimeDelayMax {
-		return fmt.Errorf("IO_Thread delay on slave too large than master(%d >= %d)", timeDelay,
+		return fmt.Errorf("heartbeat delay on slave too large than master(%d >= %d)", timeDelay,
 			gmConf.GCM.AllowedTimeDelayMax)
 	}
 	ins.ReportLogs(constvar.InfoResult, fmt.Sprintf("IO_Thread delay [%d] in allowed range[%d]",
@@ -526,7 +526,7 @@ func (ins *MySQLCommonSwitch) CheckSlaveSlow(ignoreDelay bool) error {
 	}
 
 	binlogSizeMByte := maxBinlogSize.VariableValue / (1024 * 1024)
-	log.Logger.Infof("the slave max_binlog_size value is %d M!", binlogSizeMByte)
+	log.Logger.Infof("the slave max_binlog_size value is %dM!", binlogSizeMByte)
 
 	status, err := GetSlaveStatus(db)
 	if err != nil {

--- a/dbm-services/common/dbha/ha-module/gm/gcm.go
+++ b/dbm-services/common/dbha/ha-module/gm/gcm.go
@@ -1,6 +1,7 @@
 package gm
 
 import (
+	"dbm-services/common/dbha/ha-module/util"
 	"dbm-services/common/dbha/hadb-api/model"
 	"fmt"
 	"time"
@@ -205,6 +206,8 @@ func (gcm *GCM) InsertSwitchQueue(instance dbutil.DataBaseSwitch) error {
 			SwitchStartTime:  &currentTime,
 			DbRole:           instance.GetRole(),
 			ConfirmResult:    doubleCheckInfo,
+			SwitchHashID: util.GenerateHash(fmt.Sprintf("%#%d", ip, port),
+				int64(max(300, gcm.Conf.GMConf.ReportInterval))),
 		},
 	}
 

--- a/dbm-services/common/dbha/ha-module/gm/gm.go
+++ b/dbm-services/common/dbha/ha-module/gm/gm.go
@@ -11,12 +11,6 @@ import (
 	"dbm-services/common/dbha/ha-module/log"
 )
 
-// InstanceKey instance key info
-type InstanceKey struct {
-	Ip   string
-	Port int
-}
-
 // DoubleCheckInstanceInfo double check instance info
 type DoubleCheckInstanceInfo struct {
 	AgentIp      string
@@ -26,7 +20,7 @@ type DoubleCheckInstanceInfo struct {
 	ConfirmTime  time.Time
 	//double check result
 	ResultInfo string
-	//gmm double check id
+	//gmm double check id, ha_gm_logs's uid
 	CheckID int64
 }
 

--- a/dbm-services/common/dbha/ha-module/test/MySQL_test.go
+++ b/dbm-services/common/dbha/ha-module/test/MySQL_test.go
@@ -52,9 +52,9 @@ func TestDetectionSuccess(t *testing.T) {
 			t.Errorf("detection failed.err:%s", err.Error())
 		}
 		fmt.Printf("status: %s\n", d.GetStatus())
-		if d.NeedReporter() {
+		if d.NeedReportAgent() {
 			fmt.Println("need reporter")
-			d.UpdateReporterTime()
+			d.UpdateReportTime()
 		} else {
 			fmt.Println("needn't reporter")
 		}

--- a/dbm-services/common/dbha/ha-module/test/agent_test.go
+++ b/dbm-services/common/dbha/ha-module/test/agent_test.go
@@ -68,7 +68,7 @@ func TestAgentNetTransfor(t *testing.T) {
 		case 3:
 			dbIns.App = "APP4444"
 		}
-		err = agentIns.ReporterDetectInfo(d)
+		err = agentIns.ReportDetectInfoToGM(d)
 		if err != nil {
 			t.Errorf("reporter gmInfo failed.err:%s", err.Error())
 			return

--- a/dbm-services/common/dbha/ha-module/util/util.go
+++ b/dbm-services/common/dbha/ha-module/util/util.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"hash/crc32"
+	"hash/fnv"
 	"net"
 	"os/exec"
 	"reflect"
@@ -73,11 +73,6 @@ func HostCheck(host string) bool {
 	return true
 }
 
-// CRC32 TODO
-func CRC32(str string) uint32 {
-	return crc32.ChecksumIEEE([]byte(str))
-}
-
 // CheckRedisErrIsAuthFail check if the return error of
 //
 //	redis api is authentication failure,
@@ -96,7 +91,7 @@ func CheckRedisErrIsAuthFail(err error) bool {
 	return false
 }
 
-// CheckSSHErrIsAuthFail check if the the return error of ssh api
+// CheckSSHErrIsAuthFail check if the ssh return error of ssh api
 //
 //	is authentication failure.
 func CheckSSHErrIsAuthFail(err error) bool {
@@ -156,4 +151,21 @@ func GraceStructString(v interface{}) string {
 		return ""
 	}
 	return string(data)
+}
+
+// GenerateHash generates a consistent hash value for a given factor within a specified time window (in seconds).
+func GenerateHash(factor string, timeWindow int64) uint32 {
+	// Get the current Unix timestamp
+	now := time.Now().Unix()
+
+	// Calculate the start of the time window
+	windowStart := now - (now % timeWindow)
+
+	// Combine the factor and windowStart into a single input string
+	input := fmt.Sprintf("%s:%d", factor, windowStart)
+
+	// Use FNV-1a to hash the input string
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(input))
+	return hasher.Sum32()
 }

--- a/dbm-services/common/dbha/hadb-api/model/HASwitchQueue.go
+++ b/dbm-services/common/dbha/hadb-api/model/HASwitchQueue.go
@@ -19,8 +19,8 @@ type HASwitchQueue struct {
 	Uid                int64      `gorm:"column:uid;type:bigint;primary_key;AUTO_INCREMENT" json:"uid,omitempty"`
 	CheckID            int64      `gorm:"column:check_id;type:bigint;" json:"check_id,omitempty"`
 	App                string     `gorm:"column:app;type:varchar(32);index:idx_app_ip_port" json:"app,omitempty"`
-	IP                 string     `gorm:"column:ip;type:varchar(32);index:idx_app_ip_port;NOT NULL" json:"ip,omitempty"`
-	Port               int        `gorm:"column:port;type:int(11);index:idx_app_ip_port;NOT NULL" json:"port,omitempty"`
+	IP                 string     `gorm:"column:ip;type:varchar(32);uniqueIndex:uniq_ip_port_hashid;index:idx_app_ip_port;NOT NULL" json:"ip,omitempty"`
+	Port               int        `gorm:"column:port;type:int(11);uniqueIndex:uniq_ip_port_hashid;index:idx_app_ip_port;NOT NULL" json:"port,omitempty"`
 	ConfirmCheckTime   *time.Time `gorm:"column:confirm_check_time;type:datetime;default:CURRENT_TIMESTAMP" json:"confirm_check_time,omitempty"`
 	DbRole             string     `gorm:"column:db_role;type:varchar(32);NOT NULL" json:"db_role,omitempty"`
 	SlaveIP            string     `gorm:"column:slave_ip;type:varchar(32)" json:"slave_ip,omitempty"`
@@ -35,6 +35,7 @@ type HASwitchQueue struct {
 	IdcID              int        `gorm:"column:idc_id;type:int(11)" json:"idc_id,omitempty"`
 	CloudID            int        `gorm:"column:cloud_id;type:int(11);default:0" json:"cloud_id,omitempty"`
 	Cluster            string     `gorm:"column:cluster;type:varchar(64)" json:"cluster,omitempty"`
+	SwitchHashID       uint32     `gorm:"column:switch_hash_id;type:bigint;uniqueIndex:uniq_ip_port_hashid" json:"switch_hash_id,omitempty"`
 }
 
 // TableName TODO


### PR DESCRIPTION
1. agent增加cache，对同周期的故障时候，不要一直上报，每次拉取最新元数据时cache失效
2. 同一个ip，尽量确保每次上报的gm相同。基于hash取模排序，这样还一个好处是在大批量故障场景避免都上报同一个gm
3. 同一ip，在同一时间区间（例如5分钟)，尽量保证生成的hash值相同，这样就算同1个ip，上报给不同gm，gm也会因为插入db时hash唯一值冲突而退出