### PR TITLE
fix(redis): 修复dts分片变更bug #8670

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_online_switch.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_online_switch.go
@@ -361,6 +361,8 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForSameType() (err error) {
 			dstConfContent = strings.ReplaceAll(dstConfContent, logRootDir+"/", consts.GetRedisDataDir()+"/")
 		}
 	}
+	// 避免跟密码字段有重复，放在最后面替换集群名
+	dstConfContent = strings.ReplaceAll(dstConfContent, job.params.DstClusterName, job.params.SrcClusterName)
 
 	newFile := fmt.Sprintf("dts_new_config.billid_%d.%s_%d.%s", job.params.DtsBillID, job.params.SrcProxyIP,
 		job.params.SrcProxyPort, job.getSrcConfigFileSuffix())
@@ -392,6 +394,10 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForSameType() (err error) {
 	if err != nil {
 		return
 	}
+
+	// 修改目录归属
+	util.LocalDirChownMysql(job.getSrcProxyConfigSaveDir())
+
 	return nil
 }
 
@@ -418,6 +424,8 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForDiffType() (err error) {
 			dstConfContent = strings.ReplaceAll(dstConfContent, logRootDir+"/", consts.GetRedisDataDir()+"/")
 		}
 	}
+	// 避免跟密码字段有重复，放在最后面替换集群名
+	dstConfContent = strings.ReplaceAll(dstConfContent, job.params.DstClusterName, job.params.SrcClusterName)
 
 	proxyFileForDstPort := job.getProxyFile(job.params.DstClusterType, job.params.DstProxyPort)
 	proxyFileForDstPort = filepath.Join(saveDirForDstPort, proxyFileForDstPort)


### PR DESCRIPTION
修复：
1. 分片变更切换后，proxy的集群名未修改问题
2. 分片变更后，文件归属用户变更问题
![image](https://github.com/user-attachments/assets/03fe619e-4a46-4283-b72f-b388ac2c82fc)
