### PR TITLE
fix(redis): ssd创建备份log-count #8857

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_makesync.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_makesync.py
@@ -247,7 +247,7 @@ def backup_and_restore(
     act_kwargs.cluster["backup_host"] = params[data_from]
     act_kwargs.cluster["backup_instances"] = []
     act_kwargs.cluster["ssd_log_count"] = {
-        "log-count": 600000,
+        "log-count": 16789000,  # 让master 多保留点日志 2k/s 的写入保留2.5个小时 （备份+传输）
         "log-keep-count": 20000000,
         "slave-log-keep-count": 20000000,
     }


### PR DESCRIPTION
让master 多保留点日志 2k/s 的写入保留2.5个小时 （备份+传输）