### PR TITLE
fix(redis): redis集群回档bug修复 #9254

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/tendisSSD_incrback.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/tendisSSD_incrback.go
@@ -239,7 +239,8 @@ func (incr *TredisRocksDBIncrBack) GetTredisIncrbacks(binlogFileList []FileDetai
 
 		// 过滤节点维度的文件,这里比较重要，因为flow传下来的是这台机器涉及到的所有节点信息，
 		// 这里是针对单节点的，所以需要过滤出来，这个值返回给前置函数
-		if strings.Contains(back01.BackupFile, incr.FileName) && (back01.NodeIP == incr.SourceIP) {
+		// 不能用strings.contains来判断因为backupfile可能存在xxx-20250210130000.log.zst的情况，直接用port段匹配
+		if match01[1] == incr.FileName && (back01.NodeIP == incr.SourceIP) {
 			mylog.Logger.Info("back01.BackupFile:%s,incr.FileName:%s,back01.NodeIP:%s,incr.SourceIP:%s",
 				back01.BackupFile, incr.FileName, back01.NodeIP, incr.SourceIP)
 			backs = append(backs, back01)


### PR DESCRIPTION
1、问题：某实例文件缺失时任务执行会失败，无法重试。优化： 在回档正式流程发起前，先做一次文件齐全性检查。如果有文件缺失，直接终止。 方便处理后进行任务重试。
2、问题：大SSD实例启动较慢，存活探测失败导致后续任务无法继续执行。优化：增加回档后redis存活性探测重试逻辑。
3、问题：恢复binlog日志时，使用Contains函数匹配到了不属于该实例的binlog文件，导致导入binlog任务失败。 修复该问题。