### PR TITLE
fix(kafka): 2.4.bkbase版本cmak没有正确配置 #9315

### DIFF
--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/install_kafka.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/install_kafka.go
@@ -822,6 +822,11 @@ func (i *InstallKafkaComp) InstallManager() error {
 		return err
 	}
 
+	// 0.10.2版本默认不开启鉴权
+	if version == cst.Kafka0102 {
+		noSecurity = 1
+	}
+
 	// Sleep 10 secs
 	time.Sleep(10 * time.Second)
 
@@ -871,7 +876,7 @@ func (i *InstallKafkaComp) InstallManager() error {
 	cmak := CmakConfig{
 		ZookeeperIP: zookeeperIP,
 		ClusterName: clusterName,
-		Version:     version,
+		Version:     kafkautil.KfVersionMap(version),
 		Username:    username,
 		Password:    password,
 		NodeIP:      nodeIP,
@@ -1020,6 +1025,11 @@ func configCluster(cmak CmakConfig, noSecurity int) (err error) {
 		postData.Add("securityProtocol", "SASL_PLAINTEXT")
 		postData.Add("saslMechanism", "SCRAM-SHA-512")
 		postData.Add("jaasConfig", jaasConfig)
+	}
+	if noSecurity == 1 {
+		postData.Add("securityProtocol", "PLAINTEXT")
+		postData.Add("saslMechanism", "DEFAULT")
+		postData.Add("jaasConfig", "")
 	}
 	// http://localhost:9000/{prefix}/clusters
 	url := "http://" + cmak.NodeIP + ":9000" + cmak.HTTPPath + "/clusters"

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/util/kafkautil/kafkautil.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/util/kafkautil/kafkautil.go
@@ -534,3 +534,15 @@ func ReadDataDirs(configFilePath string) ([]string, error) {
 
 	return dataDirs, nil
 }
+
+// KfVersionMap 转换成cmak能识别的版本
+func KfVersionMap(version string) string {
+	switch version {
+	case "2.4.0":
+		return "2.4.0"
+	case "0.10.2":
+		return "0.10.2.1"
+	default:
+		return "2.4.0"
+	}
+}


### PR DESCRIPTION
部署2.4.bkbase版本的kafka，由于版本号与非kafka官方的版本，因此kafka manager无法正确识别，导致添加集群失败。