### PR TITLE
fix(redis): redis删除key单据报错 #9488

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_datacheck.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_datacheck.go
@@ -299,8 +299,7 @@ func NewRedisInsDtsDataCheckAndRepairTask(ip string, portAndSeg PortAndSegment, 
 		"", "", "", "", "", "", // FileServer相关参数不需要
 		job.params.KeyWhiteRegex, job.params.KeyBlackRegex,
 		false, 0, 0, 0, // key删除相关参数不需要
-		portAndSeg.SegmentStart, portAndSeg.SegmentEnd,
-	)
+		portAndSeg.SegmentStart, portAndSeg.SegmentEnd, nil)
 	return
 }
 


### PR DESCRIPTION
1、删除key，密码有特殊字符导致shell命令执行失败问题修复
2、修复集群版redis，提取删除key时，访问到db1问题
3、单实例多DB，提取删除key提前act实现。（还需要验证deletTool是否支持多db）