### PR TITLE
fix(mysql): 重建slave添加reset slave #9450

### DIFF
--- a/dbm-services/mysql/db-priv/service/v2/add_priv/add_on_mysql.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/add_on_mysql.go
@@ -125,7 +125,7 @@ func (c *PrivTaskPara) addOneDtOnMySQLForSplitClient(
 				),
 			},
 			true,
-			30,
+			600,
 		)
 		// 调用 api 有问题, 比如 request body
 		if err != nil {
@@ -195,7 +195,7 @@ func readConflictReport(uuid string, bkCloudId int64, addr string, reports map[s
 			fmt.Sprintf(`SELECT * FROM infodba_schema.dba_grant_result WHERE id = '%s'`, uuid),
 		},
 		false,
-		30,
+		600,
 	)
 	if err != nil {
 		slog.Error("add on mysql read conflict report", slog.String("err", err.Error()))

--- a/dbm-services/mysql/db-priv/service/v2/add_priv/add_priv.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/add_priv.go
@@ -117,6 +117,7 @@ func (c *PrivTaskPara) AddPriv(jsonPara, ticket string) (err error) {
 				// TenDBHA 如果申请的是 slave 权限, 也是一样的
 				// TenDBHA 如果申请的是 master 权限, 并且有 padding Proxy, 有一部分是一样的
 				clientIps, workingMySQLInstances := c.prepareMySQLPayload(tii)
+
 				slog.Info(
 					"add priv",
 					slog.String("clientIps", strings.Join(clientIps, ",")),

--- a/dbm-services/mysql/db-priv/service/v2/add_priv/add_proxy_white_list.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/add_proxy_white_list.go
@@ -43,6 +43,10 @@ func (c *PrivTaskPara) addWhiteList(targetMetaInfos []*service.Instance) (err er
 		slog.Any("cmds", cmds),
 	)
 
+	if len(cmds) == 0 {
+		return nil
+	}
+
 	// drs 执行多个 sql 是循环一个一个来的
 	// 所以批量发送是可以的, 只是这么搞 drs 负载估计要炸
 	// 这里搞并发的意义不大
@@ -58,7 +62,7 @@ func (c *PrivTaskPara) addWhiteList(targetMetaInfos []*service.Instance) (err er
 			addresses,
 			cmds,
 			false,
-			0,
+			600,
 		)
 		if err != nil {
 			slog.Error("add proxy white list", slog.String("err", err.Error()))

--- a/dbm-services/mysql/db-priv/service/v2/add_priv/prepare.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/prepare.go
@@ -5,6 +5,7 @@ import (
 	"dbm-services/mysql/priv-service/service/v2/internal"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 )
 
@@ -96,6 +97,17 @@ func (c *PrivTaskPara) prepareTenDBHA(targetMetaInfos []*service.Instance) (
 				fmt.Sprintf(`%s:%d`, s.IP, s.Port),
 			)
 		}
+	}
+
+	/*
+		如果来源有 localhost
+		1. 只有 localhost 时, 说明不需要通过 proxy 访问, 只保留 localhost 授权
+		2. 如果还有其他的 ip, 则把 localhost 追加进去
+	*/
+	if len(c.SourceIPs) == 1 && c.SourceIPs[0] == "localhost" {
+		clientIps = []string{"localhost"}
+	} else if slices.Index(c.SourceIPs, "localhost") >= 0 {
+		clientIps = append(clientIps, "localhost")
 	}
 
 	return

--- a/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/general_handler.go
+++ b/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/general_handler.go
@@ -36,6 +36,10 @@ func generalHandler(rpcEmbed rpc_core.RPCEmbedInterface) func(*gin.Context) {
 		}
 		req.TrimSpace()
 
+		if req.QueryTimeout <= 0 {
+			req.QueryTimeout = 600
+		}
+
 		slog.Info(
 			"enter rpc handler",
 			slog.String("addresses", strings.Join(req.Addresses, ",")),

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/install_mysql.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/install_mysql.go
@@ -569,6 +569,11 @@ func (i *InstallMySQLComp) generateMycnfOnePort(port Port, tmplFileName string) 
 		return err
 	}
 
+	if port == Port(3306) {
+		_ = os.Remove(cst.DefaultMyCnfName)
+		_ = os.Symlink(cnf, cst.DefaultMyCnfName)
+	}
+
 	return nil
 }
 

--- a/dbm-ui/backend/db_meta/api/cluster/tendbcluster/decommission.py
+++ b/dbm-ui/backend/db_meta/api/cluster/tendbcluster/decommission.py
@@ -62,9 +62,13 @@ def decommission(cluster: Cluster):
 
     # 删除集群相关的配置模板
     TendbOpenAreaConfig.objects.filter(source_cluster_id=cluster.id).delete()
-    DBPartitionApi.cluster_del_conf(
-        params={"cluster_type": cluster.cluster_type, "bk_biz_id": cluster.bk_biz_id, "cluster_ids": [cluster.id]}
-    )
+    try:
+        DBPartitionApi.cluster_del_conf(
+            params={"cluster_type": cluster.cluster_type, "bk_biz_id": cluster.bk_biz_id, "cluster_ids": [cluster.id]}
+        )
+    except Exception as e:  # noqa
+        logger.error(e)
+
     # 删除集群在bkcc对应的模块
     # todo 目前cc没有封装移除主机模块接口,先保留写法
     # delete_cluster_modules(db_type=DBType.MySQL.value, del_cluster_id=cluster.id)

--- a/dbm-ui/backend/db_meta/api/cluster/tendbha/decommission.py
+++ b/dbm-ui/backend/db_meta/api/cluster/tendbha/decommission.py
@@ -68,9 +68,13 @@ def decommission(cluster: Cluster):
     ClusterDBHAExt.objects.filter(cluster=cluster).delete()
     # 删除集群相关的配置模板
     TendbOpenAreaConfig.objects.filter(source_cluster_id=cluster.id).delete()
-    DBPartitionApi.cluster_del_conf(
-        params={"cluster_type": cluster.cluster_type, "bk_biz_id": cluster.bk_biz_id, "cluster_ids": [cluster.id]}
-    )
+    try:
+        DBPartitionApi.cluster_del_conf(
+            params={"cluster_type": cluster.cluster_type, "bk_biz_id": cluster.bk_biz_id, "cluster_ids": [cluster.id]}
+        )
+    except Exception as e:  # noqa
+        logger.error(e)
+
     # 删除集群在bkcc对应的模块
     # TODO CC 目前没有把主机移出当前模块的接口，主机还在模块下，无法删除
     # cc_manage.delete_cluster_modules(db_type=DBType.MySQL.value, cluster=cluster)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
@@ -48,6 +48,7 @@ from backend.flow.plugins.components.collections.mysql.mysql_check_binlog_dump i
 from backend.flow.plugins.components.collections.mysql.mysql_crond_control import MysqlCrondMonitorControlComponent
 from backend.flow.plugins.components.collections.mysql.mysql_db_meta import MySQLDBMetaComponent
 from backend.flow.plugins.components.collections.mysql.mysql_rds_execute import MySQLExecuteRdsComponent
+from backend.flow.plugins.components.collections.mysql.reset_slave_via_drs import ResetSlaveViaDRSComponent
 from backend.flow.plugins.components.collections.mysql.trans_flies import TransFileComponent
 from backend.flow.utils.common_act_dataclass import DownloadBackupClientKwargs
 from backend.flow.utils.mysql.common.mysql_cluster_info import get_ports, get_version_and_charset
@@ -59,6 +60,7 @@ from backend.flow.utils.mysql.mysql_act_dataclass import (
     ExecActuatorKwargs,
     ExecuteRdsKwargs,
     InstanceUserCloneKwargs,
+    ResetSlaveViaDRSKwargs,
     UpdateDnsRecordKwargs,
 )
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
@@ -480,6 +482,17 @@ class MySQLRestoreSlaveRemoteFlow(object):
                 cluster_type=self.data["cluster_type"],
             )
             tendb_migrate_pipeline = SubBuilder(root_id=self.root_id, data=copy.deepcopy(self.data))
+
+            tendb_migrate_pipeline.add_act(
+                act_name=_("当前 master reset slave {}".format(master.ip_port)),
+                act_component_code=ResetSlaveViaDRSComponent.code,
+                kwargs=asdict(
+                    ResetSlaveViaDRSKwargs(
+                        address=master.ip_port,
+                        bk_cloud_id=cluster_model.bk_cloud_id,
+                    )
+                ),
+            )
 
             tendb_migrate_pipeline.add_act(
                 act_name=_("下发db-actor到节点{}".format(target_slave.machine.ip)),

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/db_table_backup.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/db_table_backup.py
@@ -308,12 +308,16 @@ class TenDBClusterDBTableBackupFlow(object):
                 },
             )
             if job["backup_local"] == "remote":
-                job_flow.add_parallel_sub_pipeline(
-                    sub_flow_list=self.backup_on_remote(
+                flist = [self.backup_on_spider_ctl(backup_id, job, cluster_obj)]
+                flist.extend(
+                    self.backup_on_remote(
                         backup_id=backup_id,
                         job=job,
                         cluster_obj=cluster_obj,
                     )
+                )
+                job_flow.add_parallel_sub_pipeline(
+                    sub_flow_list=flist,
                 )
             elif job["backup_local"] == "spider_mnt":
                 job_flow.add_sub_pipeline(

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/full_backup.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/full_backup.py
@@ -86,12 +86,16 @@ class TenDBClusterFullBackupFlow(object):
             )
 
             if backup_local == InstanceInnerRole.SLAVE.value:  # "remote":
+                flist = [self.backup_on_spider_ctl(backup_id=backup_id, cluster_obj=cluster_obj)]
+                flist.extend(self.backup_on_remote_slave(backup_id=backup_id, cluster_obj=cluster_obj))
                 cluster_pipe.add_parallel_sub_pipeline(
-                    sub_flow_list=self.backup_on_remote_slave(backup_id=backup_id, cluster_obj=cluster_obj)
+                    sub_flow_list=flist,
                 )
             elif backup_local == InstanceInnerRole.MASTER.value:
+                flist = [self.backup_on_spider_ctl(backup_id=backup_id, cluster_obj=cluster_obj)]
+                flist.extend(self.backup_on_remote_master(backup_id=backup_id, cluster_obj=cluster_obj))
                 cluster_pipe.add_parallel_sub_pipeline(
-                    sub_flow_list=self.backup_on_remote_master(backup_id=backup_id, cluster_obj=cluster_obj)
+                    sub_flow_list=flist,
                 )
             elif backup_local == TenDBClusterSpiderRole.SPIDER_MNT.value:
                 cluster_pipe.add_sub_pipeline(

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/reset_slave_via_drs.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/reset_slave_via_drs.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import ugettext as _
+from pipeline.component_framework.component import Component
+
+from backend.components import DRSApi
+from backend.flow.plugins.components.collections.common.base_service import BaseService
+
+
+class ResetSlaveViaDRSService(BaseService):
+    def _execute(self, data, parent_data) -> bool:
+        kwargs = data.get_one_of_inputs("kwargs")
+
+        self.log_info(_("传入参数:{}").format(kwargs))
+        res = DRSApi.rpc(
+            {
+                "addresses": [kwargs["address"]],
+                "cmds": ["reset slave"],
+                "force": False,
+                "bk_cloud_id": kwargs["bk_cloud_id"],
+            }
+        )
+
+        if res[0]["error_msg"]:
+            self.log_info("reset slave failed: {}".format(res[0]["error_msg"]))
+            return False
+        else:
+            if res[0]["cmd_results"][0]["error_msg"]:
+                self.log_info("reset slave failed: {}".format(res[0]["cmd_results"][0]["error_msg"]))
+                return False
+
+        return True
+
+
+class ResetSlaveViaDRSComponent(Component):
+    name = __name__
+    code = "reset_slave_via_drs"
+    bound_service = ResetSlaveViaDRSService

--- a/dbm-ui/backend/flow/utils/mysql/mysql_act_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_act_dataclass.py
@@ -615,3 +615,9 @@ class DropProxyUsersInBackendKwargs:
 
     cluster_id: int
     origin_proxy_host: str
+
+
+@dataclass
+class ResetSlaveViaDRSKwargs:
+    address: str
+    bk_cloud_id: int

--- a/dbm-ui/backend/flow/utils/mysql/mysql_db_meta.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_db_meta.py
@@ -468,7 +468,10 @@ class MySQLDBMeta(object):
             "operator": self.ticket_data["created_by"],
             "cluster_ids": [cluster.id],
         }
-        DBPartitionApi.disable_partition_cluster(params=disable_partition_params)
+        try:
+            DBPartitionApi.disable_partition_cluster(params=disable_partition_params)
+        except Exception as e:  # noqa
+            logger.error(e)
 
     def mysql_cluster_online(self):
         """


### PR DESCRIPTION
1. 重建slave在新master增加reset slave
2. TenDBCluster的库表和全备增加中控备份库表结构
3. 修复 权限服务没有正确处理 tendbHa的localhost来源问题
4. 修复权限服务在操作 proxy 没有正确设置超时的问题
5. 安装 3306 端口的mysql 增加 ln -s my.cnf.3306 my.cnf 操作