### PR TITLE
feat(mysql): mysql-crond-auto-update-instance-info #9889

### DIFF
--- a/dbm-services/common/reverse-api/config/init.go
+++ b/dbm-services/common/reverse-api/config/init.go
@@ -2,6 +2,7 @@ package config
 
 const CommonConfigDir = "/home/mysql/common_config"
 const NginxProxyAddrsFileName = "nginx_proxy.list"
+const InstanceInfoFileName = "instance_info.info"
 const ReverseApiBase = "apis/proxypass/reverse_api"
 
 type ReverseApiName string

--- a/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/init.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/init.go
@@ -1,6 +1,7 @@
 package third_party
 
 import (
+	"dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/instance_info_updater"
 	"dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/nginx_updater"
 
 	"github.com/robfig/cron/v3"
@@ -11,5 +12,6 @@ var ThirdPartyRegisters []func(cron *cron.Cron)
 func init() {
 	ThirdPartyRegisters = []func(*cron.Cron){
 		nginx_updater.Register,
+		instance_info_updater.Register,
 	}
 }

--- a/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/instance_info_updater/init.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/instance_info_updater/init.go
@@ -1,0 +1,76 @@
+package instance_info_updater
+
+import (
+	"dbm-services/common/reverse-api/apis/mysql"
+	rconfig "dbm-services/common/reverse-api/config"
+	"dbm-services/mysql/db-tools/mysql-crond/pkg/config"
+	"log/slog"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/robfig/cron/v3"
+)
+
+func Register(cj *cron.Cron) {
+	id, err := cj.AddFunc(
+		"@every 30m",
+		func() {
+			err := updater()
+			if err != nil {
+				slog.Error("update instance info job", slog.String("err", err.Error()))
+			} else {
+				slog.Info("update instance info job finished")
+			}
+		},
+	)
+	if err != nil {
+		slog.Error("register instance info updater job", slog.String("err", err.Error()))
+	} else {
+		slog.Info("register instance info updater job success", slog.Int("entry id", int(id)))
+	}
+}
+
+func updater() error {
+	err := os.MkdirAll(rconfig.CommonConfigDir, 0777)
+	if err != nil {
+		return errors.Wrap(err, "can't create config directory")
+	}
+
+	sleepN := time.Second * time.Duration(rand.Intn(120))
+	slog.Info("rand sleep", slog.Float64("seconds", sleepN.Seconds()))
+	time.Sleep(sleepN)
+	slog.Info("rand sleep awake")
+
+	info, layer, err := mysql.ListInstanceInfo(*config.RuntimeConfig.BkCloudID)
+	if err != nil {
+		slog.Error("list instance info failed", slog.String("err", err.Error()))
+		return errors.Wrap(err, "list instance info failed")
+	}
+	slog.Info(
+		"list instance info",
+		slog.Any("info", info),
+		slog.String("layer", layer),
+	)
+
+	f, err := os.OpenFile(
+		filepath.Join(rconfig.CommonConfigDir, rconfig.InstanceInfoFileName),
+		os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0777,
+	)
+	if err != nil {
+		return errors.Wrap(err, "open instance info file failed")
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	slog.Info("update instance info recreate file success")
+
+	if _, err := f.WriteString(string(info) + "\n"); err != nil {
+		slog.Error("write instance info failed", slog.String("err", err.Error()))
+		return errors.Wrap(err, "write instance info failed")
+	}
+	slog.Info("update instance info recreate file success")
+	return nil
+}


### PR DESCRIPTION
1. /home/mysql/common_config/instance_info.info  每 30 分钟更新一次机器所有实例的信息
2. 信息结构定义在 dbm-services/common/reverse-api/apis/mysql/list_instance_info.go
3. 没有互斥文件锁, 读取的时候可以考虑忽略掉某些错误

<img width="719" alt="image" src="https://github.com/user-attachments/assets/bff7a774-8d80-473b-8004-19aa80126573" />

