### PR TITLE
feat(redis): proxy下架前先设置权重为0 #9909

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/tests/redistest/redis_install.go
+++ b/dbm-services/redis/db-tools/dbactuator/tests/redistest/redis_install.go
@@ -419,7 +419,7 @@ func (test *RedisInstallTest) SetTendisplusRedisConf() {
 		"logdir":                              "{{redis_data_dir}}/data/log",
 		"dir":                                 "{{redis_data_dir}}/data/db",
 		"dumpdir":                             "{{redis_data_dir}}/data/dump",
-		"pidfile":                             "{{redis_data_dir}}data/tendisplus.pid",
+		"pidfile":                             "{{redis_data_dir}}/data/tendisplus.pid",
 		"slowlog":                             "{{redis_data_dir}}/data/slowlog",
 		"databases":                           "{{databases}}",
 		"requirepass":                         "{{password}}",

--- a/dbm-ui/backend/flow/consts.py
+++ b/dbm-ui/backend/flow/consts.py
@@ -748,6 +748,7 @@ class DnsOpType(str, StructuredEnum):
     SELECT = EnumField("select", _("select"))
     ADD_AND_DELETE = EnumField("add_and_delete", _("add_and_delete"))
     IP_DNS_RECORD_RECYCLE = EnumField("ip_dns_recycle_record", _("ip_dns对应记录回收"))
+    CLB_CHANGE_WEIGHT = EnumField("clb_change_weight", _("clb修改权重"))
 
 
 class ManagerOpType(str, StructuredEnum):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_version_update_online.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_version_update_online.py
@@ -693,6 +693,9 @@ class RedisClusterVersionUpdateOnline(object):
             )
         sub_pipeline.add_parallel_acts(acts_list=acts_list)
 
+        # 这个地方需要增加一个人工确认节点。并且尽量慢点执行。否则client可能还会访问到old master
+        sub_pipeline.add_act(act_name=_("Redis-人工确认"), act_component_code=PauseComponent.code, kwargs={})
+
         # 升级old master
         act_kwargs.cluster = {}
         act_kwargs.exec_ip = master_ip

--- a/dbm-ui/backend/flow/plugins/components/collections/common/clb_manage.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/clb_manage.py
@@ -61,6 +61,15 @@ class RedisClbManageService(BaseService):
 
             add_instance_list = [f"{ip}:{kwargs['clb_op_exec_port']}" for ip in exec_ips]
             result = clb_manager.add_clb_rs(instance_list=add_instance_list)
+        elif dns_op_type == DnsOpType.CLB_CHANGE_WEIGHT:
+            # 安全删除CLB，前置行为：修改权重
+            exec_ips = self.__get_exec_ips(kwargs=kwargs, trans_data=trans_data)
+            if not exec_ips:
+                self.log_error(_("该节点获取到执行ip信息为空，请联系系统管理员"))
+                return False
+
+            change_instance_list = [f"{ip}:{kwargs['clb_op_exec_port']}" for ip in exec_ips]
+            result = clb_manager.update_clb_rs_weight(instance_list=change_instance_list, weight=0)
         elif dns_op_type == DnsOpType.RECYCLE_RECORD:
             # 删除CLB映射,proxy缩容场景
             exec_ips = self.__get_exec_ips(kwargs=kwargs, trans_data=trans_data)

--- a/dbm-ui/backend/flow/utils/clb_manage.py
+++ b/dbm-ui/backend/flow/utils/clb_manage.py
@@ -77,3 +77,19 @@ class CLBManage(object):
             raw=True,
         )
         return True
+
+    def update_clb_rs_weight(self, instance_list: list, weight: int) -> bool:
+        """
+        修改clb权重;适用场景：proxy缩容前置行为
+        """
+        NameServiceApi.clb_change_target_weight(
+            {
+                "region": self.clb_region,
+                "loadbalancerid": self.clb_id,
+                "listenerid": self.listener_id,
+                "ips": instance_list,
+                "weight": weight,
+            },
+            raw=True,
+        )
+        return True

--- a/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
@@ -132,7 +132,7 @@ class RedisActPayload(object):
 
         self.__init_dbconfig_params()
         if self.ticket_data["ticket_type"] in apply_list + cutoff_list + tool_list + migrate_list:
-            self.account = self.__get_define_config(NameSpaceEnum.Common, ConfigFileEnum.OS, ConfigTypeEnum.OSConf)
+            # self.account = self.__get_define_config(NameSpaceEnum.Common, ConfigFileEnum.OS, ConfigTypeEnum.OSConf)
             db_version = ""
             if "db_version" in self.cluster:
                 db_version = self.cluster["db_version"]
@@ -148,7 +148,8 @@ class RedisActPayload(object):
                 NameSpaceEnum.Common, ConfigFileEnum.Redis, ConfigTypeEnum.ActConf
             )
         if self.ticket_data["ticket_type"] in redis_scale_list + proxy_scale_list:
-            self.account = self.__get_define_config(NameSpaceEnum.Common, ConfigFileEnum.OS, ConfigTypeEnum.OSConf)
+            pass
+            # self.account = self.__get_define_config(NameSpaceEnum.Common, ConfigFileEnum.OS, ConfigTypeEnum.OSConf)
 
     def __init_dbconfig_params(self) -> Any:
         if "cluster_type" in self.cluster:


### PR DESCRIPTION
1、proxy缩容和整机替换时，先修改权重为0，然后再下节点
2、主从版本升级前，old master升级前增加人工确认节点
3、tendis pid目录不正确
4、后端扩缩容重做slave master告警屏蔽
5、后端扩缩容重做slave，slave机器dbmon配置问题修复
6、注释从dbconfig获取os account代码(之前改造遗漏的)

![image](https://github.com/user-attachments/assets/5883d45a-e625-436a-8154-87864eb11827)
