### PR TITLE
fix(redis): 增大job执行超时时间 #10050

### DIFF
--- a/dbm-ui/backend/flow/plugins/components/collections/redis/exec_actuator_script.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/exec_actuator_script.py
@@ -117,7 +117,7 @@ class ExecuteDBActuatorScriptService(BkJobService):
             "script_content": base64_encode(template.render(db_act_template)),
             "script_language": 1,
             "target_server": {"ip_list": target_ip_info},
-            "timeout": 86400,
+            "timeout": 259200,
         }
         # 外边可以指定执行账户，不指定则采用默认账户Root
         common_kwargs = copy.deepcopy(redis_fast_execute_script_common_kwargs)


### PR DESCRIPTION
在部分需要持续执行的job任务中，1天的超时时间可能不够。所以直接设置超时时间为上限