### PR TITLE
feat(mysql): 合并tendbha和tendbsingle重命名db单据 #10442

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/uninstall_mysql.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/uninstall_mysql.go
@@ -111,14 +111,14 @@ func (u *UnInstallMySQLComp) PreCheck() (err error) {
 			Socket: u.runTimeCtx.insMyObj[port].Socket,
 		}
 		if _, err := inst.ConnBySocket(); err != nil {
-			logger.Warn("try connent this mysql instance [%p] failed:%s", port, err.Error())
+			logger.Warn("try connect this mysql instance [%p] failed:%s", port, err.Error())
 			u.insMyObj[port].IsShutdown = true
 		}
 		if !u.Params.Force && !u.insMyObj[port].IsShutdown {
 			// 非强制下架，且实例正常的情况下，需要判断实例是否有业务连接,
 			// todo 这里重新去创建连接，如果检测实例状态和连接业务访问之间出现实例异常，则会触发bug，后续考虑怎么优化这点
 			if err := inst.CheckInstanceConnIdle(u.GeneralParam.GetAllSysAccount(), time.Second*1); err != nil {
-				logger.Warn("try connent this mysql instance [%p] failed:%s", port, err.Error())
+				logger.Warn("try connect this mysql instance [%p] failed:%s", port, err.Error())
 				u.insMyObj[port].IsShutdown = true
 			}
 		}
@@ -226,7 +226,7 @@ func (u *UnInstallMySQLComp) ClearMachine() (err error) {
 		if cmutil.FileExists(dataPath) {
 			var shellCMD string
 			if !cmutil.FileExists(dataBak) {
-				shellCMD += fmt.Sprintf("mkdir %s;", dataBak)
+				shellCMD += fmt.Sprintf("mkdir -p %s;", dataBak)
 			}
 			shellCMD += fmt.Sprintf(
 				"mv %s %s_%d%s;",
@@ -245,7 +245,7 @@ func (u *UnInstallMySQLComp) ClearMachine() (err error) {
 		if cmutil.FileExists(data1Path) {
 			var shellCMD string
 			if !cmutil.FileExists(data1Bak) {
-				shellCMD += fmt.Sprintf("mkdir %s;", data1Bak)
+				shellCMD += fmt.Sprintf("mkdir -p %s;", data1Bak)
 			}
 			shellCMD += fmt.Sprintf(
 				"mv %s %s_%d%s;",

--- a/dbm-ui/backend/flow/engine/controller/mysql.py
+++ b/dbm-ui/backend/flow/engine/controller/mysql.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from deprecated import deprecated
 
 from backend.db_meta.enums import ClusterType
 from backend.flow.engine.bamboo.scene.common.account_rule_manage import AccountRulesFlows
@@ -358,6 +359,7 @@ class MySQLController(BaseController):
         flow = MySQLFakeSemanticCheck(root_id=self.root_id, data=self.ticket_data)
         flow.fake_semantic_check()
 
+    @deprecated
     def mysql_ha_rename_database_scene(self):
         """
         TenDBHA 重命名数据库
@@ -526,6 +528,7 @@ class MySQLController(BaseController):
         )
         flow.truncate_flow()
 
+    @deprecated
     def mysql_single_rename_database_scene(self):
         """
         TenDBHA 重命名数据库
@@ -718,3 +721,12 @@ class MySQLController(BaseController):
         """
         flow = ProxyInplaceAutofixFlow(root_id=self.root_id, data=self.ticket_data)
         flow.autofix()
+
+    def mysql_rename_database_scene(self):
+        """
+        tendbsingle 和 tendbha db 重命名
+        """
+        flow = MySQLRenameDatabaseFlow(
+            root_id=self.root_id, data=self.ticket_data  # , cluster_type=ClusterType.TenDBSingle.value
+        )
+        flow.rename_database()

--- a/dbm-ui/backend/ticket/builders/mysql/mysql_rename_database.py
+++ b/dbm-ui/backend/ticket/builders/mysql/mysql_rename_database.py
@@ -8,57 +8,65 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from backend.db_meta.enums import ClusterType
+from backend.db_meta.models import Cluster
 from backend.db_services.mysql.remote_service.handlers import RemoteServiceHandler
 from backend.flow.engine.controller.mysql import MySQLController
 from backend.ticket import builders
 from backend.ticket.builders.common.base import CommonValidate
 from backend.ticket.builders.mysql.base import (
-    BaseMySQLHATicketFlowBuilder,
+    BaseMySQLTicketFlowBuilder,
     DBTableField,
     MySQLBaseOperateDetailSerializer,
 )
 from backend.ticket.constants import FlowRetryType, TicketType
 
 
-class MySQLHaRenameSerializer(MySQLBaseOperateDetailSerializer):
-    class RenameDatabaseInfoSerializer(serializers.Serializer):
+class MySQLRenameDatabaseSerializer(MySQLBaseOperateDetailSerializer):
+    class RenameDBInfoSLZ(serializers.Serializer):
         cluster_id = serializers.IntegerField(help_text=_("集群ID"))
-        # 源database无需校验，考虑将存量不合法的DB名重命名为合法DB名
         from_database = serializers.CharField(help_text=_("源数据库名"))
         to_database = DBTableField(help_text=_("目标数据库名"), db_field=True)
 
-    infos = serializers.ListField(help_text=_("重命名数据库列表"), child=RenameDatabaseInfoSerializer())
-    force = serializers.BooleanField(help_text=_("是否强制执行"), default=False)
+    infos = serializers.ListField(help_text=_("重命名数据库列表"), child=RenameDBInfoSLZ())
+    force = serializers.BooleanField(help_text=_("强制执行"), default=False)
 
-    def validate_rename_db(self, attrs):
-        # 集群与业务库的映射
-        cluster_ids = [info["cluster_id"] for info in attrs["infos"]]
+    def validate(self, attrs):
+        super().validate_cluster_can_access(attrs)
+
+        cluster_ids = [info["cluster_id"] for info in attrs["info"]]
+        bad_cluster = []
+
+        for cluster_obj in Cluster.objects.filter(id__in=cluster_ids):
+            if cluster_obj.cluster_type not in [ClusterType.TenDBHA, ClusterType.TenDBSingle]:
+                bad_cluster.append(cluster_obj.immute_domain)
+
+        if bad_cluster:
+            raise serializers.ValidationError(_("{} 集群类型不是[tendbsingle, tendbha]".format(bad_cluster)))
+
+        self.validate_db(attrs)
+
+    def validate_db(self, attrs):
+        cluster_ids = [info["cluster_id"] for info in attrs["info"]]
         database_info = RemoteServiceHandler(self.context["bk_biz_id"]).show_databases(cluster_ids)
         cluster__databases = {info["cluster_id"]: info["databases"] for info in database_info}
         # DB重命名校验
         CommonValidate.validate_mysql_db_rename(attrs["infos"], cluster__databases)
 
-    def validate(self, attrs):
-        super().validate_cluster_can_access(attrs)
-        # 集群类型校验
-        super().validated_cluster_type(attrs, cluster_type=ClusterType.TenDBHA)
-        # DB重命名校验
-        self.validate_rename_db(attrs)
-        return attrs
+
+class MySQLRenameDatabaseFlowParamBuilder(builders.FlowParamBuilder):
+    controller = MySQLController.mysql_rename_database_scene
+
+    def format_ticket_data(self):
+        pass
 
 
-class MySQLHaRenameFlowParamBuilder(builders.FlowParamBuilder):
-    controller = MySQLController.mysql_ha_rename_database_scene
-
-
-@builders.BuilderFactory.register(TicketType.MYSQL_HA_RENAME_DATABASE)
-class MySQLHaRenameFlowBuilder(BaseMySQLHATicketFlowBuilder):
-    serializer = MySQLHaRenameSerializer
-    inner_flow_builder = MySQLHaRenameFlowParamBuilder
-    inner_flow_name = _("DB重命名执行")
+@builders.BuilderFactory.register(TicketType.MYSQL_RENAME_DATABASE)
+class MySQLRenameDatabaseFlowBuilder(BaseMySQLTicketFlowBuilder):
+    serializer = MySQLRenameDatabaseSerializer
+    inner_flow_builder = MySQLRenameDatabaseFlowParamBuilder
+    inner_flow_name = _("DB重命名")
     retry_type = FlowRetryType.MANUAL_RETRY

--- a/dbm-ui/backend/ticket/constants.py
+++ b/dbm-ui/backend/ticket/constants.py
@@ -244,6 +244,7 @@ class TicketType(str, StructuredEnum):
     MYSQL_EXCEL_AUTHORIZE_RULES = TicketEnumField("MYSQL_EXCEL_AUTHORIZE_RULES", _("MySQL EXCEL授权"), _("权限管理"))
     MYSQL_CLIENT_CLONE_RULES = TicketEnumField("MYSQL_CLIENT_CLONE_RULES", _("MySQL 客户端权限克隆"), register_iam=False)
     MYSQL_INSTANCE_CLONE_RULES = TicketEnumField("MYSQL_INSTANCE_CLONE_RULES", _("MySQL DB实例权限克隆"), _("权限管理"))
+    # deprecated
     MYSQL_HA_RENAME_DATABASE = TicketEnumField("MYSQL_HA_RENAME_DATABASE", _("MySQL 高可用DB重命名"), _("集群维护"))
     MYSQL_HA_TRUNCATE_DATA = TicketEnumField("MYSQL_HA_TRUNCATE_DATA", _("MySQL 高可用清档"), _("数据处理"))
     MYSQL_HA_DB_TABLE_BACKUP = TicketEnumField("MYSQL_HA_DB_TABLE_BACKUP", _("MySQL 库表备份"), _("备份"))
@@ -255,6 +256,7 @@ class TicketType(str, StructuredEnum):
     MYSQL_ROLLBACK_CLUSTER = TicketEnumField("MYSQL_ROLLBACK_CLUSTER", _("MySQL 定点构造"), _("回档"))
     MYSQL_HA_FULL_BACKUP = TicketEnumField("MYSQL_HA_FULL_BACKUP", _("MySQL 全库备份"), _("备份"))
     MYSQL_SINGLE_TRUNCATE_DATA = TicketEnumField("MYSQL_SINGLE_TRUNCATE_DATA", _("MySQL 单节点清档"), _("数据处理"))
+    # deprecated
     MYSQL_SINGLE_RENAME_DATABASE = TicketEnumField("MYSQL_SINGLE_RENAME_DATABASE", _("MySQL 单节点DB重命名"), _("集群维护"))  # noqa
     MYSQL_HA_STANDARDIZE = TicketEnumField("MYSQL_HA_STANDARDIZE", _("TendbHA 标准化"), register_iam=False)
     MYSQL_HA_METADATA_IMPORT = TicketEnumField("MYSQL_HA_METADATA_IMPORT", _("TendbHA 元数据导入"), register_iam=False)
@@ -272,6 +274,7 @@ class TicketType(str, StructuredEnum):
     MYSQL_PROXY_INPLACE_AUTOFIX = TicketEnumField(
         "MYSQL_PROXY_INPLACE_AUTOFIX", _("MySQL Proxy 原地自愈"), register_iam=False)
     MYSQL_ACCOUNT_RULE_CHANGE = TicketEnumField("MYSQL_ACCOUNT_RULE_CHANGE", _("MySQL 授权规则变更"), register_iam=False)
+    MYSQL_RENAME_DATABASE = TicketEnumField("MYSQL_RENAME_DATABASE", _("MySQL DB重命名"))
 
     # MYSQL_PUSH_PERIPHERAL_CONFIG = TicketEnumField("MYSQL_PUSH_PERIPHERAL_CONFIG", _("推送周边配置"),
     #                                                register_iam=False)


### PR DESCRIPTION
1. 新增一个单据类型 MYSQL_RENAME_DATABASE, 合并 tendbsingle 和 tendbha 的 db 重命名单据
2. 参数完全没有变
3. 自测混合提单可以正常生产单据流程

![image](https://github.com/user-attachments/assets/c83060f6-8a3a-4561-b222-c222f3d3862d)

