### PR TITLE
feat(mysql): 使用反向接口的标准化 #10478

### DIFF
--- a/dbm-services/common/reverseapi/api.go
+++ b/dbm-services/common/reverseapi/api.go
@@ -30,7 +30,7 @@ func NewReverseApiWithAddrsFile(bkCloudId int64, alterNginxAddrsFile string) (*R
 		cwd, _ := os.Getwd()
 		alterNginxAddrsFile = filepath.Join(cwd, alterNginxAddrsFile)
 	}
-	addrs, err := readNginxProxyAddrs(alterNginxAddrsFile)
+	addrs, err := ReadNginxProxyAddrs(alterNginxAddrsFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read nginx proxy addrs")
 	}

--- a/dbm-services/common/reverseapi/define/mysql/dbbackup.go
+++ b/dbm-services/common/reverseapi/define/mysql/dbbackup.go
@@ -1,0 +1,19 @@
+package mysql
+
+import "encoding/json"
+
+type DBBackupConfig struct {
+	ConfigsTemplate map[string]map[string]string `json:"configs"`
+	Options         json.RawMessage              `json:"options"`
+	Ip              string                       `json:"ip"`
+	Port            int                          `json:"port"`
+	Role            string                       `json:"role"`
+	ClusterType     string                       `json:"cluster_type"`
+	ImmuteDomain    string                       `json:"immute_domain"`
+	ClusterId       int                          `json:"cluster_id"`
+	ShardId         int                          `json:"shard_id"`
+	User            string                       `json:"user"`
+	Password        string                       `json:"password"`
+	BkBizId         int                          `json:"bk_biz_id"`
+	BkCloudId       int                          `json:"bk_cloud_id"`
+}

--- a/dbm-services/common/reverseapi/internal/core/reverse_call.go
+++ b/dbm-services/common/reverseapi/internal/core/reverse_call.go
@@ -46,6 +46,7 @@ func (c *Core) ReverseCall(apiEndPoint string, ports ...int) (data []byte, err e
 			q.Add("port", strconv.Itoa(port))
 		}
 		req.URL.RawQuery = q.Encode()
+		slog.Info("reserve call", slog.String("req", req.URL.String()))
 
 		data, err = do(req)
 		if err == nil {
@@ -72,6 +73,7 @@ func do(request *http.Request) (data []byte, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
+	slog.Info("reserve call", slog.String("response body", string(b)))
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(b))

--- a/dbm-services/common/reverseapi/internal/mysql/checksum_config.go
+++ b/dbm-services/common/reverseapi/internal/mysql/checksum_config.go
@@ -3,7 +3,7 @@ package mysql
 import "github.com/pkg/errors"
 
 func (c *MySQL) ChecksumConfig(ports ...int) ([]byte, error) {
-	data, err := c.core.ReverseCall("mysql/checksum_config", ports...)
+	data, err := c.core.ReverseCall("mysql/checksum_config/", ports...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to call checksum_config")
 	}

--- a/dbm-services/common/reverseapi/internal/mysql/crond_config.go
+++ b/dbm-services/common/reverseapi/internal/mysql/crond_config.go
@@ -3,7 +3,7 @@ package mysql
 import "github.com/pkg/errors"
 
 func (c *MySQL) CrondConfig() ([]byte, error) {
-	data, err := c.core.ReverseCall("mysql/mysql_crond_config")
+	data, err := c.core.ReverseCall("mysql/mysql_crond_config/")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to call mysql_crond_config")
 	}

--- a/dbm-services/common/reverseapi/internal/mysql/dbbackup_config.go
+++ b/dbm-services/common/reverseapi/internal/mysql/dbbackup_config.go
@@ -3,7 +3,7 @@ package mysql
 import "github.com/pkg/errors"
 
 func (c *MySQL) DBBackupConfig(ports ...int) ([]byte, error) {
-	data, err := c.core.ReverseCall("mysql/dbbackup_config", ports...)
+	data, err := c.core.ReverseCall("mysql/dbbackup_config/", ports...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to call dbbackup_config")
 	}

--- a/dbm-services/common/reverseapi/internal/mysql/exporter_config.go
+++ b/dbm-services/common/reverseapi/internal/mysql/exporter_config.go
@@ -1,0 +1,11 @@
+package mysql
+
+import "github.com/pkg/errors"
+
+func (c *MySQL) ExporterConfig(ports ...int) ([]byte, error) {
+	data, err := c.core.ReverseCall("mysql/exporter_config/", ports...)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return data, nil
+}

--- a/dbm-services/common/reverseapi/internal/mysql/list_instance_info.go
+++ b/dbm-services/common/reverseapi/internal/mysql/list_instance_info.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *MySQL) ListInstanceInfo(ports ...int) ([]byte, string, error) {
-	data, err := c.core.ReverseCall("mysql/list_instance_info", ports...)
+	data, err := c.core.ReverseCall("mysql/list_instance_info/", ports...)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "failed to call list_instance_info")
 	}

--- a/dbm-services/common/reverseapi/internal/mysql/monitor_config.go
+++ b/dbm-services/common/reverseapi/internal/mysql/monitor_config.go
@@ -40,7 +40,7 @@ import "github.com/pkg/errors"
 `
 */
 func (c *MySQL) MonitorItemsConfig(ports ...int) ([]byte, error) {
-	data, err := c.core.ReverseCall("mysql/monitor_items_config", ports...)
+	data, err := c.core.ReverseCall("mysql/monitor_items_config/", ports...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to call monitor_items_config")
 	}

--- a/dbm-services/common/reverseapi/internal/mysql/rotatebinlog_config.go
+++ b/dbm-services/common/reverseapi/internal/mysql/rotatebinlog_config.go
@@ -3,7 +3,7 @@ package mysql
 import "github.com/pkg/errors"
 
 func (c *MySQL) RotatebinlogConfig(ports ...int) ([]byte, error) {
-	data, err := c.core.ReverseCall("mysql/rotatebinlog_config", ports...)
+	data, err := c.core.ReverseCall("mysql/rotatebinlog_config/", ports...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to call rotatebinlog_config")
 	}

--- a/dbm-services/common/reverseapi/read_ningx_proxy_addr.go
+++ b/dbm-services/common/reverseapi/read_ningx_proxy_addr.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func readNginxProxyAddrs(fp string) (addrs []string, err error) {
+func ReadNginxProxyAddrs(fp string) (addrs []string, err error) {
 	f, err := os.Open(fp)
 
 	if err != nil {

--- a/dbm-services/mysql/db-priv/service/v2/clone_instance_priv/init.go
+++ b/dbm-services/mysql/db-priv/service/v2/clone_instance_priv/init.go
@@ -11,7 +11,7 @@ type CloneInstancePrivPara struct {
 	sourceMySQLVersion int
 	targetMySQLVersion int
 	SystemUsers        []string `json:"system_users"`
-	Uid                int64    `json:"uid"`
+	Uid                string   `json:"uid"`
 	NodeId             string   `json:"node_id"`
 	RootId             string   `json:"root_id"`
 	VersionId          string   `json:"version_id"`

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/mysqlcmd.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/mysqlcmd.go
@@ -91,6 +91,9 @@ func NewMysqlCommand() *cobra.Command {
 				v2.NewPushMySQLRotateBinlogConfigCommand(),
 				v2.NewPushChecksumConfigCommand(),
 				v2.NewPushExporterCnfCommand(),
+				v2.NewGenPeripheralToolsConfigCommand(),
+				v2.NewReloadPeripheralToolsConfigCommand(),
+				v2.NewInitNginxAddressesCommand(),
 			},
 		},
 		{

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/gen_peripheraltools_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/gen_peripheraltools_config.go
@@ -1,0 +1,67 @@
+package mysqlcmd
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/util"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type GenPeripheralToolsConfigAct struct {
+	*subcmd.BaseOptions
+	Service peripheraltools.GenConfig
+}
+
+const GenPeripheralToolsConfig = `gen-peripheraltools-config`
+
+func NewGenPeripheralToolsConfigCommand() *cobra.Command {
+	act := GenPeripheralToolsConfigAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   GenPeripheralToolsConfig,
+		Short: "Generate peripheraltools config",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			GenPeripheralToolsConfig, subcmd.CmdBaseExampleStr, subcmd.ToPrettyJson(act.Service.Example())),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *GenPeripheralToolsConfigAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *GenPeripheralToolsConfigAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializeAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *GenPeripheralToolsConfigAct) Run() error {
+	steps := subcmd.Steps{
+		{
+			FunName: "生成周边配置",
+			Func:    c.Service.Run,
+		},
+	}
+	if err := steps.Run(); err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	logger.Info("配置生成完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/init_nginx_addresses.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/init_nginx_addresses.go
@@ -1,0 +1,67 @@
+package mysqlcmd
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/util"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const InitNginxAddressesCommand = `init-nginx-addresses`
+
+type InitNginxAddressesAct struct {
+	*subcmd.BaseOptions
+	Service peripheraltools.InitNginxAddresses
+}
+
+func NewInitNginxAddressesCommand() *cobra.Command {
+	act := InitNginxAddressesAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   InitNginxAddressesCommand,
+		Short: "Initialize the Nginx addresses for peripheral",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			InitNginxAddressesCommand, subcmd.CmdBaseExampleStr, subcmd.ToPrettyJson(act.Service.Example())),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *InitNginxAddressesAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *InitNginxAddressesAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializeAndValidate err %s", err.Error())
+		return err
+	}
+	//c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *InitNginxAddressesAct) Run() error {
+	steps := subcmd.Steps{
+		{
+			FunName: "初始化 nginx 地址",
+			Func:    c.Service.Run,
+		},
+	}
+	if err := steps.Run(); err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	logger.Info("初始化 nginx 地址完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_checksum_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_checksum_config.go
@@ -17,6 +17,8 @@ type PushChecksumConfigAct struct {
 
 const PushChecksumConfig = `push-checksum-config`
 
+// NewPushChecksumConfigCommand
+// Deprecated
 func NewPushChecksumConfigCommand() *cobra.Command {
 	act := PushChecksumConfigAct{
 		BaseOptions: subcmd.GBaseOptions,

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_dbbackup_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_dbbackup_config.go
@@ -18,6 +18,8 @@ type PushNewDbBackupConfigAct struct {
 
 const PushNewDbBackupConfig = `push-new-db-backup-config`
 
+// NewPushNewDbBackupConfigCommand
+// Deprecated
 func NewPushNewDbBackupConfigCommand() *cobra.Command {
 	act := PushNewDbBackupConfigAct{
 		BaseOptions: subcmd.GBaseOptions,

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_exporter_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_exporter_config.go
@@ -17,6 +17,8 @@ type PushExporterCnfAct struct {
 
 const PushExporterCnf = `push-exporter-cnf`
 
+// NewPushExporterCnfCommand
+// Deprecated
 func NewPushExporterCnfCommand() *cobra.Command {
 	act := PushExporterCnfAct{
 		BaseOptions: subcmd.GBaseOptions,

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_monitor_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_monitor_config.go
@@ -18,6 +18,8 @@ type PushMySQLMonitorConfigAct struct {
 
 const PushMySQLMonitorConfig = "push-mysql-monitor-config"
 
+// NewPushMySQLMonitorConfigCommand
+// Deprecated
 func NewPushMySQLMonitorConfigCommand() *cobra.Command {
 	act := PushMySQLMonitorConfigAct{
 		BaseOptions: subcmd.GBaseOptions,
@@ -61,12 +63,8 @@ func (c *PushMySQLMonitorConfigAct) Run() (err error) {
 			Func:    c.Service.Init,
 		},
 		{
-			FunName: "生成二进制程序配置",
-			Func:    c.Service.GenerateRuntimeConfig,
-		},
-		{
-			FunName: "生成监控项配置",
-			Func:    c.Service.GenerateItemsConfig,
+			FunName: "生成监控配置",
+			Func:    c.Service.GenConfig,
 		},
 		{
 			FunName: "重载配置",

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_mysql_crond_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_mysql_crond_config.go
@@ -18,6 +18,8 @@ type PushMySQLCrondConfigAct struct {
 
 const PushMySQLCrondConfig = "push-mysql-crond-config"
 
+// NewPushMySQLCrondConfigCommand
+// Deprecated
 func NewPushMySQLCrondConfigCommand() *cobra.Command {
 	act := PushMySQLCrondConfigAct{
 		BaseOptions: subcmd.GBaseOptions,

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_mysql_rotatebinlog_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/push_mysql_rotatebinlog_config.go
@@ -19,6 +19,8 @@ type PushMySQLRotateBinlogConfigAct struct {
 
 const PushMySQLRotatebinlogConfig = "push-mysql-rotatebinlog-config"
 
+// NewPushMySQLRotateBinlogConfigCommand
+// Deprecated
 func NewPushMySQLRotateBinlogConfigCommand() *cobra.Command {
 	act := PushMySQLRotateBinlogConfigAct{
 		BaseOptions: subcmd.GBaseOptions,

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/reload_peripheraltools_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/reload_peripheraltools_config.go
@@ -1,0 +1,67 @@
+package mysqlcmd
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/util"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type ReloadPeripheralToolsConfigAct struct {
+	*subcmd.BaseOptions
+	Service peripheraltools.Reload
+}
+
+const ReloadPeripheralToolsConfig = "reload-peripheraltools-config"
+
+func NewReloadPeripheralToolsConfigCommand() *cobra.Command {
+	act := ReloadPeripheralToolsConfigAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   ReloadPeripheralToolsConfig,
+		Short: "ReloadPeripheralToolsConfig",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			ReloadPeripheralToolsConfig, subcmd.CmdBaseExampleStr, subcmd.ToPrettyJson(act.Service.Example())),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *ReloadPeripheralToolsConfigAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *ReloadPeripheralToolsConfigAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializeAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *ReloadPeripheralToolsConfigAct) Run() error {
+	steps := subcmd.Steps{
+		{
+			FunName: "重载周边配置",
+			Func:    c.Service.Run,
+		},
+	}
+	if err := steps.Run(); err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	logger.Info("配置重载完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/internal/register_crond.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/internal/register_crond.go
@@ -14,14 +14,14 @@ func RegisterCrond(toolPath, configPath, user string) error {
 			fmt.Sprintf("%s reschedule --staff %s --config %s", toolPath, user, configPath),
 		}...,
 	)
+	logger.Info(command.String())
 
-	var stdout, stderr bytes.Buffer
-	command.Stdout = &stdout
+	var stderr bytes.Buffer
 	command.Stderr = &stderr
 
 	err := command.Run()
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("%s: %s", err.Error(), stderr.String())
 		return err
 	}
 	return nil

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum/add_crond.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum/add_crond.go
@@ -10,19 +10,29 @@ import (
 )
 
 func (c *MySQLChecksumComp) AddToCrond() (err error) {
-	mysqlTableChecksum, err := c.tools.Get(tools.ToolMysqlTableChecksum)
+	return AddCrond(c.Params.Ports)
+}
+
+func AddCrond(ports []int) (err error) {
+	tl, err := tools.NewToolSetWithPick(tools.ToolMysqlTableChecksum)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	mysqlTableChecksum, err := tl.Get(tools.ToolMysqlTableChecksum)
 	if err != nil {
 		logger.Error("get %s failed: %s", tools.ToolMysqlTableChecksum, err.Error())
 		return err
 	}
 
-	for _, port := range c.Params.Ports {
+	for _, port := range ports {
 		configPath := filepath.Join(
 			cst.ChecksumInstallPath,
 			fmt.Sprintf("checksum_%d.yaml", port),
 		)
 
-		err = internal.RegisterCrond(mysqlTableChecksum, configPath, c.Params.ExecUser)
+		err = internal.RegisterCrond(mysqlTableChecksum, configPath, "system")
 		if err != nil {
 			logger.Error("register %s failed: %s", mysqlTableChecksum, err.Error())
 			return err

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum/binary.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum/binary.go
@@ -11,6 +11,7 @@ import (
 )
 
 func DeployBinary(medium *components.Medium) (err error) {
+	logger.Info("deploy mysql-checksum")
 	err = os.MkdirAll(cst.ChecksumInstallPath, 0755)
 	if err != nil {
 		logger.Error("mkdir %s failed: %s", cst.ChecksumInstallPath, err.Error())

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum/init.go
@@ -28,6 +28,7 @@ func (c *MySQLChecksumComp) Init() (err error) {
 
 type MySQLChecksumParam struct {
 	//components.Medium
+	BkCloudId    int64    `json:"bk_cloud_id"`
 	BkBizId      int      `json:"bk_biz_id"`
 	IP           string   `json:"ip"`
 	Ports        []int    `json:"port_list"`

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/crond/binary.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/crond/binary.go
@@ -10,6 +10,7 @@ import (
 )
 
 func DeployBinary(medium *components.Medium) (err error) {
+	logger.Info("deploy mysql-crond")
 	err = os.MkdirAll(cst.MySQLCrondInstallPath, 0755)
 	if err != nil {
 		logger.Error("mkdir %s failed: %s", cst.MySQLCrondInstallPath, err.Error())

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/crond/control.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/crond/control.go
@@ -4,7 +4,9 @@ import (
 	"dbm-services/common/go-pubpkg/cmutil"
 	"fmt"
 	"os/exec"
+	"os/user"
 	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -14,15 +16,28 @@ import (
 )
 
 func (c *MySQLCrondComp) Stop() (err error) {
-	cmd := exec.Command(
-		"su", []string{
-			"-", "mysql", "-c",
-			fmt.Sprintf(
-				`/bin/sh %s`,
-				path.Join(cst.MySQLCrondInstallPath, "stop.sh"),
-			),
-		}...,
-	)
+	return Stop()
+}
+
+func Stop() (err error) {
+	var cmd *exec.Cmd
+
+	cu, _ := user.Current()
+	if cu.Uid == "0" {
+		cmd = exec.Command(
+			"su", []string{
+				"-", "mysql", "-c",
+				fmt.Sprintf(
+					`/bin/sh %s`,
+					path.Join(cst.MySQLCrondInstallPath, "stop.sh"),
+				),
+			}...,
+		)
+	} else {
+		cmd = exec.Command(
+			"sh", "-c", filepath.Join(cst.MySQLCrondInstallPath, "stop.sh"),
+		)
+	}
 
 	err = cmd.Run()
 	if err != nil {

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dba_toolkit/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dba_toolkit/init.go
@@ -9,6 +9,7 @@ import (
 )
 
 func DeployBinary(medium *components.Medium) (err error) {
+	logger.Info("deploy dba-toolkit")
 	decompressCmd := fmt.Sprintf(
 		`tar zxf %s -C %s`,
 		medium.GetAbsolutePath(), cst.MYSQL_TOOL_INSTALL_PATH,

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dbbackup/add_crond.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dbbackup/add_crond.go
@@ -2,14 +2,18 @@ package dbbackup
 
 import (
 	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/common/reverseapi"
+	"dbm-services/common/reverseapi/define/mysql"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
-	"dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil"
 	ma "dbm-services/mysql/db-tools/mysql-crond/api"
+	"dbm-services/mysql/db-tools/mysql-dbbackup/pkg/config"
+	"encoding/json"
 	"fmt"
 	"path"
 	"path/filepath"
-	"strings"
-	"time"
+	"slices"
+
+	"gopkg.in/ini.v1"
 )
 
 func (c *NewDbBackupComp) AddCrontab() error {
@@ -22,6 +26,11 @@ func (c *NewDbBackupComp) AddCrontab() error {
 
 func (c *NewDbBackupComp) addCrontabLegacy() (err error) {
 	crondManager := ma.NewManager("http://127.0.0.1:9999")
+	return addCrontabLegacy(crondManager, c.Params.Options.CrontabTime)
+}
+
+func addCrontabLegacy(cm *ma.Manager, schedule string) (err error) {
+	logger.Info("legacy")
 	var jobItem ma.JobDefine
 	logFile := path.Join(cst.DbbackupGoInstallPath, "logs/main.log")
 	jobItem = ma.JobDefine{
@@ -29,76 +38,198 @@ func (c *NewDbBackupComp) addCrontabLegacy() (err error) {
 		Command:  filepath.Join(cst.DbbackupGoInstallPath, "dbbackup_main.sh"),
 		WorkDir:  cst.DbbackupGoInstallPath,
 		Args:     []string{">", logFile, "2>&1"},
-		Schedule: c.Params.Options.CrontabTime,
-		Creator:  c.Params.ExecUser,
+		Schedule: schedule,
+		Creator:  "system",
 		Enable:   true,
 	}
 	logger.Info("adding job_item to crond: %+v", jobItem)
-	if _, err = crondManager.CreateOrReplace(jobItem, true); err != nil {
+	if _, err = cm.CreateOrReplace(jobItem, true); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c *NewDbBackupComp) addCrontabSpider() (err error) {
-	crondManager := ma.NewManager("http://127.0.0.1:9999")
+func addCrontabSpider(cm *ma.Manager, role string, port int, schedule string) (err error) {
+	logger.Info("spider")
 	var jobItem ma.JobDefine
-	if c.Params.Role == cst.BackupRoleSpiderMaster {
-		dbbackupConfFile := fmt.Sprintf("dbbackup.%d.ini", c.Params.Ports[0])
+	if role == cst.BackupRoleSpiderMaster {
+		dbbackupConfFile := fmt.Sprintf("dbbackup.%d.ini", port)
 		jobItem = ma.JobDefine{
 			Name:     "spiderbackup-schedule",
 			Command:  filepath.Join(cst.DbbackupGoInstallPath, "dbbackup"),
 			WorkDir:  cst.DbbackupGoInstallPath,
 			Args:     []string{"spiderbackup", "schedule", "--config", dbbackupConfFile},
-			Schedule: c.Params.Options.CrontabTime, //c.getInsHostCrontabTime(),
-			Creator:  c.Params.ExecUser,
+			Schedule: schedule,
+			Creator:  "system",
 			Enable:   true,
 		}
 		logger.Info("adding job_item to crond: %+v", jobItem)
-		if _, err = crondManager.CreateOrReplace(jobItem, true); err != nil {
+		if _, err = cm.CreateOrReplace(jobItem, true); err != nil {
 			return err
 		}
 	}
-	if !(c.Params.Role == cst.BackupRoleSpiderMnt || c.Params.Role == cst.BackupRoleSpiderSlave) { // MASTER,SLAVE,REPEATER
+	if !(role == cst.BackupRoleSpiderMnt || role == cst.BackupRoleSpiderSlave) { // MASTER,SLAVE,REPEATER
 		jobItem = ma.JobDefine{
 			Name:     "spiderbackup-check",
 			Command:  filepath.Join(cst.DbbackupGoInstallPath, "dbbackup"),
 			WorkDir:  cst.DbbackupGoInstallPath,
 			Args:     []string{"spiderbackup", "check", "--run"},
 			Schedule: "*/1 * * * *",
-			Creator:  c.Params.ExecUser,
+			Creator:  "system",
 			Enable:   true,
 		}
 		logger.Info("adding job_item to crond: %+v", jobItem)
-		if _, err = crondManager.CreateOrReplace(jobItem, true); err != nil {
+		if _, err = cm.CreateOrReplace(jobItem, true); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *NewDbBackupComp) addCrontabOld() (err error) {
-	var newCrontab []string
-	err = osutil.RemoveSystemCrontab("dbbackup")
-	if err != nil {
-		return fmt.Errorf(`删除原备份crontab任务失败("dbbackup") get an error:%w`, err)
+func (c *NewDbBackupComp) addCrontabSpider() (err error) {
+
+	crondManager := ma.NewManager("http://127.0.0.1:9999")
+	return addCrontabSpider(crondManager, c.Params.Role, c.Params.Ports[0], c.Params.Options.CrontabTime)
+
+	//var jobItem ma.JobDefine
+	//if c.Params.Role == cst.BackupRoleSpiderMaster {
+	//	dbbackupConfFile := fmt.Sprintf("dbbackup.%d.ini", c.Params.Ports[0])
+	//	jobItem = ma.JobDefine{
+	//		Name:     "spiderbackup-schedule",
+	//		Command:  filepath.Join(cst.DbbackupGoInstallPath, "dbbackup"),
+	//		WorkDir:  cst.DbbackupGoInstallPath,
+	//		Args:     []string{"spiderbackup", "schedule", "--config", dbbackupConfFile},
+	//		Schedule: c.Params.Options.CrontabTime, //c.getInsHostCrontabTime(),
+	//		Creator:  c.Params.ExecUser,
+	//		Enable:   true,
+	//	}
+	//	logger.Info("adding job_item to crond: %+v", jobItem)
+	//	if _, err = crondManager.CreateOrReplace(jobItem, true); err != nil {
+	//		return err
+	//	}
+	//}
+	//if !(c.Params.Role == cst.BackupRoleSpiderMnt || c.Params.Role == cst.BackupRoleSpiderSlave) { // MASTER,SLAVE,REPEATER
+	//	jobItem = ma.JobDefine{
+	//		Name:     "spiderbackup-check",
+	//		Command:  filepath.Join(cst.DbbackupGoInstallPath, "dbbackup"),
+	//		WorkDir:  cst.DbbackupGoInstallPath,
+	//		Args:     []string{"spiderbackup", "check", "--run"},
+	//		Schedule: "*/1 * * * *",
+	//		Creator:  c.Params.ExecUser,
+	//		Enable:   true,
+	//	}
+	//	logger.Info("adding job_item to crond: %+v", jobItem)
+	//	if _, err = crondManager.CreateOrReplace(jobItem, true); err != nil {
+	//		return err
+	//	}
+	//}
+	//return nil
+}
+
+//func (c *NewDbBackupComp) addCrontabOld() (err error) {
+//	var newCrontab []string
+//	err = osutil.RemoveSystemCrontab("dbbackup")
+//	if err != nil {
+//		return fmt.Errorf(`删除原备份crontab任务失败("dbbackup") get an error:%w`, err)
+//	}
+//	entryShell := path.Join(cst.DbbackupGoInstallPath, "dbbackup_main.sh")
+//	logfile := path.Join(cst.DbbackupGoInstallPath, "dbbackup.log")
+//	newCrontab = append(
+//		newCrontab,
+//		fmt.Sprintf(
+//			"#dbbackup/dbbackup_main.sh: backup database every day, distribute at %s by %s",
+//			time.Now().Format(cst.TIMELAYOUT), c.Params.ExecUser,
+//		),
+//	)
+//	newCrontab = append(
+//		newCrontab,
+//		fmt.Sprintf(
+//			"%s %s 1>>%s 2>&1\n",
+//			c.Params.Options.CrontabTime, entryShell, logfile,
+//		),
+//	)
+//	crontabStr := strings.Join(newCrontab, "\n")
+//	return osutil.AddCrontab(crontabStr)
+//}
+
+func AddCrond(ports []int) (err error) {
+	for _, port := range ports {
+		err = addOneCrond(port)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
 	}
-	entryShell := path.Join(cst.DbbackupGoInstallPath, "dbbackup_main.sh")
-	logfile := path.Join(cst.DbbackupGoInstallPath, "dbbackup.log")
-	newCrontab = append(
-		newCrontab,
-		fmt.Sprintf(
-			"#dbbackup/dbbackup_main.sh: backup database every day, distribute at %s by %s",
-			time.Now().Format(cst.TIMELAYOUT), c.Params.ExecUser,
-		),
-	)
-	newCrontab = append(
-		newCrontab,
-		fmt.Sprintf(
-			"%s %s 1>>%s 2>&1\n",
-			c.Params.Options.CrontabTime, entryShell, logfile,
-		),
-	)
-	crontabStr := strings.Join(newCrontab, "\n")
-	return osutil.AddCrontab(crontabStr)
+	return nil
+}
+
+func addOneCrond(port int) (err error) {
+	cfgFp := filepath.Join(cst.DbbackupGoInstallPath, fmt.Sprintf("dbbackup.%d.ini", port))
+	cfgIni, err := ini.Load(cfgFp)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	var cfg config.BackupConfig
+	err = cfgIni.MapTo(&cfg)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	rvApi, err := reverseapi.NewReverseApi(int64(cfg.Public.BkCloudId))
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	data, err := rvApi.MySQL.DBBackupConfig(port)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	var backupCfgs []mysql.DBBackupConfig
+	err = json.Unmarshal(data, &backupCfgs)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	if len(backupCfgs) == 0 || slices.IndexFunc(backupCfgs, func(e mysql.DBBackupConfig) bool {
+		return e.Port == port
+	}) < 0 {
+		err = fmt.Errorf("backup config does not contain backup port:%d", port)
+		logger.Error(err.Error())
+		return err
+	}
+
+	backupCfg := backupCfgs[0]
+
+	var opt BackupOptions
+	err = json.Unmarshal(backupCfg.Options, &opt)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	cm := ma.NewManager("http://127.0.0.1:9999")
+	logger.Info("cluster type: %s", backupCfg.ClusterType)
+
+	if backupCfg.ClusterType == cst.TendbCluster {
+		err = addCrontabSpider(cm, backupCfg.Role, port, opt.CrontabTime)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+
+	} else {
+		err = addCrontabLegacy(cm, opt.CrontabTime)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+	}
 }

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dbbackup/binary.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dbbackup/binary.go
@@ -12,6 +12,7 @@ import (
 )
 
 func DeployBinary(medium *components.Medium) (err error) {
+	logger.Info("deploy mysql-dbbackup")
 	if err = medium.Check(); err != nil {
 		return err
 	}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/exporter/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/exporter/init.go
@@ -2,10 +2,12 @@ package exporter
 
 import (
 	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/common/reverseapi"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/common"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/native"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -108,4 +110,83 @@ func (c *PushCnfComp) Example() interface{} {
 			MachineType: "proxy",
 		},
 	}
+}
+
+type exporterConfig struct {
+	Ip          string `json:"ip"`
+	Port        int    `json:"port"`
+	User        string `json:"user"`
+	Password    string `json:"password"`
+	MachineType string `json:"machine_type"`
+}
+
+func GenConfig(bkCloudId int64, nginxAddrs []string, ports ...int) error {
+	rvApi := reverseapi.NewReverseApiWithAddr(bkCloudId, nginxAddrs...)
+	data, err := rvApi.MySQL.ExporterConfig(ports...)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	logger.Info("exporter config: %s", string(data))
+
+	var exporterConfigs []exporterConfig
+	err = json.Unmarshal(data, &exporterConfigs)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	for _, cfg := range exporterConfigs {
+		err := genOne(&cfg)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+	}
+
+	return nil
+}
+
+func genOne(cfg *exporterConfig) error {
+	if cfg.MachineType == "proxy" {
+		return genOneProxy(cfg)
+	} else {
+		return genOneMySQL(cfg)
+	}
+}
+
+func genOneProxy(cfg *exporterConfig) error {
+	fp := fmt.Sprintf("/etc/exporter_%d.cnf", cfg.Port)
+	f, err := os.OpenFile(fp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	content := fmt.Sprintf(
+		`%s:%d,,,%s:%d,%s,%s`,
+		cfg.Ip, cfg.Port,
+		cfg.Ip, native.GetProxyAdminPort(cfg.Port),
+		cfg.User, cfg.Password,
+	)
+
+	_, err = f.WriteString(content)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	return nil
+}
+
+func genOneMySQL(cfg *exporterConfig) error {
+	fp := fmt.Sprintf("/etc/exporter_%d.cnf", cfg.Port)
+	err := util.CreateExporterConf(fp, cfg.Ip, cfg.Port, cfg.User, cfg.Password)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	return nil
 }

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/gen_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/gen_config.go
@@ -1,0 +1,78 @@
+package peripheraltools
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/common"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/crond"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dbbackup"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/exporter"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog"
+
+	"github.com/pkg/errors"
+)
+
+type GenConfig struct {
+	GeneralParam *components.GeneralParam `json:"general"`
+	Param        *GenConfigParam          `json:"extend"`
+}
+
+type GenConfigParam struct {
+	BKCloudId  int64    `json:"bk_cloud_id"`
+	IP         string   `json:"ip"`
+	Ports      []int    `json:"ports"`
+	Departs    []string `json:"departs"`
+	NginxAddrs []string `json:"nginx_addrs"`
+}
+
+func (c *GenConfig) Run() (err error) {
+	for _, depart := range c.Param.Departs {
+		err = c.genOne(depart)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *GenConfig) genOne(depart string) (err error) {
+	if depart == DepartExporter {
+		return exporter.GenConfig(c.Param.BKCloudId, c.Param.NginxAddrs, c.Param.Ports...)
+	}
+
+	switch depart {
+	case DepartMySQLCrond:
+		return crond.GenConfig(c.Param.BKCloudId, c.Param.NginxAddrs)
+	case DepartMySQLMonitor:
+		return monitor.GenConfig(c.Param.BKCloudId, c.Param.NginxAddrs, c.Param.Ports)
+	case DepartMySQLDBBackup:
+		return dbbackup.GenConfig(c.Param.BKCloudId, c.Param.NginxAddrs, c.Param.Ports)
+	case DepartMySQLRotateBinlog:
+		return rotatebinlog.GenConfig(c.Param.BKCloudId, c.Param.NginxAddrs, c.Param.Ports)
+	case DepartMySQLTableChecksum:
+		return checksum.GenConfig(c.Param.BKCloudId, c.Param.NginxAddrs, c.Param.Ports)
+	default:
+		err = errors.New("unknown depart " + depart)
+		logger.Error(err.Error())
+		return nil
+	}
+}
+
+func (c *GenConfig) Example() interface{} {
+	return GenConfig{
+		GeneralParam: &components.GeneralParam{
+			RuntimeAccountParam: components.RuntimeAccountParam{
+				MySQLAccountParam: common.AccountMonitorExample,
+			},
+		},
+		Param: &GenConfigParam{
+			BKCloudId:  0,
+			IP:         "1.1.1.1",
+			Ports:      []int{3306},
+			Departs:    []string{DepartExporter, DepartMySQLCrond},
+			NginxAddrs: []string{"2.2.2.2:88"},
+		}}
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/init.go
@@ -1,5 +1,15 @@
 package peripheraltools
 
+const (
+	DepartDBAToolKit         = "dba-toolkit"
+	DepartMySQLCrond         = "mysql-crond"
+	DepartMySQLMonitor       = "mysql-monitor"
+	DepartMySQLDBBackup      = "mysql-dbbackup"
+	DepartMySQLRotateBinlog  = "rotate-binlog"
+	DepartMySQLTableChecksum = "mysql-checksum"
+	DepartExporter           = "exporter"
+)
+
 type LogConfig struct {
 	Console    bool    `yaml:"console"`
 	LogFileDir *string `yaml:"log_file_dir"`

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/init_nginx_addresses.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/init_nginx_addresses.go
@@ -1,0 +1,77 @@
+package peripheraltools
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/common/reverseapi"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+type InitNginxAddresses struct {
+	Param *InitNginxAddressesParam `json:"extend"`
+}
+
+type InitNginxAddressesParam struct {
+	NginxAddrs []string `json:"nginx_addrs"`
+}
+
+func (c *InitNginxAddresses) Run() (err error) {
+	if len(c.Param.NginxAddrs) == 0 {
+		err = fmt.Errorf("no nginx addresses specified")
+		logger.Error(err.Error())
+		return err
+	}
+
+	err = os.MkdirAll(reverseapi.DefaultCommonConfigDir, 0777)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	fp := filepath.Join(reverseapi.DefaultCommonConfigDir, reverseapi.DefaultNginxProxyAddrsFileName)
+	f, err := os.OpenFile(fp, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	for _, nginxAddr := range c.Param.NginxAddrs {
+		_, err = f.WriteString(nginxAddr + "\n")
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+	}
+
+	cu, err := user.Current()
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+	if cu.Uid == "0" {
+		_, err = osutil.ExecShellCommand(
+			false,
+			fmt.Sprintf(`chown -R mysql %s`, reverseapi.DefaultCommonConfigDir),
+		)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *InitNginxAddresses) Example() interface{} {
+	return InitNginxAddresses{
+		Param: &InitNginxAddressesParam{
+			NginxAddrs: []string{"fake_ip1:13333", "fake_ip2:13333"},
+		},
+	}
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/binary.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/binary.go
@@ -11,6 +11,7 @@ import (
 )
 
 func DeployBinary(medium *components.Medium) (err error) {
+	logger.Info("deploy mysql-monitor")
 	err = os.MkdirAll(cst.MySQLMonitorInstallPath, 0755)
 	if err != nil {
 		logger.Error("mkdir %s failed: %s", cst.MySQLCrondInstallPath, err.Error())

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/config.go
@@ -1,0 +1,62 @@
+package monitor
+
+import (
+	"bytes"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/common/reverseapi"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/tools"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func (c *MySQLMonitorComp) GenConfig() error {
+	nginxAddrs, err := reverseapi.ReadNginxProxyAddrs(
+		filepath.Join(reverseapi.DefaultCommonConfigDir, reverseapi.DefaultNginxProxyAddrsFileName),
+	)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	var ports []int
+	for _, ele := range c.Params.PortBkInstanceList {
+		ports = append(ports, ele.Port)
+	}
+	return GenConfig(int64(c.Params.BkCloudId), nginxAddrs, ports)
+}
+
+func GenConfig(bkCloudId int64, nginxAddrs []string, ports []int) error {
+	t, err := tools.NewToolSetWithPick(tools.ToolMySQLMonitor)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
+	genCmdStr := fmt.Sprintf(
+		"%s gen-config --bk-cloud-id %d --nginx-address %s",
+		t.MustGet(tools.ToolMySQLMonitor),
+		bkCloudId,
+		strings.Join(nginxAddrs, ","),
+	)
+	for _, port := range ports {
+		genCmdStr += fmt.Sprintf(" --port %d", port)
+	}
+	logger.Info(genCmdStr)
+
+	cmd := exec.Command("sh", "-c", genCmdStr)
+	logger.Info(cmd.String())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		logger.Error("%s: %s", err, stderr.String())
+		return errors.Wrap(err, stderr.String())
+	}
+
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/items_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/items_config.go
@@ -1,46 +1,31 @@
 package monitor
 
-import (
-	"fmt"
-	"path/filepath"
-	"slices"
-	"strings"
-
-	"dbm-services/common/go-pubpkg/logger"
-	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/internal"
-	"dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
-	"dbm-services/mysql/db-tools/mysql-monitor/pkg/config"
-
-	"golang.org/x/exp/maps"
-	"gopkg.in/yaml.v2"
-)
-
-func (c *MySQLMonitorComp) GenerateItemsConfig() (err error) {
-	for _, ele := range c.Params.PortBkInstanceList {
-		err = c.generateItemsConfigIns(ele.Port)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *MySQLMonitorComp) generateItemsConfigIns(port int) (err error) {
-	itemList := maps.Values(c.Params.ItemsConfig)
-	slices.SortFunc(itemList, func(a, b *config.MonitorItem) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-
-	b, err := yaml.Marshal(itemList)
-	if err != nil {
-		logger.Error(err.Error())
-		return err
-	}
-
-	itemConfigPath := filepath.Join(
-		cst.MySQLMonitorInstallPath,
-		fmt.Sprintf(`items-config_%d.yaml`, port),
-	)
-
-	return internal.WriteConfig(itemConfigPath, append(b, []byte("\n")...))
-}
+//func (c *MySQLMonitorComp) GenerateItemsConfig() (err error) {
+//	for _, ele := range c.Params.PortBkInstanceList {
+//		err = c.generateItemsConfigIns(ele.Port)
+//		if err != nil {
+//			return err
+//		}
+//	}
+//	return nil
+//}
+//
+//func (c *MySQLMonitorComp) generateItemsConfigIns(port int) (err error) {
+//	itemList := maps.Values(c.Params.ItemsConfig)
+//	slices.SortFunc(itemList, func(a, b *config.MonitorItem) int {
+//		return strings.Compare(a.Name, b.Name)
+//	})
+//
+//	b, err := yaml.Marshal(itemList)
+//	if err != nil {
+//		logger.Error(err.Error())
+//		return err
+//	}
+//
+//	itemConfigPath := filepath.Join(
+//		cst.MySQLMonitorInstallPath,
+//		fmt.Sprintf(`items-config_%d.yaml`, port),
+//	)
+//
+//	return internal.WriteConfig(itemConfigPath, append(b, []byte("\n")...))
+//}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/runtime_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor/runtime_config.go
@@ -1,161 +1,145 @@
 package monitor
 
-import (
-	"context"
-	"dbm-services/common/go-pubpkg/logger"
-	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/internal"
-	"dbm-services/mysql/db-tools/mysql-monitor/pkg/config"
-
-	"dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
-	"fmt"
-	"path/filepath"
-	"time"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
-)
-
-func (c *MySQLMonitorComp) GenerateRuntimeConfig() (err error) {
-	for _, ele := range c.Params.PortBkInstanceList {
-		err = c.generateRuntimeConfigIns(ele.Port, ele.BkInstanceId)
-		if err != nil {
-			return err
-		}
-
-		if c.Params.MachineType == "backend" {
-			err = c.createUserListBackupTable(ele.Port)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (c *MySQLMonitorComp) createUserListBackupTable(port int) (err error) {
-	db, err := sqlx.Connect(
-		"mysql",
-		fmt.Sprintf("%s:%s@tcp(%s:%d)/",
-			c.GeneralParam.RuntimeAccountParam.MonitorUser, c.GeneralParam.RuntimeAccountParam.MonitorPwd,
-			c.Params.IP, port,
-		))
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = db.Close()
-	}()
-
-	_, err = db.ExecContext(
-		context.Background(),
-		`CREATE TABLE IF NOT EXISTS infodba_schema.proxy_user_list(
-					proxy_ip varchar(32) NOT NULL,
-					username varchar(64) NOT NULL,
-					host varchar(32) NOT NULL,
-					create_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-					PRIMARY KEY (proxy_ip, username, host),
-					KEY IDX_USERNAME_HOST(username, host, create_at),
-					KEY IDX_HOST(host, create_at),
-					KEY IDX_IP_HOST(proxy_ip, host, create_at)
-				) ENGINE=InnoDB;`,
-	)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *MySQLMonitorComp) generateRuntimeConfigIns(port int, bkInstanceId int64) (err error) {
-	logDir := filepath.Join(cst.MySQLMonitorInstallPath, "logs")
-
-	ac, err := c.authByMachineType()
-	if err != nil {
-		return err
-	}
-
-	if bkInstanceId < 0 {
-		err = errors.Errorf(
-			"%s:%d invalid bk_instance_id: %d",
-			c.Params.IP, port, bkInstanceId,
-		)
-		logger.Error(err.Error())
-		return err
-	}
-
-	cfg := config.Config{
-		BkBizId:      c.Params.BKBizId,
-		Ip:           c.Params.IP,
-		Port:         port,
-		BkInstanceId: bkInstanceId,
-		ImmuteDomain: c.Params.ImmuteDomain,
-		MachineType:  c.Params.MachineType,
-		Role:         &c.Params.Role,
-		BkCloudID:    &c.Params.BkCloudId,
-		ClusterType:  c.Params.ClusterType,
-		//DBModuleID:   &c.Params.DBModuleId,
-		Log: &config.LogConfig{
-			Console:    false,
-			LogFileDir: &logDir,
-			Debug:      false,
-			Source:     true,
-			Json:       true,
-		},
-		ItemsConfigFile: filepath.Join(
-			cst.MySQLMonitorInstallPath,
-			fmt.Sprintf("items-config_%d.yaml", port),
-		),
-		Auth:            *ac,
-		ApiUrl:          c.Params.ApiUrl,
-		DBASysDbs:       c.Params.SystemDbs,
-		InteractTimeout: 5 * time.Second,
-		DefaultSchedule: "@every 1m",
-	}
-
-	b, err := yaml.Marshal(cfg)
-	if err != nil {
-		logger.Error(err.Error())
-		return err
-	}
-
-	cfgFilePath := filepath.Join(
-		filepath.Join(cst.MySQLMonitorInstallPath,
-			fmt.Sprintf("monitor-config_%d.yaml", port)),
-	)
-
-	err = internal.WriteConfig(cfgFilePath, b)
-	if err != nil {
-		logger.Error(err.Error())
-		return err
-	}
-	//}
-	return nil
-}
-
-func (c *MySQLMonitorComp) authByMachineType() (ac *config.AuthCollect, err error) {
-	switch c.Params.MachineType {
-	case "proxy":
-		ac = &config.AuthCollect{
-			Proxy: &config.ConnectAuth{
-				User:     c.GeneralParam.RuntimeAccountParam.MonitorAccessAllUser,
-				Password: c.GeneralParam.RuntimeAccountParam.MonitorAccessAllPwd,
-			},
-			ProxyAdmin: &config.ConnectAuth{
-				User:     c.GeneralParam.RuntimeAccountParam.ProxyAdminUser,
-				Password: c.GeneralParam.RuntimeAccountParam.ProxyAdminPwd,
-			},
-		}
-	case "backend", "single", "remote", "spider":
-		ac = &config.AuthCollect{
-			Mysql: &config.ConnectAuth{
-				User:     c.GeneralParam.RuntimeAccountParam.MonitorUser,
-				Password: c.GeneralParam.RuntimeAccountParam.MonitorPwd,
-			},
-		}
-	default:
-		err = errors.Errorf("not support machine type: %s", c.Params.MachineType)
-		logger.Error(err.Error())
-		return nil, err
-	}
-	return ac, nil
-}
+//func (c *MySQLMonitorComp) GenerateRuntimeConfig() (err error) {
+//	for _, ele := range c.Params.PortBkInstanceList {
+//		err = c.generateRuntimeConfigIns(ele.Port, ele.BkInstanceId)
+//		if err != nil {
+//			return err
+//		}
+//
+//		if c.Params.MachineType == "backend" {
+//			err = c.createUserListBackupTable(ele.Port)
+//			if err != nil {
+//				return err
+//			}
+//		}
+//	}
+//	return nil
+//}
+//
+//func (c *MySQLMonitorComp) createUserListBackupTable(port int) (err error) {
+//	db, err := sqlx.Connect(
+//		"mysql",
+//		fmt.Sprintf("%s:%s@tcp(%s:%d)/",
+//			c.GeneralParam.RuntimeAccountParam.MonitorUser, c.GeneralParam.RuntimeAccountParam.MonitorPwd,
+//			c.Params.IP, port,
+//		))
+//	if err != nil {
+//		return err
+//	}
+//	defer func() {
+//		_ = db.Close()
+//	}()
+//
+//	_, err = db.ExecContext(
+//		context.Background(),
+//		`CREATE TABLE IF NOT EXISTS infodba_schema.proxy_user_list(
+//					proxy_ip varchar(32) NOT NULL,
+//					username varchar(64) NOT NULL,
+//					host varchar(32) NOT NULL,
+//					create_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+//					PRIMARY KEY (proxy_ip, username, host),
+//					KEY IDX_USERNAME_HOST(username, host, create_at),
+//					KEY IDX_HOST(host, create_at),
+//					KEY IDX_IP_HOST(proxy_ip, host, create_at)
+//				) ENGINE=InnoDB;`,
+//	)
+//	if err != nil {
+//		return err
+//	}
+//	return nil
+//}
+//
+//func (c *MySQLMonitorComp) generateRuntimeConfigIns(port int, bkInstanceId int64) (err error) {
+//	logDir := filepath.Join(cst.MySQLMonitorInstallPath, "logs")
+//
+//	ac, err := c.authByMachineType()
+//	if err != nil {
+//		return err
+//	}
+//
+//	if bkInstanceId < 0 {
+//		err = errors.Errorf(
+//			"%s:%d invalid bk_instance_id: %d",
+//			c.Params.IP, port, bkInstanceId,
+//		)
+//		logger.Error(err.Error())
+//		return err
+//	}
+//
+//	cfg := config.Config{
+//		BkBizId:      c.Params.BKBizId,
+//		Ip:           c.Params.IP,
+//		Port:         port,
+//		BkInstanceId: bkInstanceId,
+//		ImmuteDomain: c.Params.ImmuteDomain,
+//		MachineType:  c.Params.MachineType,
+//		Role:         &c.Params.Role,
+//		BkCloudID:    &c.Params.BkCloudId,
+//		ClusterType:  c.Params.ClusterType,
+//		//DBModuleID:   &c.Params.DBModuleId,
+//		Log: &config.LogConfig{
+//			Console:    false,
+//			LogFileDir: &logDir,
+//			Debug:      false,
+//			Source:     true,
+//			Json:       true,
+//		},
+//		ItemsConfigFile: filepath.Join(
+//			cst.MySQLMonitorInstallPath,
+//			fmt.Sprintf("items-config_%d.yaml", port),
+//		),
+//		Auth:            *ac,
+//		ApiUrl:          c.Params.ApiUrl,
+//		DBASysDbs:       c.Params.SystemDbs,
+//		InteractTimeout: 5 * time.Second,
+//		DefaultSchedule: "@every 1m",
+//	}
+//
+//	b, err := yaml.Marshal(cfg)
+//	if err != nil {
+//		logger.Error(err.Error())
+//		return err
+//	}
+//
+//	cfgFilePath := filepath.Join(
+//		filepath.Join(cst.MySQLMonitorInstallPath,
+//			fmt.Sprintf("monitor-config_%d.yaml", port)),
+//	)
+//
+//	err = internal.WriteConfig(cfgFilePath, b)
+//	if err != nil {
+//		logger.Error(err.Error())
+//		return err
+//	}
+//	//}
+//	return nil
+//}
+//
+//func (c *MySQLMonitorComp) authByMachineType() (ac *config.AuthCollect, err error) {
+//	switch c.Params.MachineType {
+//	case "proxy":
+//		ac = &config.AuthCollect{
+//			Proxy: &config.ConnectAuth{
+//				User:     c.GeneralParam.RuntimeAccountParam.MonitorAccessAllUser,
+//				Password: c.GeneralParam.RuntimeAccountParam.MonitorAccessAllPwd,
+//			},
+//			ProxyAdmin: &config.ConnectAuth{
+//				User:     c.GeneralParam.RuntimeAccountParam.ProxyAdminUser,
+//				Password: c.GeneralParam.RuntimeAccountParam.ProxyAdminPwd,
+//			},
+//		}
+//	case "backend", "single", "remote", "spider":
+//		ac = &config.AuthCollect{
+//			Mysql: &config.ConnectAuth{
+//				User:     c.GeneralParam.RuntimeAccountParam.MonitorUser,
+//				Password: c.GeneralParam.RuntimeAccountParam.MonitorPwd,
+//			},
+//		}
+//	default:
+//		err = errors.Errorf("not support machine type: %s", c.Params.MachineType)
+//		logger.Error(err.Error())
+//		return nil, err
+//	}
+//	return ac, nil
+//}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/prepare_binary.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/prepare_binary.go
@@ -13,15 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	DepartDBAToolKit         = "dba-toolkit"
-	DepartMySQLCrond         = "mysql-crond"
-	DepartMySQLMonitor       = "mysql-monitor"
-	DepartMySQLDBBackup      = "mysql-dbbackup"
-	DepartMySQLRotateBinlog  = "rotate-binlog"
-	DepartMySQLTableChecksum = "mysql-checksum"
-)
-
 type PrepareBinary struct {
 	GeneralParam *components.GeneralParam `json:"general"`
 	Params       *PrepareBinaryParams     `json:"extend"`
@@ -51,6 +42,7 @@ func (c *PrepareBinary) Run() (err error) {
 }
 
 func (c *PrepareBinary) prepareOne(depart string) (err error) {
+	logger.Info("enter deploy binary %s", depart)
 	switch depart {
 	case DepartMySQLCrond:
 		return crond.DeployBinary(c.Params.Departs[DepartMySQLCrond])

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/reload.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/reload.go
@@ -1,0 +1,99 @@
+package peripheraltools
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/common"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/checksum"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/crond"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/dbbackup"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/monitor"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog"
+	"fmt"
+)
+
+type Reload struct {
+	GeneralParam *components.GeneralParam `json:"general"`
+	Param        *ReloadParam             `json:"extend"`
+}
+
+type ReloadParam struct {
+	IP      string   `json:"ip"`
+	Ports   []int    `json:"ports"`
+	Departs []string `json:"departs"`
+}
+
+func (c *Reload) Run() (err error) {
+	for _, depart := range c.Param.Departs {
+		err = c.reloadDepart(depart)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Reload) reloadDepart(depart string) (err error) {
+	switch depart {
+	case DepartMySQLCrond:
+		err = crond.Stop()
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		err = crond.Start()
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+	case DepartMySQLRotateBinlog:
+		err = rotatebinlog.AddCrond()
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+	case DepartMySQLTableChecksum:
+		err = checksum.AddCrond(c.Param.Ports)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+	case DepartMySQLDBBackup:
+		err = dbbackup.AddCrond(c.Param.Ports)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+	case DepartMySQLMonitor:
+		err = monitor.AddCrond(c.Param.Ports)
+		if err != nil {
+			logger.Error(err.Error())
+			return err
+		}
+		return nil
+	default:
+		err = fmt.Errorf("unknown depart %s", depart)
+		logger.Error(err.Error())
+		return nil
+	}
+}
+
+func (c *Reload) Example() interface{} {
+	return Reload{
+		GeneralParam: &components.GeneralParam{
+			RuntimeAccountParam: components.RuntimeAccountParam{
+				MySQLAccountParam: common.AccountMonitorExample,
+			},
+		},
+		Param: &ReloadParam{
+			IP:      "127.0.0.1",
+			Ports:   []int{20000},
+			Departs: []string{DepartExporter},
+		},
+	}
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/add_crond.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/add_crond.go
@@ -1,20 +1,36 @@
 package rotatebinlog
 
 import (
+	"dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/tools"
 	"fmt"
+	"path/filepath"
 
 	"dbm-services/common/go-pubpkg/logger"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil"
 )
 
 func (c *MySQLRotateBinlogComp) AddCrond() (err error) {
+	return AddCrond()
+}
+
+func AddCrond() (err error) {
+	tl, err := tools.NewToolSetWithPick(tools.ToolMysqlRotatebinlog)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
 	err = osutil.RemoveSystemCrontab("rotate_logbin")
 	if err != nil {
 		logger.Error("remove old rotate_logbin crontab failed: %s", err.Error())
 		return err
 	}
 	scheduleCmd := fmt.Sprintf("%s -c %s crond --add 2>/dev/null && chown -R mysql:mysql %s",
-		c.binPath, c.configFile, c.installPath)
+		tl.MustGet(tools.ToolMysqlRotatebinlog),
+		filepath.Join(cst.MysqlRotateBinlogInstallPath, "main.yaml"),
+		cst.MysqlRotateBinlogInstallPath,
+	)
 	str, err := osutil.ExecShellCommand(false, scheduleCmd)
 	if err != nil {
 		logger.Error(

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/binary.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/binary.go
@@ -13,6 +13,7 @@ import (
 )
 
 func DeployBinary(medium *components.Medium) (err error) {
+	logger.Info("deploy rotate-binlog")
 	err = os.MkdirAll(filepath.Join(cst.MysqlRotateBinlogInstallPath, "logs"), 0755)
 	if err != nil {
 		logger.Error("mkdir %s failed: %s", cst.MysqlRotateBinlogInstallPath, err.Error())

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/init.go
@@ -23,6 +23,7 @@ type MySQLRotateBinlogComp struct {
 }
 
 type MySQLRotateBinlogParam struct {
+	BkCloudId     int           `json:"bk_cloud_id"`
 	Configs       rotate.Config `json:"configs" validate:"required"`
 	IP            string        `json:"ip"`
 	Ports         []int         `json:"port_list"`

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/runtime_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/rotatebinlog/runtime_config.go
@@ -1,72 +1,58 @@
 package rotatebinlog
 
 import (
-	"encoding/json"
+	"bytes"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/common/reverseapi"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/tools"
 	"fmt"
-	"os"
+	"os/exec"
 	"path/filepath"
-	"reflect"
+	"strings"
 
-	gyaml "github.com/ghodss/yaml"
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
-	"github.com/spf13/cast"
-
-	"dbm-services/mysql/db-tools/mysql-rotatebinlog/pkg/backup"
 )
 
 func (c *MySQLRotateBinlogComp) GenerateRuntimeConfig() (err error) {
-	for k, val := range c.Params.Configs.BackupClient {
-		if k == "ibs" {
-			ibsClient := backup.IBSBackupClient{}
-			if reflect.TypeOf(val).Kind() == reflect.Map {
-				// backup_client.ibs 返回的是 json map,比如 {"enable": true,"ibs_mode": "hdfs","with_md5": true,"file_tag": "INCREMENT_BACKUP","tool_path": "backup_client"}
-				if err := mapstructure.Decode(val, &ibsClient); err != nil {
-					return errors.Wrapf(err, "fail to decode backup_client.ibs value:%v", val)
-				} else {
-					c.Params.Configs.BackupClient[k] = ibsClient
-				}
-			} else {
-				// backup_client.ibs 返回的是 string, 比如：{\"enable\": true,\"ibs_mode\": \"hdfs\",\"with_md5\": true,\"file_tag\": \"INCREMENT_BACKUP\",\"tool_path\": \"backup_client\"}
-				if err := json.Unmarshal([]byte(cast.ToString(val)), &ibsClient); err != nil {
-					return errors.Wrapf(err, "fail to parse backup_client.ibs value:%v", val)
-				} else {
-					c.Params.Configs.BackupClient[k] = ibsClient
-				}
-			}
-		} else {
-			mapObj := make(map[string]interface{})
-			if reflect.TypeOf(val).Kind() == reflect.Map {
-				mapObj = val.(map[string]interface{})
-			} else if err := json.Unmarshal([]byte(cast.ToString(val)), &mapObj); err != nil {
-				return errors.Wrapf(err, "fail to parse backup_client value:%v", val)
-			}
-			c.Params.Configs.BackupClient[k] = mapObj
-		}
-	}
-
-	// rotatebinlog config has main:main.yaml and instance:server.<port>.yaml
-	// first: render instance server.<port>.yaml
-	for _, serverConfig := range c.Params.Configs.Servers {
-		yamlData, err := gyaml.Marshal(serverConfig) // use json tag
-		if err != nil {
-			return err
-		}
-		serverConfigFile := filepath.Join(c.installPath, fmt.Sprintf("server.%d.yaml", serverConfig.Port))
-		if err := os.WriteFile(serverConfigFile, yamlData, 0644); err != nil {
-			return err
-		}
-	}
-
-	// then: render mail main.yaml (remove servers section)
-	c.Params.Configs.Servers = nil
-	yamlData, err := gyaml.Marshal(c.Params.Configs) // use json tag
+	nginxAddrs, err := reverseapi.ReadNginxProxyAddrs(
+		filepath.Join(reverseapi.DefaultCommonConfigDir, reverseapi.DefaultNginxProxyAddrsFileName),
+	)
 	if err != nil {
+		logger.Error(err.Error())
 		return err
 	}
-	c.configFile = filepath.Join(c.installPath, "main.yaml")
-	if err := os.WriteFile(c.configFile, yamlData, 0644); err != nil {
+
+	return GenConfig(int64(c.Params.BkCloudId), nginxAddrs, c.Params.Ports)
+}
+
+func GenConfig(bkCloudId int64, nginxAddrs []string, ports []int) error {
+	t, err := tools.NewToolSetWithPick(tools.ToolMysqlRotatebinlog)
+	if err != nil {
+		logger.Error(err.Error())
 		return err
 	}
+
+	genCmdStr := fmt.Sprintf(
+		"%s gen-config --bk-cloud-id %d --nginx-address %s",
+		t.MustGet(tools.ToolMysqlRotatebinlog),
+		bkCloudId,
+		strings.Join(nginxAddrs, ","),
+	)
+	for _, port := range ports {
+		genCmdStr += fmt.Sprintf(" --port %d", port)
+	}
+	logger.Info(genCmdStr)
+
+	cmd := exec.Command("sh", "-c", genCmdStr)
+	logger.Info(cmd.String())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		logger.Error("%s: %s", err, stderr.String())
+		return errors.Wrap(err, stderr.String())
+	}
+
 	return nil
 }

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/tools/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/tools/init.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
@@ -22,7 +21,7 @@ const (
 	ToolXLoad ExternalTool = "xload"
 	// ToolQPress qpress
 	ToolQPress ExternalTool = "qpress"
-	// ToolPv TODO
+	// ToolPv pv
 	ToolPv ExternalTool = "pv"
 	// ToolMysqlbinlogRollback mysqlbinlog_rollback
 	ToolMysqlbinlogRollback ExternalTool = "mysqlbinlog_rollback"
@@ -56,12 +55,13 @@ var defaultPath = map[ExternalTool]string{
 	ToolGoMysqlbinlog:         filepath.Join(cst.DBAToolkitPath, string(ToolGoMysqlbinlog)),
 	ToolMysqlbinlogRollback:   filepath.Join(cst.DBAToolkitPath, string(ToolMysqlbinlogRollback)),
 	ToolMysqlbinlogRollback80: filepath.Join(cst.DBAToolkitPath, "mysqlbinlog_rollback_80"),
-	ToolMysqlTableChecksum:    path.Join(cst.ChecksumInstallPath, string(ToolMysqlTableChecksum)),
-	ToolPtTableChecksum:       path.Join(cst.ChecksumInstallPath, string(ToolPtTableChecksum)),
-	ToolPtTableSync:           path.Join(cst.ChecksumInstallPath, string(ToolPtTableSync)),
-	ToolDbbackupGo:            path.Join(cst.DbbackupGoInstallPath, string(ToolDbbackupGo)),
-	ToolMySQLCrond:            path.Join(cst.MySQLCrondInstallPath, string(ToolMySQLCrond)),
-	ToolMySQLMonitor:          path.Join(cst.MySQLMonitorInstallPath, string(ToolMySQLMonitor)),
+	ToolMysqlTableChecksum:    filepath.Join(cst.ChecksumInstallPath, string(ToolMysqlTableChecksum)),
+	ToolPtTableChecksum:       filepath.Join(cst.ChecksumInstallPath, string(ToolPtTableChecksum)),
+	ToolPtTableSync:           filepath.Join(cst.ChecksumInstallPath, string(ToolPtTableSync)),
+	ToolDbbackupGo:            filepath.Join(cst.DbbackupGoInstallPath, string(ToolDbbackupGo)),
+	ToolMySQLCrond:            filepath.Join(cst.MySQLCrondInstallPath, string(ToolMySQLCrond)),
+	ToolMySQLMonitor:          filepath.Join(cst.MySQLMonitorInstallPath, string(ToolMySQLMonitor)),
+	ToolMysqlRotatebinlog:     filepath.Join(cst.MysqlRotateBinlogInstallPath, string(ToolMysqlRotatebinlog)),
 }
 
 // ToolPath 基本结构

--- a/dbm-services/mysql/db-tools/mysql-crond/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/cmd/subcmd_gen_config.go
@@ -88,9 +88,9 @@ jobs_config: {{ .InstallPath }}/jobs-config.yaml`,
 			EventDataToken   string `json:"event_data_token"`
 			MetricsDataId    int    `json:"metrics_data_id"`
 			MetricsDataToken string `json:"metrics_data_token"`
-			LogPath          string `json:"log_path"`
-			PidPath          string `json:"pid_path"`
-			InstallPath      string `json:"install_path"`
+			LogPath          string `json:"-"`
+			PidPath          string `json:"-"`
+			InstallPath      string `json:"-"`
 			BeatPath         string `json:"beat_path"`
 			AgentAddress     string `json:"agent_address"`
 		}{}

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/proxyuserlist/backup.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/proxyuserlist/backup.go
@@ -30,6 +30,23 @@ func (c *Checker) backupToBackend(users []string) error {
 		return err
 	}
 
+	_, err = conn.ExecContext(
+		context.Background(),
+		`CREATE TABLE IF NOT EXISTS infodba_schema.proxy_user_list(
+					proxy_ip varchar(32) NOT NULL,
+					username varchar(64) NOT NULL,
+					host varchar(32) NOT NULL,
+					create_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					PRIMARY KEY (proxy_ip, username, host),
+					KEY IDX_USERNAME_HOST(username, host, create_at),
+					KEY IDX_HOST(host, create_at),
+					KEY IDX_IP_HOST(proxy_ip, host, create_at)
+				) ENGINE=InnoDB;`,
+	)
+	if err != nil {
+		return err
+	}
+
 	stmt, err := conn.PreparexContext(
 		context.Background(),
 		`REPLACE INTO infodba_schema.proxy_user_list 

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/subcmd_gen_config.go
@@ -83,7 +83,7 @@ func generateOneRuntimeConfig(cfg *mysql.ChecksumConfig) error {
 	}
 
 	logDir := filepath.Join(checksumInstallPath, "logs")
-	tl := tools.NewToolSetWithPickNoValidate(tools.ToolMysqlTableChecksum, tools.ToolMysqlTableChecksum)
+	tl := tools.NewToolSetWithPickNoValidate(tools.ToolMysqlTableChecksum, tools.ToolPtTableChecksum)
 
 	var ptChecksumPath string
 	if viper.GetString("debug-pt-path") != "" {

--- a/dbm-ui/backend/db_proxy/reverse_api/mysql/views.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/mysql/views.py
@@ -19,7 +19,7 @@ from backend.db_proxy.reverse_api.decorators import reverse_api
 from backend.db_proxy.reverse_api.mysql.impl import list_instance_info
 from backend.db_proxy.reverse_api.mysql.impl.checksum_config import checksum_config
 from backend.db_proxy.reverse_api.mysql.impl.dbbackup_config import dbbackup_config
-from backend.db_proxy.reverse_api.mysql.impl.expoter_cnf import exporter_config
+from backend.db_proxy.reverse_api.mysql.impl.expoter_config import exporter_config
 from backend.db_proxy.reverse_api.mysql.impl.monitor_items_config import monitor_items_config
 from backend.db_proxy.reverse_api.mysql.impl.monitor_runtime_config import monitor_runtime_config
 from backend.db_proxy.reverse_api.mysql.impl.mysql_crond_config import mysql_crond_config

--- a/dbm-ui/backend/flow/consts.py
+++ b/dbm-ui/backend/flow/consts.py
@@ -474,6 +474,11 @@ class DBActuatorActionEnum(str, StructuredEnum):
     PushMySQLRotatebinlogConfig = EnumField("push-mysql-rotatebinlog-config", _("推送rotatebinlog配置"))
     PushExporterCnf = EnumField("push-exporter-cnf", _("push-exporter-cnf"))
     ProxyInplaceAutofix = EnumField("proxy-inplace-autofix", _("原地启动 proxy"))
+    # use reverse api
+    GenPeripheralToolsConfig = EnumField("gen-peripheraltools-config", _("生成周边配置"))
+    ReloadPeripheralToolsConfig = EnumField("reload-peripheraltools-config", _("重载周边配置"))
+    DeployPeripheralToolsBinary = EnumField("prepare-peripheraltools-binary", _("prepare-peripheraltools-binary"))
+    InitNginxAddresses = EnumField("init-nginx-addresses", _("初始化 nginx 地址"))
 
 
 class RedisActuatorActionEnum(str, StructuredEnum):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/common/builder.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/common/builder.py
@@ -58,7 +58,13 @@ class Builder(object):
 
     """
 
-    def __init__(self, root_id: str, data: Optional[Dict] = None, need_random_pass_cluster_ids: list = None):
+    def __init__(
+        self,
+        root_id: str,
+        data: Optional[Dict] = None,
+        need_random_pass_cluster_ids: list = None,
+        need_random_pass_instances: list = None,
+    ):
         """
         声明builder类的属性
         @param root_id: 流程id
@@ -68,6 +74,7 @@ class Builder(object):
         self.root_id = root_id
         self.data = data
         self.need_random_pass_cluster_ids = need_random_pass_cluster_ids
+        self.need_random_pass_instances = need_random_pass_instances
         self.start_act = EmptyStartEvent()
         self.end_act = EmptyEndEvent()
         if not self.data:
@@ -101,7 +108,7 @@ class Builder(object):
         act = self.add_act(
             act_name="create temp job account",
             act_component_code=AddTempUserForClusterComponent.code,
-            kwargs={"cluster_ids": self.need_random_pass_cluster_ids},
+            kwargs={"cluster_ids": self.need_random_pass_cluster_ids, "instances": self.need_random_pass_instances},
         )
         # 提出上下文的映射，这里存在bamboo的 bug
         self.rewritable_node_source_keys = [i for i in self.rewritable_node_source_keys if i["source_act"] != act.id]

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/departs.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/departs.py
@@ -24,6 +24,7 @@ class DeployPeripheralToolsDepart(str, StructuredEnum):
     MySQLMonitor = EnumField("mysql-monitor", _("mysql-monitor"))
     MySQLRotateBinlog = EnumField("rotate-binlog", _("rotate-binlog"))
     MySQLTableChecksum = EnumField("mysql-checksum", _("mysql-checksum"))
+    Exporter = EnumField("exporter", _("exporter"))
 
 
 ALLDEPARTS = [
@@ -37,6 +38,10 @@ ALLDEPARTS = [
 ]
 
 
-def remove_depart(d: DeployPeripheralToolsDepart, departs: List[DeployPeripheralToolsDepart]):
+def remove_depart(
+    d: DeployPeripheralToolsDepart, departs: List[DeployPeripheralToolsDepart]
+) -> List[DeployPeripheralToolsDepart]:
     if d in departs:
         departs.remove(d)
+
+    return departs

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/flow.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext as _
 
 from backend.db_meta.models import Cluster
 from backend.flow.engine.bamboo.scene.common.builder import Builder
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.departs import ALLDEPARTS
 from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.subflow import standardize_mysql_cluster_subflow
 from backend.flow.utils.mysql.mysql_context_dataclass import SystemInfoContext
 
@@ -75,14 +76,14 @@ class MySQLStandardizeFlow(object):
                     bk_biz_id=bk_biz_id,
                     cluster_type=self.data.get("cluster_type"),
                     clusters_detail=cluster_details,
-                    departs=self.data.get("departs"),
-                    with_deploy_binary=self.data.get("with_deploy_binary"),
-                    with_push_config=self.data.get("with_push_config"),
-                    with_collect_sysinfo=self.data.get("with_collect_sysinfo"),
+                    departs=self.data.get("departs", ALLDEPARTS),
+                    with_deploy_binary=self.data.get("with_deploy_binary", True),
+                    with_push_config=self.data.get("with_push_config", True),
+                    with_collect_sysinfo=self.data.get("with_collect_sysinfo", True),
                     with_actuator=True,
-                    with_bk_plugin=self.data.get("with_bk_plugin"),
-                    with_cc_standardize=self.data.get("with_cc_standardize"),
-                    with_instance_standardize=self.data.get("with_instance_standardize"),
+                    with_bk_plugin=self.data.get("with_bk_plugin", True),
+                    with_cc_standardize=self.data.get("with_cc_standardize", True),
+                    with_instance_standardize=self.data.get("with_instance_standardize", True),
                 )
             )
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/instance_standardize.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/instance_standardize.py
@@ -8,10 +8,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from collections import defaultdict
 from dataclasses import asdict
 from typing import Dict, List
 
 from bamboo_engine.builder import SubProcess
+from deprecated import deprecated
 from django.utils.translation import ugettext as _
 
 from backend.db_meta.enums import AccessLayer, ClusterMachineAccessTypeDefine, ClusterType, MachineType
@@ -21,10 +23,12 @@ from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.clusters_deta
     clusters_detail_ip_ports_by_access_layer,
 )
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
+from backend.flow.utils.mysql.act_payload.mysql.peripheraltools import PeripheralToolsPayload
 from backend.flow.utils.mysql.mysql_act_dataclass import ExecActuatorKwargs
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
 
 
+@deprecated
 def instance_standardize(
     root_id: str,
     data: Dict,
@@ -79,6 +83,7 @@ def make_proxy_standardize_acts(bk_cloud_id: int, ip_port_dict) -> List:
     return acts
 
 
+@deprecated
 def make_mysql_standardize_acts(bk_cloud_id: int, ip_port_dict, machine_type: MachineType) -> List:
     acts = []
     for ip, port_list in ip_port_dict.items():
@@ -98,3 +103,33 @@ def make_mysql_standardize_acts(bk_cloud_id: int, ip_port_dict, machine_type: Ma
             }
         )
     return acts
+
+
+def standardize_instance(root_id: str, data: Dict, bk_cloud_id: int, instances: List[str]) -> SubProcess:
+    ip_port_dict = defaultdict(list)
+    for ins in instances:
+        ip, port = ins.split(":")
+        ip_port_dict[ip].append(int(port))
+
+    acts = []
+    for ip, ports in ip_port_dict.items():
+        acts.append(
+            {
+                "act_name": "{}:{}".format(ip, ports),
+                "act_component_code": ExecuteDBActuatorScriptComponent.code,
+                "kwargs": asdict(
+                    ExecActuatorKwargs(
+                        exec_ip=[ip],
+                        run_as_system_user=DBA_ROOT_USER,
+                        payload_class=PeripheralToolsPayload.payload_class_path(),
+                        get_mysql_payload_func=PeripheralToolsPayload.standardize_instance.__name__,
+                        bk_cloud_id=bk_cloud_id,
+                        cluster={"ports": ports},
+                    )
+                ),
+            }
+        )
+
+    sp = SubBuilder(root_id=root_id, data=data)
+    sp.add_parallel_acts(acts_list=acts)
+    return sp.build_sub_process(sub_name=_("实例标准化"))

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/subflow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/subflow.py
@@ -15,7 +15,10 @@ from django.utils.translation import ugettext as _
 
 from backend.db_meta.enums import ClusterType
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder, SubProcess
-from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.cc_trans_module import cc_trans_module
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.cc_trans_module import (
+    cc_standardize,
+    cc_trans_module,
+)
 from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.clusters_detail_helper import (
     clusters_detail_ips,
     is_empty_clusters_detail,
@@ -26,9 +29,16 @@ from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.departs impor
     DeployPeripheralToolsDepart,
     remove_depart,
 )
-from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.instance_standardize import instance_standardize
-from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.prepare_departs_binary import prepare_departs_binary
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.instance_standardize import (
+    instance_standardize,
+    standardize_instance,
+)
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.prepare_departs_binary import (
+    deploy_binary,
+    prepare_departs_binary,
+)
 from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.push_config import (
+    gen_reload_departs_config,
     push_departs_config,
     push_mysql_crond_config,
 )
@@ -165,3 +175,122 @@ def standardize_mysql_cluster_subflow(
             pipe.add_sub_pipeline(sub_flow=sf)
 
     return pipe.build_sub_process(sub_name=_("{} 集群标准化".format(cluster_type)))
+
+
+def standardize_mysql_cluster_subflow_reverse(
+    root_id: str,
+    data: Dict,
+    bk_cloud_id: int,
+    bk_biz_id: int,  # 这个参数其实根本不需要
+    instances: List[str],
+    departs: List[DeployPeripheralToolsDepart] = ALLDEPARTS,
+    with_deploy_binary: bool = True,
+    with_push_config: bool = True,
+    with_collect_sysinfo: bool = True,
+    with_actuator: bool = True,
+    with_bk_plugin: bool = True,
+    with_cc_standardize: bool = True,
+    with_instance_standardize: bool = True,
+) -> SubProcess:
+    """
+    使用反向接口生成周边配置
+    所以根本不要业务, 集群等信息
+    只要知道实例地址, 去机器上执行配置生成就行
+    参数输入了 bk_cloud_id, 所以隐式的约束是 instances 都是这个 bk_cloud_id
+    """
+    if not instances or not departs:
+        # ToDo
+        raise Exception  # noqa
+
+    departs = copy.deepcopy(departs)
+    ips = list(set(ele.split(":")[0] for ele in instances))
+
+    pipe = SubBuilder(root_id=root_id, data=data)
+
+    # 下发公共文件 [actuator, bk plugin, backup client]
+    if with_actuator or with_bk_plugin or DeployPeripheralToolsDepart.BackupClient in departs:
+        pipe.add_sub_pipeline(
+            sub_flow=trans_common_files(
+                root_id=root_id,
+                data=data,
+                bk_cloud_id=bk_cloud_id,
+                bk_biz_id=bk_biz_id,
+                ips=ips,
+                with_actuator=with_actuator,
+                with_bk_plugin=with_bk_plugin,
+                with_backup_client=DeployPeripheralToolsDepart.BackupClient in departs,
+            )
+        )
+
+    remove_depart(DeployPeripheralToolsDepart.BackupClient, departs)
+
+    # 收集系统信息
+    if with_collect_sysinfo:
+        pipe.add_sub_pipeline(
+            sub_flow=collect_sysinfo(
+                root_id=root_id,
+                data=data,
+                bk_cloud_id=bk_cloud_id,
+                ips=ips,
+            )
+        )
+
+    # cc 模块标准化, 推送 exporter 配置
+    # ToDo cc 模块移动没做的
+    if with_cc_standardize:
+        pipe.add_sub_pipeline(
+            sub_flow=cc_standardize(
+                root_id=root_id,
+                data=data,
+                bk_cloud_id=bk_cloud_id,
+                instances=instances,
+            )
+        )
+
+    if with_deploy_binary:
+        pipe.add_sub_pipeline(
+            sub_flow=deploy_binary(
+                root_id=root_id,
+                data=data,
+                bk_cloud_id=bk_cloud_id,
+                ips=ips,
+                departs=departs,
+            )
+        )
+
+    if with_instance_standardize:
+        pipe.add_sub_pipeline(
+            sub_flow=standardize_instance(
+                root_id=root_id,
+                data=data,
+                bk_cloud_id=bk_cloud_id,
+                instances=instances,
+            )
+        )
+
+    if with_push_config and {
+        DeployPeripheralToolsDepart.MySQLDBBackup,
+        DeployPeripheralToolsDepart.MySQLRotateBinlog,
+        DeployPeripheralToolsDepart.MySQLMonitor,
+        DeployPeripheralToolsDepart.MySQLTableChecksum,
+        DeployPeripheralToolsDepart.MySQLCrond,
+    } & set(departs):
+        if DeployPeripheralToolsDepart.MySQLCrond in departs:
+            remove_depart(DeployPeripheralToolsDepart.MySQLCrond, departs)
+            pipe.add_sub_pipeline(
+                sub_flow=gen_reload_departs_config(
+                    root_id=root_id,
+                    data=data,
+                    bk_cloud_id=bk_cloud_id,
+                    instances=instances,
+                    departs=[DeployPeripheralToolsDepart.MySQLCrond],
+                )
+            )
+
+        pipe.add_sub_pipeline(
+            sub_flow=gen_reload_departs_config(
+                root_id=root_id, data=data, bk_cloud_id=bk_cloud_id, instances=instances, departs=departs
+            )
+        )
+
+    return pipe.build_sub_process(sub_name=_("标准化"))

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/clone_rules.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/clone_rules.py
@@ -100,7 +100,7 @@ class CloneRules(BaseService):
             operator,
             clone_data,
             inst_machine_type_map,
-            global_data.get("uid", "0"),
+            global_data.get("uid", "0"),  # 保持是字符串
         )
         # 实例化权限克隆记录，后续存到数据库中
         record = MySQLPermissionCloneRecord(

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/clone_user.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/clone_user.py
@@ -61,7 +61,7 @@ class CloneUserService(BaseService):
                         "gcs_dba",
                     ],
                     **self.extra_log,
-                    "uid": "{}".format(global_data.get("uid", "0")),
+                    "uid": "{}".format(global_data.get("uid", "0")),  # 保持是字符串
                 }
                 params.update(
                     {

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/exec_actuator_script.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/exec_actuator_script.py
@@ -9,6 +9,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import copy
+import importlib
 import json
 import logging
 import re
@@ -84,8 +85,16 @@ class ExecuteDBActuatorScriptService(BkJobService):
 
         target_ip_info = [{"bk_cloud_id": kwargs["bk_cloud_id"], "ip": ip} for ip in exec_ips]
 
+        payload_class_path = kwargs.get("payload_class")
+        if not payload_class_path:
+            payload_class = MysqlActPayload
+        else:
+            plist = payload_class_path.split(".")
+            module = importlib.import_module(".".join(plist[0:-1]))
+            payload_class = getattr(module, plist[-1])
+
         # 获取mysql actuator 组件所需要执行的参数
-        mysql_act_payload = MysqlActPayload(
+        mysql_act_payload = payload_class(
             bk_cloud_id=kwargs["bk_cloud_id"],
             ticket_data=global_data,
             cluster=kwargs.get("cluster", None),

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/__init__.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/base/__init__.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/base/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/base/payload_base.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/base/payload_base.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+
+class PayloadBase(object):
+    def __init__(self, bk_cloud_id: int, ticket_data: dict, cluster: dict, cluster_type: str = None):
+        """
+        @param bk_cloud_id 操作的云区域
+        @param ticket_data 单据信息
+        @param cluster 需要操作的集群信息
+        @param cluster_type 表示操作的集群类型，会决定到db_config获取配置的空间
+        """
+        self.bk_cloud_id = bk_cloud_id
+        self.ticket_data = ticket_data
+        self.cluster = cluster
+        self.cluster_type = cluster_type
+
+        # todo 后面可能优化这个问题
+        if self.ticket_data.get("module"):
+            self.db_module_id = self.ticket_data["module"]
+        elif self.ticket_data.get("db_module_id"):
+            self.db_module_id = self.ticket_data["db_module_id"]
+        elif self.cluster and self.cluster.get("db_module_id"):
+            self.db_module_id = self.cluster["db_module_id"]
+        else:
+            self.db_module_id = 0
+
+    @classmethod
+    def payload_class_path(cls) -> str:
+        return "{}.{}".format(cls.__module__, cls.__name__)

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/mixed/__init__.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/mixed/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/mixed/mysql_account_mixed.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/mixed/mysql_account_mixed.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import base64
+import re
+from typing import Dict, Optional
+
+from backend import env
+from backend.components import DBPrivManagerApi
+from backend.constants import IP_RE_PATTERN
+from backend.core.encrypt.constants import AsymmetricCipherConfigType
+from backend.core.encrypt.handlers import AsymmetricHandler
+from backend.db_proxy.constants import ExtensionType
+from backend.db_proxy.models import DBExtension
+from backend.flow.consts import DBM_MYSQL_JOB_TMP_USER_PREFIX, DEFAULT_INSTANCE, MySQLPrivComponent, UserName
+from backend.ticket.constants import TicketType
+
+
+class MySQLAccountMixed(object):
+    @staticmethod
+    def all_account(ticket_data):
+        res = MySQLAccountMixed.static_account()
+        if ticket_data.get("ticket_type", None) in [
+            TicketType.MYSQL_SINGLE_APPLY,
+            TicketType.MYSQL_HA_APPLY,
+            TicketType.TENDBCLUSTER_APPLY,
+            TicketType.TENDBCLUSTER_APPEND_DEPLOY_CTL,
+        ]:
+            res["admin_user"] = "ADMIN"
+        else:
+            res["admin_user"] = "{}{}".format(DBM_MYSQL_JOB_TMP_USER_PREFIX, ticket_data["job_root_id"])
+
+        res["admin_pwd"] = ticket_data["job_root_id"]
+        return res
+
+    @staticmethod
+    def static_account(*users: UserName):
+        if not users:
+            users = [
+                UserName.BACKUP,
+                UserName.MONITOR,
+                UserName.MONITOR_ACCESS_ALL,
+                UserName.OS_MYSQL,
+                UserName.REPL,
+                UserName.YW,
+                UserName.PARTITION_YW,
+            ]
+
+        user_map = {}
+        value_to_name = {member.value: member.name.lower() for member in UserName}
+
+        data = DBPrivManagerApi.get_password(
+            {
+                "instances": [DEFAULT_INSTANCE],
+                "users": [
+                    {"username": username.value, "component": MySQLPrivComponent.MYSQL.value} for username in users
+                ],
+            }
+        )
+        for user in data["items"]:
+            user_map[value_to_name[user["username"]] + "_user"] = (
+                "MONITOR" if user["username"] == UserName.MONITOR_ACCESS_ALL else user["username"]
+            )
+            user_map[value_to_name[user["username"]] + "_pwd"] = base64.b64decode(user["password"]).decode("utf-8")
+
+        return user_map
+
+    @staticmethod
+    def partition_yw_account():
+        res = MySQLAccountMixed.static_account(UserName.PARTITION_YW)
+        return {k.removeprefix("partition_yw_"): v for k, v in res.items()}
+
+    @staticmethod
+    def drs_account(bk_cloud_id) -> Dict:
+        if env.DRS_USERNAME:
+            access_hosts = env.TEST_ACCESS_HOSTS or re.compile(IP_RE_PATTERN).findall(env.DRS_APIGW_DOMAIN)
+            return {
+                "access_hosts": access_hosts,
+                "user": env.DRS_USERNAME,
+                "pwd": env.DRS_PASSWORD,
+            }
+        else:
+            return MySQLAccountMixed.__extension_account(bk_cloud_id=bk_cloud_id, et=ExtensionType.DRS)
+
+    @staticmethod
+    def dbha_account(bk_cloud_id: int) -> Dict:
+        if env.DBHA_USERNAME:
+            access_hosts = env.TEST_ACCESS_HOSTS or re.compile(IP_RE_PATTERN).findall(env.DBHA_APIGW_DOMAIN_LIST)
+            return {
+                "access_hosts": access_hosts,
+                "user": env.DBHA_USERNAME,
+                "pwd": env.DBHA_PASSWORD,
+            }
+        else:
+            return MySQLAccountMixed.__extension_account(bk_cloud_id=bk_cloud_id, et=ExtensionType.DBHA)
+
+    @staticmethod
+    def webconsole_account(bk_cloud_id: int):
+        if env.WEBCONSOLE_USERNAME:
+            access_hosts = env.TEST_ACCESS_HOSTS or re.compile(IP_RE_PATTERN).findall(env.DRS_APIGW_DOMAIN)
+            return {
+                "access_hosts": access_hosts,
+                "user": env.WEBCONSOLE_USERNAME,
+                "pwd": env.WEBCONSOLE_PASSWORD,
+            }
+        else:
+            return MySQLAccountMixed.__extension_account(
+                bk_cloud_id=bk_cloud_id,
+                et=ExtensionType.DRS,
+                alt_user_key="webconsole_user",
+                alt_pwd_key="webconsole_pwd",
+            )
+
+    @staticmethod
+    def __extension_account(
+        bk_cloud_id: int, et: ExtensionType, alt_user_key: Optional[str] = None, alt_pwd_key: Optional[str] = None
+    ) -> Dict:
+        bk_cloud_name = AsymmetricCipherConfigType.get_cipher_cloud_name(bk_cloud_id)
+        drs = DBExtension.get_latest_extension(bk_cloud_id=bk_cloud_id, extension_type=et)
+
+        if not alt_user_key:
+            alt_user_key = "user"
+        if not alt_pwd_key:
+            alt_pwd_key = "pwd"
+
+        return {
+            "access_hosts": DBExtension.get_extension_access_hosts(bk_cloud_id=bk_cloud_id, extension_type=et),
+            "pwd": AsymmetricHandler.decrypt(name=bk_cloud_name, content=drs.details[alt_pwd_key]),
+            "user": AsymmetricHandler.decrypt(name=bk_cloud_name, content=drs.details[alt_user_key]),
+        }

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/mysql/__init__.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/mysql/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/mysql/peripheraltools.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/mysql/peripheraltools.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from backend.db_meta.enums import MachineType
+from backend.db_meta.models import Cluster, Machine
+from backend.db_package.models import Package
+from backend.db_proxy.reverse_api.common.impl import list_nginx_addrs
+from backend.flow.consts import DBActuatorActionEnum, DBActuatorTypeEnum, MediumEnum, MysqlVersionToDBBackupForMap
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.departs import DeployPeripheralToolsDepart
+from backend.flow.utils.mysql.act_payload.base.payload_base import PayloadBase
+from backend.flow.utils.mysql.act_payload.mixed.mysql_account_mixed import MySQLAccountMixed
+
+
+class PeripheralToolsPayload(PayloadBase, MySQLAccountMixed):
+    def gen_config(self, **kwargs):
+        return {
+            "db_type": DBActuatorTypeEnum.MySQL.value,
+            "action": DBActuatorActionEnum.GenPeripheralToolsConfig.value,
+            "payload": {
+                "general": {"runtime_account": self.static_account()},
+                "extend": {
+                    "ip": kwargs["ip"],
+                    "bk_cloud_id": self.bk_cloud_id,
+                    "ports": self.cluster["ports"],
+                    "departs": self.cluster["departs"],
+                    "nginx_addrs": list_nginx_addrs(bk_cloud_id=self.bk_cloud_id),
+                },
+            },
+        }
+
+    def reload_config(self, **kwargs):
+        return {
+            "db_type": DBActuatorTypeEnum.MySQL.value,
+            "action": DBActuatorActionEnum.ReloadPeripheralToolsConfig.value,
+            "payload": {
+                "general": {"runtime_account": self.static_account()},
+                "extend": {
+                    "ip": kwargs["ip"],
+                    "bk_cloud_id": self.bk_cloud_id,
+                    "ports": self.cluster["ports"],
+                    "departs": self.cluster["departs"],
+                },
+            },
+        }
+
+    def deploy_binary(self, **kwargs):
+        departs = self.cluster["departs"]
+        ip = kwargs["ip"]
+        m = Machine.objects.get(ip=ip, bk_cloud_id=self.bk_cloud_id)
+        depart_pkgs = {}
+
+        if DeployPeripheralToolsDepart.MySQLDBBackup in departs:
+            departs.remove(DeployPeripheralToolsDepart.MySQLDBBackup)
+            if m.machine_type == MachineType.PROXY:
+                pass
+            else:
+                if m.machine_type == MachineType.SPIDER:
+                    dbbackup_pkg_type = MediumEnum.DbBackup
+                else:
+                    db_version = Cluster.objects.filter(storageinstance__machine__ip=ip).first().major_version
+                    dbbackup_pkg_type = MysqlVersionToDBBackupForMap[db_version]
+
+                dbbackup_pkg = Package.get_latest_package(version=MediumEnum.Latest, pkg_type=dbbackup_pkg_type)
+                depart_pkgs[DeployPeripheralToolsDepart.MySQLDBBackup] = {
+                    "pkg": dbbackup_pkg.name,
+                    "pkg_md5": dbbackup_pkg.md5,
+                }
+
+        for depart in departs:
+            pkg = Package.get_latest_package(version=MediumEnum.Latest, pkg_type=depart)
+            depart_pkgs[depart] = {
+                "pkg": pkg.name,
+                "pkg_md5": pkg.md5,
+            }
+
+        return {
+            "db_type": DBActuatorTypeEnum.MySQL.value,
+            "action": DBActuatorActionEnum.DeployPeripheralToolsBinary.value,
+            "payload": {
+                "general": {
+                    "runtime_account": self.static_account(),
+                },
+                "extend": {
+                    "ip": ip,
+                    "departs": depart_pkgs,
+                },
+            },
+        }
+
+    def standardize_instance(self, **kwargs):
+        ip = kwargs["ip"]
+        m = Machine.objects.get(ip=ip, bk_cloud_id=self.bk_cloud_id)
+
+        if m.machine_type == MachineType.PROXY:
+            return {
+                "db_type": DBActuatorTypeEnum.Proxy.value,
+                "action": DBActuatorActionEnum.StandardizeTenDBHAProxy.value,
+                "payload": {
+                    "general": {"runtime_account": self.all_account(self.ticket_data)},
+                    "extend": {
+                        "dbha_account": "",
+                        "port_list": self.cluster["ports"],
+                        "ip": ip,
+                    },
+                },
+            }
+        else:
+            if m.machine_type == MachineType.SPIDER:
+                major_version = Cluster.objects.filter(proxyinstance__machine__ip=ip).first().major_version
+            else:
+                major_version = Cluster.objects.filter(storageinstance__machine__ip=ip).first().major_version
+
+            pkg = Package.get_latest_package(version=major_version, pkg_type=MediumEnum.MySQL)
+
+            return {
+                "db_type": DBActuatorTypeEnum.MySQL.value,
+                "action": DBActuatorActionEnum.StandardizeMySQLInstance.value,
+                "payload": {
+                    "general": {
+                        "runtime_account": self.all_account(self.ticket_data),
+                    },
+                    "extend": {
+                        "pkg": pkg.name,
+                        "pkg_md5": pkg.md5,
+                        "ip": ip,
+                        "ports": self.cluster["ports"],
+                        "mysql_version": major_version,
+                        "super_account": self.drs_account(self.bk_cloud_id),
+                        "dbha_account": self.dbha_account(self.bk_cloud_id),
+                        "webconsolers_account": self.webconsole_account(self.bk_cloud_id),
+                        "partition_yw_account": self.partition_yw_account(),
+                    },
+                },
+            }
+
+    def init_nginx_addresses(self, **kwargs):
+        return {
+            "db_type": DBActuatorTypeEnum.MySQL.value,
+            "action": DBActuatorActionEnum.InitNginxAddresses.value,
+            "payload": {"extend": {"nginx_addrs": list_nginx_addrs(bk_cloud_id=self.bk_cloud_id)}},
+        }

--- a/dbm-ui/backend/flow/utils/mysql/mysql_act_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_act_dataclass.py
@@ -41,6 +41,7 @@ class ExecActuatorBaseKwargs:
 
     bk_cloud_id: int  # 对应的云区域ID
     run_as_system_user: str = None  # 表示执行job的api的操作用户, None 默认是用root用户
+    payload_class: str = None
     get_mysql_payload_func: str = None  # 上下文中MysqlActPayload类的获取参数方法名称。空则传入None
     cluster_type: str = None  # 表示操作的集群类型,如果过程中不需要这个变量，则可以传None
     cluster: dict = field(default_factory=dict)  # 表示单据执行的集群信息，比如集群名称，集群域名等

--- a/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_act_playload.py
@@ -773,85 +773,6 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
             },
         }
 
-    # def push_dbbackup_config_payload(self, **kwargs) -> dict:
-    #     ini = get_backup_ini_config(
-    #         bk_biz_id=self.ticket_data["bk_biz_id"],
-    #         db_module_id=self.cluster["db_module_id"],
-    #         cluster_type=self.cluster["cluster_type"],
-    #     )
-    #
-    #     port_domain_map = {}
-    #     cluster_id_map = {}
-    #     shard_port_map = {}  # port as key
-    #     options_map = {}
-    #
-    #     if self.cluster["machine_type"] == MachineType.SPIDER.value:
-    #         ins_list = ProxyInstance.objects.filter(machine__ip=kwargs["ip"], port__in=self.cluster["ports"])
-    #         role = ins_list[0].tendbclusterspiderext.spider_role
-    #     elif self.cluster["machine_type"] in [
-    #         MachineType.REMOTE.value,
-    #         MachineType.BACKEND.value,
-    #         MachineType.SINGLE.value,
-    #     ]:
-    #         ins_list = StorageInstance.objects.filter(machine__ip=kwargs["ip"], port__in=self.cluster["ports"])
-    #         role = ins_list[0].instance_inner_role
-    #     else:
-    #         raise DBMetaException(message=_("不支持的机器类型: {}".format(self.cluster["machine_type"])))
-    #
-    #     if self.cluster["machine_type"] == MachineType.REMOTE.value:
-    #         for ins in ins_list:
-    #             if ins.instance_inner_role == InstanceInnerRole.MASTER.value:
-    #                 tp = StorageInstanceTuple.objects.filter(ejector=ins).first()
-    #             else:
-    #                 tp = StorageInstanceTuple.objects.get(receiver=ins)
-    #             shard_port_map[ins.port] = tp.tendbclusterstorageset.shard_id
-    #
-    #     for instance in ins_list:
-    #         port_domain_map[instance.port] = self.cluster["immute_domain"]
-    #         cluster_id_map[instance.port] = self.cluster["cluster_id"]
-    #
-    #         shard_port_map[instance.port] = shard_port_map.get(instance.port, 0)
-    #         options_map[instance.port] = get_backup_options_config(
-    #             bk_biz_id=self.ticket_data["bk_biz_id"],
-    #             db_module_id=self.cluster["db_module_id"],
-    #             cluster_type=self.cluster["cluster_type"],
-    #             cluster_domain=self.cluster["immute_domain"],
-    #         )
-    #
-    #     db_backup_pkg_type = self.cluster.get("db_backup_pkg_type", MediumEnum.DbBackup)
-    #     if self.cluster["machine_type"] != MachineType.SPIDER.value:
-    #         db_version = ins_list[0].cluster.get().major_version
-    #         db_backup_pkg_type = MysqlVersionToDBBackupForMap[db_version]
-    #
-    #     db_backup_pkg = Package.get_latest_package(
-    #         version=MediumEnum.Latest,
-    #         pkg_type=db_backup_pkg_type,
-    #     )
-    #
-    #     return {
-    #         "db_type": DBActuatorTypeEnum.MySQL.value,
-    #         "action": DBActuatorActionEnum.PushNewDbBackupConfig.value,
-    #         "payload": {
-    #             "general": {"runtime_account": self.account},
-    #             "extend": {
-    #                 "pkg": db_backup_pkg.name,
-    #                 "pkg_md5": db_backup_pkg.md5,
-    #                 "host": kwargs["ip"],
-    #                 "ports": self.cluster["ports"],
-    #                 "bk_cloud_id": int(self.bk_cloud_id),
-    #                 "bk_biz_id": int(self.ticket_data["bk_biz_id"]),
-    #                 "role": role,
-    #                 "configs": ini,
-    #                 "options": options_map,
-    #                 "cluster_address": port_domain_map,
-    #                 "cluster_id": cluster_id_map,
-    #                 "cluster_type": self.cluster["cluster_type"],
-    #                 "exec_user": self.ticket_data["created_by"],
-    #                 "shard_value": shard_port_map,
-    #             },
-    #         },
-    #     }
-
     def get_import_sqlfile_payload(self, **kwargs) -> dict:
         """
         return import sqlfile payload
@@ -1404,47 +1325,6 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
             },
         }
 
-    # def push_mysql_checksum_config_payload(self, **kwargs) -> dict:
-    #     """
-    #     ToDo
-    #     和监控一样, 安装校验的 get_install_mysql_checksum_payload
-    #     现在也是机器级别
-    #     """
-    #     checksum_pkg = Package.get_latest_package(version=MediumEnum.Latest, pkg_type=MediumEnum.MySQLChecksum)
-    #
-    #     instances_info = []
-    #     for ins_obj in StorageInstance.objects.filter(machine__ip=kwargs["ip"], port__in=self.cluster["ports"]):
-    #         instances_info.append(
-    #             {
-    #                 "bk_biz_id": self.ticket_data["bk_biz_id"],
-    #                 "ip": kwargs["ip"],
-    #                 "port": ins_obj.port,
-    #                 "role": ins_obj.instance_inner_role,
-    #                 "cluster_id": self.cluster["cluster_id"],
-    #                 "immute_domain": self.cluster["immute_domain"],
-    #                 "db_module_id": self.cluster["db_module_id"],
-    #                 "schedule": "0 5 2 * * 1-5",
-    #             }
-    #         )
-    #
-    #     return {
-    #         "db_type": DBActuatorTypeEnum.MySQL.value,
-    #         "action": DBActuatorActionEnum.PushChecksumConfig.value,
-    #         "payload": {
-    #             "general": {"runtime_account": self.account},
-    #             "extend": {
-    #                 "pkg": checksum_pkg.name,
-    #                 "pkg_md5": checksum_pkg.md5,
-    #                 "system_dbs": SYSTEM_DBS,
-    #                 "stage_db_header": STAGE_DB_HEADER,
-    #                 "rollback_db_tail": ROLLBACK_DB_TAIL,
-    #                 "instances_info": instances_info,
-    #                 "exec_user": self.ticket_data["created_by"],
-    #                 "api_url": "http://127.0.0.1:9999",  # 长时间可以写死
-    #             },
-    #         },
-    #     }
-
     def get_mysql_edit_config_payload(self, **kwargs) -> dict:
         """
         mysql 配置修改
@@ -1517,11 +1397,6 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
                 },
             },
         }
-
-    # def push_mysql_rotatebinlog_config_payload(self, **kwargs) -> dict:
-    #     res = self.get_install_mysql_rotatebinlog_payload(**kwargs)
-    #     res["action"] = DBActuatorActionEnum.PushMySQLRotatebinlogConfig.value
-    #     return res
 
     def get_install_dba_toolkit_payload(self, **kwargs):
         """
@@ -1785,91 +1660,6 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
                 },
             },
         }
-
-    # def push_mysql_monitor_config_payload(self, **kwargs) -> dict:
-    #     """
-    #     ToDo
-    #     上面的get_deploy_mysql_monitor_payload有点问题
-    #     是基于机器级别生成配置的
-    #     在迁移完成后, 实际维护中应该是基于集群级别
-    #     所以 push 单独实现
-    #     以后应该都替换成这个函数
-    #     """
-    #     mysql_monitor_pkg = Package.get_latest_package(version=MediumEnum.Latest, pkg_type=MediumEnum.MySQLMonitor)
-    #
-    #     instances_info = []
-    #
-    #     config_items = DBConfigApi.query_conf_item(
-    #         {
-    #             "bk_biz_id": "{}".format(self.ticket_data["bk_biz_id"]),
-    #             "level_name": "cluster",
-    #             "level_value": "act3",
-    #             "conf_file": "items-config.yaml",
-    #             "conf_type": "mysql_monitor",
-    #             "namespace": "tendbha",
-    #             "level_info": {"module": "act"},
-    #             "format": "map",
-    #         }
-    #     )
-    #     logger.info("config_items: {}".format(config_items))
-    #
-    #     # instance_info = {
-    #     #     "bk_biz_id": self.ticket_data["bk_biz_id"],
-    #     #     "ip": kwargs["ip"],
-    #     #     "cluster_id": self.cluster["cluster_id"],
-    #     #     "immute_domain": self.cluster["immute_domain"],
-    #     #     "items_config": config_items["content"],
-    #     # }
-    #     if self.cluster["access_layer"] == AccessLayer.PROXY.value:
-    #         for ins_obj in ProxyInstance.objects.filter(machine__ip=kwargs["ip"], port__in=self.cluster["ports"]):
-    #             instance_info = {
-    #                 "bk_biz_id": self.ticket_data["bk_biz_id"],
-    #                 "ip": kwargs["ip"],
-    #                 "cluster_id": self.cluster["cluster_id"],
-    #                 "immute_domain": self.cluster["immute_domain"],
-    #                 "items_config": config_items["content"],
-    #                 "port": ins_obj.port,
-    #                 "bk_instance_id": ins_obj.bk_instance_id,
-    #                 "db_module_id": ins_obj.db_module_id,
-    #             }
-    #
-    #             if self.cluster["machine_type"] == MachineType.SPIDER.value:
-    #                 instance_info["role"] = ins_obj.tendbclusterspiderext.spider_role
-    #
-    #             instances_info.append(instance_info)
-    #     else:
-    #         for ins_obj in StorageInstance.objects.filter(machine__ip=kwargs["ip"], port__in=self.cluster["ports"]):
-    #             instance_info = {
-    #                 "bk_biz_id": self.ticket_data["bk_biz_id"],
-    #                 "ip": kwargs["ip"],
-    #                 "cluster_id": self.cluster["cluster_id"],
-    #                 "immute_domain": self.cluster["immute_domain"],
-    #                 "items_config": config_items["content"],
-    #                 "port": ins_obj.port,
-    #                 "bk_instance_id": ins_obj.bk_instance_id,
-    #                 "db_module_id": ins_obj.db_module_id,
-    #                 "role": ins_obj.instance_inner_role,
-    #             }
-    #
-    #             instances_info.append(instance_info)
-    #
-    #     return {
-    #         "db_type": DBActuatorTypeEnum.MySQL.value,
-    #         "action": DBActuatorActionEnum.PushMySQLMonitorConfig.value,
-    #         "payload": {
-    #             "general": {"runtime_account": {**self.account, **self.proxy_account}},
-    #             "extend": {
-    #                 "pkg": mysql_monitor_pkg.name,
-    #                 "pkg_md5": mysql_monitor_pkg.md5,
-    #                 "system_dbs": SYSTEM_DBS,
-    #                 "exec_user": self.ticket_data["created_by"],
-    #                 "api_url": "http://127.0.0.1:9999",
-    #                 "machine_type": self.cluster["machine_type"],
-    #                 "bk_cloud_id": int(self.bk_cloud_id),
-    #                 "instances_info": instances_info,
-    #             },
-    #         },
-    #     }
 
     def get_grant_repl_for_ctl_payload(self, **kwargs) -> dict:
         """
@@ -3213,6 +3003,7 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
             "payload": {
                 "general": {"runtime_account": self.account},
                 "extend": {
+                    "bk_cloud_id": ins.cluster.first().bk_cloud_id,
                     "configs": self.__get_mysql_rotatebinlog_config_v2(self.cluster["cluster_type"]),
                     "ip": kwargs["ip"],
                     "port_list": self.cluster["port_list"],
@@ -3241,6 +3032,7 @@ class MysqlActPayload(PayloadHandler, ProxyActPayload, TBinlogDumperActPayload):
             "payload": {
                 "general": {"runtime_account": self.account},
                 "extend": {
+                    "bk_cloud_id": ins.cluster.first().bk_cloud_id,
                     "bk_biz_id": bk_biz_id,
                     "ip": ip,
                     "port_list": port_list,


### PR DESCRIPTION
1. 部署周边工具 v2 全部使用反向接口
2. 部署周边工具 v2 只需要输入实例地址, 不再需要任何集群信息
3. 拆分 mysql act payload

拆分后的 act payload 可以参考
基类: dbm-ui/backend/flow/utils/mysql/act_payload/base/payload_base.py
定义: dbm-ui/backend/flow/utils/mysql/act_payload/mysql/peripheraltools.py
引用: 
<img width="769" alt="image" src="https://github.com/user-attachments/assets/5747957b-b5ef-443e-b65c-13bb7dfe0553" />

原有的 payload 定义依然兼容, 不传入 payload_class 就是使用原有定义