### PR TITLE
feat(backend): dbm-reverse-post #10950

### DIFF
--- a/dbm-services/common/reverseapi/define/mysql/checksum.go
+++ b/dbm-services/common/reverseapi/define/mysql/checksum.go
@@ -15,4 +15,5 @@ type ChecksumConfig struct {
 	RollbackDBTail string   `json:"rollback_db_tail"`
 	User           string   `json:"user"`
 	Password       string   `json:"password"`
+	Enable         *bool    `json:"enable"`
 }

--- a/dbm-services/mysql/db-priv/service/v2/clone_instance_priv/internal/mysql/init.go
+++ b/dbm-services/mysql/db-priv/service/v2/clone_instance_priv/internal/mysql/init.go
@@ -4,6 +4,6 @@ var systemUsers []string
 
 func init() {
 	systemUsers = []string{
-		"mysql.session", "mysql.sys", "mysql.infoschema",
+		"mysql.session", "mysql.sys", "mysql.infoschema", "mysql", //, "mariadb.sys", "PUBLIC",
 	}
 }

--- a/dbm-services/mysql/db-priv/service/v2/clone_instance_priv/internal/mysql/query_user_list.go
+++ b/dbm-services/mysql/db-priv/service/v2/clone_instance_priv/internal/mysql/query_user_list.go
@@ -18,7 +18,11 @@ func QueryUserList(bkCloudId int64, addr string, excludeUsers []string, targetAd
 	// 必须排除掉 host = targetIp 的账号
 	// account@source 克隆后会变成 account@target
 	// 如果源上已经存在 account@target, 而且和 account@source 密码不一样, 就可能出问题
-	sql := fmt.Sprintf(`SELECT user, host FROM mysql.user WHERE user NOT in (%s) AND host <> '%s'`, excludeUsersStr, targetIp)
+	// spider 4 基于 mariadb, 不写成 user as user 这样, 返回的是 User 这样的大写
+	sql := fmt.Sprintf(
+		`SELECT user as user, host as host FROM mysql.user WHERE user NOT in (%s) AND host <> '%s'`,
+		excludeUsersStr, targetIp,
+	)
 
 	drsRes, err := drs.RPCMySQL(
 		bkCloudId,

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/core/staticembed/procedure.sql
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/core/staticembed/procedure.sql
@@ -248,6 +248,7 @@ BEGIN
     SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = username AND host = ip) INTO @user_host_exists;
     IF NOT @user_host_exists THEN
         -- 用户不存在, 直接创建, 只使用新版本密码, 传入的密码是密文
+        -- 只有 spider 1 会拿到 5.5, 其他的都 > 5.7. 所以也是兼容的
         IF SUBSTRING_INDEX(@@version, ".", 2) < 5.7 THEN
             SET @create_user_sql = CONCAT("GRANT USAGE ON *.* TO '", username, "'@'", ip, "' IDENTIFIED BY PASSWORD '", psw, "'");
             PREPARE stmt FROM @create_user_sql;

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/subcmd_gen_config.go
@@ -134,6 +134,11 @@ func generateOneRuntimeConfig(cfg *mysql.ChecksumConfig) error {
 		},
 		Schedule: cfg.Schedule,
 		ApiUrl:   cfg.ApiUrl,
+		Enable:   true, //cfg.Enable,
+	}
+
+	if cfg.Enable != nil && *cfg.Enable == false {
+		rcfg.Enable = false
 	}
 
 	rcfg.SetFilter(nil, ignoreDbs, nil, nil)

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report.py
@@ -8,10 +8,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from rest_framework import serializers
+from typing import Dict, List
 
 
-class ReverseApiParamSerializer(serializers.Serializer):
-    port = serializers.ListField(child=serializers.IntegerField(), required=False)
-    bk_cloud_id = serializers.IntegerField()
-    ip = serializers.IPAddressField()
+def sync_report(bk_cloud_id: int, ip: str, port_list: List[int], data: Dict):
+    """
+    写入 kafka
+    ToDo
+    1. 按什么规则确定 kafka topic
+    """
+    pass

--- a/dbm-ui/backend/db_proxy/reverse_api/common/views.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/views.py
@@ -9,6 +9,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import logging
+from typing import List
 
 from django.http import JsonResponse
 from django.utils.translation import ugettext_lazy as _
@@ -16,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from backend.bk_web.swagger import common_swagger_auto_schema
 from backend.db_proxy.reverse_api.base_reverse_api_view import BaseReverseApiView
 from backend.db_proxy.reverse_api.common.impl import list_nginx_addrs
+from backend.db_proxy.reverse_api.common.impl.sync_report import sync_report
 from backend.db_proxy.reverse_api.decorators import reverse_api
 
 logger = logging.getLogger("root")
@@ -24,13 +26,12 @@ logger = logging.getLogger("root")
 class CommonReverseApiView(BaseReverseApiView):
     @common_swagger_auto_schema(operation_summary=_("获取NGINX 地址"))
     @reverse_api(url_path="list_nginx_addrs")
-    def list_nginx_addrs(self, request, *args, **kwargs):
+    def list_nginx_addrs(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         """
         返回特定云区域的 NGINX 地址 列表
         param: bk_cloud_id: int
         return: ["ip1:90", "ip2:90", ...]
         """
-        bk_cloud_id, _, _ = self.get_api_params()
         logger.info(f"bk_cloud_id: {bk_cloud_id}")
         res = list_nginx_addrs(bk_cloud_id=bk_cloud_id)
         logger.info(f"res: {res}")
@@ -44,3 +45,13 @@ class CommonReverseApiView(BaseReverseApiView):
                 "errors": None,
             }
         )
+
+    @common_swagger_auto_schema(operation_summary=_("同步上报"))
+    @reverse_api(url_path="sync_report", method="POST")
+    def sync_report(self, bk_cloud_id: int, ip: str, port_list: List[int], data):
+        """
+        method: POST
+        """
+        logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port_list: {port_list}, data: {data}")
+        sync_report(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list, data=data)
+        return JsonResponse({"result": True, "code": 0, "data": "", "message": "", "errors": None})

--- a/dbm-ui/backend/db_proxy/reverse_api/mysql/views.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/mysql/views.py
@@ -9,6 +9,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import logging
+from typing import List
 
 from django.http import JsonResponse
 from django.utils.translation import ugettext_lazy as _
@@ -31,8 +32,7 @@ logger = logging.getLogger("root")
 class MySQLReverseApiView(BaseReverseApiView):
     @common_swagger_auto_schema(operation_summary=_("获取实例基本信息"))
     @reverse_api(url_path="list_instance_info")
-    def list_instance_info(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def list_instance_info(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = list_instance_info(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"instance info: {res}")
@@ -48,8 +48,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取实例监控 runtime 配置"))
     @reverse_api(url_path="monitor_runtime_config")
-    def monitor_runtime_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def monitor_runtime_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = monitor_runtime_config(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"runtime config: {res}")
@@ -65,8 +64,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取实例监控项配置"))
     @reverse_api(url_path="monitor_items_config")
-    def monitor_items_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def monitor_items_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = monitor_items_config(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"items config: {res}")
@@ -82,8 +80,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取 mysql-crond 配置"))
     @reverse_api(url_path="mysql_crond_config")
-    def mysql_crond_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def mysql_crond_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = mysql_crond_config(bk_cloud_id=bk_cloud_id, ip=ip)
         logger.info(f"mysql-crond config: {res}")
@@ -99,8 +96,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取备份配置"))
     @reverse_api(url_path="dbbackup_config")
-    def dbbackup_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def dbbackup_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = dbbackup_config(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"dbbackup config: {res}")
@@ -116,8 +112,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取 rotatebinlog 配置"))
     @reverse_api(url_path="rotatebinlog_config")
-    def rotatebinlog_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def rotatebinlog_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = rotatebinlog_config(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"rotatebinlog config: {res}")
@@ -133,8 +128,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取数据校验配置"))
     @reverse_api(url_path="checksum_config")
-    def checksum_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def checksum_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = checksum_config(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"checksum config: {res}")
@@ -150,8 +144,7 @@ class MySQLReverseApiView(BaseReverseApiView):
 
     @common_swagger_auto_schema(operation_summary=_("获取 exporter 配置"))
     @reverse_api(url_path="exporter_config")
-    def exporter_config(self, request, *args, **kwargs):
-        bk_cloud_id, ip, port_list = self.get_api_params()
+    def exporter_config(self, bk_cloud_id: int, ip: str, port_list: List[int]):
         logger.info(f"bk_cloud_id: {bk_cloud_id}, ip: {ip}, port:{port_list}")
         res = exporter_config(bk_cloud_id=bk_cloud_id, ip=ip, port_list=port_list)
         logger.info(f"exporter config: {res}")

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/cc_trans_module.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/cc_trans_module.py
@@ -17,12 +17,16 @@ from deprecated import deprecated
 from django.utils.translation import ugettext as _
 
 from backend.db_meta.enums import AccessLayer, ClusterMachineAccessTypeDefine, ClusterType, MachineType
+from backend.db_meta.models import Cluster
 from backend.flow.consts import DBA_ROOT_USER
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.clusters_detail_helper import (
     clusters_detail_ip_ports_by_access_layer,
 )
 from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.departs import DeployPeripheralToolsDepart
+from backend.flow.plugins.components.collections.mysql.cluster_standardize_trans_module import (
+    ClusterStandardizeTransModuleComponent,
+)
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.utils.mysql.act_payload.mysql.peripheraltools import PeripheralToolsPayload
 from backend.flow.utils.mysql.mysql_act_dataclass import ExecActuatorKwargs
@@ -125,6 +129,13 @@ def cc_standardize(
         gen_exporter_cnf(root_id=root_id, data=data, bk_cloud_id=bk_cloud_id, instances=instances),
     ]
 
+    if with_cc_standardize and len(data.get("cluster_ids", [])) > 0:
+        sub_flow_list.append(
+            trans_cc_module(
+                root_id=root_id, data=data, bk_cloud_id=bk_cloud_id, cluster_ids=data.get("cluster_ids", [])
+            )
+        )
+
     sp = SubBuilder(root_id=root_id, data=data)
     sp.add_parallel_sub_pipeline(sub_flow_list=sub_flow_list)
     return sp.build_sub_process(sub_name=_("CC 标准化"))
@@ -160,6 +171,18 @@ def gen_exporter_cnf(root_id: str, data: Dict, bk_cloud_id: int, instances: List
     return sp.build_sub_process(sub_name=_("生成 exporter 配置"))
 
 
-def trans_cc_module() -> SubProcess:
-    # ToDo
-    pass
+def trans_cc_module(root_id: str, data: Dict, bk_cloud_id: int, cluster_ids: List[int]) -> SubProcess:
+    acts = []
+    for cluster_id in cluster_ids:
+        cluster_obj = Cluster.objects.get(pk=cluster_id)
+        acts.append(
+            {
+                "act_name": _("CC 模块标准化: {}".format(cluster_obj.immute_domain)),
+                "act_component_code": ClusterStandardizeTransModuleComponent.code,
+                "kwargs": {"cluster_id": cluster_id},
+            }
+        )
+
+    sp = SubBuilder(root_id=root_id, data=data)
+    sp.add_parallel_acts(acts_list=acts)
+    return sp.build_sub_process(sub_name=_("CC 模块标准化"))

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/subflow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/deploy_peripheraltools/subflow.py
@@ -40,7 +40,7 @@ def standardize_mysql_cluster_subflow(
     with_collect_sysinfo: bool = True,
     with_actuator: bool = True,
     with_bk_plugin: bool = True,
-    with_cc_standardize: bool = True,
+    with_cc_standardize: bool = False,
     with_instance_standardize: bool = True,
     with_backup_client: bool = True,
     with_exporter_config: bool = True,
@@ -88,7 +88,6 @@ def standardize_mysql_cluster_subflow(
         )
 
     # cc 模块标准化, 推送 exporter 配置
-    # ToDo cc 模块移动没做的
     if with_cc_standardize or with_exporter_config:
         pipe.add_sub_pipeline(
             sub_flow=cc_standardize(
@@ -166,7 +165,7 @@ def standardize_mysql_cluster_by_ip_subflow(
     with_collect_sysinfo: bool = True,
     with_actuator: bool = True,
     with_bk_plugin: bool = True,
-    with_cc_standardize: bool = True,
+    with_cc_standardize: bool = False,
     with_instance_standardize: bool = True,
     with_backup_client: bool = True,
 ) -> SubProcess:
@@ -206,13 +205,20 @@ def standardize_mysql_cluster_by_cluster_subflow(
     with_collect_sysinfo: bool = True,
     with_actuator: bool = True,
     with_bk_plugin: bool = True,
-    with_cc_standardize: bool = True,
+    with_cc_standardize: bool = False,
     with_instance_standardize: bool = True,
 ) -> SubProcess:
     instances = []
     for cluster_obj in Cluster.objects.filter(bk_cloud_id=bk_cloud_id, pk__in=cluster_ids):
         instances.extend([e.ip_port for e in cluster_obj.storageinstance_set.all()])
         instances.extend([e.ip_port for e in cluster_obj.proxyinstance_set.all()])
+
+    if with_cc_standardize:
+        d = {
+            **copy.deepcopy(data),
+            "cluster_ids": cluster_ids,
+        }
+        data = d
 
     return standardize_mysql_cluster_subflow(
         root_id=root_id,


### PR DESCRIPTION
1. 实现反向 post 上报接口
2. 校验配置文件添加 Enable 来空跑校验
3. 校验给 rocks, tokudb 生成 enable=false的配置
4. 校验空跑也会写假数据
5. 校验在general模式下会强制纠正配置文件, 并且受 enable影响
6. 校验在demand模式下不会强制纠正配置文件, 不受 enable影响
7. 调整了反向接口框架的实现
8. 权限申请, db 实例权限克隆 spider 4兼容