### PR TITLE
fix(mysql): 分区服务flush tables会卡主 #11215

### DIFF
--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/general_check_db_in_using.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/general_check_db_in_using.py
@@ -63,9 +63,10 @@ class GeneralCheckDBInUsingService(BaseService):
             flush_table_res = DRSApi.rpc(
                 {
                     "addresses": ["{}{}{}".format(ip, IP_PORT_DIVIDER, port)],
-                    "cmds": ["flush tables"],
+                    "cmds": ["set lock_wait_timeout=5", "flush tables with read lock"],
                     "force": False,
                     "bk_cloud_id": kwargs["bk_cloud_id"],
+                    "query_timeout": 5,
                 }
             )
             self.log_info("[{}] flush tables response: {}".format(kwargs["node_name"], flush_table_res))


### PR DESCRIPTION
1. golang context timeout 无法正确终止部分语句
2. 分区服务和saas的库表检查把 flush tables 替换为 set lock_wait_timeout && flush tables with read lock, 利用锁超时保证安全
3. drs 在处理 context timeout 时, 主动尝试发送 kill $conn_id