### PR TITLE
feat(backend): reverse-api-new-core-skip-bkcloudid #11238

### DIFF
--- a/dbm-services/common/reverseapi/core_test.go
+++ b/dbm-services/common/reverseapi/core_test.go
@@ -1,0 +1,137 @@
+package reverseapi
+
+import (
+	"dbm-services/common/reverseapi/internal/core"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestNewCore(t *testing.T) {
+	cases := []struct {
+		Name      string
+		BkCloudId int64
+		MixAddrs  []string
+		IsOK      func(core *core.Core, err error) bool
+	}{
+		{
+			"with-bk-cloud-id",
+			0,
+			[]string{"99:1.1.1.1:80", "99:2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err != nil {
+					return false
+				}
+				if core.BkCloudId() != 99 {
+					return false
+				}
+				a := []string{"1.1.1.1:80", "2.2.2.2:80"}
+				b := core.NginxAddrs()
+				slices.Sort(a)
+				slices.Sort(b)
+				return reflect.DeepEqual(a, b)
+			},
+		},
+		{
+			"without-bk-cloud-id",
+			0,
+			[]string{"1.1.1.1:80", "2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err != nil {
+					return false
+				}
+				if core.BkCloudId() != 0 {
+					return false
+				}
+				a := []string{"1.1.1.1:80", "2.2.2.2:80"}
+				b := core.NginxAddrs()
+				slices.Sort(a)
+				slices.Sort(b)
+				return reflect.DeepEqual(a, b)
+			},
+		},
+		{
+			"different-bk-cloud-id",
+			0,
+			[]string{"99:1.1.1.1:80", "98:2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err == nil {
+					return false
+				}
+				if core != nil {
+					return false
+				}
+				return true
+			},
+		},
+		{
+			"partial-bk-cloud-id",
+			0,
+			[]string{"99:1.1.1.1:80", "2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err != nil {
+					return false
+				}
+				if core.BkCloudId() != 99 {
+					return false
+				}
+				a := []string{"1.1.1.1:80", "2.2.2.2:80"}
+				b := core.NginxAddrs()
+				slices.Sort(a)
+				slices.Sort(b)
+				return reflect.DeepEqual(a, b)
+			},
+		},
+		{
+			"missing-port",
+			0,
+			[]string{"99:1.1.1.1", "98:2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err == nil {
+					return false
+				}
+				if core != nil {
+					return false
+				}
+				return true
+			},
+		},
+		{
+			"bad-line-1",
+			0,
+			[]string{"99:1.1.1.1:", "98:2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err == nil {
+					return false
+				}
+				if core != nil {
+					return false
+				}
+				return true
+			},
+		},
+		{
+			"bad-line-2",
+			0,
+			[]string{"a:1.1.1.1:80", "98:2.2.2.2:80"},
+			func(core *core.Core, err error) bool {
+				if err == nil {
+					return false
+				}
+				if core != nil {
+					return false
+				}
+				return true
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			rc, err := newCore(c.BkCloudId, c.MixAddrs...)
+			if !c.IsOK(rc, err) {
+				t.Fatalf("%s not pass", c.Name)
+			}
+		})
+	}
+}

--- a/dbm-services/common/reverseapi/example/main.go
+++ b/dbm-services/common/reverseapi/example/main.go
@@ -61,7 +61,6 @@ func main() {
 		}
 		panic(err)
 	}
-
 }
 
 func ReportEvent(ac *core.Core, event *demoEvent) error {

--- a/dbm-services/common/reverseapi/init.go
+++ b/dbm-services/common/reverseapi/init.go
@@ -4,12 +4,21 @@ import (
 	"dbm-services/common/reverseapi/define"
 	"dbm-services/common/reverseapi/internal/core"
 	"dbm-services/common/reverseapi/pkg"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 )
 
+// NewCore
+/*
+根据 nginx addrs file 的内容格式不同, bkCloudId 不是必要的参数
+1. 格式是 IP:PORT 时, bkCloudId 必须是正确的, 有意义的
+2. 格式是 BK_CLOUD_ID:IP:PORT 时, bkCloudId 可以随便写一个, 会被文件内容覆盖
+*/
 func NewCore(bkCloudId int64) (*core.Core, error) {
 	return NewCoreWithAddrsFile(
 		bkCloudId,
@@ -17,18 +26,75 @@ func NewCore(bkCloudId int64) (*core.Core, error) {
 	)
 }
 
-func NewCoreWithAddr(bkCloudId int64, alterNginxAddrs ...string) *core.Core {
-	return core.NewCore(bkCloudId, alterNginxAddrs...)
+// NewCoreWithAddr
+/*
+根据 nginx addrs 的内容格式不同, bkCloudId 不是必要的参数
+1. 格式是 IP:PORT 时, bkCloudId 必须是正确的, 有意义的
+2. 格式是 BK_CLOUD_ID:IP:PORT 时, bkCloudId 可以随便写一个, 会被文件内容覆盖
+*/
+func NewCoreWithAddr(bkCloudId int64, alterNginxAddrs ...string) (*core.Core, error) {
+	return newCore(bkCloudId, alterNginxAddrs...)
 }
 
+// NewCoreWithAddrsFile
+/*
+根据 nginx addrs file 的内容格式不同, bkCloudId 不是必要的参数
+1. 格式是 IP:PORT 时, bkCloudId 必须是正确的, 有意义的
+2. 格式是 BK_CLOUD_ID:IP:PORT 时, bkCloudId 可以随便写一个, 会被文件内容覆盖
+*/
 func NewCoreWithAddrsFile(bkCloudId int64, alterNginxAddrsFile string) (*core.Core, error) {
 	if !filepath.IsAbs(alterNginxAddrsFile) {
 		cwd, _ := os.Getwd()
 		alterNginxAddrsFile = filepath.Join(cwd, alterNginxAddrsFile)
 	}
-	addrs, err := pkg.ReadNginxProxyAddrs(alterNginxAddrsFile)
+	lines, err := pkg.ReadNginxProxyAddrs(alterNginxAddrsFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read nginx proxy addrs")
 	}
-	return NewCoreWithAddr(bkCloudId, addrs...), nil
+
+	return newCore(bkCloudId, lines...)
+}
+
+func newCore(bkCloudId int64, mixAddrs ...string) (*core.Core, error) {
+	var err error
+	var addrs []string
+	var bkCloudIdMap = make(map[int64]int64) // case 3 时判断是不是一样的 bk cloud id
+
+	for _, line := range mixAddrs {
+		var addr string
+		splitLine := strings.Split(line, ":")
+		switch len(splitLine) {
+		case 2:
+			bkCloudIdMap[bkCloudId] = 0
+
+			_, err = strconv.ParseInt(splitLine[1], 10, 64)
+			if err != nil {
+				return nil, errors.Wrapf(err, "bad nginx proxy port: %s", line)
+			}
+
+			addr = fmt.Sprintf("%s:%s", splitLine[0], splitLine[1])
+		case 3:
+			bkCloudId, err = strconv.ParseInt(splitLine[0], 10, 64)
+			if err != nil {
+				return nil, errors.Wrapf(err, "bad nginx bk cloud id: %s", line)
+			}
+
+			_, err = strconv.ParseInt(splitLine[2], 10, 64)
+			if err != nil {
+				return nil, errors.Wrapf(err, "bad nginx proxy port: %s", line)
+			}
+
+			bkCloudIdMap[bkCloudId] = 0
+			addr = fmt.Sprintf("%s:%s", splitLine[1], splitLine[2])
+		default:
+			return nil, errors.Wrapf(err, "failed to parse line from %s", line)
+		}
+		addrs = append(addrs, addr)
+	}
+
+	if len(bkCloudIdMap) > 1 {
+		return nil, errors.Errorf("different bk_cloud_id from %v", mixAddrs)
+	}
+
+	return core.NewCore(bkCloudId, addrs...), nil
 }

--- a/dbm-services/common/reverseapi/internal/core/init.go
+++ b/dbm-services/common/reverseapi/internal/core/init.go
@@ -23,6 +23,14 @@ type Core struct {
 	client     *http.Client
 }
 
+func (c *Core) BkCloudId() int64 {
+	return c.bkCloudId
+}
+
+func (c *Core) NginxAddrs() []string {
+	return c.nginxAddrs
+}
+
 func NewCore(bkCloudId int64, addrs ...string) *Core {
 	return &Core{
 		bkCloudId:  bkCloudId,

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_core/execute_cmds_on_addr.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_core/execute_cmds_on_addr.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (c *RPCWrapper) executeOneAddr(address string) (res []CmdResultType, err error) {
-	db, err := c.MakeConnection(address, c.user, c.password, c.connectTimeout, c.timezone)
+	db, err := c.MakeConnection(address, c.user, c.password, c.connectTimeout, c.timezone, c.charset)
 
 	if err != nil {
 		c.logger.Error("make connection", slog.String("error", err.Error()))

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_core/interface.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_core/interface.go
@@ -12,6 +12,7 @@ type RPCEmbedInterface interface {
 		password string,
 		timeout int,
 		timezone string,
+		charset string,
 	) (*sqlx.DB, error)
 	ParseCommand(command string) (*ParseQueryBase, error)
 	IsQueryCommand(*ParseQueryBase) bool

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_core/rpc_wrapper.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_core/rpc_wrapper.go
@@ -11,6 +11,7 @@ type RPCWrapper struct {
 	connectTimeout int
 	queryTimeout   int
 	timezone       string
+	charset        string
 	force          bool
 	logger         *slog.Logger
 	RPCEmbedInterface
@@ -25,6 +26,7 @@ func NewRPCWrapper(
 	connectTimeout int,
 	queryTimeout int,
 	timezone string,
+	charset string,
 	force bool,
 	em RPCEmbedInterface,
 	requestId string,
@@ -37,6 +39,7 @@ func NewRPCWrapper(
 		connectTimeout:    connectTimeout,
 		queryTimeout:      queryTimeout,
 		timezone:          timezone,
+		charset:           charset,
 		force:             force,
 		RPCEmbedInterface: em,
 	}

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/proxy_rpc/proxy_rpc.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/proxy_rpc/proxy_rpc.go
@@ -37,7 +37,7 @@ func (c *ProxyRPCEmbed) ParseCommand(command string) (*rpc_core.ParseQueryBase, 
 }
 
 // MakeConnection proxy 建立连接
-func (c *ProxyRPCEmbed) MakeConnection(address string, user string, password string, timeout int, timezone string) (*sqlx.DB, error) {
+func (c *ProxyRPCEmbed) MakeConnection(address string, user string, password string, timeout int, timezone string, charset string) (*sqlx.DB, error) {
 	connectParam := fmt.Sprintf("timeout=%ds", timeout)
 	db, err := sqlx.Open(
 		"mysql",

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/sqlserver_rpc/sqlserver_rpc.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/sqlserver_rpc/sqlserver_rpc.go
@@ -55,7 +55,7 @@ func (c *SqlserverRPCEmbed) ParseCommand(command string) (*rpc_core.ParseQueryBa
 }
 
 // MakeConnection sqlserver 建立连接
-func (c *SqlserverRPCEmbed) MakeConnection(address string, user string, password string, timeout int, timezone string) (*sqlx.DB, error) {
+func (c *SqlserverRPCEmbed) MakeConnection(address string, user string, password string, timeout int, timezone string, charset string) (*sqlx.DB, error) {
 	host := strings.Split(address, ":")[0]
 	port := strings.Split(address, ":")[1]
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(timeout))

--- a/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/general_handler.go
+++ b/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/general_handler.go
@@ -1,7 +1,6 @@
 package handler_rpc
 
 import (
-	"dbm-services/mysql/db-remote-service/pkg/config"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -21,7 +20,8 @@ func generalHandler(rpcEmbed rpc_core.RPCEmbedInterface) func(*gin.Context) {
 			ConnectTimeout: 2,
 			QueryTimeout:   600, // 默认超时时间 10 分钟
 			Force:          false,
-			Timezone:       config.RuntimeConfig.Timezone,
+			Timezone:       "", //config.RuntimeConfig.Timezone,
+			Charset:        "",
 		}
 
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -39,6 +39,9 @@ func generalHandler(rpcEmbed rpc_core.RPCEmbedInterface) func(*gin.Context) {
 		if req.QueryTimeout <= 0 {
 			req.QueryTimeout = 600
 		}
+		if req.Charset == "" {
+			req.Charset = "default"
+		}
 
 		slog.Info(
 			"enter rpc handler",
@@ -48,6 +51,8 @@ func generalHandler(rpcEmbed rpc_core.RPCEmbedInterface) func(*gin.Context) {
 			slog.Int("connect_timeout", req.ConnectTimeout),
 			slog.Int("query_timeout", req.QueryTimeout),
 			slog.String("request-id", requestId),
+			slog.String("charset", req.Charset),
+			slog.String("timezone", req.Timezone),
 		)
 		dupAddrs := findDuplicateAddresses(req.Addresses)
 
@@ -69,7 +74,7 @@ func generalHandler(rpcEmbed rpc_core.RPCEmbedInterface) func(*gin.Context) {
 		rpcWrapper := rpc_core.NewRPCWrapper(
 			req.Addresses, req.Cmds,
 			rpcEmbed.User(), rpcEmbed.Password(),
-			req.ConnectTimeout, req.QueryTimeout, req.Timezone, req.Force,
+			req.ConnectTimeout, req.QueryTimeout, req.Timezone, req.Charset, req.Force,
 			rpcEmbed,
 			requestId,
 		)

--- a/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/init.go
@@ -10,7 +10,8 @@ type queryRequest struct {
 	Force          bool     `form:"force" json:"force"`
 	ConnectTimeout int      `form:"connect_timeout" json:"connect_timeout"`
 	QueryTimeout   int      `form:"query_timeout" json:"query_timeout"`
-	Timezone       string   `form:"time_zone" json:"time_zone"`
+	Timezone       string   `form:"timezone" json:"timezone"`
+	Charset        string   `form:"charset" json:"charset"`
 }
 
 // TrimSpace delete space around address

--- a/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/mysql_complex.go
+++ b/dbm-services/mysql/db-remote-service/pkg/service/handler_rpc/mysql_complex.go
@@ -105,7 +105,7 @@ func MySQLComplexHandler(c *gin.Context) {
 				rpcWrapper := rpc_core.NewRPCWrapper(
 					postReq.Addresses, postReq.Cmds,
 					config.RuntimeConfig.MySQLAdminUser, config.RuntimeConfig.MySQLAdminPassword,
-					postReq.ConnectTimeout, postReq.QueryTimeout, postReq.Timezone, postReq.Force,
+					postReq.ConnectTimeout, postReq.QueryTimeout, postReq.Timezone, postReq.Charset, postReq.Force,
 					&mysql_rpc.MySQLRPCEmbed{},
 					requestId,
 				)

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/exporter/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/exporter/init.go
@@ -127,13 +127,18 @@ type exporterConfig struct {
 }
 
 func GenConfig(bkCloudId int64, nginxAddrs []string, ports ...int) error {
-	apiCore := reverseapi.NewCoreWithAddr(bkCloudId, nginxAddrs...)
-	data, err := reversemysqlapi.ExporterConfig(apiCore, ports...)
-
+	apiCore, err := reverseapi.NewCoreWithAddr(bkCloudId, nginxAddrs...)
 	if err != nil {
 		logger.Error(err.Error())
 		return err
 	}
+
+	data, err := reversemysqlapi.ExporterConfig(apiCore, ports...)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
 	logger.Info("exporter config: %s", string(data))
 
 	b, l, err := reversemysqlapi.ListInstanceInfo(apiCore)

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/init_common_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/peripheraltools/v2/init_common_config.go
@@ -98,7 +98,12 @@ func (c *InitCommonConfig) initInstanceInfo() (err error) {
 		_ = f.Close()
 	}()
 
-	apiCore := reverseapi.NewCoreWithAddr(c.Param.BkCloudId, c.Param.NginxAddrs...)
+	apiCore, err := reverseapi.NewCoreWithAddr(c.Param.BkCloudId, c.Param.NginxAddrs...)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	}
+
 	data, _, err := reversemysqlapi.ListInstanceInfo(apiCore)
 	if err != nil {
 		logger.Error(err.Error())

--- a/dbm-services/mysql/db-tools/mysql-crond/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/cmd/subcmd_gen_config.go
@@ -76,7 +76,11 @@ jobs_config: {{ .InstallPath }}/jobs-config.yaml`,
 		nginxAddrs := viper.GetStringSlice("nginx-address")
 		bkCloudId := viper.GetInt("bk-cloud-id")
 
-		apiCore := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		apiCore, err := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		if err != nil {
+			return err
+		}
+
 		data, err := reversemysqlapi.CrondConfig(apiCore)
 		if err != nil {
 			return err

--- a/dbm-services/mysql/db-tools/mysql-dbbackup/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-dbbackup/cmd/subcmd_gen_config.go
@@ -37,7 +37,11 @@ var subCmdGenConfig = &cobra.Command{
 		bkCloudId := viper.GetInt("bk-cloud-id")
 		ports := viper.GetIntSlice("port")
 
-		apiCore := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		apiCore, err := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		if err != nil {
+			return err
+		}
+
 		data, err := reversemysqlapi.DBBackupConfig(apiCore, ports...)
 		if err != nil {
 			return err

--- a/dbm-services/mysql/db-tools/mysql-monitor/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/cmd/subcmd_gen_config.go
@@ -70,7 +70,11 @@ func generateRuntimeConfigs() error {
 	bkCloudId := viper.GetInt("bk-cloud-id")
 	ports := viper.GetIntSlice("port")
 
-	apiCore := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+	apiCore, err := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+	if err != nil {
+		return err
+	}
+
 	data, err := reversemysqlapi.MonitorRuntimeConfig(apiCore, ports...)
 	if err != nil {
 		return err
@@ -158,7 +162,11 @@ func generateItemsConfigs() error {
 	bkCloudId := viper.GetInt("bk-cloud-id")
 	ports := viper.GetIntSlice("port")
 
-	apiCore := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+	apiCore, err := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+	if err != nil {
+		return err
+	}
+
 	data, err := reversemysqlapi.MonitorItemsConfig(apiCore, ports...)
 	if err != nil {
 		return err

--- a/dbm-services/mysql/db-tools/mysql-rotatebinlog/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-rotatebinlog/cmd/subcmd_gen_config.go
@@ -43,7 +43,11 @@ var subCmdGenConfig = &cobra.Command{
 		bkCloudId := viper.GetInt("bk-cloud-id")
 		ports := viper.GetIntSlice("port")
 
-		apiCore := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		apiCore, err := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		if err != nil {
+			return err
+		}
+
 		data, err := reversemysqlapi.RotatebinlogConfig(apiCore, ports...)
 		if err != nil {
 			return err

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/subcmd_gen_config.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/subcmd_gen_config.go
@@ -29,7 +29,11 @@ var subCmdGenConfig = &cobra.Command{
 		bkCloudId := viper.GetInt("bk-cloud-id")
 		ports := viper.GetIntSlice("port")
 
-		apiCore := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		apiCore, err := reverseapi.NewCoreWithAddr(int64(bkCloudId), nginxAddrs...)
+		if err != nil {
+			return err
+		}
+
 		data, err := reversemysqlapi.ChecksumConfig(apiCore, ports...)
 		if err != nil {
 			return err

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/__init__.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/__init__.py
@@ -17,3 +17,4 @@ from .sync_report import sync_report
 
 producers: Union[List[KafkaProducer], None] = None
 lock = threading.Lock()
+event_type_cache = []

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/schema_validate.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/schema_validate.py
@@ -9,11 +9,12 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-# from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
-# from backend.configuration.constants import SystemSettingsEnum
-# from backend.configuration.models import SystemSettings
+import backend.db_proxy.reverse_api.common.impl.sync_report as sr
+from backend.configuration.constants import SystemSettingsEnum
+from backend.configuration.models import SystemSettings
 from backend.db_meta.enums import ClusterType
 
 
@@ -22,7 +23,11 @@ class SyncReportEventSerializer(serializers.Serializer):
     cluster_type = serializers.ChoiceField(choices=ClusterType.get_choices())
     event_type = serializers.CharField()
 
-    # def validate(self, attrs):
-    #     event_type = attrs.get("event_type", "")
-    #     if event_type not in SystemSettings.get_setting_value(SystemSettingsEnum.REVERSE_REPORT_EVENT_TYPES):
-    #         raise serializers.ValidationError(_(f"{event_type} not a registered event type"))
+    def validate(self, attrs):
+        event_type = attrs.get("event_type", "")
+        if event_type not in sr.event_type_cache:
+            if event_type in SystemSettings.get_setting_value(SystemSettingsEnum.REVERSE_REPORT_EVENT_TYPES):
+                with sr.lock:
+                    sr.event_type_cache.append(event_type)
+            else:
+                raise serializers.ValidationError(_(f"{event_type} not a registered event type"))

--- a/dbm-ui/backend/flow/plugins/components/collections/common/add_alarm_shield.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/add_alarm_shield.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import json
+import logging
+
+from pipeline.component_framework.component import Component
+
+from backend import env
+from backend.components.bkmonitorv3.client import BKMonitorV3Api
+from backend.flow.plugins.components.collections.common.base_service import BaseService
+
+logger = logging.getLogger("flow")
+
+
+class AddAlarmShieldService(BaseService):
+    def _execute(self, data, parent_data):
+        kwargs = data.get_one_of_inputs("kwargs")
+        global_data = data.get_one_of_inputs("global_data")
+
+        bk_biz_id = global_data["bk_biz_id"]
+
+        data = {
+            "category": "dimension",
+            "begin_time": kwargs["begin_time"],
+            "end_time": kwargs["end_time"],
+            "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
+            "cycle_config": {"begin_time": "", "end_time": "", "day_list": [], "week_list": [], "type": 1},
+            "shield_notice": False,
+            "notice_config": {},
+            "description": kwargs["description"],
+            "dimension_config": {
+                "dimension_conditions": [
+                    {"condition": "and", "key": "appid", "method": "eq", "value": [f"{bk_biz_id}"], "name": "appid"},
+                ]
+            },
+        }
+
+        dimensions = kwargs["dimensions"]
+        for dim in dimensions:
+            data["dimension_config"]["dimension_conditions"].append(
+                {
+                    "condition": "and",
+                    "key": dim["name"],
+                    "method": "eq",
+                    "value": dim["values"],
+                    "name": dim["name"],
+                }
+            )
+
+        data.update({"description": self.format_shield_description(bk_biz_id, description=data["description"])})
+        logger.info(json.dumps(data))
+
+        BKMonitorV3Api.add_shield(data)
+
+        return True
+
+    @staticmethod
+    def format_shield_description(bk_biz_id, description=""):
+        prefix = f"[dbm:appid={bk_biz_id}]"
+        # 先删后补，避免出现多个前缀
+        description = description.replace(prefix, "").strip()
+        return f"{prefix}{description}"
+
+
+class AddAlarmShieldComponent(Component):
+    name = __name__
+    code = "add_alarm_shield"
+    bound_service = AddAlarmShieldService

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/mysql_os_init.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/mysql_os_init.py
@@ -229,7 +229,9 @@ class SysInit(BkJobService):
         echo '{}' >> /home/mysql/common_config/nginx_proxy.list
         chown mysql /home/mysql/common_config/nginx_proxy.list
         """.format(
-            "\n".join(list_nginx_addrs(kwargs["bk_cloud_id"]))
+            "\n".join(
+                ["{}:{}".format(kwargs["bk_cloud_id"], line) for line in list_nginx_addrs(kwargs["bk_cloud_id"])]
+            )
         )
 
         # 脚本内容

--- a/dbm-ui/backend/flow/utils/spider/tendb_cluster_info.py
+++ b/dbm-ui/backend/flow/utils/spider/tendb_cluster_info.py
@@ -45,6 +45,7 @@ def get_rollback_clusters_info(
     target_obj = Cluster.objects.get(id=target_cluster_id)
     source_spiders = source_obj.proxyinstance_set.filter()
     target_spiders = target_obj.proxyinstance_set.filter()
+    cluster_info["target_immute_domain"] = target_obj.immute_domain
     cluster_info["bk_cloud_id"] = source_obj.bk_cloud_id
     cluster_info["source"] = source_obj.to_dict()
     cluster_info["target"] = target_obj.to_dict()


### PR DESCRIPTION
1. 反向上报 new api core 在符合预定格式的情况下, 不再强制要求 bk cloud id
2. 增加 创建告警屏蔽策略 component: dbm-ui/backend/flow/plugins/components/collections/common/add_alarm_shield.py
3. tendbha 和 tendbcluster 的定点回档改用新的屏蔽 component了
4. drs mysql rpc  支持指定时区和字符集

![企业微信截图_304d0032-f8f7-4a7e-937e-91efe73e4280](https://github.com/user-attachments/assets/34a471fa-0ec5-4561-b476-d3b39176c8e7)

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/1b04251a-cd1b-402a-b395-7d567eae6387" />
