### PR TITLE
fix(backend): 增加上报api连接kafka鉴权 #11306

### DIFF
--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/sync_report.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/sync_report.py
@@ -21,9 +21,10 @@ from backend.db_proxy.reverse_api.exceptions import SyncReportEventValidationExc
 
 
 def sync_report(bk_cloud_id: int, ip: str, port_list: List[int], data: List):
+    kafka_opts = env.REVERSE_REPORT_KAFKA_OPTIONS
     with sr.lock:
         if sr.producers is None:
-            sr.producers = [KafkaProducer(bootstrap_servers=env.REVERSE_REPORT_KAFKA_BROKER) for i in range(5)]
+            sr.producers = [KafkaProducer(api_version=(0, 11), **kafka_opts) for i in range(5)]
 
     vd = SyncReportEventSerializer(data=data, many=True)
     if not vd.is_valid():

--- a/dbm-ui/backend/env/__init__.py
+++ b/dbm-ui/backend/env/__init__.py
@@ -205,5 +205,11 @@ INITIATIVE_DOWNLOAD = get_type_env(key="INITIATIVE_DOWNLOAD", _type=bool, defaul
 # 反向查询接口禁用安全检查
 DEBUG_REVERSE_API = get_type_env(key="DEBUG_REVERSE_API", _type=bool, default=False)
 
-# 反向上报接口 kafka broker
-REVERSE_REPORT_KAFKA_BROKER = get_type_env(key="REVERSE_REPORT_KAFKA_BROKER", _type=str, default=":9092")
+# 反向上报接口 kafka 参数
+# DBM 带鉴权的连接串
+# export REVERSE_REPORT_KAFKA_OPTIONS=bootstrap_servers=:9092, \
+# sasl_mechanism=SCRAM-SHA-512,security_protocol=SASL_PLAINTEXT, \
+# sasl_plain_username=kafka_user,sasl_plain_password=kafka_pass
+REVERSE_REPORT_KAFKA_OPTIONS = get_type_env(
+    key="REVERSE_REPORT_KAFKA_OPTIONS", _type=dict, default={"bootstrap_servers": ":9092"}
+)


### PR DESCRIPTION
export REVERSE_REPORT_KAFKA_OPTIONS=bootstrap_servers=:9092, \
sasl_mechanism=SCRAM-SHA-512,security_protocol=SASL_PLAINTEXT, \
sasl_plain_username=kafka_user,sasl_plain_password=kafka_pass