### PR TITLE
fix(mysql): drs-connection-when-default-charaset #11814

### DIFF
--- a/dbm-services/mysql/db-remote-service/go.mod
+++ b/dbm-services/mysql/db-remote-service/go.mod
@@ -5,18 +5,21 @@ go 1.23.0
 toolchain go1.24.2
 
 require (
+	github.com/avast/retry-go/v4 v4.6.1
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/gin-contrib/pprof v1.5.2
 	github.com/gin-contrib/requestid v1.0.4
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.7.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0
 	go.mongodb.org/mongo-driver v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.46.1
+	golang.org/x/time v0.1.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 

--- a/dbm-services/mysql/db-remote-service/go.sum
+++ b/dbm-services/mysql/db-remote-service/go.sum
@@ -41,6 +41,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJc
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/bytedance/sonic v1.12.6 h1:/isNmCUF2x3Sh8RAp/4mh4ZGkcFAX/hLrzrK3AvpRzk=
 github.com/bytedance/sonic v1.12.6/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKzMzT9r/rk=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
@@ -176,6 +178,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -457,6 +461,8 @@ golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.1.0 h1:xYY+Bajn2a7VBmTM5GikTmnK8ZuX8YgnQCqZpbBNtmA=
+golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/dbm-services/mysql/db-remote-service/pkg/config/config.go
+++ b/dbm-services/mysql/db-remote-service/pkg/config/config.go
@@ -82,4 +82,6 @@ func InitConfig() {
 		Source:     viper.GetBool("log_source"),
 		Json:       viper.GetBool("log_json"),
 	}
+
+	InitGlobalLimiter()
 }

--- a/dbm-services/mysql/db-remote-service/pkg/config/limiter.go
+++ b/dbm-services/mysql/db-remote-service/pkg/config/limiter.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+var GlobalLimiter *rate.Limiter
+
+func InitGlobalLimiter() {
+	GlobalLimiter = rate.NewLimiter(
+		rate.Every(
+			time.Duration(1000*1000/RuntimeConfig.Concurrent)*time.Microsecond),
+		1,
+	)
+}

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_core/execute_cmd.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_core/execute_cmd.go
@@ -57,7 +57,7 @@ func executeAtom(logger *slog.Logger, db *sqlx.DB, conn *sqlx.Conn, connId int64
 
 	result, err := conn.ExecContext(ctx, cmd)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) && connId > 0 {
 			logger.Error("execute cmd timeout, try to kill conn", slog.String("cmd", cmd), slog.Int64("connId", connId))
 			_, _ = db.Exec(`KILL ?`, connId)
 		}
@@ -100,7 +100,7 @@ func queryAtom(logger *slog.Logger, db *sqlx.DB, conn *sqlx.Conn, connId int64, 
 
 	rows, err := conn.QueryxContext(ctx, cmd)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) && connId > 0 {
 			logger.Info("query cmd timeout, try to kill conn", slog.String("cmd", cmd), slog.Int64("connId", connId))
 			_, _ = db.Exec(`KILL ?`, connId)
 		}

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_core/execute_cmds_on_addr.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_core/execute_cmds_on_addr.go
@@ -67,12 +67,12 @@ func (c *RPCWrapper) executeOneAddr(address string) (res []CmdResultType, err er
 	}()
 	slog.Info("execute one addr get conn", slog.Any("stat", db.Stats()))
 
-	var connId int64
-	err = conn.GetContext(context.Background(), &connId, `SELECT CONNECTION_ID()`)
-	if err != nil {
-		c.logger.Error("get conn id", slog.String("error", err.Error()))
-		return nil, err
-	}
+	var connId int64 = 0
+	_ = conn.GetContext(context.Background(), &connId, `SELECT CONNECTION_ID()`)
+	//if err != nil {
+	//	c.logger.Error("get conn id", slog.String("error", err.Error()))
+	//	return nil, err
+	//}
 
 	for idx, command := range c.commands {
 		command = strings.TrimSpace(command)

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/mysql_rpc/embed.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/mysql_rpc/embed.go
@@ -86,6 +86,10 @@ CONNSTART:
 	}()
 
 	if charset == "default" {
+		defer func() {
+			_ = db.Close()
+		}()
+
 		slog.Info("recursion mysql connection", slog.String("charset", charset))
 		var serverCharset string
 		err = db.QueryRow(`SELECT @@character_set_server`).Scan(&serverCharset)

--- a/dbm-services/mysql/db-remote-service/pkg/service/router.go
+++ b/dbm-services/mysql/db-remote-service/pkg/service/router.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"dbm-services/mysql/db-remote-service/pkg/service/handler_rpc"
+	"dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc"
+	"dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket"
 
 	"github.com/gin-gonic/gin"
 )
@@ -34,4 +36,15 @@ func RegisterRouter(engine *gin.Engine) {
 
 	webConsoleGroup := engine.Group("/webconsole")
 	webConsoleGroup.POST("/rpc", handler_rpc.WebConsoleRPCHandler)
+
+	v2Group(engine)
+}
+
+func v2Group(engine *gin.Engine) {
+	v2Group := engine.Group("/v2")
+	WSGroup := v2Group.Group("/ws")
+	RPCGroup := v2Group.Group("/rpc")
+
+	WSGroup.GET("/mysql", websocket.Handler)
+	RPCGroup.POST("/mysql", rpc.Handler)
 }

--- a/dbm-services/mysql/db-remote-service/pkg/v2/client/main.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/client/main.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/gorilla/websocket"
+)
+
+type WSBaseRequest struct {
+	RequestType string          `json:"request-type"`
+	Body        json.RawMessage `json:"body"`
+}
+
+type WSConnectRequest struct {
+	Address  string `json:"address"`
+	Charset  string `json:"charset"`
+	Timezone string `json:"timezone"`
+	Timeout  int    `json:"timeout"`
+}
+
+type WSCommandRequest struct {
+	Command string `json:"command"`
+	Timeout int    `json:"timeout"`
+}
+
+func main() {
+	header := make(http.Header)
+	header.Set("token", "123456")
+	u := url.URL{
+		Scheme: "ws",
+		Host:   os.Args[1],
+		Path:   "/v2/ws/mysql",
+	}
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err, resp)
+		return
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGINT)
+
+	responseChan := make(chan string, 8)
+	defer close(responseChan)
+
+	go func(responseChan chan string) {
+		for {
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				responseChan <- err.Error()
+				return
+			}
+			responseChan <- string(message)
+		}
+	}(responseChan)
+
+	wcr := WSConnectRequest{
+		Address: os.Args[2],
+		Charset: "utf8mb4",
+		//Timezone: "",
+		Timeout: 30,
+	}
+	b, err := json.Marshal(wcr)
+	if err != nil {
+		panic(err)
+	}
+
+	wbr := WSBaseRequest{
+		RequestType: "connect",
+		Body:        json.RawMessage(b),
+	}
+	bb, err := json.Marshal(wbr)
+	if err != nil {
+		panic(err)
+	}
+
+	err = conn.WriteMessage(websocket.TextMessage, bb)
+	if err != nil {
+		panic(err)
+	}
+	connResp := <-responseChan
+	fmt.Println(connResp)
+
+	for {
+		select {
+		case <-interrupt:
+			log.Println("interrupt")
+			err := conn.WriteMessage(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			)
+			if err != nil {
+				log.Println("write:", err)
+			}
+			<-responseChan
+			return
+		default:
+			in := bufio.NewReader(os.Stdin)
+			input, err := in.ReadString('\n')
+			if err != nil {
+				log.Println("read:", err)
+				return
+			}
+			if len(input) == 0 {
+				continue
+			}
+			switch strings.TrimSpace(input) {
+			case "exit":
+				log.Println("exit")
+				err := conn.WriteMessage(
+					websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+				)
+				if err != nil {
+					log.Println("write:", err)
+					return
+				}
+				return
+			default:
+				wcmr := WSCommandRequest{
+					Command: strings.TrimSpace(input),
+					Timeout: 30,
+				}
+				b, err := json.Marshal(wcmr)
+				if err != nil {
+					panic(err)
+				}
+				wbr := WSBaseRequest{
+					RequestType: "command",
+					Body:        json.RawMessage(b),
+				}
+				bb, err := json.Marshal(wbr)
+				if err != nil {
+					panic(err)
+				}
+				err = conn.WriteMessage(websocket.TextMessage, bb)
+				if err != nil {
+					log.Println("write:", err)
+					continue
+				}
+				resp := <-responseChan
+				fmt.Println(resp)
+			}
+		}
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/clean.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/clean.go
@@ -1,0 +1,17 @@
+package impl
+
+import "github.com/jmoiron/sqlx"
+
+func Clean(db *sqlx.DB, conn *sqlx.Conn, connId int64) {
+	if connId != 0 {
+		_, _ = db.Exec(`KILL ?`, connId)
+	}
+
+	if conn != nil {
+		_ = conn.Close()
+	}
+
+	if db != nil {
+		_ = db.Close()
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/docmd.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/docmd.go
@@ -1,0 +1,82 @@
+package impl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/jmoiron/sqlx"
+)
+
+func DoSQL(conn *sqlx.Conn, sql string, timeout int) ([]byte, int64, error) {
+	sql = strings.TrimSpace(sql)
+	var cmdWorker func(*sqlx.Conn, string, int) (SQLResultRows, int64, error)
+	if IsQueryCommand(sql) {
+		cmdWorker = doQuery
+	} else {
+		cmdWorker = doExecute
+	}
+
+	crs := make(SQLResultRows, 0)
+	var n int64
+	var err error
+	err = retry.Do(
+		func() error {
+			crs, n, err = cmdWorker(conn, sql, timeout)
+			return err
+		},
+		retryOpts...,
+	)
+
+	b, _ := json.Marshal(crs)
+
+	var rErrs retry.Error
+	errors.As(err, &rErrs)
+
+	return b, n, errors.Join(rErrs...)
+}
+
+func doQuery(conn *sqlx.Conn, sql string, timeout int) (SQLResultRows, int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	rows, err := conn.QueryxContext(ctx, sql)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	srs := make(SQLResultRows, 0)
+	for rows.Next() {
+		data := make(map[string]interface{})
+		if err := rows.MapScan(data); err != nil {
+			return nil, 0, err
+		}
+		for k, v := range data {
+			if value, ok := v.([]byte); ok {
+				data[k] = string(value)
+			}
+		}
+		srs = append(srs, data)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return srs, 0, nil
+}
+
+func doExecute(conn *sqlx.Conn, sql string, timeout int) (SQLResultRows, int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+	result, err := conn.ExecContext(ctx, sql)
+	if err != nil {
+		return nil, 0, err
+	}
+	n, err := result.RowsAffected()
+	return nil, n, err
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/init.go
@@ -1,0 +1,50 @@
+package impl
+
+import (
+	"time"
+
+	"github.com/avast/retry-go/v4"
+)
+
+// SQLResultRow
+/*
+{
+	COLNAME1: COLVALUE1,
+	COLNAME2: COLVALUE2,
+}
+*/
+type SQLResultRow map[string]interface{}
+
+// SQLResultRows
+/*
+[
+	{...}, # row1
+	{...}, # row2
+]
+*/
+type SQLResultRows []SQLResultRow
+
+var retryOpts []retry.Option
+
+var queryCmds = []string{
+	"use",
+	"explain",
+	"select",
+	"show",
+	"desc",
+}
+var retryAbleErrNum []uint16
+
+func init() {
+	retryOpts = []retry.Option{
+		retry.RetryIf(IsRetryAbleError),
+		retry.Attempts(3),
+		retry.Delay(1 * time.Second),
+		retry.DelayType(retry.FixedDelay),
+	}
+
+	retryAbleErrNum = []uint16{
+		1130, // ERROR 1130 (HY000): Host is not allowed to connect
+		1045, // ERROR 1045 (28000): Access denied for user
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/isquery.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/isquery.go
@@ -1,0 +1,32 @@
+package impl
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+)
+
+func IsQueryCommand(command string) bool {
+	pattern := regexp.MustCompile(`\s+`)
+	firstWord := strings.ToLower(pattern.Split(command, -1)[0])
+	if firstWord == "tdbctl" {
+		return isTDBCTLQuery(command)
+	} else {
+		return slices.Index(queryCmds, firstWord) >= 0
+	}
+}
+
+func isTDBCTLQuery(command string) bool {
+	splitPattern := regexp.MustCompile(`\s+`)
+	secondWord := strings.ToLower(splitPattern.Split(command, -1)[1])
+	switch secondWord {
+	case "get", "show":
+		return true
+	case "connect":
+		catchPattern := regexp.MustCompile(`(?mi)^.*execute\s+['"](.*)['"]$`)
+		executeCmd := catchPattern.FindAllStringSubmatch(command, -1)[0][1]
+		return IsQueryCommand(executeCmd)
+	default:
+		return false
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/makeconnection.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/makeconnection.go
@@ -1,0 +1,76 @@
+package impl
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/jmoiron/sqlx"
+)
+
+func Prepare(addr, user, password, timezone, charset string, timeout int) (*sqlx.DB, *sqlx.Conn, int64, error) {
+	db, err := makeConnection(
+		addr, user, password,
+		timezone, charset, timeout,
+	)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	conn, err := db.Connx(context.Background())
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	var connId int64
+	err = conn.GetContext(context.Background(), &connId, `SELECT CONNECTION_ID()`)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	return db, conn, connId, nil
+}
+
+func makeConnection(addr, user, password, timezone, charset string, timeout int) (db *sqlx.DB, err error) {
+	dsn := fmt.Sprintf(`%s:%s@tcp(%s)/?timeout=%ds`, user, password, addr, timeout)
+	if timezone != "" {
+		dsn = dsn + fmt.Sprintf("&time_zone=%s", url.QueryEscape(fmt.Sprintf(`%s`, timezone)))
+	}
+	if charset != "default" {
+		dsn = dsn + fmt.Sprintf("&charset=%s", charset)
+	}
+
+	err = retry.Do(
+		func() error {
+			db, err = sqlx.Connect("mysql", dsn)
+			if err != nil {
+				return err
+			}
+			if charset == "default" {
+				defer func() {
+					_ = db.Close()
+				}()
+				var serverCharset string
+				err := db.QueryRow(`SELECT @@character_set_server`).Scan(&serverCharset)
+				if err != nil {
+					return err
+				}
+				db, err = makeConnection(addr, user, password, timezone, serverCharset, timeout)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		retry.Attempts(3),
+		retry.Delay(2*time.Second),
+		retry.DelayType(retry.FixedDelay),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/retryable.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/retryable.go
@@ -1,0 +1,16 @@
+package impl
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+func IsRetryAbleError(err error) bool {
+	var me *mysql.MySQLError
+	if errors.As(err, &me) && slices.Index(retryAbleErrNum, me.Number) >= 0 {
+		return true
+	}
+	return false
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/do.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/do.go
@@ -1,0 +1,60 @@
+package rpc
+
+import (
+	"context"
+	"dbm-services/mysql/db-remote-service/pkg/config"
+	"sync"
+)
+
+func (c *MySQLRPCRequest) do() (res [][]MySQLRPCResponse, err error) {
+	rChan := make(chan []MySQLRPCResponse)
+	done := make(chan struct{})
+	errChan := make(chan error)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer func() {
+			close(rChan)
+			close(done)
+			close(errChan)
+		}()
+		var wg = &sync.WaitGroup{}
+		wg.Add(len(c.Addresses))
+		for _, addr := range c.Addresses {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			_ = config.GlobalLimiter.Wait(context.Background())
+			go func(addr string) {
+				defer wg.Done()
+				ores, err := c.oneAddr(addr)
+				if ores != nil {
+					rChan <- ores
+				}
+				if err != nil {
+					errChan <- err
+				}
+			}(addr)
+		}
+		wg.Wait()
+		done <- struct{}{}
+	}()
+
+	for {
+		select {
+		case <-done:
+			return res, nil
+		case err := <-errChan:
+			cancel()
+			return res, err
+		case r := <-rChan:
+			res = append(res, r)
+		default:
+		}
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/handler.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/handler.go
@@ -1,0 +1,39 @@
+package rpc
+
+import (
+	"context"
+	"dbm-services/mysql/db-remote-service/pkg/config"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Handler(c *gin.Context) {
+	_ = config.GlobalLimiter.Wait(context.Background())
+
+	req, err := BuildRequestWithDefault(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	res, err := req.do()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			gin.H{
+				"code": 1,
+				"data": res,
+				"msg":  err.Error(),
+			})
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		gin.H{
+			"code": 0,
+			"data": res,
+			"msg":  "",
+		})
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/init.go
@@ -1,0 +1,57 @@
+package rpc
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type MySQLRPCRequest struct {
+	Addresses      []string `form:"addresses" json:"addresses" binding:"required"`
+	Cmds           []string `form:"cmds" json:"cmds" binding:"required"`
+	Force          bool     `form:"force" json:"force"`
+	ConnectTimeout int      `form:"connect_timeout" json:"connect_timeout"`
+	QueryTimeout   int      `form:"query_timeout" json:"query_timeout"`
+	Timezone       string   `form:"timezone" json:"timezone"`
+	Charset        string   `form:"charset" json:"charset"`
+	TraceId        string   `form:"trace_id" json:"trace_id"`
+}
+
+func (c *MySQLRPCRequest) TrimSpace() {
+	c.Timezone = strings.TrimSpace(c.Timezone)
+	for idx, val := range c.Addresses {
+		c.Addresses[idx] = strings.TrimSpace(val)
+	}
+}
+
+type MySQLRPCResponse struct {
+	Cmd          string
+	Result       json.RawMessage //[]byte //impl.SQLResultRows
+	RowsAffected int64
+	Error        string
+}
+
+func BuildRequestWithDefault(c *gin.Context) (*MySQLRPCRequest, error) {
+	r := &MySQLRPCRequest{
+		ConnectTimeout: 2,
+		QueryTimeout:   600,
+		Force:          false,
+		Timezone:       "",
+		Charset:        "",
+	}
+	err := c.ShouldBindJSON(r)
+	if err != nil {
+		return nil, err
+	}
+
+	r.TrimSpace()
+	if r.QueryTimeout <= 0 {
+		r.QueryTimeout = 600
+	}
+	if r.Charset == "" {
+		r.Charset = "default"
+	}
+
+	return r, nil
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/oneaddr.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/oneaddr.go
@@ -1,0 +1,82 @@
+package rpc
+
+import (
+	"context"
+	"dbm-services/mysql/db-remote-service/pkg/config"
+	"dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl"
+	"sync"
+)
+
+func (c *MySQLRPCRequest) oneAddr(addr string) (res []MySQLRPCResponse, err error) {
+	db, conn, connId, err := impl.Prepare(
+		addr, config.RuntimeConfig.MySQLAdminUser, config.RuntimeConfig.MySQLAdminPassword,
+		c.Timezone, c.Charset, c.ConnectTimeout,
+	)
+	// 这个必须放在错误处理前面
+	// clean 函数内部自适应了
+	defer func() {
+		impl.Clean(db, conn, connId)
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	rChan := make(chan MySQLRPCResponse)
+	done := make(chan struct{})
+	errChan := make(chan error)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer func() {
+			close(rChan)
+			close(done)
+			close(errChan)
+		}()
+
+		var wg = &sync.WaitGroup{}
+		wg.Add(len(c.Cmds))
+		for _, sql := range c.Cmds {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			_ = config.GlobalLimiter.Wait(context.Background())
+			go func(sql string) {
+				defer wg.Done()
+				srs, n, err := impl.DoSQL(conn, sql, c.QueryTimeout)
+				srp := MySQLRPCResponse{
+					Cmd:          sql,
+					Result:       srs,
+					RowsAffected: n,
+					Error:        "",
+				}
+				if err != nil {
+					srp.Error = err.Error()
+				}
+				rChan <- srp
+				if err != nil && !c.Force {
+					errChan <- err
+				}
+			}(sql)
+		}
+		wg.Wait()
+		done <- struct{}{}
+	}()
+
+	for {
+		select {
+		case <-done:
+			return res, nil
+		case err := <-errChan:
+			cancel()
+			return res, err
+		case srp := <-rChan:
+			res = append(res, srp)
+		default:
+		}
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/domessage.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/domessage.go
@@ -1,0 +1,34 @@
+package websocket
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func doMessage(db **sqlx.DB, conn **sqlx.Conn, connId *int64, msg []byte) (srs []byte, n int64, err error) {
+	wbr := WSBaseRequest{}
+	err = json.Unmarshal(msg, &wbr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	switch strings.ToUpper(wbr.RequestType) {
+	case "CONNECT":
+		*db, *conn, *connId, err = msgConnect(wbr.Body)
+		if err != nil {
+			return nil, 0, err
+		}
+	case "COMMAND":
+		srs, n, err = msgCommand(*conn, wbr.Body)
+		if err != nil {
+			return nil, 0, err
+		}
+	default:
+		return nil, 0, errors.New("invalid request type")
+	}
+
+	return srs, n, nil
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/handler.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/handler.go
@@ -1,0 +1,76 @@
+package websocket
+
+import (
+	"context"
+	"dbm-services/mysql/db-remote-service/pkg/config"
+	"dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/jmoiron/sqlx"
+)
+
+func Handler(c *gin.Context) {
+	_ = config.GlobalLimiter.Wait(context.Background())
+
+	wsUpgrader := websocket.Upgrader{
+		HandshakeTimeout: 10 * time.Second,
+		ReadBufferSize:   1024,
+		WriteBufferSize:  1024,
+	}
+
+	ws, err := wsUpgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		c.JSON(
+			http.StatusBadRequest,
+			gin.H{
+				"code": 1,
+				"data": "",
+				"msg":  err.Error(),
+			})
+		return
+	}
+	defer func() {
+		_ = ws.Close()
+	}()
+
+	var db *sqlx.DB
+	var conn *sqlx.Conn
+	var connId int64
+	defer func() {
+		impl.Clean(db, conn, connId)
+	}()
+
+	for {
+		mt, message, err := ws.ReadMessage()
+		if err != nil {
+			_ = ws.WriteMessage(websocket.TextMessage, WSResponse{
+				Result:       nil,
+				RowsAffected: 0,
+				Error:        err.Error(),
+			}.Bytes())
+			return
+		}
+
+		switch mt {
+		case websocket.TextMessage:
+			srs, n, err := doMessage(&db, &conn, &connId, message)
+			if err != nil {
+				_ = ws.WriteMessage(websocket.TextMessage, []byte(err.Error()))
+			} else {
+				_ = ws.WriteMessage(websocket.TextMessage, WSResponse{
+					Result:       srs,
+					RowsAffected: n,
+					Error:        "",
+				}.Bytes())
+			}
+
+		case websocket.CloseMessage:
+			impl.Clean(db, conn, connId)
+		default:
+			return
+		}
+	}
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/init.go
@@ -1,0 +1,32 @@
+package websocket
+
+import "encoding/json"
+
+type WSBaseRequest struct {
+	RequestType string          `json:"request-type"`
+	Body        json.RawMessage `json:"body"`
+}
+
+type WSConnectRequest struct {
+	Address  string `json:"address"`
+	Charset  string `json:"charset"`
+	Timezone string `json:"timezone"`
+	Timeout  int    `json:"timeout"`
+}
+
+type WSCommandRequest struct {
+	Command string `json:"command"`
+	Timeout int    `json:"timeout"`
+}
+
+type WSResponse struct {
+	//Data         json.RawMessage `json:"data"`
+	Result       json.RawMessage `json:"result"`
+	RowsAffected int64           `json:"rows_affected"`
+	Error        string          `json:"error"`
+}
+
+func (c WSResponse) Bytes() []byte {
+	b, _ := json.Marshal(c)
+	return b
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/msgcommand.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/msgcommand.go
@@ -1,0 +1,23 @@
+package websocket
+
+import (
+	"dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl"
+	"encoding/json"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func msgCommand(conn *sqlx.Conn, b []byte) ([]byte, int64, error) {
+	wcr := WSCommandRequest{}
+	err := json.Unmarshal(b, &wcr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if strings.TrimSpace(wcr.Command) == "" {
+		return []byte(""), 0, nil
+	}
+
+	return impl.DoSQL(conn, wcr.Command, wcr.Timeout)
+}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/msgconnect.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/msgconnect.go
@@ -1,0 +1,21 @@
+package websocket
+
+import (
+	"dbm-services/mysql/db-remote-service/pkg/config"
+	"dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl"
+	"encoding/json"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func msgConnect(b []byte) (*sqlx.DB, *sqlx.Conn, int64, error) {
+	wcr := WSConnectRequest{}
+	err := json.Unmarshal(b, &wcr)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return impl.Prepare(
+		wcr.Address, config.RuntimeConfig.WebConsoleUser, config.RuntimeConfig.WebConsolePassword,
+		wcr.Timezone, wcr.Charset, wcr.Timeout,
+	)
+}


### PR DESCRIPTION
1. 修复获取db字符集时连接数失控的问题
2. 修复 kill conn_id 影响 sqlsvr 和 proxy 的问题
3. 添加 pkg/v2 用于预研 websocket

v2 的变化
1. 放弃老版本的 interface 和 embed, 因为除了带来麻烦并没有任何好处
2. 连接和查询全部自由实现, 只要能正常注册go-gin Handler就行
3. 增加了一个全局的 ratelimiter
4. 并不强制迁移, 但是非常建议, 因为老版本的代码没办法适配websocket, 总得要改造的
5. v2/client 是一个使用了 ws的客户端, 能跑通

<img width="852" height="341" alt="企业微信截图_e0af5000-7206-4409-bf45-e561d9abe9e3" src="https://github.com/user-attachments/assets/07ed8ee7-a0a5-4abf-87af-9d2980e1de9d" />
