### PR TITLE
fix(kafka): 优化kafka替换流程 #12063

### DIFF
--- a/dbm-ui/backend/flow/utils/kafka/kafka_act_playload.py
+++ b/dbm-ui/backend/flow/utils/kafka/kafka_act_playload.py
@@ -209,6 +209,8 @@ class KafkaActPayload(object):
                     "zookeeper_ip": zookeeper_ip,
                     "exclude_brokers": host,
                     "new_brokers": new_host,
+                    "throttle_rate": self.ticket_data.get("throttle_rate", 20000000),
+                    "topics": self.ticket_data.get("topics", ["*"]),
                 },
             },
         }
@@ -240,7 +242,7 @@ class KafkaActPayload(object):
                 "extend": {
                     "brokers": host,
                     "throttle_rate": self.ticket_data.get("throttle_rate", 20000000),
-                    "topics": self.ticket_data.get("topics", [".*"]),
+                    "topics": self.ticket_data.get("topics", ["*"]),
                 },
             },
         }


### PR DESCRIPTION
修复新替换的机器最后才写cmdb，导致搬迁数据过程没有监控
数据搬迁改为逐个topic搬迁