### PR TITLE
feat(mysql): mysql-dbha-api-add-standby-info #12819

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-dbbackup/pkg/src/dbareport/backup_report.go
+++ b/dbm-services/mysql/db-tools/mysql-dbbackup/pkg/src/dbareport/backup_report.go
@@ -407,6 +407,7 @@ func (r *BackupLogReport) ReportBackupResult(indexFilePath string, index, upload
 		return errors.WithMessagef(err, "report backup result")
 	}
 	var ev = MysqlBackupResultEvent(*metaInfo)
+	logger.Log.Infof("backup result event: %s", ev.String())
 	if resp, reportErr := reapi.SyncReport(reportCore, &ev); reportErr != nil {
 		// TODO if failed, need save to local and report it later
 		return reportErr

--- a/dbm-ui/backend/configuration/constants.py
+++ b/dbm-ui/backend/configuration/constants.py
@@ -140,7 +140,7 @@ class SystemSettingsEnum(str, StructuredEnum):
     # 内置标签列表
     BUILTIN_LABELS = EnumField("BUILTIN_LABELS", _("内置标签列表"))
     # 反向上报事件类型
-    REVERSE_REPORT_EVENT_TYPES = EnumField("REVERSE_REPORT_EVENT_TYPES", _("反向上报事件类型"))
+    # REVERSE_REPORT_EVENT_TYPES = EnumField("REVERSE_REPORT_EVENT_TYPES", _("反向上报事件类型"))
     # 大数据管理端域名映射
     DBM_MANAGE_ADDRESS = EnumField("DBM_MANAGE_ADDRESS", _("大数据管理端域名映射"))
     # Doris使用COS地域映射
@@ -273,7 +273,7 @@ DEFAULT_MACHINE_PROPERTY = {
     "storage_device": True,  # 磁盘
 }
 
-DEFAULT_REVERSE_REPORT_EVENT_TYPES = ["mysql_dbbackup_result", "mysql_dbbackup_progress", "mysql_binlog_result"]
+# DEFAULT_REVERSE_REPORT_EVENT_TYPES = ["mysql_dbbackup_result", "mysql_dbbackup_progress", "mysql_binlog_result"]
 
 # 默认具备迁移权限的人员
 DBM_DEFAULT_MIGRATE_USER = ["admin"]
@@ -295,7 +295,7 @@ DEFAULT_SETTINGS = [
     [SystemSettingsEnum.MACHINE_PROPERTY, "dict", DEFAULT_MACHINE_PROPERTY, _("主机属性开关配置")],
     [SystemSettingsEnum.PADDING_PROXY_APPS, "list", [], _("补全proxy业务")],
     [SystemSettingsEnum.DISABLE_DBHA_APPS_CLUSTER_TYPE, "dict", {}, _("禁用DBHA业务")],
-    [SystemSettingsEnum.REVERSE_REPORT_EVENT_TYPES, "list", DEFAULT_REVERSE_REPORT_EVENT_TYPES, _("反向上报事件类型")],
+    # [SystemSettingsEnum.REVERSE_REPORT_EVENT_TYPES, "list", DEFAULT_REVERSE_REPORT_EVENT_TYPES, _("反向上报事件类型")],
 ]
 
 # 环境配置项 是否支持DNS解析 pulsar flow used

--- a/dbm-ui/backend/db_meta/flatten/storage_instance.py
+++ b/dbm-ui/backend/db_meta/flatten/storage_instance.py
@@ -74,6 +74,7 @@ def storage_instance(storages: QuerySet) -> List[Dict]:
             "instance_inner_role": ins.instance_inner_role,
             "cluster_type": ins.cluster_type,
             "status": ins.status,
+            "is_stand_by": ins.is_stand_by,
         }
 
         receiver = []

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/__init__.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/__init__.py
@@ -8,21 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
-
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
-
-
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/direct_report.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/direct_report.py
@@ -8,21 +8,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
+from typing import List
 
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.writers.get_writer import get_writer
 
 
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")
+def direct_report(bk_cloud_id: int, trace_id: str, ip: str, port_list: List[int], events: List):
+    event_type = events[0]["event_type"]
+    event_writer = get_writer(event_type)
+    event_writer.write_event(bk_cloud_id=bk_cloud_id, trace_id=trace_id, ip=ip, port_list=port_list, events=events)

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/register_writer.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/register_writer.py
@@ -8,21 +8,16 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
+from typing import Dict
 
-from backend.exceptions import AppBaseException, ErrorCode
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.writers.backup_report_result_writer import (
+    BackupReportResultWriter,
+)
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.writers.writers_base import DirectWriterABS
+from backend.db_proxy.reverse_api.common.impl.sync_report.event_type import ReverseReportEventTypeEnum
 
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
-
-
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")
+writers_map: Dict[str, DirectWriterABS] = {
+    ReverseReportEventTypeEnum.MySQLDbbackupResult.value: BackupReportResultWriter()
+    # ToDo
+    # "mysql_dbbackup_progress", "mysql_binlog_result"
+}

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/__init__.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/__init__.py
@@ -8,21 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
-
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
-
-
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/backup_report_result_writer.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/backup_report_result_writer.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from typing import List
+
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.writers.writers_base import DirectWriterABS
+from backend.db_report.models.mysql_backup_result import MysqlBackupResult
+
+
+class BackupReportResultWriter(DirectWriterABS):
+    @classmethod
+    def write_event(cls, bk_cloud_id: int, trace_id: str, ip: str, port_list: List[int], events: List):
+        """
+        ToDo 这个函数没实现完
+        """
+        for ev in events:
+            MysqlBackupResult.objects.create(
+                event_source_ip=ev["event_source_ip"],
+                event_bk_cloud_id=ev["event_bk_cloud_id"],
+                event_receive_timestamp=ev["event_receive_timestamp"],
+                backup_id=ev["backup_id"],
+                backup_type=ev["backup_type"],
+                cluster_id=ev["cluster_id"],
+                cluster_address=ev["cluster_address"],
+                backup_host=ev["backup_host"],
+                backup_port=ev["backup_port"],
+                mysql_role=ev["mysql_role"],
+                shard_value=ev["shard_value"],
+                bill_id=ev["bill_id"],
+                bk_biz_id=ev["bk_biz_id"],
+                mysql_version=ev["mysql_version"],
+                data_schema_grant=ev["data_schema_grant"],
+                is_full_backup=ev["is_full_backup"],
+                file_retention_tag=ev["file_retention_tag"],
+                total_filesize=ev["total_filesize"],
+                backup_consistent_time=ev["backup_consistent_time"],
+                backup_begin_time=ev["backup_begin_time"],
+                backup_end_time=ev["backup_end_time"],
+                binlog_info=ev["binlog_info"],
+                file_list=ev["file_list"],
+                extra_fields="",
+                backup_status="",
+                backup_method="",
+                is_standby="",
+            )

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/get_writer.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/get_writer.py
@@ -8,21 +8,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
-
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.register_writer import writers_map
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.writers.writers_base import (
+    DirectWriterABS,
+    EmptyDirectWriter,
+)
 
 
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")
+def get_writer(event_type: str) -> DirectWriterABS:
+    return writers_map.get(event_type, EmptyDirectWriter())

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/writers_base.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/direct_mode/writers/writers_base.py
@@ -8,31 +8,18 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-import json
-import time
+from abc import ABC, abstractmethod
 from typing import List
 
-from kafka import KafkaProducer
+
+class DirectWriterABS(ABC):
+    @classmethod
+    @abstractmethod
+    def write_event(cls, bk_cloud_id: int, trace_id: str, ip: str, port_list: List[int], events: List):
+        pass
 
 
-def inject_fields(bk_cloud_id, ip, data: List) -> List:
-    res = []
-    for ev in data:
-        res.append(
-            {
-                **ev,
-                "event_source_ip": ip,
-                "event_receive_timestamp": int(time.time() * 1000 * 1000),  # us
-                "event_bk_cloud_id": bk_cloud_id,
-            }
-        )
-
-    return res
-
-
-def send_events(producer: KafkaProducer, bk_cloud_id, ip, data: List):
-    events = inject_fields(bk_cloud_id=bk_cloud_id, ip=ip, data=data)
-    for ev in events:
-        event_type = ev["event_type"]
-        topic = f"{event_type}"
-        producer.send(topic=topic, value=json.dumps(ev).encode("utf-8"))
+class EmptyDirectWriter(DirectWriterABS):
+    @classmethod
+    def write_event(cls, bk_cloud_id: int, trace_id: str, ip: str, port_list: List[int], events: List):
+        raise

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/event_type.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/event_type.py
@@ -8,21 +8,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
+from blue_krill.data_types.enum import EnumField, StructuredEnum
 
 
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")
+class ReverseReportEventTypeEnum(str, StructuredEnum):
+    MySQLDbbackupResult = EnumField("mysql_dbbackup_result", _("mysql_dbbackup_result"))
+    MySQLDbbackupProgress = EnumField("mysql_dbbackup_progress", _("mysql_dbbackup_progress"))
+    MySQLBinlogResult = EnumField("mysql_binlog_result", _("mysql_binlog_result"))

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/inject_fields.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/inject_fields.py
@@ -8,21 +8,20 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
-
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
+import time
+from typing import List
 
 
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
+def inject_fields(bk_cloud_id, ip, data: List) -> List:
+    res = []
+    for ev in data:
+        res.append(
+            {
+                **ev,
+                "event_source_ip": ip,
+                "event_receive_timestamp": int(time.time() * 1000 * 1000),  # us
+                "event_bk_cloud_id": bk_cloud_id,
+            }
+        )
 
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")
+    return res

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/kafka_mode/__init__.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/kafka_mode/__init__.py
@@ -8,21 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
-
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
-
-
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/kafka_mode/kafka_report.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/kafka_mode/kafka_report.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import datetime
+import logging
+import random
+from typing import List
+
+from kafka import KafkaProducer
+
+import backend.db_proxy.reverse_api.common.impl.sync_report as sr
+from backend import env
+from backend.db_proxy.reverse_api.common.impl.sync_report.kafka_mode.send_event_to_kafka import send_events_to_kafka
+
+logger = logging.getLogger("root")
+
+
+def kafka_report(bk_cloud_id: int, trace_id: str, ip: str, port_list: List[int], events: List):
+    kafka_opts = env.REVERSE_REPORT_KAFKA_OPTIONS
+    with sr.lock:
+        if sr.producers is None:
+            logger.info("sync report new kafka connect. time:{}".format(datetime.datetime.now()))
+            sr.producers = [
+                KafkaProducer(
+                    api_version=(0, 11),
+                    retries=5,
+                    request_timeout_ms=2000,
+                    reconnect_backoff_max_ms=2000,
+                    max_block_ms=2000,
+                    **kafka_opts
+                )
+                for i in range(5)
+            ]
+
+    logger.info("sync kafka report release lock. trace_id:{}, time:{}".format(trace_id, datetime.datetime.now()))
+
+    producer = random.choice(tuple(sr.producers))
+    logger.info("sync kafka report got producer. trace_id:{}, time:{}".format(trace_id, datetime.datetime.now()))
+
+    send_events_to_kafka(producer=producer, bk_cloud_id=bk_cloud_id, ip=ip, events=events)

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/kafka_mode/send_event_to_kafka.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/kafka_mode/send_event_to_kafka.py
@@ -8,21 +8,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.utils.translation import ugettext as _
+import json
+from typing import List
 
-from backend.exceptions import AppBaseException, ErrorCode
-
-
-class ReverseApiBaseException(AppBaseException):
-    MODULE_CODE = ErrorCode.PROXY_PASS_REVERSE_API_CODE
+from kafka import KafkaProducer
 
 
-class SyncReportEventValidationException(ReverseApiBaseException):
-    MESSAGE = "event validate failed"
-    ERROR_CODE = "500"
-
-
-class SyncReportBadMode(ReverseApiBaseException):
-    MESSAGE = "bad reverse report mode"
-    ERROR_CODE = "501"
-    MESSAGE_TPL = _("bad mode: {mode}")
+def send_events_to_kafka(producer: KafkaProducer, bk_cloud_id, ip, events: List):
+    for ev in events:
+        event_type = ev["event_type"]
+        topic = f"{event_type}"
+        producer.send(topic=topic, value=json.dumps(ev).encode("utf-8"))

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/schema_validate.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/schema_validate.py
@@ -13,9 +13,8 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
 import backend.db_proxy.reverse_api.common.impl.sync_report as sr
-from backend.configuration.constants import SystemSettingsEnum
-from backend.configuration.models import SystemSettings
 from backend.db_meta.enums import ClusterType
+from backend.db_proxy.reverse_api.common.impl.sync_report.event_type import ReverseReportEventTypeEnum
 
 
 class SyncReportEventSerializer(serializers.Serializer):
@@ -26,7 +25,7 @@ class SyncReportEventSerializer(serializers.Serializer):
     def validate(self, attrs):
         event_type = attrs.get("event_type", "")
         if event_type not in sr.event_type_cache:
-            if event_type in SystemSettings.get_setting_value(SystemSettingsEnum.REVERSE_REPORT_EVENT_TYPES):
+            if event_type in ReverseReportEventTypeEnum.get_values():
                 with sr.lock:
                     sr.event_type_cache.append(event_type)
             else:

--- a/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/sync_report.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/common/impl/sync_report/sync_report.py
@@ -10,41 +10,31 @@ specific language governing permissions and limitations under the License.
 """
 import datetime
 import logging
-import random
 import uuid
 from typing import List
 
-from kafka import KafkaProducer
-
-import backend.db_proxy.reverse_api.common.impl.sync_report as sr
 from backend import env
+from backend.db_proxy.reverse_api.common.impl.sync_report.direct_mode.direct_report import direct_report
+from backend.db_proxy.reverse_api.common.impl.sync_report.inject_fields import inject_fields
+from backend.db_proxy.reverse_api.common.impl.sync_report.kafka_mode.kafka_report import kafka_report
 from backend.db_proxy.reverse_api.common.impl.sync_report.schema_validate import SyncReportEventSerializer
-from backend.db_proxy.reverse_api.common.impl.sync_report.send_event import send_events
-from backend.db_proxy.reverse_api.exceptions import SyncReportEventValidationException
+from backend.db_proxy.reverse_api.exceptions import SyncReportBadMode, SyncReportEventValidationException
 
 logger = logging.getLogger("root")
 
+# 避免热点
+reverse_report_mode = env.REVERSE_REPORT_MODE.upper()
+if reverse_report_mode == "KAFKA":
+    report_handler = kafka_report
+elif reverse_report_mode == "DIRECT":
+    report_handler = direct_report
+else:
+    raise SyncReportBadMode(mode=reverse_report_mode)
+
 
 def sync_report(bk_cloud_id: int, ip: str, port_list: List[int], data: List):
-    trace_id = uuid.uuid1()
+    trace_id = uuid.uuid1().__str__()
     logger.info("enter sync report. trace_id:{}, time:{}, data:{}".format(trace_id, datetime.datetime.now(), data))
-    kafka_opts = env.REVERSE_REPORT_KAFKA_OPTIONS
-    with sr.lock:
-        if sr.producers is None:
-            logger.info("sync report new kafka connect. time:{}".format(datetime.datetime.now()))
-            sr.producers = [
-                KafkaProducer(
-                    api_version=(0, 11),
-                    retries=5,
-                    request_timeout_ms=2000,
-                    reconnect_backoff_max_ms=2000,
-                    max_block_ms=2000,
-                    **kafka_opts
-                )
-                for i in range(5)
-            ]
-
-    logger.info("sync report release lock. trace_id:{}, time:{}".format(trace_id, datetime.datetime.now()))
 
     vd = SyncReportEventSerializer(data=data, many=True)
     logger.info("sync report slz created. trace_id:{}, time:{}".format(trace_id, datetime.datetime.now()))
@@ -54,7 +44,6 @@ def sync_report(bk_cloud_id: int, ip: str, port_list: List[int], data: List):
         )
     logger.info("sync report validate finish. trace_id:{}, time:{}".format(trace_id, datetime.datetime.now()))
 
-    producer = random.choice(tuple(sr.producers))
-    logger.info("sync report got producer. trace_id:{}, time:{}".format(trace_id, datetime.datetime.now()))
+    events = inject_fields(bk_cloud_id=bk_cloud_id, ip=ip, data=data)
 
-    send_events(producer=producer, bk_cloud_id=bk_cloud_id, ip=ip, data=data)
+    report_handler(bk_cloud_id=bk_cloud_id, trace_id=trace_id, ip=ip, port_list=port_list, events=events)

--- a/dbm-ui/backend/env/__init__.py
+++ b/dbm-ui/backend/env/__init__.py
@@ -205,6 +205,9 @@ INITIATIVE_DOWNLOAD = get_type_env(key="INITIATIVE_DOWNLOAD", _type=bool, defaul
 # 反向查询接口禁用安全检查
 DEBUG_REVERSE_API = get_type_env(key="DEBUG_REVERSE_API", _type=bool, default=False)
 
+# 反向上报接口工作模式
+# 默认为kafka, 某些环境可以配置成 DIRECT
+REVERSE_REPORT_MODE = get_type_env(key="REVERSE_REPORT_MODE", _type=str, default="KAFKA")
 # 反向上报接口 kafka 参数
 # DBM 带鉴权的连接串
 # export REVERSE_REPORT_KAFKA_OPTIONS=bootstrap_servers=:9092, \


### PR DESCRIPTION
1. dbha instances api 增加存储实例 is_standby:Bool 信息
2. 反向上报接口增加 REVERSE_REPORT_MODE=kafka 环境变量, 可选值为 [kafka, direct]. 用来控制反向上报是写入kafka还是直写db
3. 反向上报接口已注册 event type 不再写入 systemsettings. 改为枚举类型 ReverseReportEventTypeEnum