### PR TITLE
fix(redis): 分片变更后exporter未卸载问题 #12881

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_data_copy.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_data_copy.py
@@ -921,6 +921,18 @@ class RedisClusterDataCopyFlow(object):
                 kwargs=asdict(act_kwargs),
             )
 
+            # 交换源集群、目标集群的CC信息
+            act_kwargs.cluster = {
+                "src_cluster_id": src_cluster_info["cluster_id"],
+                "dst_cluster_id": dst_cluster_info["cluster_id"],
+                "meta_func_name": RedisDBMeta.dts_online_switch_swap_cc.__name__,
+            }
+            redis_pipeline.add_act(
+                act_name=_("交换源集群、目标集群的storageinstance CC数据"),
+                act_component_code=RedisDBMetaComponent.code,
+                kwargs=asdict(act_kwargs),
+            )
+
             # 更新源集群、目标集群的 cluster nodes 域名
             act_kwargs.cluster = {
                 "src_cluster_id": src_cluster_info["cluster_id"],

--- a/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
@@ -57,9 +57,14 @@ from backend.db_services.redis.util import (
     is_tendisplus_instance_type,
     is_tendisssd_instance_type,
 )
-from backend.flow.consts import DEFAULT_DB_MODULE_ID, DEFAULT_REDIS_START_PORT, InstanceStatus
+from backend.flow.consts import (
+    DEFAULT_DB_MODULE_ID,
+    DEFAULT_REDIS_START_PORT,
+    InstanceStatus,
+    OperateCollectorActionEnum,
+)
 from backend.flow.utils.base.payload_handler import PayloadHandler
-from backend.flow.utils.cc_manage import CcManage
+from backend.flow.utils.cc_manage import CcManage, trigger_operate_collector
 from backend.flow.utils.dns_manage import DnsManage
 from backend.flow.utils.redis.redis_module_operate import RedisCCTopoOperator
 from backend.ticket.constants import TicketType
@@ -1575,6 +1580,32 @@ class RedisDBMeta(object):
             self.dts_switch_update_cluster_entry(src_cluster)
             self.dts_switch_update_cluster_entry(dst_cluster)
 
+        return True
+
+    def dts_online_switch_swap_cc(self):
+        """
+        将重操作挪cc的操作独立出来，避免元数据锁等待问题
+        """
+        src_cluster_id: int = self.cluster["src_cluster_id"]
+        dst_cluster_id: int = self.cluster["dst_cluster_id"]
+        src_cluster = Cluster.objects.get(id=src_cluster_id)
+        dst_cluster = Cluster.objects.get(id=dst_cluster_id)
+        src_proxyinstances = copy.deepcopy(src_cluster.proxyinstance_set.all())
+        dst_proxyinstances = copy.deepcopy(dst_cluster.proxyinstance_set.all())
+
+        src_storageinstances = copy.deepcopy(src_cluster.storageinstance_set.all())
+        dst_storageinstances = copy.deepcopy(dst_cluster.storageinstance_set.all())
+
+        # 提前卸载实例采集配置
+        instance_model = StorageInstance
+        instances = instance_model.objects.filter(cluster__in=[src_cluster_id, dst_cluster_id])
+        machine_type = instances.first().machine.machine_type
+        bk_instance_ids = list(instances.values_list("bk_instance_id", flat=True))
+        db_type = ClusterType.cluster_type_to_db_type(src_cluster.cluster_type)
+        action = OperateCollectorActionEnum.UNINSTALL.value
+        trigger_operate_collector(db_type, machine_type, bk_instance_ids, action)
+
+        with atomic():
             # 交换 cc module
             logger.info(_("dts 交换两个集群的 cc module"))
             logger.info(
@@ -1590,9 +1621,9 @@ class RedisDBMeta(object):
             )
             RedisCCTopoOperator(dst_cluster).transfer_instances_to_cluster_module(src_storageinstances)
             # 两个集群的 proxy ip均是不变的,但类型变化后,模块信息需变化
+            # 这一步默认会下发安装export的操作，但是没有卸载的操作
             RedisCCTopoOperator(src_cluster).transfer_instances_to_cluster_module(src_proxyinstances)
             RedisCCTopoOperator(dst_cluster).transfer_instances_to_cluster_module(dst_proxyinstances)
-
         return True
 
     def dts_online_switch_update_nodes_domain(self):


### PR DESCRIPTION
1、将挪cc操作单独拆出来，减小事务，避免锁等待
2、在重装export之前将老export卸载