### PR TITLE
fix(redis): 容灾演练报告缺陷 #13399

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/common/failover_drill_base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/common/failover_drill_base.py
@@ -22,6 +22,10 @@ class FailoverDrillTargetType:
     PROXY = "proxy"
     BACKEND = "backend"
 
+    @classmethod
+    def valid_types(cls):
+        return [cls.PROXY, cls.BACKEND]
+
 
 class BaseFailoverDrill:
     def __init__(

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_failover_drill/failover_drill.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_failover_drill/failover_drill.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from copy import deepcopy
 from typing import Dict, List
 
 from django.utils.translation import ugettext as _
@@ -63,6 +64,7 @@ class RedisFailoverDrill(BaseFailoverDrill):
         self.city_map = city_map
         self.failover_drill_info = {}
         self.instance_type = instance_type
+        self.target_instances = []
         self.init_report()
 
     @staticmethod
@@ -143,18 +145,21 @@ class RedisFailoverDrill(BaseFailoverDrill):
         获取演练目标主机的ip
         目前Redis演练只对一台Proxy或Backend进行
         """
-        if self.instance_type == FailoverDrillTargetType.PROXY:
-            return self.failover_drill_info["drill_infos"][0]["proxy"]["ip"]
-        elif self.instance_type == FailoverDrillTargetType.BACKEND:
-            return self.failover_drill_info["drill_infos"][0]["backend"]["ip"]
-        else:
-            raise ValueError("Proxy or backend is not set in failover drill info")
+        if not self.failover_drill_info:
+            return "<IP not set>"
+        if self.instance_type not in FailoverDrillTargetType.valid_types():
+            raise ValueError(_(f"Invalid instance_type: {self.instance_type}"))
+
+        return self.failover_drill_info["drill_infos"][0][self.instance_type]["ip"]
 
     def create_run_failover_drill_ticket(self):
         """
         构建参数，创建并执行容灾演练单据，返回待观察的实例
         """
         self.get_failover_drill_params()
+        self.target_instances = (
+            self.get_drill_instances()
+        )  # For later checks, in case targets are switched and deleted.
         FailoverDrillReport.objects.filter(main_task_id=self.main_task_id).update(
             drill_info=_("容灾演练单据执行信息： {}").format(self.failover_drill_info)
         )
@@ -200,8 +205,7 @@ class RedisFailoverDrill(BaseFailoverDrill):
             "error": "",
         }
         """
-        drill_instances = self.get_drill_instances()
-
+        drill_instances = deepcopy(self.target_instances)
         drill_ip = self.get_drill_ip()
         dbha_infos = {
             "error": "",
@@ -233,7 +237,7 @@ class RedisFailoverDrill(BaseFailoverDrill):
         """
         更新 DBHA 信息
         """
-        instances = self.get_drill_instances()
+        instances = deepcopy(self.target_instances)
         rpt = FailoverDrillReport.objects.get(main_task_id=self.main_task_id)
 
         start_times = []

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_failover_drill/failover_drill_unit.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_failover_drill/failover_drill_unit.py
@@ -92,7 +92,6 @@ def failover_drill_unit(city: str, conf: Dict[str, Any]) -> None:
     # 设置轮询限制条件
     polling_restriction = {
         "bk_biz_id": rfod.bk_biz_id,
-        "cluster_id": cluster.id,
         "ip": rfod.get_drill_ip(),
         "earliest_create_allowed": drill_start_time,
     }

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_failover_drill/utils.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_failover_drill/utils.py
@@ -84,7 +84,6 @@ def autofix_ticket_polling(restriction, max_retries, interval) -> Tuple[bool, in
     轮询是否出现自愈单据
     restriction: {
         "bk_biz_id": int,
-        "cluster_id": int,
         "ip": str,
         "earliest_create_allowed": datetime,
     }
@@ -127,14 +126,10 @@ def __is_target_ticket(ticket: Ticket, restriction) -> bool:
     if ticket.create_at < earliest_create_at:
         return False
 
-    infos = ticket.details["infos"]
-    for info in infos:
-        contains_cluster = any(cluster_id == restriction["cluster_id"] for cluster_id in info["cluster_ids"])
-        contains_ip = any(slave["ip"] == restriction["ip"] for slave in info["redis_slave"])
-        if contains_cluster and contains_ip:
-            return True
+    recycle_hosts = ticket.details["recycle_hosts"]
+    contains_ip = any(ip == restriction["ip"] for ip in recycle_hosts["ip"])
 
-    return False
+    return contains_ip
 
 
 def send_drill_alert_to_qywx(


### PR DESCRIPTION
- 通过`recycle_hosts`来判断是否目标自愈单据
- 提前加载实例信息，避免在检查演练状态时因为自愈后元数据被清理报`ModelNotExists`
- 其他改进