### PR TITLE
fix(kafka): kafka替换单据bug, tlinux4执行命令异常 #13509

### DIFF
--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/doris/node_operation.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/doris/node_operation.go
@@ -52,7 +52,7 @@ func (i *NodeOperationService) CleanData() (err error) {
 	}
 
 	// 强杀进程
-	extraCmd := `ps -ef | egrep 'supervisord|java'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
+	extraCmd := `ps -ef | grep -E 'supervisord|java'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/elasticsearch/clean_data.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/elasticsearch/clean_data.go
@@ -53,7 +53,7 @@ func (d *CleanDataComp) CleanData() (err error) {
 
 	// 强杀进程
 	extraCmd :=
-		`ps -ef | egrep 'java|supervisord|node_exporter|telegraf|x-pack-ml'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
+		`ps -ef | grep -E 'java|supervisord|node_exporter|telegraf|x-pack-ml'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/hdfs/node_operation.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/hdfs/node_operation.go
@@ -68,7 +68,7 @@ func (i *NodeOperationService) CleanData() (err error) {
 	}
 
 	// 强杀进程
-	extraCmd := `ps -ef | egrep 'supervisord|telegraf|consul'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
+	extraCmd := `ps -ef | grep -E 'supervisord|telegraf|consul'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/influxdb/clean_data.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/influxdb/clean_data.go
@@ -52,7 +52,7 @@ func (d *CleanDataComp) CleanData() (err error) {
 	}
 
 	// 强杀进程
-	extraCmd := `ps -ef | egrep 'supervisord|telegraf'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
+	extraCmd := `ps -ef | grep -E 'supervisord|telegraf'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/clean_data.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/clean_data.go
@@ -52,7 +52,7 @@ func (d *CleanDataComp) CleanData() (err error) {
 	}
 
 	// 强杀进程
-	extraCmd := `ps -ef | egrep 'supervisord|burrow|telegraf|java'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
+	extraCmd := `ps -ef | grep -E 'supervisord|burrow|telegraf|java'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/startstop_process.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/startstop_process.go
@@ -48,7 +48,7 @@ func (d *StartStopProcessComp) StopProcess() (err error) {
 		return err
 	}
 
-	extraCmd = "ps -ef | egrep 'cmak' | grep -v grep |awk {'print \"kill -9 \" $2'}|sh"
+	extraCmd = "ps -ef | grep -E 'cmak' | grep -v grep |awk {'print \"kill -9 \" $2'}|sh"
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)
 		return err
@@ -95,7 +95,7 @@ func (d *StartStopProcessComp) RestartProcess() (err error) {
 		return err
 	}
 
-	extraCmd = "ps -ef | egrep 'cmak' | grep -v grep |awk {'print \"kill -9 \" $2'}|sh"
+	extraCmd = "ps -ef | grep -E 'cmak' | grep -v grep |awk {'print \"kill -9 \" $2'}|sh"
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)
 		return err

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/topic_reassign.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/topic_reassign.go
@@ -74,7 +74,7 @@ func (t *TopicReassignComp) GenerateReassignmentPlans() error {
 	// Get list of topics
 	cmd := fmt.Sprintf("%s --list --zookeeper %s", cst.DefaultTopicBin, zkStr)
 	logger.Info("Executing command to get topic list: %s", cmd)
-	output, err := osutil.ExecShellCommand(false, cmd)
+	output, err := osutil.ExecShellCommandJ(false, cmd)
 	if err != nil {
 		return fmt.Errorf("failed to get topic list: %w", err)
 	}
@@ -163,7 +163,7 @@ func (t *TopicReassignComp) GenerateReassignmentPlans() error {
 		cmd = fmt.Sprintf("%s --broker-list %s --topics-to-move-json-file %s --generate --zookeeper %s",
 			cst.DefaultReassignPartitionsBin, brokerListStr, topicJSONFile, zkStr)
 		logger.Info("Executing command to generate reassignment plan: %s", cmd)
-		output, err := osutil.ExecShellCommand(false, cmd)
+		output, err := osutil.ExecShellCommandJ(false, cmd)
 		if err != nil {
 			return fmt.Errorf("failed to generate reassignment plan: %w", err)
 		}

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/pulsar/clean_data.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/pulsar/clean_data.go
@@ -52,7 +52,7 @@ func (d *CleanDataComp) CleanData() (err error) {
 	}
 
 	// 强杀进程
-	extraCmd := `ps -ef | egrep 'supervisord'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
+	extraCmd := `ps -ef | grep -E 'supervisord'|grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("[%s] execute failed, %v", extraCmd, err)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/victoriametrics/clean_data.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/victoriametrics/clean_data.go
@@ -53,7 +53,7 @@ func (d *CleanDataComp) CleanData() (err error) {
 
 	// 强杀进程
 	extraCmd :=
-		`ps -ef | egrep 'supervisord|node_exporter|telegraf|vminsert|vmstorage|vmselect'| ` +
+		`ps -ef | grep -E 'supervisord|node_exporter|telegraf|vminsert|vmstorage|vmselect'| ` +
 			`grep -v grep |awk {'print "kill -9 " $2'}|sh`
 	logger.Info("强杀进程, [%s]", extraCmd)
 	if _, err = osutil.ExecShellCommand(false, extraCmd); err != nil {

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/util/esutil/es_operate.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/util/esutil/es_operate.go
@@ -445,11 +445,11 @@ func GetPath() []string {
 		/dev/vdb1      412715432 165966836 225760744  43% /data
 		tmpfs            1612500         0   1612500   0% /run/user/0
 	*/
-	extraCmd := `df | grep ^/dev |egrep -vw '/|/usr|/boot'|awk '{print $1":"$2":"$NF}'`
+	extraCmd := `df | grep ^/dev |grep -E -vw '/|/usr|/boot'|awk '{print $1":"$2":"$NF}'`
 	logger.Info("Command [%s]", extraCmd)
 	output, err := osutil.ExecShellCommand(false, extraCmd)
 	if err != nil {
-		logger.Info("[%s] execute failed, %s", extraCmd, err.Error())
+		logger.Error("[%s] execute failed, %s", extraCmd, err.Error())
 		return paths
 	}
 	logger.Info("Commnad output, %s", output)

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/util/kafkautil/kafkautil.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/util/kafkautil/kafkautil.go
@@ -166,7 +166,7 @@ func GenReassignmentJSON(conn *zk.Conn, zkHost string, root string, xBrokerIds [
 		cst.DefaultReassignPartitionsBin, cst.DefaultKafkaEnv, zk, tempIds, planJSONFile)
 
 	logger.Info("extraCmd, %s", extraCmd)
-	output, _ := osutil.ExecShellCommand(false, extraCmd)
+	output, _ := osutil.ExecShellCommandJ(false, extraCmd)
 	logger.Info("output: %s", output)
 	b, err := os.ReadFile(planJSONFile)
 	if err != nil {
@@ -232,7 +232,7 @@ func GenReplaceReassignmentJSON(conn *zk.Conn, zkHost string, root string, oldBr
 		cst.DefaultReassignPartitionsBin, cst.DefaultKafkaEnv, zk, ids, planJSONFile)
 
 	logger.Info("extraCmd, %s", extraCmd)
-	output, _ := osutil.ExecShellCommand(false, extraCmd)
+	output, _ := osutil.ExecShellCommandJ(false, extraCmd)
 	logger.Info("output: %s", output)
 	b, err := os.ReadFile(planJSONFile)
 	if err != nil {
@@ -340,7 +340,7 @@ func DoReassignPartitions(zk string, jsonFile string) error {
 		cst.DefaultReassignPartitionsBin,
 		zk, jsonFile, speedLimit)
 	logger.Info("extraCmd: %s", extraCmd)
-	output, _ := osutil.ExecShellCommand(false, extraCmd)
+	output, _ := osutil.ExecShellCommandJ(false, extraCmd)
 	logger.Info("output %s", output)
 	logger.Info("Doing patitions reassignment, default speed rate is 30MB/s")
 	logger.Info("Changing the rate, please rerun [%s] with other rate", extraCmd)
@@ -349,7 +349,7 @@ func DoReassignPartitions(zk string, jsonFile string) error {
 
 // CheckReassignPartitions TODO
 func CheckReassignPartitions(zk string, jsonFile string) (output string, err error) {
-	extraCmd := fmt.Sprintf(`%s --zookeeper %s --reassignment-json-file %s --verify|egrep -v 'Status|successfully'|tail`,
+	extraCmd := fmt.Sprintf(`%s --zookeeper %s --reassignment-json-file %s --verify|grep -Ev 'Status|successfully'|tail`,
 		cst.DefaultReassignPartitionsBin,
 		zk, jsonFile)
 	logger.Info("cmd: [%s]", extraCmd)
@@ -423,11 +423,11 @@ func GenerateReassginFile(zk, topic, idStrs, host string) error {
 	}
 	extraCmd := fmt.Sprintf(
 		`%s  --zookeeper %s  --topics-to-move-json-file %s \
-		--broker-list %s --generate | egrep -A1 ^Proposed|egrep -v ^Proposed`,
+		--broker-list %s --generate | grep -E -A1 ^Proposed|grep -E -v ^Proposed`,
 		cst.DefaultReassignPartitionsBin,
 		zk, topicFile, idStrs)
 	logger.Info("cmd: [%s]", extraCmd)
-	output, err := osutil.ExecShellCommand(false, extraCmd)
+	output, err := osutil.ExecShellCommandJ(false, extraCmd)
 	if err != nil {
 		logger.Error("生成迁移计划失败, %v", err)
 		return err

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/util/osutil/cmdexec.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/util/osutil/cmdexec.go
@@ -191,3 +191,23 @@ func ExecShellCommandBd(isSudo bool, param string) (stdoutStr string, stderrStr 
 	}
 	return stdoutStr, stderrStr, exitCode
 }
+
+// ExecShellCommandJ 执行 shell 命令(大数据专用)
+// 如果有 err, 返回 stderr; 如果没有 err 返回的是 stdout
+func ExecShellCommandJ(isSudo bool, param string) (stdoutStr string, err error) {
+	if isSudo {
+		param = "sudo " + param
+	}
+	cmd := exec.Command("bash", "-c", param)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		// 只在 exitcode 非 0 时返回错误，把 stderr 作为错误提示
+		return stderr.String(), errors.WithMessage(err, stderr.String())
+	}
+	// exitcode为0，则认为执行成功，即便有stderr输出也不算失败
+	return stdout.String(), nil
+}

--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/util/osutil/crontab.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/util/osutil/crontab.go
@@ -94,7 +94,7 @@ func RemoveSystemCrontab(removeKey string) (err error) {
  * @return {*}
  */
 func ListCrontb(user string) (output string, err error) {
-	crontabList := fmt.Sprintf("crontab -u %s -l|egrep -v ^$ || true", user)
+	crontabList := fmt.Sprintf("crontab -u %s -l|grep -E -v ^$ || true", user)
 	// "crontab -u " + user + " -l"
 	output, err = ExecShellCommand(false, crontabList)
 	if err != nil {

--- a/dbm-ui/backend/flow/engine/bamboo/scene/kafka/kafka_replace_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/kafka/kafka_replace_flow.py
@@ -125,6 +125,7 @@ class KafkaReplaceFlow(object):
         self.data["factor"] = int(kafka_config["factor"])
         self.data["old_zookeeper_conf"] = kafka_config["zookeeper_conf"]
         self.data["zookeeper_conf"] = self.data["old_zookeeper_conf"]
+        self.data["no_security"] = int(kafka_config["no_security"])
 
         # get username
         query_params = {


### PR DESCRIPTION
1. 修复kafka替换单据获取不到鉴权信息的问题
2. 修复大数据的dbactuator在tlinux 4.0获取不到分区信息的问题
3. 修复tlinux 4.0调用kafka命令行工具异常的问题