### PR TITLE
feat(redis): 回档演练子任务归于演练业务；资源回收优化 #14568

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
@@ -27,6 +27,7 @@ from backend.ticket.builders.common.base import IpSource
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
 from backend.ticket.models import ClusterOperateRecord, SystemSettings, Ticket
 from backend.utils.redis import RedisConn
+from backend.utils.time import datetime2str, str2datetime
 
 logger = logging.getLogger("root")
 
@@ -403,6 +404,8 @@ class RedisRollbackExercise:
             instance: StorageInstance = item["instance"]
             backup_info = item["backup_info"]
 
+            recovery_time_point = str2datetime(backup_info["uptime"]) + timedelta(minutes=30)
+
             logger.info(_("instance: {}").format(instance))
 
             # Prepare instance info for ticket
@@ -410,7 +413,7 @@ class RedisRollbackExercise:
                 "cluster_id": cluster.id,
                 "instance_ip": instance.machine.ip,
                 "instance_port": instance.port,
-                "recovery_time_point": backup_info.get("uptime", "") + timedelta(minutes=30),
+                "recovery_time_point": datetime2str(recovery_time_point),
                 "task_id": 0,  # Link to task record for status updates, currently dry-run
                 "resource_spec": {
                     "redis": {

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
@@ -124,6 +124,7 @@ class RedisDataStructureFlow(object):
             cluster_type = act_kwargs.cluster["cluster_type"]
             # 获取 kvstorecount
             redis_config = self.__get_cluster_config(
+                str(act_kwargs.cluster["bk_biz_id"]),
                 act_kwargs.cluster["domain_name"],
                 act_kwargs.cluster["db_version"],
                 ConfigTypeEnum.DBConf,
@@ -193,7 +194,7 @@ class RedisDataStructureFlow(object):
                 sub_builder = RedisBatchInstallAtomJob(
                     self.root_id,
                     self.data,
-                    act_kwargs,
+                    self.get_ticket_biz_based_kwargs(act_kwargs),
                     {
                         "ip": new_master,
                         "meta_role": InstanceRole.REDIS_MASTER.value,
@@ -267,7 +268,7 @@ class RedisDataStructureFlow(object):
                 kwargs=asdict(
                     DownloadBackupClientKwargs(
                         bk_cloud_id=act_kwargs.cluster["bk_cloud_id"],
-                        bk_biz_id=int(act_kwargs.cluster["bk_biz_id"]),
+                        bk_biz_id=int(self.data["bk_biz_id"]),
                         download_host_list=new_master_list,
                     ),
                 ),
@@ -585,7 +586,7 @@ class RedisDataStructureFlow(object):
         logger.info(_("cluster_id: {},所有的redis_instance_set:{}".format(info["cluster_id"], redis_instance_set)))
         return cluster_backup_instance, redis_instance_set
 
-    def __get_cluster_info(self, bk_biz_id: int, cluster_id: int) -> dict:
+    def __get_cluster_info(self, cluster_id: int) -> dict:
         """获取集群现有信息
         1. slave 对应 master 机器
         2. slave 上的端口列表
@@ -594,7 +595,7 @@ class RedisDataStructureFlow(object):
         if self.cluster_cache.get(cluster_id):
             return self.cluster_cache[cluster_id]
 
-        cluster = Cluster.objects.get(id=cluster_id, bk_biz_id=bk_biz_id)
+        cluster = Cluster.objects.get(id=cluster_id)
         slave_master_map = defaultdict()
         slave_ports = defaultdict(list)
         slave_ins_map = defaultdict()
@@ -651,7 +652,7 @@ class RedisDataStructureFlow(object):
         return self.cluster_cache[cluster_id]
 
     def __init_builder(self, operate_name: str, info: dict):
-        cluster_info = self.__get_cluster_info(self.data["bk_biz_id"], info["cluster_id"])
+        cluster_info = self.__get_cluster_info(info["cluster_id"])
         logger.info(_("__init_builder_cluster_info: {}".format(cluster_info)))
         flow_data = self.data
         flow_data.update(cluster_info)
@@ -674,13 +675,15 @@ class RedisDataStructureFlow(object):
         )
         return redis_pipeline, act_kwargs
 
-    def __get_cluster_config(self, domain_name: str, db_version: str, conf_type: str, namespace: str) -> Any:
+    def __get_cluster_config(
+        self, bk_biz_id: str, domain_name: str, db_version: str, conf_type: str, namespace: str
+    ) -> Any:
         """
         获取已部署的实例配置
         """
         data = DBConfigApi.query_conf_item(
             params={
-                "bk_biz_id": str(self.data["bk_biz_id"]),
+                "bk_biz_id": bk_biz_id,
                 "level_name": LevelName.CLUSTER,
                 "level_value": domain_name,
                 "level_info": {"module": str(DEFAULT_DB_MODULE_ID)},
@@ -907,6 +910,11 @@ class RedisDataStructureFlow(object):
             logger.info(_("redis_data_structure_flow_full_backupinfo: {}".format(full_backup_info)))
             logger.info(_("redis_data_structure_flow_binlog_backupinfo: {}".format(binlog_backup_info)))
         return acts_list, acts_list_push_json
+
+    def get_ticket_biz_based_kwargs(self, act_kwargs: ActKwargs) -> ActKwargs:
+        new_kwargs = deepcopy(act_kwargs)
+        new_kwargs.cluster["bk_biz_id"] = self.data["bk_biz_id"]
+        return new_kwargs
 
     @staticmethod
     def get_backupfile(cluster_id, rollback_time, source_ip, source_port, tendis_type, kvstorecount) -> (dict, dict):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_task_delete.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_task_delete.py
@@ -8,13 +8,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-import logging.config
+import logging
 from copy import deepcopy
 from dataclasses import asdict
 from datetime import datetime
 from typing import Dict, Optional
 
+from django.forms.models import model_to_dict
 from django.utils.translation import gettext as _
 
 from backend.configuration.constants import DBType
@@ -68,26 +68,27 @@ class RedisDataStructureTaskDeleteFlow(object):
         1、删除构造记录：需要提供哪些参数呢？ （bk_cloud_id，源集群名，记录id （related_rollback_bill_id））
         """
 
-        task = TbTendisRollbackTasks.objects.filter(
-            related_rollback_bill_id=related_rollback_bill_id, bk_biz_id=bk_biz_id, prod_cluster=prod_cluster
-        ).order_by("-update_at")
-        task_list = list(task.values())
-        # 这里需要加吗
-        # if len(task_list) != 1:
-        #     raise Exception(
-        #         "单据{},构造源集群{},返回{}条记录不唯一，请检查！！！".format(related_rollback_bill_id, prod_cluster, len(task_list))
-        #     )
-        formatted_tasks = []
-        for task in task_list:
-            formatted_task = {}
-            for key, value in task.items():
-                if isinstance(value, datetime):
-                    # TODO: 改为带时区的时间字符串是否影响？
-                    formatted_task[key] = value.strftime("%Y-%m-%d %H:%M:%S")
-                else:
-                    formatted_task[key] = value
-            formatted_tasks.append(formatted_task)
-        return dict(formatted_tasks[0])
+        task = (
+            TbTendisRollbackTasks.objects.filter(
+                related_rollback_bill_id=related_rollback_bill_id, bk_biz_id=bk_biz_id, prod_cluster=prod_cluster
+            )
+            .order_by("-update_at")
+            .first()
+        )
+
+        if not task:
+            raise Exception(
+                "No rollback task found for bill_id={}, cluster={}, bk_biz_id={}".format(
+                    related_rollback_bill_id, prod_cluster, bk_biz_id
+                )
+            )
+
+        formatted_task = model_to_dict(task)
+        for key, value in formatted_task.items():
+            if isinstance(value, datetime):
+                formatted_task[key] = value.strftime("%Y-%m-%d %H:%M:%S")
+
+        return formatted_task
 
     def redis_rollback_task_delete_flow(self):
         """
@@ -99,10 +100,14 @@ class RedisDataStructureTaskDeleteFlow(object):
         redis_pipeline_all = Builder(root_id=self.root_id, data=self.data)
         trans_files = GetFileList(db_type=DBType.Redis)
         sub_pipelines_multi_cluster = []
-        for info in self.data["infos"]:
 
+        ticket_bk_biz_id = self.data["bk_biz_id"]
+
+        for info in self.data["infos"]:
             tasks_info = self.__get_cluster_info(
-                self.data["bk_biz_id"], info["related_rollback_bill_id"], info["prod_cluster"]
+                bk_biz_id=ticket_bk_biz_id,
+                related_rollback_bill_id=info["related_rollback_bill_id"],
+                prod_cluster=info["prod_cluster"],
             )
 
             logger.info("redis_rollback_task_delete_flow tasks_info:{}".format(tasks_info))
@@ -118,10 +123,9 @@ class RedisDataStructureTaskDeleteFlow(object):
             act_kwargs.cluster["cluster_type"] = act_kwargs.cluster["temp_cluster_type"]
 
             cluster_kwargs = deepcopy(act_kwargs)
-            # 更新构造记录为销毁中
             cluster_kwargs.cluster = {
                 "related_rollback_bill_id": info["related_rollback_bill_id"],
-                "bk_biz_id": self.data["bk_biz_id"],
+                "bk_biz_id": ticket_bk_biz_id,
                 "prod_cluster": info["prod_cluster"],
                 "meta_func_name": RedisDBMeta.update_rollback_task_status.__name__,
                 "cluster_type": cluster_kwargs.cluster["cluster_type"],
@@ -193,10 +197,9 @@ class RedisDataStructureTaskDeleteFlow(object):
                 kwargs=asdict(act_kwargs),
             )
             # #### 下架旧实例完成 #############################################################################
-            # 更新构造记录为已销毁
             act_kwargs.cluster = {
                 "related_rollback_bill_id": info["related_rollback_bill_id"],
-                "bk_biz_id": self.data["bk_biz_id"],
+                "bk_biz_id": ticket_bk_biz_id,
                 "prod_cluster": info["prod_cluster"],
                 "meta_func_name": RedisDBMeta.update_rollback_task_status.__name__,
                 "cluster_type": act_kwargs.cluster["cluster_type"],

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
@@ -11,27 +11,22 @@ specific language governing permissions and limitations under the License.
 import copy
 import logging
 from dataclasses import asdict
+from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from django.utils.translation import gettext as _
 
-from backend.components.dbresource.client import DBResourceApi
 from backend.db_meta.models import Cluster
-from backend.db_services.cmdb.biz import get_or_create_resource_module, get_resource_biz
 from backend.db_services.ipchooser.constants import BkOsTypeCode
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
-from backend.flow.engine.bamboo.scene.common.machine_os_init import insert_host_event
-from backend.flow.plugins.components.collections.common.exec_clear_machine import ClearMachineScriptComponent
-from backend.flow.plugins.components.collections.common.external_service import ExternalServiceComponent
-from backend.flow.plugins.components.collections.common.transfer_host_service import TransferHostServiceComponent
-from backend.flow.plugins.components.collections.redis.redis_db_meta import RedisDBMetaComponent
+from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldComponent
+from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
     RedisFlowPollingComponent,
     RedisRollbackFlowCreateComponent,
     RedisTempInstanceDeleteComponent,
 )
-from backend.flow.utils.redis.redis_context_dataclass import ActKwargs, CommonContext, RedisRollbackExerciseContext
-from backend.flow.utils.redis.redis_db_meta import RedisDBMeta
+from backend.flow.utils.redis.redis_context_dataclass import ActKwargs, RedisRollbackExerciseContext
 
 logger = logging.getLogger("flow")
 
@@ -119,6 +114,7 @@ class RedisRollbackExerciseFlow(object):
             act_kwargs = ActKwargs()
             act_kwargs.set_trans_data_dataclass = RedisRollbackExerciseContext.__name__
             act_kwargs.cluster = {
+                "bk_biz_id": self.ticket_data["bk_biz_id"],
                 "task_id": task_record_id,
                 "cluster_id": cluster.id,
                 "instance_ip": ip,
@@ -130,14 +126,31 @@ class RedisRollbackExerciseFlow(object):
                 "polling_timeout": config.get("polling_timeout", 3600),
             }
 
-            # Step 2: RollbackFlowCreate - Generate a rollback flow
+            # Step 2: Add alert shield for the applied machine
+            sub_flow.add_act(
+                act_name=_("屏蔽主机 {} 告警(超时1h)").format(resource_applied[0]["ip"]),
+                act_component_code=AddAlarmShieldComponent.code,
+                kwargs={
+                    "begin_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    "end_time": (datetime.now() + timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S"),
+                    "description": _("主机 {} Redis回档演练操作").format(resource_applied[0]["ip"]),
+                    "dimensions": [
+                        {
+                            "name": "instance_host",
+                            "values": [resource_applied[0]["ip"]],
+                        }
+                    ],
+                },
+            )
+
+            # Step 3: RollbackFlowCreate - Generate a rollback flow
             sub_flow.add_act(
                 act_name=_("生成构造任务"),
                 act_component_code=RedisRollbackFlowCreateComponent.code,
                 kwargs=asdict(act_kwargs),
             )
 
-            # Step 3: FlowPoll - Poll until the creation is done
+            # Step 4: FlowPoll - Poll until the creation is done
             act_kwargs.cluster["flow_type"] = "rollback_flow_id"
             sub_flow.add_act(
                 act_name=_("等待构造完成"),
@@ -145,14 +158,14 @@ class RedisRollbackExerciseFlow(object):
                 kwargs=asdict(act_kwargs),
             )
 
-            # Step 4: TempInstanceDelete - Delete temp instance
+            # Step 5: TempInstanceDelete - Delete temp instance
             sub_flow.add_act(
                 act_name=_("销毁临时实例"),
                 act_component_code=RedisTempInstanceDeleteComponent.code,
                 kwargs=asdict(act_kwargs),
             )
 
-            # Step 5: FlowPoll - Poll until the deletion is done
+            # Step 6: FlowPoll - Poll until the deletion is done
             act_kwargs.cluster["flow_type"] = "delete_flow_id"
             sub_flow.add_act(
                 act_name=_("等待销毁完成"),
@@ -160,61 +173,11 @@ class RedisRollbackExerciseFlow(object):
                 kwargs=asdict(act_kwargs),
             )
 
-            # Step 6: Clear meta info and delete data on machine
-            clear_host = resource_applied[0]
-            clear_hosts = [{"ip": clear_host["ip"], "bk_cloud_id": clear_host["bk_cloud_id"]}]
-            # Note: RedisDBMeta.clear_machines expects ticket_data["clear_hosts"]
-            self.ticket_data["clear_hosts"] = clear_hosts
-            clear_meta_kwargs = ActKwargs(
-                cluster={"meta_func_name": RedisDBMeta.clear_machines.__name__},
-                set_trans_data_dataclass=CommonContext.__name__,
-            )
+            # Step 7: Remove alert shield for the applied machine
             sub_flow.add_act(
-                act_name=_("删除元数据 - {}").format(clear_host["ip"]),
-                act_component_code=RedisDBMetaComponent.code,
-                kwargs=asdict(clear_meta_kwargs),
-            )
-            sub_flow.add_act(
-                act_name=_("清理机器上的数据"),
-                act_component_code=ClearMachineScriptComponent.code,
-                kwargs={"exec_ips": clear_hosts},
-            )
-
-            # Step 7: Return machine to resource pool
-            import_data = {
-                "resource_type": self.ticket_data["db_type"],
-                "for_biz": 0,  # Return to public resource pool
-                "bk_biz_id": get_resource_biz(),
-                "hosts": [
-                    {
-                        "ip": clear_host["ip"],
-                        "host_id": clear_host["bk_host_id"],
-                        "bk_cloud_id": clear_host["bk_cloud_id"],
-                    }
-                ],
-                "labels": {},
-                "operator": self.ticket_data["created_by"],
-            }
-            sub_flow.add_act(
-                act_name=_("退回资源池"),
-                act_component_code=ExternalServiceComponent.code,
-                kwargs={
-                    "params": import_data,
-                    "api_import_path": DBResourceApi.__module__,
-                    "api_import_module": "DBResourceApi",
-                    "api_call_func": "resource_import",
-                    "success_callback_path": f"{insert_host_event.__module__}.{insert_host_event.__name__}",
-                },
-            )
-            sub_flow.add_act(
-                act_name=_("转移CC模块"),
-                act_component_code=TransferHostServiceComponent.code,
-                kwargs={
-                    "bk_biz_id": get_resource_biz(),
-                    "bk_module_ids": [get_or_create_resource_module()],
-                    "bk_host_ids": [clear_host["bk_host_id"]],
-                    "update_host_properties": {"dbm_meta": [], "need_monitor": False, "update_operator": False},
-                },
+                act_name=_("解除主机 {} 告警屏蔽").format(resource_applied[0]["ip"]),
+                act_component_code=DisableAlarmShieldComponent.code,
+                kwargs={},
             )
 
             sub_flows.append(

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -260,6 +260,7 @@ class RedisRollbackFlowCreateSerivce(RedisLogCapturingService):
         task_id = kwargs["cluster"].get("task_id")
         self.trans_data.task_id = task_id
 
+        bk_biz_id = kwargs["cluster"].get("bk_biz_id")  # biz_id of the ticket, not cluster
         cluster_id = kwargs["cluster"].get("cluster_id")
         instance_ip = kwargs["cluster"].get("instance_ip")
         instance_port = kwargs["cluster"].get("instance_port")
@@ -273,7 +274,7 @@ class RedisRollbackFlowCreateSerivce(RedisLogCapturingService):
             rollback_flow_id = generate_root_id()
             # Prepare data structure flow data
             data_structure_data = {
-                "bk_biz_id": cluster.bk_biz_id,
+                "bk_biz_id": bk_biz_id,
                 "uid": global_data["uid"],
                 "created_by": global_data["created_by"],
                 "ticket_type": "REDIS_DATA_STRUCTURE",
@@ -348,9 +349,9 @@ class RedisTempInstanceDeleteService(RedisLogCapturingService):
             cluster_id = kwargs["cluster"].get("cluster_id")
             cluster = Cluster.objects.get(id=cluster_id)
 
-            bk_biz_id = cluster.bk_biz_id
             delete_flow_id = generate_root_id()
             global_data = data.get_one_of_inputs("global_data")
+            bk_biz_id = kwargs["cluster"].get("bk_biz_id")  # biz_id of the ticket, not cluster
             task_id = kwargs["cluster"].get("task_id")
 
             flow_data = {

--- a/dbm-ui/backend/ticket/builders/common/recycle.py
+++ b/dbm-ui/backend/ticket/builders/common/recycle.py
@@ -31,6 +31,7 @@ class RecycleHostDetailSerializer(serializers.Serializer):
     recycle_hosts = serializers.JSONField(help_text=_("下架机器的回收信息"), default=[])
     group = serializers.ChoiceField(help_text=_("所属组件"), choices=DBType.get_choices())
     parent_ticket = serializers.IntegerField(help_text=_("发起单据号"))
+    immediate_recycle = serializers.BooleanField(help_text=_("立即回收", default=False))
 
 
 class MachineIdleCheckParamBuilder(FlowParamBuilder):
@@ -74,8 +75,9 @@ class RecycleHostFlowBuilder(TicketFlowBuilder):
 
         # 对于独立管控的回收单，跳过空闲检查和数据清理
         if not self.check_independent_recycle():
-            # 定时执行
-            if env.HOST_RECYCLE_RETENTION_DAYS:
+            # 定时执行 - 如果父单据设置了immediate_recycle标志，则跳过定时器
+            immediate_recycle = self.ticket.details.get("immediate_recycle", False)
+            if env.HOST_RECYCLE_RETENTION_DAYS and not immediate_recycle:
                 flows.append(
                     Flow(ticket=self.ticket, flow_type=FlowType.TIMER.value, flow_alias=_("定时执行")),
                 )

--- a/dbm-ui/backend/ticket/builders/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/ticket/builders/redis/redis_rollback_exercise.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from backend.db_services.dbresource.handlers import ResourceHandler
 from backend.flow.engine.controller.redis import RedisController
 from backend.ticket import builders
 from backend.ticket.builders.common.base import AffinityEnum, BaseOperateResourceParamBuilder, IpSource
@@ -45,7 +46,23 @@ class RedisRollbackExerciseParamBuilder(builders.FlowParamBuilder):
         super().format_ticket_data()
 
     def post_callback(self):
-        return super().post_callback()
+        applied_hosts = []
+        for info in self.ticket_data.get("infos", []):
+            if "redis" in info:
+                for host in info["redis"]:
+                    applied_hosts.append(
+                        {
+                            "bk_host_id": host["bk_host_id"],
+                            "ip": host["ip"],
+                            "bk_cloud_id": host["bk_cloud_id"],
+                        }
+                    )
+
+        if applied_hosts:
+            self.ticket.details["recycle_hosts"] = ResourceHandler.standardized_resource_host(applied_hosts)
+            # Set immediate_recycle flag for rollback exercise to skip timer delay
+            self.ticket.details["immediate_recycle"] = True
+            self.ticket.save(update_fields=["details"])
 
 
 class RedisRollbackExerciseResourceParamBuilder(BaseOperateResourceParamBuilder):
@@ -61,7 +78,11 @@ class RedisRollbackExerciseResourceParamBuilder(BaseOperateResourceParamBuilder)
             info.update(bk_cloud_id=cluster.bk_cloud_id, bk_biz_id=self.ticket.bk_biz_id)
 
 
-@builders.BuilderFactory.register(TicketType.REDIS_ROLLBACK_EXERCISE)
+@builders.BuilderFactory.register(
+    TicketType.REDIS_ROLLBACK_EXERCISE,
+    is_apply=True,
+    is_recycle=True,
+)
 class RedisRollbackExerciseFlowBuilder(BaseRedisTicketFlowBuilder):
     serializer = RedisRollbackExerciseDetailSerializer
     inner_flow_builder = RedisRollbackExerciseParamBuilder

--- a/dbm-ui/backend/ticket/builders/redis/redis_toolbox_rollback_data_copy.py
+++ b/dbm-ui/backend/ticket/builders/redis/redis_toolbox_rollback_data_copy.py
@@ -56,6 +56,7 @@ class RedisRollbackDataCopyDetailSerializer(RedisBaseOperateDetailSerializer):
             ClusterValidateMixin.check_cluster_phase(dst_cluster)
 
             if not TbTendisRollbackTasks.objects.filter(
+                bk_biz_id=self.context["bk_biz_id"],
                 prod_cluster_id=dst_cluster,
                 temp_cluster_proxy=src_cluster,
                 recovery_time_point=info.get("recovery_time_point"),

--- a/dbm-ui/backend/ticket/models/ticket.py
+++ b/dbm-ui/backend/ticket/models/ticket.py
@@ -340,6 +340,8 @@ class Ticket(AuditedModel):
         dba, second_dba, other_dba = DBAdministrator.get_dba_for_db_type(revoke_ticket.bk_biz_id, revoke_ticket.group)
         creator = dba[0] if dba else revoke_ticket.creator
         helpers = [*second_dba, *other_dba]
+        # 支持通过终止单据设置立刻执行清理单据
+        immediate_recycle = revoke_ticket.details.get("immediate_recycle", False)
         # 创建回收单据流程
         recycle_ticket = Ticket.create_ticket(
             ticket_type=ticket_type,
@@ -351,6 +353,7 @@ class Ticket(AuditedModel):
                 "parent_ticket": revoke_ticket_id,
                 "group": revoke_ticket.group,
                 "recycle_hosts": hosts,
+                "immediate_recycle": immediate_recycle,
             },
         )
 


### PR DESCRIPTION
- 资源回收序列器新增 `immediate_recycle` 支持回收单据立刻执行 “已下架主机处理”
- 单据资源回收采用派生单据的方式
- 调整演练任务的归属为演练单据所在业务
- 修正触发演练单据的字段类型
- 构造实例回写单据校验构造实例 新增对 `bk_biz_id` 的校验，避免演练影响