### PR TITLE
feat(backend): bill-sidecar-subflow #14653

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/common/builder.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/common/builder.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Self
 
 from bamboo_engine import api, builder
 from bamboo_engine.builder import (
@@ -75,6 +75,7 @@ class Builder(object):
         self.data = data
         self.need_random_pass_cluster_ids = need_random_pass_cluster_ids
         self.need_random_pass_instances = need_random_pass_instances
+
         self.start_act = EmptyStartEvent()
         self.end_act = EmptyEndEvent()
         if not self.data:
@@ -100,6 +101,28 @@ class Builder(object):
         # 判断是否添加临时账号的流程逻辑
         if self.need_random_pass_cluster_ids:
             self.create_random_pass_act()
+
+    def with_sidecar_acts(self, worker_name: str, sidecar_acts: List) -> Self:
+        if sidecar_acts and isinstance(sidecar_acts, list) and len(sidecar_acts) > 0:
+            sidecar_subpipe = SubBuilder(root_id=self.root_id, data=copy.deepcopy(self.data))
+            sidecar_subpipe.add_parallel_acts(acts_list=sidecar_acts)
+
+            pipe = Builder(
+                root_id=self.root_id,
+                data=copy.deepcopy(self.data),
+                need_random_pass_cluster_ids=self.need_random_pass_cluster_ids,
+                need_random_pass_instances=self.need_random_pass_instances,
+            )
+
+            pipe.add_parallel_sub_pipeline(
+                sub_flow_list=[
+                    sidecar_subpipe.build_sub_process(_("旁路子流程")),
+                    SubBuilder.from_builder(self).build_sub_process(worker_name),
+                ]
+            )
+            return pipe
+        else:
+            return self
 
     def create_random_pass_act(self):
         """
@@ -295,8 +318,10 @@ class Builder(object):
             self.global_data.inputs[f"${{{i['conditions_param']}}}"] = NodeOutput(
                 type=Var.SPLICE, source_act=i["source_act_id"], source_key=f"{i['conditions_param']}"
             )
+
         self.pipe.extend(self.end_act)
         pipeline = builder.build_tree(self.start_act, id=self.root_id, data=self.global_data)
+
         pipeline_copy = copy.deepcopy(pipeline)
         insensitive_data = self.hide_sensitive_data(pipeline_copy)
         # 考虑到有些任务没有单据关联，因此uid一般为root_id，此时创建FlowTree的时候uid应该为null
@@ -357,6 +382,24 @@ class SubBuilder(Builder):
         sub_params = Params({"${trans_data}": Var(type=Var.SPLICE, value="${trans_data}")})
         self.pipe.extend(self.end_act)
         return SubProcess(start=self.start_act, data=sub_data, params=sub_params, name=sub_name)
+
+    @classmethod
+    def from_builder(cls, b: Builder) -> Self:
+        sb = SubBuilder(root_id=b.root_id, data=b.data)
+        sb.need_random_pass_cluster_ids = None
+        sb.need_random_pass_instances = None
+
+        sb.start_act = b.start_act
+        # worker 子流程删除原有的临时账号部分
+        if b.need_random_pass_instances or b.need_random_pass_cluster_ids:
+            sb.start_act.outgoing = b.start_act.outgoing[0].outgoing
+
+        sb.end_act = b.end_act
+        sb.global_data = b.global_data
+        sb.pipe = b.pipe
+        sb.rewritable_node_source_keys = b.rewritable_node_source_keys
+        sb.node_output_list = b.node_output_list
+        return sb
 
 
 class RewritableNode(RewritableNodeOutput):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
@@ -481,6 +481,7 @@ class MySQLRestoreSlaveRemoteFlow(object):
             data=copy.deepcopy(self.ticket_data),
             need_random_pass_cluster_ids=list(set(cluster_ids)),
         )
+
         tendb_migrate_pipeline_list = []
         for info in self.ticket_data["infos"]:
             self.data = copy.deepcopy(info)
@@ -823,4 +824,8 @@ class MySQLRestoreSlaveRemoteFlow(object):
             )
 
         tendb_migrate_pipeline_all.add_parallel_sub_pipeline(sub_flow_list=tendb_migrate_pipeline_list)
-        tendb_migrate_pipeline_all.run_pipeline(init_trans_data_class=ClusterInfoContext(), is_drop_random_user=True)
+
+        tendb_migrate_pipeline_all.run_pipeline(
+            init_trans_data_class=ClusterInfoContext(),
+            is_drop_random_user=True,
+        )

--- a/dbm-ui/backend/flow/plugins/components/collections/common/sidecar_mysql_master_slave_heartbeat_service.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/sidecar_mysql_master_slave_heartbeat_service.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from pipeline.component_framework.component import Component
+from pipeline.core.flow import StaticIntervalGenerator
+
+from backend.flow.plugins.components.collections.common.sidecar_service_abc import SidecarServiceABC
+
+
+class SidecarMySQLMasterSlaveHeartbeatService(SidecarServiceABC):
+    interval = StaticIntervalGenerator(30)
+
+    def sidecar_func(self, *args, **kwargs) -> bool:
+        cluster_ids = kwargs["cluster_ids"]
+        self.log_info("try to write heartbeat in {}".format(cluster_ids))
+        return True
+
+
+class SidecarMySQLMasterSlaveHeartbeatComponent(Component):
+    name = __name__
+    code = "sidecar-mysql-master-slave-heartbeat"
+    bound_service = SidecarMySQLMasterSlaveHeartbeatService

--- a/dbm-ui/backend/flow/plugins/components/collections/common/sidecar_service_abc.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/sidecar_service_abc.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from abc import ABC, abstractmethod
+
+from bamboo_engine import api
+from docutils import Component
+from pipeline.core.flow import StaticIntervalGenerator
+from pipeline.eri.runtime import BambooDjangoRuntime
+
+from backend.flow.consts import StateType
+from backend.flow.plugins.components.collections.common.base_service import BaseService
+
+
+class SidecarServiceABC(BaseService, ABC):
+    """
+    示例
+    class SidecarDemoService(SidecarServiceABC):
+        interval = StaticIntervalGenerator(30)
+
+        def sidecar_func(self, *args, **kwargs) -> bool:
+            custom_param = kwargs["custom_param"]
+            self.log_info("output {}".format(custom_param))
+            return True
+
+
+    class SidecarDemoComponent(Component):
+        name = __name__
+        code = "sidecar-demo"
+        bound_service = SidecarDemoService
+
+    1. 这样就定义了一个每 30s 打印一行日志的 component
+    2. 如何使用这个 component 注入子流程可以参考 dbm-ui/backend/flow/engine/bamboo/scene/common/build_sidecar_wrapper.py
+    """
+
+    __need_schedule__ = True
+    interval = StaticIntervalGenerator(30)
+
+    def _execute(self, data, parent_data):
+        kwargs = data.get_one_of_inputs("kwargs")
+        root_id = kwargs["root_id"]
+
+        data.outputs.root_id = root_id
+        return True
+
+    def _schedule(self, data, parent_data, callback_data=None):
+        kwargs = data.get_one_of_inputs("kwargs")
+
+        root_id = data.outputs.root_id
+
+        if self._worker_is_running(root_id=root_id):
+            ret = self.sidecar_func(**kwargs)
+            if ret:
+                return True
+            else:
+                self.finish_schedule()
+                return False
+
+        self.finish_schedule()
+        return True
+
+    def _worker_is_running(self, root_id: str) -> bool:
+        ret = api.get_pipeline_states(BambooDjangoRuntime(), root_id, False)
+        for child in ret.data[root_id]["children"].values():
+            child_id = child["id"]
+            if self.runtime_attrs["top_pipeline_id"] == child_id:
+                continue
+
+            if child["state"] == StateType.RUNNING:
+                return True
+
+        return False
+
+    @abstractmethod
+    def sidecar_func(self, *args, **kwargs) -> bool:
+        pass
+
+
+class SidecarComponent(Component, ABC):
+    @abstractmethod
+    def node_name(self) -> str:
+        return ""


### PR DESCRIPTION
1. 新增基础组件 `SidecarServiceABC`
2. Builder 类添加 with_sidecar_acts 方法用于注入旁路行为

用途是
1. 以低侵入方式给单据工作流程注入一个附加流程
2. 附加流程在工作流程运行期间保持运行, 并周期调用自定义函数
4. 可以注入任意多个附加流程

适用场景, 如
1. 迁移db时维持主备同步心跳
2. 单据全生命周期监控
<img width="1003" height="726" alt="image" src="https://github.com/user-attachments/assets/ce7312d7-4cfb-4a7e-ab80-46650b2041cf" />



```python
        tendb_migrate_pipeline_all.with_sidecar_acts(
            sidecar_acts=[
                {
                    "act_name": _("主备同步心跳 1"),
                    "act_component_code": SidecarMySQLMasterSlaveHeartbeatComponent.code,
                    "kwargs": {"cluster_ids": list(set(cluster_ids))},
                },
                {
                    "act_name": _("主备同步心跳 2"),
                    "act_component_code": SidecarMySQLMasterSlaveHeartbeatComponent.code,
                    "kwargs": {"cluster_ids": list(set(cluster_ids))},
                },
            ],
            worker_name=_("slave 原地重建"),
        ).run_pipeline(
            init_trans_data_class=ClusterInfoContext(),
            is_drop_random_user=True,
        )
```

详情可参考
`dbm-ui/backend/flow/plugins/components/collections/common/sidecar_service_abc.py`
`dbm-ui/backend/flow/plugins/components/collections/common/sidecar_mysql_master_slave_heartbeat_service.py`

