### PR TITLE
fix(backend): Avoid importing periodic task module elsewhere #15005

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/__init__.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/__init__.py
@@ -8,7 +8,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .base import create_meta_check_report
 from .check_affinity import check_redis_affinity
 from .check_instance import check_redis_instance
 from .check_role import check_redis_instance_role

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
@@ -22,10 +22,13 @@ from backend.configuration.models import DBAdministrator
 from backend.db_meta.enums import ClusterPhase, ClusterType, InstanceRole, MachineType
 from backend.db_meta.models import Cluster, StorageInstance
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.flow.utils.redis.redis_meta_report import (
+    create_meta_check_report,
+    delete_old_meta_check_reports,
+    is_cluster_labeled_with,
+)
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
 from backend.ticket.models.ticket import ClusterOperateRecord
-
-from .base import create_meta_check_report, delete_old_meta_check_reports, is_cluster_labeled_with
 
 logger = logging.getLogger("root")
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
@@ -21,10 +21,13 @@ from backend.configuration.models import DBAdministrator
 from backend.db_meta.enums import ClusterPhase, ClusterType, InstanceRole, InstanceStatus
 from backend.db_meta.models import Cluster
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.flow.utils.redis.redis_meta_report import (
+    create_meta_check_report,
+    delete_old_meta_check_reports,
+    is_cluster_labeled_with,
+)
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
 from backend.ticket.models.ticket import ClusterOperateRecord
-
-from .base import create_meta_check_report, delete_old_meta_check_reports, is_cluster_labeled_with
 
 logger = logging.getLogger("root")
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_role.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_role.py
@@ -20,10 +20,9 @@ from backend.configuration.constants import SystemSettingsEnum
 from backend.db_meta.enums import ClusterPhase, ClusterType
 from backend.db_meta.models import Cluster
 from backend.db_report.enums import MetaCheckSubType
+from backend.flow.utils.redis.redis_meta_report import delete_old_meta_check_reports
 from backend.ticket.models import SystemSettings
 from backend.utils.basic import generate_root_id
-
-from .base import delete_old_meta_check_reports
 
 logger = logging.getLogger("root")
 

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_role_check.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_role_check.py
@@ -22,11 +22,11 @@ from pipeline.core.flow.activity import Service, StaticIntervalGenerator
 from backend import env
 from backend.components import JobApi
 from backend.db_meta.models import Cluster
-from backend.db_periodic_task.local_tasks.db_meta.db_meta_check.redis_cluster_check import create_meta_check_report
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
 from backend.flow.consts import SUCCESS_LIST
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils.redis.redis_context_dataclass import RedisRoleCheckContext
+from backend.flow.utils.redis.redis_meta_report import create_meta_check_report
 from backend.flow.utils.redis.redis_script_template import (
     build_redis_role_check_script,
     redis_fast_execute_script_common_kwargs,

--- a/dbm-ui/backend/flow/utils/redis/redis_meta_report.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_meta_report.py
@@ -100,8 +100,8 @@ def create_meta_check_report(
         subtype: Meta check subtype
         msg: Report message
         state: Report state (NORMAL/WARNING/ABNORMAL)
-        status: Legacy status field (True=pass, False=fail)
-        instance: Optional StorageInstance object (avoids DB query if provided)
+        machine_type: Machine type string
+        creator: Creator name
 
     Returns:
         Created MetaCheckReport object


### PR DESCRIPTION
将redis元数据检查的helper函数放到backend/flow/utils/redis下，避免从外部引用 db_periodic_task 的模块