### PR TITLE
feat(redis): Default cluster types for rollback exercise #15375

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/fullback.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/fullback.go
@@ -135,6 +135,7 @@ func (full *TendisFullBackPull) GetFullFilesSpecTimeRange(fullFileList []FileDet
 		// tendis cache  （cache 这里没有做文件分割）
 		// 2005000194-redis-master-127.0.0.x-30000-20230426-210004.rdb
 		// 2005000194-redis-slave-127.0.0.x-30000-20230508-130108.aof.zst
+		// 2005000194-redis-slave-127.0.0.x-30000-20230508-130108.aof.gz
 		// 127.0.0.xx-30000-20231219-200152-appendonly.aof.lzo
 		// rdb 文件不会压缩，因为redis本身有做压缩
 		// aof 文件会压缩，需要解压
@@ -174,6 +175,11 @@ func (full *TendisFullBackPull) GetFullFilesSpecTimeRange(fullFileList []FileDet
 		// xx-appendonly.aof.lzo`
 		if match01 == nil {
 			match01 = lastDateReg2.FindStringSubmatch(str01.FileName)
+		}
+		// xx-xx-xx.aof.gz (fallback when zstd is not available)
+		if match01 == nil {
+			lastDateReg3 := regexp.MustCompile(`^.*?(\d+-\d+).aof.gz`)
+			match01 = lastDateReg3.FindStringSubmatch(str01.FileName)
 		}
 
 		if len(match01) < 2 {
@@ -478,6 +484,8 @@ func (full *TendisFullBackPull) GetBackupFileExt() (fileExt string) {
 		fileExt = ".tar.gz"
 	} else if strings.HasSuffix(full.ResultFullbackup[0].BackupFile, ".zst") {
 		fileExt = ".zst"
+	} else if strings.HasSuffix(full.ResultFullbackup[0].BackupFile, ".gz") {
+		fileExt = ".gz"
 	} else if strings.HasSuffix(full.ResultFullbackup[0].BackupFile, ".rdb") {
 		fileExt = ".rdb"
 	} else if strings.HasSuffix(full.ResultFullbackup[0].BackupFile, ".lzo") {
@@ -501,7 +509,8 @@ func (full *TendisFullBackPull) SetDecompressedDir() {
 	}
 	mylog.Logger.Info("SetDecompressedDir bkFileExt:%s", bkFileExt)
 	var prefix, cmd01 string
-	if bkFileExt == "split" {
+	switch bkFileExt {
+	case "split":
 		// 2005000194-TENDISPLUS-FULL-slave-127.0.0.x-30000-20230311-214752.split.004
 		// 需要的：2005000194-TENDISPLUS-FULL-slave-127.0.0.x-30000-20230311-214752
 		prefix = strings.Split(full.ResultFullbackup[0].BackupFile, ".split")[0]
@@ -511,7 +520,7 @@ func (full *TendisFullBackPull) SetDecompressedDir() {
 		if full.Err != nil {
 			return
 		}
-	} else if bkFileExt == ".tar" {
+	case ".tar":
 		prefix = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, bkFileExt)
 		cmd01 := fmt.Sprintf("cd %s && mkdir -p %s ", full.SaveDir, prefix)
 		mylog.Logger.Info("SetDecompressedDir bkFileExt:%s, cmd01:%s", bkFileExt, cmd01)
@@ -519,7 +528,7 @@ func (full *TendisFullBackPull) SetDecompressedDir() {
 		if full.Err != nil {
 			return
 		}
-	} else if bkFileExt == ".zst" {
+	case ".zst":
 		// xx-xx-xx.aof.zst
 		prefix = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".aof.zst")
 		mylog.Logger.Info("prefix:%s", prefix)
@@ -529,7 +538,17 @@ func (full *TendisFullBackPull) SetDecompressedDir() {
 		if full.Err != nil {
 			return
 		}
-	} else if bkFileExt == ".lzo" {
+	case ".gz":
+		// xx-xx-xx.aof.gz
+		prefix = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".aof.gz")
+		mylog.Logger.Info("prefix:%s", prefix)
+		cmd01 := fmt.Sprintf("cd %s && mkdir -p %s ", full.SaveDir, prefix)
+		mylog.Logger.Info("SetDecompressedDir bkFileExt:%s, cmd01:%s", bkFileExt, cmd01)
+		_, full.Err = util.RunLocalCmd("bash", []string{"-c", cmd01}, "", nil, 1800*time.Second)
+		if full.Err != nil {
+			return
+		}
+	case ".lzo":
 		// xx-xx-xx.aof.lzo
 		prefix = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".aof.lzo")
 		mylog.Logger.Info("prefix:%s", prefix)
@@ -539,7 +558,7 @@ func (full *TendisFullBackPull) SetDecompressedDir() {
 		if full.Err != nil {
 			return
 		}
-	} else if bkFileExt == ".rdb" {
+	case ".rdb":
 		// xx-xx.rdb
 		prefix = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".rdb")
 		mylog.Logger.Info("prefix:%s", prefix)
@@ -630,14 +649,17 @@ func (full *TendisFullBackPull) CheckDecompressedDirIsOK() (isExists, isCompelet
 		if full.Err != nil {
 			return
 		}
-		if bkFileExt == ".zst" {
+		switch bkFileExt {
+		case ".zst":
 			backupFile = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".zst")
 			file, _ = findDstFileInDir(decpFullPath, backupFile)
-
-		} else if bkFileExt == ".rdb" {
+		case ".gz":
+			backupFile = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".gz")
+			file, _ = findDstFileInDir(decpFullPath, backupFile)
+		case ".rdb":
 			backupFile = full.ResultFullbackup[0].BackupFile
 			file, _ = findDstFileInDir(decpFullPath, backupFile)
-		} else if bkFileExt == ".lzo" {
+		case ".lzo":
 			backupFile = strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".lzo")
 			file, _ = findDstFileInDir(decpFullPath, backupFile)
 		}
@@ -705,9 +727,12 @@ func (full *TendisFullBackPull) CheckLocalBackupFileIsOK() (isExists, isCompelet
 			if full.Err != nil {
 				return
 			}
-			if bkFileExt == ".zst" {
+			switch bkFileExt {
+			case ".zst":
 				bkFileFullPathFile = fmt.Sprintf("%s%s", bkFileFullPath, ".aof.zst")
-			} else if bkFileExt == ".rdb" {
+			case ".gz":
+				bkFileFullPathFile = fmt.Sprintf("%s%s", bkFileFullPath, ".aof.gz")
+			case ".rdb":
 				bkFileFullPathFile = fmt.Sprintf("%s%s", bkFileFullPath, ".rdb")
 			}
 
@@ -792,14 +817,26 @@ func (full *TendisFullBackPull) RmLocalBakcupFile() {
 	}
 	var backupFiles string
 	// rdb 没压缩，不用处理
-	if bkFileExt == "split" {
+	switch bkFileExt {
+	case "split":
 		// 2005000194-TENDISPLUS-FULL-slave-127.0.0.x-30000-20230311-214752.split.004
 		// 需要的：2005000194-TENDISPLUS-FULL-slave-127.0.0.x-30000-20230311-214752
 		backupFiles = fmt.Sprintf("%s.split.*", full.GetDecompressedDir())
-	} else if bkFileExt == ".tar" {
+	case ".tar":
 		backupFiles = fmt.Sprintf("%s.tar", full.GetDecompressedDir())
-	} else if bkFileExt == ".zst" {
+	case ".zst":
 		backupFiles = fmt.Sprintf("%s.aof.zst", full.GetDecompressedDir())
+		DecompressDir := filepath.Join(full.SaveDir, full.GetDecompressedDir())
+		rmCmd := fmt.Sprintf("cd %s && rm -rf %s 2>/dev/null", DecompressDir, backupFiles)
+		_, full.Err = util.RunLocalCmd("bash", []string{"-c", rmCmd}, "", nil, 30*time.Minute)
+		if full.Err != nil {
+			return
+		}
+		msg := fmt.Sprintf("本地全备(未解压):%s 删除成功", backupFiles)
+		mylog.Logger.Info(msg)
+		return
+	case ".gz":
+		backupFiles = fmt.Sprintf("%s.aof.gz", full.GetDecompressedDir())
 		DecompressDir := filepath.Join(full.SaveDir, full.GetDecompressedDir())
 		rmCmd := fmt.Sprintf("cd %s && rm -rf %s 2>/dev/null", DecompressDir, backupFiles)
 		_, full.Err = util.RunLocalCmd("bash", []string{"-c", rmCmd}, "", nil, 30*time.Minute)
@@ -830,17 +867,18 @@ func (full *TendisFullBackPull) Decompressed() {
 		return
 	}
 
-	if bkFileExt == ".tar" {
+	switch bkFileExt {
+	case ".tar":
 		// 只有一个备份文件，并且后缀为.tar
 		if len(full.ResultFullbackup) == 1 {
 			cmd01 = fmt.Sprintf("tar -xf %s", full.ResultFullbackup[0].BackupFile)
 		}
 
-	} else if bkFileExt == ".tar.gz" || bkFileExt == ".tgz" {
+	case ".tar.gz", ".tgz":
 		if len(full.ResultFullbackup) == 1 {
 			cmd01 = fmt.Sprintf("tar -xf %s", full.ResultFullbackup[0].BackupFile)
 		}
-	} else if bkFileExt == ".zst" {
+	case ".zst":
 		mylog.Logger.Info("len(full.ResultFullbackup) is %d", len(full.ResultFullbackup))
 		mylog.Logger.Info("Decompressed_bkFileExt is %s", bkFileExt)
 		if len(full.ResultFullbackup) == 1 {
@@ -875,7 +913,31 @@ func (full *TendisFullBackPull) Decompressed() {
 			return
 		}
 
-	} else if bkFileExt == ".lzo" {
+	case ".gz":
+		mylog.Logger.Info("len(full.ResultFullbackup) is %d", len(full.ResultFullbackup))
+		mylog.Logger.Info("Decompressed_bkFileExt is %s", bkFileExt)
+		if len(full.ResultFullbackup) == 1 {
+			// 使用 gzip 解压 .gz 文件
+			cmd01 = fmt.Sprintf(" cd %s && gzip -d %s ", full.GetDecompressedDir(),
+				full.ResultFullbackup[0].BackupFile)
+		}
+		prefix := strings.TrimSuffix(full.ResultFullbackup[0].BackupFile, ".aof.gz")
+		mkcmd := fmt.Sprintf("cd %s && mkdir -p %s ", full.SaveDir, prefix)
+		mylog.Logger.Info("SetDecompressedDir bkFileExt:%s, mkcmd:%s", bkFileExt, mkcmd)
+		_, full.Err = util.RunLocalCmd("bash", []string{"-c", mkcmd}, "", nil, 1800*time.Second)
+		if full.Err != nil {
+			return
+		}
+		// 将备份文件mv到解压目录下
+		DecompressDir := filepath.Join(full.SaveDir, full.GetDecompressedDir())
+		mvCmd := fmt.Sprintf("cd %s && mv %s %s ", full.SaveDir, full.ResultFullbackup[0].BackupFile, DecompressDir)
+		mylog.Logger.Info("将备份文件mv到解压目录下 mvCmd:%s", mvCmd)
+		_, full.Err = util.RunLocalCmd("bash", []string{"-c", mvCmd}, "", nil, 1800*time.Second)
+		if full.Err != nil {
+			return
+		}
+
+	case ".lzo":
 		mylog.Logger.Info("Decompressed_bkFileExt is %s", bkFileExt)
 		mylog.Logger.Info("len(full.ResultFullbackup) is %d", len(full.ResultFullbackup))
 		if len(full.ResultFullbackup) == 1 {
@@ -909,7 +971,7 @@ func (full *TendisFullBackPull) Decompressed() {
 			return
 		}
 
-	} else if bkFileExt == ".rdb" {
+	case ".rdb":
 		// 将备份文件mv到目录下,rdb不用解压
 		DecompressDir := filepath.Join(full.SaveDir, full.GetDecompressedDir())
 		cmd01 := fmt.Sprintf("cd %s && mkdir -p %s ", full.SaveDir, DecompressDir)
@@ -925,7 +987,7 @@ func (full *TendisFullBackPull) Decompressed() {
 		if full.Err != nil {
 			return
 		}
-	} else if bkFileExt == "split" {
+	case "split":
 		// 2005000194-TENDISPLUS-FULL-slave-127.0.0.x-30000-20230311-214752.split.004
 		backupFilesPrefix := strings.Split(full.ResultFullbackup[0].BackupFile, ".split")[0]
 		cmd01 = fmt.Sprintf("cat %s.* |tar x ", backupFilesPrefix)
@@ -1511,6 +1573,7 @@ func (full *TendisFullBackPull) RecoverCacheRedisFromBackupFile(sourceIP string,
 	var dataPath, backupFile, backupFilePath string
 
 	if strings.Contains(full.ResultFullbackup[0].BackupFile, ".aof.zst") ||
+		strings.Contains(full.ResultFullbackup[0].BackupFile, ".aof.gz") ||
 		strings.Contains(full.ResultFullbackup[0].BackupFile, ".aof.lzo") {
 		// 解压后文件
 		backupFile := strings.TrimSuffix(full.ResultFullbackup[0].BackupFile,

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
@@ -28,7 +28,7 @@ from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.db_services.redis.rollback.handlers import DataStructureHandler
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
-from backend.ticket.builders.common.base import IpSource
+from backend.ticket.builders.common.base import ClusterType, IpSource
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
 from backend.ticket.models import ClusterOperateRecord, SystemSettings, Ticket
 from backend.utils.redis import RedisConn
@@ -62,7 +62,7 @@ class RedisRollbackExerciseConfig:
     """
 
     # Meta Configs
-    switch: bool = False
+    enabled: bool = False
     mode: RedisRollbackExerciseMode = RedisRollbackExerciseMode.RANDOM
     bk_biz_id: int = 0  # The biz where the drill ticket locates
 
@@ -74,7 +74,13 @@ class RedisRollbackExerciseConfig:
     bizs_high_priority: Optional[List[int]] = None  # Customed bizs with high priority
     clusters_ignored: Optional[List[int]] = None  # Customed clusters(id) to ignore
     bizs_ignored: Optional[List[int]] = None  # Customed bizs to ignore
-    cluster_types: Optional[List[str]] = None  # Customed ClusterTypes to exercise
+    cluster_types: List[str] = field(
+        default_factory=lambda: [
+            ClusterType.TendisTwemproxyRedisInstance.value,  # TendisCache 集群
+            ClusterType.TwemproxyTendisSSDInstance.value,  # TendisSSD 集群
+            ClusterType.TendisRedisInstance.value,  # Redis 主从
+        ]
+    )  # Customed ClusterTypes to exercise
 
     # Weighted selection: probability multipliers (how many times more likely to be selected)
     # Combined effect is multiplicative, e.g., high_priority + failed = 2.0 * 3.0 = 6x more likely
@@ -85,7 +91,7 @@ class RedisRollbackExerciseConfig:
 
     # Extra
     max_instances: int = 10  # Each round
-    rollback_days: List[int] = field(default_factory=lambda: [20, 10, 5, 3, 2, 1])
+    rollback_days: List[int] = field(default_factory=lambda: [7, 5, 3, 2, 1])
     polling_interval: int = 10  # sec
     polling_timeout: int = 3600  # sec
 
@@ -124,7 +130,7 @@ class RedisRollbackExercise:
         """
         logger.info(_("Starting Redis rollback exercise task generation"))
 
-        if not self.config.switch:
+        if not self.config.enabled:
             logger.info(_("Redis rollback exercise is disabled, exiting..."))
             return
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_task_delete.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_task_delete.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext as _
 from backend.configuration.constants import DBType
 from backend.db_meta.enums import DestroyedStatus
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
+from backend.db_services.redis.util import is_have_proxy
 from backend.flow.consts import DBActuatorTypeEnum, RedisActuatorActionEnum
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
@@ -182,21 +183,21 @@ class RedisDataStructureTaskDeleteFlow(object):
             # 重新赋值，因为下架redis时cluster会被赋值
             # act_kwargs.cluster = {**tasks_info}
             act_kwargs.cluster["cluster_type"] = act_kwargs.cluster["temp_cluster_type"]
+            if is_have_proxy(act_kwargs.cluster["cluster_type"]):
+                act_kwargs.cluster["operate"] = (
+                    DBActuatorTypeEnum.Proxy.value + "_" + RedisActuatorActionEnum.Shutdown.value
+                )
+                proxy_ip, proxy_port = act_kwargs.cluster["temp_cluster_proxy"].split(":")
+                act_kwargs.cluster["proxy_ip"] = proxy_ip
+                act_kwargs.cluster["proxy_port"] = int(proxy_port)
 
-            act_kwargs.cluster["operate"] = (
-                DBActuatorTypeEnum.Proxy.value + "_" + RedisActuatorActionEnum.Shutdown.value
-            )
-            proxy_ip, proxy_port = act_kwargs.cluster["temp_cluster_proxy"].split(":")
-            act_kwargs.cluster["proxy_ip"] = proxy_ip
-            act_kwargs.cluster["proxy_port"] = int(proxy_port)
-
-            act_kwargs.exec_ip = act_kwargs.cluster["proxy_ip"]
-            act_kwargs.get_redis_payload_func = RedisActPayload.proxy_shutdown_payload.__name__
-            redis_pipeline.add_act(
-                act_name=_("{}下架proxy实例").format(act_kwargs.cluster["proxy_ip"]),
-                act_component_code=ExecuteDBActuatorScriptComponent.code,
-                kwargs=asdict(act_kwargs),
-            )
+                act_kwargs.exec_ip = act_kwargs.cluster["proxy_ip"]
+                act_kwargs.get_redis_payload_func = RedisActPayload.proxy_shutdown_payload.__name__
+                redis_pipeline.add_act(
+                    act_name=_("{}下架proxy实例").format(act_kwargs.cluster["proxy_ip"]),
+                    act_component_code=ExecuteDBActuatorScriptComponent.code,
+                    kwargs=asdict(act_kwargs),
+                )
             # #### 下架旧实例完成 #############################################################################
             act_kwargs.cluster = {
                 "related_rollback_bill_id": info["related_rollback_bill_id"],

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_download_backup_files.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_download_backup_files.py
@@ -29,7 +29,7 @@ class RedisDownloadBackupfile(BaseService):
     """
 
     __need_schedule__ = True
-    interval = StaticIntervalGenerator(60)
+    interval = StaticIntervalGenerator(3)  # poll every 3 sec
 
     def _execute(self, data, parent_data) -> bool:
         kwargs = data.get_one_of_inputs("kwargs")
@@ -66,7 +66,11 @@ class RedisDownloadBackupfile(BaseService):
         result_response = RedisBackupApi.download_result({"bill_id": backup_bill_id})
         # 如何判断
         if result_response is not None and "total" in result_response:
-            if result_response["total"]["todo"] == 0 and result_response["total"]["fail"] == 0:
+            if (
+                result_response["total"]["todo"] == 0
+                and result_response["total"]["doing"] == 0
+                and result_response["total"]["fail"] == 0
+            ):
                 self.log_info(_("{} 下载成功").format(backup_bill_id))
                 self.finish_schedule()
                 return True

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -204,7 +204,6 @@ class RedisFlowPollingService(RedisLogCapturingService):
                 self._update_task_status(flow_type, False)
                 return False
             case _:
-                self.log_info(_("Polling: flow {} with status: {}").format(flow_obj_id, status))
                 return True
 
     def __schedule(self, data, parent_data, callback_data=None) -> bool:


### PR DESCRIPTION
- 新增 构造原子任务对 `aof.gz` 格式备份文件的支持
- 修改 回档演练默认天数、默认集群类型
- 修复 备份文件下载状态的判断条件
- 修复 销毁任务对主从类型多余的proxy下架操作