### PR TITLE
fix(mysql): mysql-crond-missing-bk-biz-id #15587

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-crond/pkg/config/job_config.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/pkg/config/job_config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"bytes"
+	"dbm-services/mysql/db-tools/mysql-crond/pkg"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -139,11 +141,14 @@ func InitJobsConfig() error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			slog.Info("init jobs config jobs-config file not found, try create it")
-			_, err := os.Create(RuntimeConfig.JobsConfigFile)
+			_f, err := os.Create(RuntimeConfig.JobsConfigFile)
 			if err != nil {
 				slog.Error("init jobs config create empty jobs-config file", slog.String("error", err.Error()))
 				return err
 			}
+			defer func() {
+				_ = _f.Close()
+			}()
 
 			err = os.Chown(RuntimeConfig.JobsConfigFile, JobsUserUid, JobsUserGid)
 			if err != nil {
@@ -168,6 +173,16 @@ func InitJobsConfig() error {
 		slog.Error("init jobs config", slog.String("error", err.Error()))
 		return err
 	}
+
+	bkBizId, err := pkg.GetBkBizId()
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	JobsConfig.BkBizId = bkBizId
 
 	for _, j := range JobsConfig.Jobs {
 		err := j.validate()

--- a/dbm-services/mysql/db-tools/mysql-crond/pkg/get_bk_biz_id.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/pkg/get_bk_biz_id.go
@@ -1,0 +1,49 @@
+package pkg
+
+import (
+	"dbm-services/common/reverseapi/define"
+	"dbm-services/common/reverseapi/define/mysql"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+func GetBkBizId() (int, error) {
+	filePath := filepath.Join(
+		define.DefaultCommonConfigDir,
+		define.DefaultInstanceInfoFileName,
+	)
+	f, err := os.OpenFile(filePath, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return 0, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return 0, err
+	}
+
+	var commInfos []mysql.ProxyInstanceInfo
+	err = json.Unmarshal(b, &commInfos)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return 0, err
+	}
+
+	if len(commInfos) == 0 {
+		slog.Error("bk_biz_id updater job", slog.String("err", "no instance info"))
+		return 0, errors.New("no instance info")
+	}
+
+	bkBizId := commInfos[0].BkBizId
+
+	return bkBizId, nil
+}

--- a/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/bk_biz_id_updater/updater.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/bk_biz_id_updater/updater.go
@@ -1,0 +1,69 @@
+package bk_biz_id_updater
+
+import (
+	"dbm-services/mysql/db-tools/mysql-crond/pkg"
+	"dbm-services/mysql/db-tools/mysql-crond/pkg/config"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/robfig/cron/v3"
+	"gopkg.in/yaml.v2"
+)
+
+func Register(cj *cron.Cron) {
+	id, err := cj.AddFunc(
+		"@every 10m",
+		func() {
+			err := Updater()
+			if err != nil {
+				slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+			} else {
+				slog.Info("bk_biz_id updater job finished")
+			}
+		},
+	)
+	if err != nil {
+		slog.Error("register bk_biz_id updater job", slog.String("err", err.Error()))
+	} else {
+		slog.Info("register bk_biz_id updater job success", slog.Int("entry id", int(id)))
+	}
+}
+
+func Updater() error {
+	bkBizId, err := pkg.GetBkBizId()
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	content, err := os.ReadFile(config.RuntimeConfig.JobsConfigFile)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return err
+	}
+
+	err = yaml.Unmarshal(content, &config.JobsConfig)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return err
+	}
+
+	config.JobsConfig.BkBizId = bkBizId
+
+	content, err = yaml.Marshal(config.JobsConfig)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return err
+	}
+
+	err = os.WriteFile(config.RuntimeConfig.JobsConfigFile, content, 0644)
+	if err != nil {
+		slog.Error("bk_biz_id updater job", slog.String("err", err.Error()))
+		return err
+	}
+	return nil
+}

--- a/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/init.go
+++ b/dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/init.go
@@ -1,6 +1,7 @@
 package third_party
 
 import (
+	"dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/bk_biz_id_updater"
 	"dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/instance_info_updater"
 	"dbm-services/mysql/db-tools/mysql-crond/pkg/third_party/nginx_updater"
 	"errors"
@@ -14,6 +15,7 @@ func init() {
 	ThirdPartyRegisters = []func(*cron.Cron){
 		nginx_updater.Register,
 		instance_info_updater.Register,
+		bk_biz_id_updater.Register,
 	}
 }
 
@@ -28,5 +30,9 @@ func Updater() (err error) {
 		err = errors.Join(err, e)
 	}
 
+	e = bk_biz_id_updater.Updater()
+	if e != nil {
+		err = errors.Join(err, e)
+	}
 	return err
 }

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_event.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_event.go
@@ -15,12 +15,12 @@ func SendMonitorEvent(name string, msg string, customDimension map[string]interf
 	crondManager := ma.NewManager(config.MonitorConfig.ApiUrl)
 
 	additionDimension := map[string]interface{}{
-		"appid":          config.MonitorConfig.BkBizId,
-		"cluster_domain": config.MonitorConfig.ImmuteDomain,
-		"cluster_type":   config.MonitorConfig.ClusterType,
-		"machine_type":   config.MonitorConfig.MachineType,
-		"bk_cloud_id":    *config.MonitorConfig.BkCloudID,
-		// "server_ip":                     config.MonitorConfig.Ip,   // 监控插件服务实例维度和自定义上报维度统一
+		"appid":                         config.MonitorConfig.BkBizId,
+		"bk_biz_id":                     config.MonitorConfig.BkBizId,
+		"cluster_domain":                config.MonitorConfig.ImmuteDomain,
+		"cluster_type":                  config.MonitorConfig.ClusterType,
+		"machine_type":                  config.MonitorConfig.MachineType,
+		"bk_cloud_id":                   *config.MonitorConfig.BkCloudID,
 		"instance_port":                 config.MonitorConfig.Port,
 		"instance_host":                 config.MonitorConfig.Ip,
 		"bk_target_service_instance_id": strconv.FormatInt(*config.MonitorConfig.BkInstanceId, 10),

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_metrics.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/send_monitor_metrics.go
@@ -14,6 +14,8 @@ func SendMonitorMetrics(name string, value int64, customDimension map[string]int
 	crondManager := ma.NewManager(config.MonitorConfig.ApiUrl)
 
 	additionDimension := map[string]interface{}{
+		"appid":                         config.MonitorConfig.BkBizId,
+		"bk_biz_id":                     config.MonitorConfig.BkBizId,
 		"cluster_domain":                config.MonitorConfig.ImmuteDomain,
 		"cluster_type":                  config.MonitorConfig.ClusterType,
 		"machine_type":                  config.MonitorConfig.MachineType,


### PR DESCRIPTION
1. mysql-crond 增加自动更新 jobs-config bkbizid 的内置任务
2. mysql-crond 启动时会从 comm_info/instance_info 更新 jobs-config bkbizid
3. mysql-monitor send event/metric 默认内置 monitorConfig.bkbizid