### PR TITLE
feat(mysql): fix-wrong-time-in-mysql-slow-log #15988

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/config/init.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/config/init.go
@@ -58,9 +58,6 @@ func InitConfig(configPath string) error {
 		slog.Error("init config", slog.String("error", err.Error()))
 		return err
 	}
-	defer func() {
-		_ = fl.Unlock()
-	}()
 
 	content, err := os.ReadFile(configPath)
 	if err != nil {

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/rotateslowlog/custom_report.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/rotateslowlog/custom_report.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/jmoiron/sqlx"
@@ -22,18 +24,26 @@ var executable string
 var reporterName = "report-slowlog"
 var schemaHeadPattern *regexp.Regexp
 var useDBPattern *regexp.Regexp
+var commentHeadTimePattern *regexp.Regexp
+var setTimestampPattern *regexp.Regexp
+var queryTimePattern *regexp.Regexp
 
 func init() {
 	executable, _ = os.Executable()
 	schemaHeadPattern = regexp.MustCompile(`(?smU)^#\s+Schema:\s+(.*)\s+.*$`)
 	useDBPattern = regexp.MustCompile(`(?smUi)^use\s+(.*)\s*;$`)
+	commentHeadTimePattern = regexp.MustCompile(`(?m)^#\s+Time:\s+(.*)$`)
+	setTimestampPattern = regexp.MustCompile(`(?m)^SET\s+timestamp\s*=\s*(\d+)\s*;$`)
+	queryTimePattern = regexp.MustCompile(`(?m)^#\s+Query_time:\s+([\d.]+)`)
 }
 
 type SlowlogReport struct {
-	db                   *sqlx.DB
-	currentDB            string
-	currentDBRegFilePath string
-	reporter             *reportlog.Reporter
+	db                         *sqlx.DB
+	currentDB                  string
+	currentDBRegFilePath       string
+	commentHeadTime            string
+	commentHeadTimeRegFilePath string
+	reporter                   *reportlog.Reporter
 }
 
 func (c *SlowlogReport) Run() (msg string, err error) {
@@ -64,6 +74,11 @@ func (c *SlowlogReport) Run() (msg string, err error) {
 		return "", err
 	}
 
+	err = c.loadCommentHeadTimeFromDisk()
+	if err != nil {
+		return "", err
+	}
+
 	err = c.initLogReporter()
 	if err != nil {
 		return "", err
@@ -87,8 +102,7 @@ func (c *SlowlogReport) Run() (msg string, err error) {
 		if line == "" ||
 			strings.HasPrefix(line, "Time") ||
 			strings.HasPrefix(line, "Tcp") ||
-			strings.HasPrefix(line, "/") ||
-			strings.HasPrefix(line, "# Time") {
+			strings.HasPrefix(line, "/") {
 			continue
 		}
 
@@ -136,21 +150,29 @@ func (c *SlowlogReport) initLogReporter() error {
 	return nil
 }
 
-func (c *SlowlogReport) loadCurrentDBFromDisk() error {
-	content, err := os.ReadFile(c.currentDBRegFilePath)
+// loadStringFromDisk 从磁盘加载字符串内容的通用方法
+func loadStringFromDisk(filePath string) (string, error) {
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			c.currentDB = ""
-			f, err := os.OpenFile(c.currentDBRegFilePath, os.O_RDONLY|os.O_CREATE, 0755)
+			f, err := os.OpenFile(filePath, os.O_RDONLY|os.O_CREATE, 0755)
 			if err != nil {
-				return err
+				return "", err
 			}
 			_ = f.Close()
-		} else {
-			return err
+			return "", nil
 		}
+		return "", err
 	}
-	c.currentDB = strings.TrimSpace(string(content))
+	return strings.TrimSpace(string(content)), nil
+}
+
+func (c *SlowlogReport) loadCurrentDBFromDisk() error {
+	val, err := loadStringFromDisk(c.currentDBRegFilePath)
+	if err != nil {
+		return err
+	}
+	c.currentDB = val
 	return nil
 }
 
@@ -164,9 +186,44 @@ func (c *SlowlogReport) rewriteSeg(slowQuerySeg []string) error {
 		}
 	}
 
+	hasCommentHeadTime, timeStr := c.catchCommentHeadTime(slowQuerySeg)
+	if hasCommentHeadTime {
+		c.commentHeadTime = timeStr
+		err := os.WriteFile(c.commentHeadTimeRegFilePath, []byte(timeStr), 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	var queryStartTs int64
+	var hasValidQueryStartTs bool
+	// 对比 commentHeadTime 和 SET timestamp 的时间戳
+	hasSetTimestamp, setTs := c.catchSetTimestamp(slowQuerySeg)
+	if hasSetTimestamp && c.commentHeadTime != "" {
+		commentTs, err := parseTimeToTimestamp(c.commentHeadTime)
+		if err == nil {
+			if commentTs == setTs {
+				// 时间戳相同，计算 query_start_ts
+				hasQueryTime, queryTime := c.catchQueryTime(slowQuerySeg)
+				if hasQueryTime {
+					queryStartTs = setTs - int64(queryTime)
+					hasValidQueryStartTs = true
+				}
+			} else {
+				queryStartTs = setTs
+				hasValidQueryStartTs = true
+			}
+		}
+	}
+
+	// 只有正常赋值才将 queryStartTs 写入 logSegContent 第一行
+	var logSegContent []string
+	if hasValidQueryStartTs {
+		logSegContent = append(logSegContent, fmt.Sprintf("# Query_start_ts: %d", queryStartTs))
+	}
+
 	hasSchemaDB, _ := c.catchSchemaDB(slowQuerySeg)
 
-	var logSegContent []string
 	for _, line := range slowQuerySeg {
 		if !hasSchemaDB && strings.HasPrefix(line, "# Query_time") {
 			logSegContent = append(logSegContent, fmt.Sprintf("# Schema: %s", c.currentDB))
@@ -187,14 +244,62 @@ func (c *SlowlogReport) catchUseDB(slowQuerySeg []string) string {
 	return ""
 }
 
-func (c *SlowlogReport) catchSchemaDB(slowQuerySeg []string) (bool, string) {
+// catchByPattern 通用的正则匹配方法
+func catchByPattern(slowQuerySeg []string, pattern *regexp.Regexp) (bool, string) {
 	for _, line := range slowQuerySeg {
-		m := schemaHeadPattern.FindAllStringSubmatch(line, -1)
+		m := pattern.FindAllStringSubmatch(line, -1)
 		if len(m) > 0 {
 			return true, strings.TrimSpace(m[0][1])
 		}
 	}
 	return false, ""
+}
+
+func (c *SlowlogReport) catchSchemaDB(slowQuerySeg []string) (bool, string) {
+	return catchByPattern(slowQuerySeg, schemaHeadPattern)
+}
+
+func (c *SlowlogReport) loadCommentHeadTimeFromDisk() error {
+	val, err := loadStringFromDisk(c.commentHeadTimeRegFilePath)
+	if err != nil {
+		return err
+	}
+	c.commentHeadTime = val
+	return nil
+}
+
+func (c *SlowlogReport) catchCommentHeadTime(slowQuerySeg []string) (bool, string) {
+	return catchByPattern(slowQuerySeg, commentHeadTimePattern)
+}
+
+// catchSetTimestamp 从 slowQuerySeg 中提取 SET timestamp=xxx 的时间戳
+func (c *SlowlogReport) catchSetTimestamp(slowQuerySeg []string) (bool, int64) {
+	for _, line := range slowQuerySeg {
+		m := setTimestampPattern.FindAllStringSubmatch(line, -1)
+		if len(m) > 0 {
+			tsStr := strings.TrimSpace(m[0][1])
+			ts, err := strconv.ParseInt(tsStr, 10, 64)
+			if err == nil {
+				return true, ts
+			}
+		}
+	}
+	return false, 0
+}
+
+// catchQueryTime 从 slowQuerySeg 中提取 Query_time 的值（秒）
+func (c *SlowlogReport) catchQueryTime(slowQuerySeg []string) (bool, float64) {
+	for _, line := range slowQuerySeg {
+		m := queryTimePattern.FindAllStringSubmatch(line, -1)
+		if len(m) > 0 {
+			qtStr := strings.TrimSpace(m[0][1])
+			qt, err := strconv.ParseFloat(qtStr, 64)
+			if err == nil {
+				return true, qt
+			}
+		}
+	}
+	return false, 0
 }
 
 func (c *SlowlogReport) Name() string {
@@ -207,6 +312,9 @@ func NewSlowlogReport(db *sqlx.DB) *SlowlogReport {
 		currentDBRegFilePath: filepath.Join(
 			cst.MySQLMonitorInstallPath, fmt.Sprintf("%d-current_db.reg", config.MonitorConfig.Port),
 		),
+		commentHeadTimeRegFilePath: filepath.Join(
+			cst.MySQLMonitorInstallPath, fmt.Sprintf("%d-comment_head_time.reg", config.MonitorConfig.Port),
+		),
 	}
 	return r
 }
@@ -218,4 +326,38 @@ func NewSlowlogReportItem(cc *monitoriteminterface.ConnectionCollect) monitorite
 
 func RegisterSlowlogReport() (string, monitoriteminterface.MonitorItemConstructorFuncType) {
 	return reporterName, NewSlowlogReportItem
+}
+
+// parseTimeToTimestamp 将三种不同格式的时间字符串转换为时间戳
+// 格式1: "260127  2:05:24" (YYMMDD  H:MM:SS，中间可能有多个空格)
+// 格式2: "2026-01-27T01:58:55.960323+08:00" (RFC3339Nano 带时区)
+// 格式3: "2026-01-24T19:03:14.039913Z" (RFC3339Nano UTC时区)
+func parseTimeToTimestamp(timeStr string) (int64, error) {
+	var t time.Time
+	var err error
+
+	// 尝试格式2和格式3: RFC3339Nano (带时区或UTC)
+	t, err = time.Parse(time.RFC3339Nano, timeStr)
+	if err == nil {
+		return t.Unix(), nil
+	}
+
+	// 尝试格式3的变体: RFC3339 (不带纳秒)
+	t, err = time.Parse(time.RFC3339, timeStr)
+	if err == nil {
+		return t.Unix(), nil
+	}
+
+	// 尝试格式1: "260127  2:05:24" (YYMMDD + 多个空格 + H:MM:SS)
+	// 先用正则标准化：将多个空格替换为单个空格
+	re := regexp.MustCompile(`\s+`)
+	normalizedStr := re.ReplaceAllString(timeStr, " ")
+
+	// 解析标准化后的格式，使用本地时区
+	t, err = time.ParseInLocation("060102 15:04:05", normalizedStr, time.Local)
+	if err == nil {
+		return t.Unix(), nil
+	}
+
+	return 0, fmt.Errorf("无法解析时间格式: %s", timeStr)
 }

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/slavestatus/slave_status.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/slavestatus/slave_status.go
@@ -119,14 +119,27 @@ func (s *slaveStatusChecker) skipErr() error {
 
 	if s.isOk() {
 		return nil
-	} else {
-		return errors.Errorf("err still stay after skip")
 	}
+
+	return errors.Errorf("err still stay after skip")
 }
 
 func (s *slaveStatusChecker) isOk() bool {
-	return strings.ToUpper(s.slaveStatus["Slave_IO_Running"].(string)) == "YES" &&
-		strings.ToUpper(s.slaveStatus["Slave_SQL_Running"].(string)) == "YES"
+	ioRunning, ok1 := s.getStringValue("Slave_IO_Running")
+	sqlRunning, ok2 := s.getStringValue("Slave_SQL_Running")
+	if !ok1 || !ok2 {
+		return false
+	}
+	return strings.ToUpper(ioRunning) == "YES" && strings.ToUpper(sqlRunning) == "YES"
+}
+
+func (s *slaveStatusChecker) getStringValue(key string) (string, bool) {
+	val, exists := s.slaveStatus[key]
+	if !exists {
+		return "", false
+	}
+	str, ok := val.(string)
+	return str, ok
 }
 
 func (s *slaveStatusChecker) masterHost() string {

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/run_checksum.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/cmd/run_checksum.go
@@ -46,58 +46,24 @@ func generateRun(mode config.CheckMode, configPath string) error {
 	}()
 
 	switch ck.Config.InnerRole {
-	case config.RoleMaster:
-		err = lock.TryLock()
-		if err != nil {
-			slog.Error("another checksum already running", slog.String("error", err.Error()))
-			return err
-		}
-		slog.Info("run checksum on master start")
-		err = ck.Run()
-		if err != nil {
-			slog.Error("run checksum on master", slog.String("error", err.Error()))
-			return err
-		}
-		slog.Info("run checksum on master finish")
-		return nil
-	case config.RoleRepeater:
+	case config.RoleMaster, config.RoleRepeater:
 		err = lock.TryLock()
 		if err != nil {
 			slog.Error("another checksum already running", slog.String("error", err.Error()))
 			return err
 		}
 
-		slog.Info("run checksum on repeater start")
+		roleName := string(ck.Config.InnerRole)
+		slog.Info(fmt.Sprintf("run checksum on %s start", roleName))
 		err = ck.Run()
 		if err != nil {
-			slog.Error("run checksum on repeater", slog.String("error", err.Error()))
+			slog.Error(fmt.Sprintf("run checksum on %s", roleName), slog.String("error", err.Error()))
 			return err
 		}
-		if ck.Mode == config.GeneralMode {
-			slog.Info("run checksum on repeater to report start")
-			err = ck.Report()
-			if err != nil {
-				slog.Error("run report on repeater", slog.String("error", err.Error()))
-				return err
-			}
-			slog.Info("run checksum on repeater to report finish")
-		}
-		slog.Info("run checksum on repeater finish")
+		slog.Info(fmt.Sprintf("run checksum on %s finish", roleName))
 		return nil
 	case config.RoleSlave:
-		slog.Info("run checksum on slave")
-		if ck.Mode == config.DemandMode {
-			err = fmt.Errorf("checksum bill should not run on slave")
-			slog.Error("role is slave", slog.String("error", err.Error()))
-			return err
-		}
-		slog.Info("run checksum on slave to report start")
-		err = ck.Report()
-		if err != nil {
-			slog.Error("run report on slave", slog.String("error", err.Error()))
-			return err
-		}
-		slog.Info("run checksum on slave to report finish")
+		slog.Info("run checksum on slave nothing to do")
 		return nil
 	default:
 		err := fmt.Errorf("unknown instance inner role: %s", ck.Config.InnerRole)
@@ -109,16 +75,16 @@ func generateRun(mode config.CheckMode, configPath string) error {
 func updateConfig(configPath string) error {
 	sii, err := getSelfInfo()
 	if err != nil {
-		slog.Error("init config", slog.String("error", err.Error()))
-		return nil
+		slog.Error("update config", slog.String("error", err.Error()))
+		return nil // 获取实例信息失败时，保持原配置继续运行
 	}
-	slog.Info("init config", slog.Any("sii", sii))
+	slog.Info("update config", slog.Any("sii", sii))
 
 	config.ChecksumConfig.InnerRole = config.InnerRoleEnum(sii.InstanceInnerRole)
 
 	cf, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
 	if err != nil {
-		slog.Error("init config", slog.String("error", err.Error()))
+		slog.Error("update config", slog.String("error", err.Error()))
 		return err
 	}
 	defer func() {
@@ -127,16 +93,16 @@ func updateConfig(configPath string) error {
 
 	b, err := yaml.Marshal(config.ChecksumConfig)
 	if err != nil {
-		slog.Error("init config", slog.String("error", err.Error()))
+		slog.Error("update config", slog.String("error", err.Error()))
 		return err
 	}
 
 	_, err = cf.WriteString(string(b) + "\n")
 	if err != nil {
-		slog.Error("init config", slog.String("error", err.Error()))
+		slog.Error("update config", slog.String("error", err.Error()))
 		return err
 	}
-	slog.Info("init config", slog.String("config", string(b)))
+	slog.Info("update config", slog.String("config", string(b)))
 	return nil
 }
 
@@ -148,18 +114,21 @@ func getSelfInfo() (sii *mysql.StorageInstanceInfo, err error) {
 	f, err := os.OpenFile(filePath, os.O_RDONLY, os.ModePerm)
 	if err != nil {
 		slog.Error(
-			"init config",
-			slog.String("err", err.Error()),
+			"get self info",
+			slog.String("error", err.Error()),
 			slog.String("filePath", filePath),
 		)
 		return nil, err
 	}
+	defer func() {
+		_ = f.Close()
+	}()
 
 	b, err := io.ReadAll(f)
 	if err != nil {
 		slog.Error(
-			"init config",
-			slog.String("err", err.Error()),
+			"get self info",
+			slog.String("error", err.Error()),
 		)
 		return nil, err
 	}
@@ -168,21 +137,23 @@ func getSelfInfo() (sii *mysql.StorageInstanceInfo, err error) {
 	err = json.Unmarshal(b, &siis)
 	if err != nil {
 		slog.Error(
-			"init config",
-			slog.String("err", err.Error()),
+			"get self info",
+			slog.String("error", err.Error()),
 		)
 		return nil, err
 	}
-	slog.Info("init config", slog.String("instance info", string(b)))
+	slog.Info("get self info", slog.String("instance info", string(b)))
 
-	idx := slices.IndexFunc(siis, func(ele mysql.StorageInstanceInfo) bool {
-		return ele.Ip == config.ChecksumConfig.Ip && ele.Port == config.ChecksumConfig.Port
-	})
+	idx := slices.IndexFunc(
+		siis, func(ele mysql.StorageInstanceInfo) bool {
+			return ele.Ip == config.ChecksumConfig.Ip && ele.Port == config.ChecksumConfig.Port
+		},
+	)
 	if idx < 0 {
 		err := fmt.Errorf("can't find %s:%d in %v", config.ChecksumConfig.Ip, config.ChecksumConfig.Port, siis)
 		slog.Error(
-			"init config",
-			slog.String("err", err.Error()),
+			"get self info",
+			slog.String("error", err.Error()),
 		)
 		return nil, err
 	}

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/go.mod
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
+	github.com/avast/retry-go/v5 v5.0.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/go.sum
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
+github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/checker.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/checker.go
@@ -3,17 +3,13 @@ package checker
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
-	"slices"
 	"strings"
 	"time"
 
 	"dbm-services/mysql/db-tools/mysql-table-checksum/pkg/config"
-	"dbm-services/mysql/db-tools/mysql-table-checksum/pkg/reporter"
 
 	_ "github.com/go-sql-driver/mysql" // mysql
 	"github.com/jmoiron/sqlx"
@@ -30,9 +26,9 @@ func NewChecker(mode config.CheckMode) (*Checker, error) {
 	}
 
 	checker := &Checker{
-		Config:   config.ChecksumConfig,
-		reporter: reporter.NewReporter(config.ChecksumConfig),
-		Mode:     mode,
+		Config: config.ChecksumConfig,
+		//reporter: reporter.NewReporter(config.ChecksumConfig),
+		Mode: mode,
 	}
 
 	// checker 需要一个序列化器方便打日志
@@ -51,10 +47,10 @@ func NewChecker(mode config.CheckMode) (*Checker, error) {
 		return nil, err
 	}
 
-	err := checker.prepareReplicateTable()
-	if err != nil {
-		return nil, err
-	}
+	//err := checker.prepareReplicateTable()
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	checker.applyForceSwitchStrategy(commonForceSwitchStrategies)
 	checker.applyDefaultSwitchStrategy(commonDefaultSwitchStrategies)
@@ -67,9 +63,9 @@ func NewChecker(mode config.CheckMode) (*Checker, error) {
 		checker.applyForceKVStrategy(generalForceKVStrategies)
 		checker.applyDefaultKVStrategy(generalDefaultKVStrategies)
 
-		if err := checker.validateHistoryTable(); err != nil {
-			return nil, err
-		}
+		//if err := checker.validateHistoryTable(); err != nil {
+		//	return nil, err
+		//}
 	} else {
 		checker.applyForceSwitchStrategy(demandForceSwitchStrategies)
 		checker.applyDefaultSwitchStrategy(demandDefaultSwitchStrategies)
@@ -143,54 +139,54 @@ func (r *Checker) validateSlaves() error {
 		实际是要能 select 所有库表, 但是权限不好查
 		这里只查下能不能连接
 	*/
-	for _, slave := range r.Config.Slaves {
-		_, err := sqlx.Connect(
-			"mysql",
-			fmt.Sprintf(
-				"%s:%s@tcp(%s:%d)/",
-				slave.User,
-				slave.Password,
-				slave.Ip,
-				slave.Port,
-			),
-		)
-		if err != nil {
-			slog.Error("validate slaves connect", slog.String("error", err.Error()))
-			return err
-		}
-	}
+	//for _, slave := range r.Config.Slaves {
+	//	_, err := sqlx.Connect(
+	//		"mysql",
+	//		fmt.Sprintf(
+	//			"%s:%s@tcp(%s:%d)/",
+	//			slave.User,
+	//			slave.Password,
+	//			slave.Ip,
+	//			slave.Port,
+	//		),
+	//	)
+	//	if err != nil {
+	//		slog.Error("validate slaves connect", slog.String("error", err.Error()))
+	//		return err
+	//	}
+	//}
 	return nil
 }
 
-func (r *Checker) prepareReplicateTable() error {
-	ctSql := fmt.Sprintf(
-		`CREATE TABLE IF NOT EXISTS %s.%s (
-     master_ip      CHAR(32)     default '0.0.0.0',
-     master_port    INT          default 3306,
-     db             CHAR(64)     NOT NULL,
-     tbl            CHAR(64)     NOT NULL,
-     chunk          INT          NOT NULL,
-     chunk_time     FLOAT            NULL,
-     chunk_index    VARCHAR(200)     NULL,
-     lower_boundary BLOB             NULL,
-     upper_boundary BLOB             NULL,
-     this_crc       CHAR(40)     NOT NULL,
-     this_cnt       INT          NOT NULL,
-     master_crc     CHAR(40)         NULL,
-     master_cnt     INT              NULL,
-     ts             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-     PRIMARY KEY (master_ip, master_port, db, tbl, chunk),
-     INDEX db_tbl_chunk (db, tbl, chunk),
-     INDEX ts_db_tbl (ts, db, tbl)
-  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`, r.resultDB, r.resultTbl,
-	)
-	_, err := r.db.Exec(ctSql)
-	if err != nil {
-		slog.Error("prepare replicate table error", slog.String("error", err.Error()))
-		return err
-	}
-	return nil
-}
+//func (r *Checker) prepareReplicateTable() error {
+//	ctSql := fmt.Sprintf(
+//		`CREATE TABLE IF NOT EXISTS %s.%s (
+//     master_ip      CHAR(32)     default '0.0.0.0',
+//     master_port    INT          default 3306,
+//     db             CHAR(64)     NOT NULL,
+//     tbl            CHAR(64)     NOT NULL,
+//     chunk          INT          NOT NULL,
+//     chunk_time     FLOAT            NULL,
+//     chunk_index    VARCHAR(200)     NULL,
+//     lower_boundary BLOB             NULL,
+//     upper_boundary BLOB             NULL,
+//     this_crc       CHAR(40)     NOT NULL,
+//     this_cnt       INT          NOT NULL,
+//     master_crc     CHAR(40)         NULL,
+//     master_cnt     INT              NULL,
+//     ts             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+//     PRIMARY KEY (master_ip, master_port, db, tbl, chunk),
+//     INDEX db_tbl_chunk (db, tbl, chunk),
+//     INDEX ts_db_tbl (ts, db, tbl)
+//  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`, r.resultDB, r.resultTbl,
+//	)
+//	_, err := r.db.Exec(ctSql)
+//	if err != nil {
+//		slog.Error("prepare replicate table error", slog.String("error", err.Error()))
+//		return err
+//	}
+//	return nil
+//}
 
 func (r *Checker) prepareDsnsTable() error {
 	_, err := r.db.Exec(`DROP TABLE IF EXISTS dsns`)
@@ -225,142 +221,142 @@ func (r *Checker) prepareDsnsTable() error {
 	return nil
 }
 
-func (r *Checker) validateHistoryTable() error {
-	r.hasHistoryTable = false
-
-	var _r interface{}
-	err := r.db.Get(
-		&_r,
-		`SELECT 1 FROM INFORMATION_SCHEMA.TABLES `+
-			`WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND TABLE_TYPE='BASE TABLE'`,
-		r.resultDB,
-		r.resultHistoryTable,
-	)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			slog.Info("history table not found")
-			if r.Config.InnerRole == config.RoleSlave {
-				slog.Info("no need create history table", slog.String("inner role", string(r.Config.InnerRole)))
-				return nil
-			} else {
-				slog.Info("create history table", slog.String("inner role", string(r.Config.InnerRole)))
-
-				err := r.db.Get(
-					&_r,
-					`SELECT 1 FROM INFORMATION_SCHEMA.TABLES `+
-						`WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND TABLE_TYPE='BASE TABLE'`,
-					r.resultDB,
-					r.resultTbl,
-				)
-
-				if err != nil {
-					if errors.Is(err, sql.ErrNoRows) {
-						slog.Info("checksum result table not found")
-						return nil
-					} else {
-						slog.Error("try to find checksum result table failed", slog.String("error", err.Error()))
-						return err
-					}
-				}
-
-				// 为了兼容 flashback, 这里拼上库前缀
-				_, err = r.db.Exec(
-					fmt.Sprintf(
-						`CREATE TABLE IF NOT EXISTS %s.%s LIKE %s.%s`,
-						r.resultDB,
-						r.resultHistoryTable,
-						r.resultDB,
-						r.resultTbl,
-					),
-				)
-				if err != nil {
-					slog.Error("create history table", slog.String("error", err.Error()))
-					return err
-				}
-
-				// 为了兼容 flashback, 这里拼上库前缀
-				_, err = r.db.Exec(
-					fmt.Sprintf(
-						`ALTER TABLE %s.%s ADD reported int default 0, `+
-							`ADD INDEX idx_reported(reported), `+
-							`DROP PRIMARY KEY, `+
-							`MODIFY ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, `+
-							`ADD PRIMARY KEY(master_ip, master_port, db, tbl, chunk, ts)`,
-						r.resultDB,
-						r.resultHistoryTable,
-					),
-				)
-				if err != nil {
-					slog.Error("add column and index to history table", slog.String("error", err.Error()))
-					return err
-				}
-			}
-		} else {
-			slog.Error("check history table exists", slog.String("error", err.Error()))
-			return err
-		}
-	}
-	r.hasHistoryTable = true
-
-	/*
-		1. 对比结果表和历史表结构, 历史表应该多出一个 reported int default 0
-		2. 历史表主键检查
-	*/
-	var diffColumn struct {
-		TableName       string `db:"TABLE_NAME"`
-		ColumnName      string `db:"COLUMN_NAME"`
-		OrdinalPosition int    `db:"ORDINAL_POSITION"`
-		DataType        string `db:"DATA_TYPE"`
-		ColumnType      string `db:"COLUMN_TYPE"`
-		RowCount        int    `db:"ROW_COUNT"`
-	}
-	err = r.db.Get(
-		&diffColumn,
-		fmt.Sprintf(
-			`SELECT `+
-				`TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, DATA_TYPE, COLUMN_TYPE, COUNT(1) as ROW_COUNT `+
-				`FROM INFORMATION_SCHEMA.COLUMNS WHERE `+
-				`TABLE_SCHEMA = '%s' AND TABLE_NAME in ('%s', '%s') `+
-				`GROUP BY COLUMN_NAME, ORDINAL_POSITION, DATA_TYPE, COLUMN_TYPE HAVING ROW_COUNT <> 2`,
-			r.resultDB,
-			r.resultTbl,
-			r.resultHistoryTable,
-		),
-	)
-	if err != nil {
-		slog.Error("compare result table column", slog.String("error", err.Error()))
-		return err
-	}
-
-	if diffColumn.TableName != r.resultHistoryTable ||
-		diffColumn.ColumnName != "reported" ||
-		diffColumn.DataType != "int" {
-		err = fmt.Errorf("%s need column as 'reported int default 0'", r.resultHistoryTable)
-		slog.Error("check history table reported column", slog.String("error", err.Error()))
-		return nil
-	}
-
-	var pkColumns []string
-	err = r.db.Select(
-		&pkColumns,
-		fmt.Sprintf(
-			`SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS `+
-				`WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND INDEX_NAME = 'PRIMARY' `+
-				`ORDER BY SEQ_IN_INDEX`,
-			r.resultDB,
-			r.resultHistoryTable,
-		),
-	)
-	if err != nil {
-		slog.Error("check history table primary key", slog.String("error", err.Error()))
-		return err
-	}
-
-	if slices.Compare(pkColumns, []string{"master_ip", "master_port", "db", "tbl", "chunk", "ts"}) != 0 {
-		err = fmt.Errorf("history table must has primary as (master_ip, master_port, db, tbl, chunk, ts])")
-		slog.Error("check history table primary key", slog.String("error", err.Error()))
-		return err
-	}
-
-	return nil
-}
+//func (r *Checker) validateHistoryTable() error {
+//	r.hasHistoryTable = false
+//
+//	var _r interface{}
+//	err := r.db.Get(
+//		&_r,
+//		`SELECT 1 FROM INFORMATION_SCHEMA.TABLES `+
+//			`WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND TABLE_TYPE='BASE TABLE'`,
+//		r.resultDB,
+//		r.resultHistoryTable,
+//	)
+//	if err != nil {
+//		if errors.Is(err, sql.ErrNoRows) {
+//			slog.Info("history table not found")
+//			if r.Config.InnerRole == config.RoleSlave {
+//				slog.Info("no need create history table", slog.String("inner role", string(r.Config.InnerRole)))
+//				return nil
+//			} else {
+//				slog.Info("create history table", slog.String("inner role", string(r.Config.InnerRole)))
+//
+//				err := r.db.Get(
+//					&_r,
+//					`SELECT 1 FROM INFORMATION_SCHEMA.TABLES `+
+//						`WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND TABLE_TYPE='BASE TABLE'`,
+//					r.resultDB,
+//					r.resultTbl,
+//				)
+//
+//				if err != nil {
+//					if errors.Is(err, sql.ErrNoRows) {
+//						slog.Info("checksum result table not found")
+//						return nil
+//					} else {
+//						slog.Error("try to find checksum result table failed", slog.String("error", err.Error()))
+//						return err
+//					}
+//				}
+//
+//				// 为了兼容 flashback, 这里拼上库前缀
+//				_, err = r.db.Exec(
+//					fmt.Sprintf(
+//						`CREATE TABLE IF NOT EXISTS %s.%s LIKE %s.%s`,
+//						r.resultDB,
+//						r.resultHistoryTable,
+//						r.resultDB,
+//						r.resultTbl,
+//					),
+//				)
+//				if err != nil {
+//					slog.Error("create history table", slog.String("error", err.Error()))
+//					return err
+//				}
+//
+//				// 为了兼容 flashback, 这里拼上库前缀
+//				_, err = r.db.Exec(
+//					fmt.Sprintf(
+//						`ALTER TABLE %s.%s ADD reported int default 0, `+
+//							`ADD INDEX idx_reported(reported), `+
+//							`DROP PRIMARY KEY, `+
+//							`MODIFY ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, `+
+//							`ADD PRIMARY KEY(master_ip, master_port, db, tbl, chunk, ts)`,
+//						r.resultDB,
+//						r.resultHistoryTable,
+//					),
+//				)
+//				if err != nil {
+//					slog.Error("add column and index to history table", slog.String("error", err.Error()))
+//					return err
+//				}
+//			}
+//		} else {
+//			slog.Error("check history table exists", slog.String("error", err.Error()))
+//			return err
+//		}
+//	}
+//	r.hasHistoryTable = true
+//
+//	/*
+//		1. 对比结果表和历史表结构, 历史表应该多出一个 reported int default 0
+//		2. 历史表主键检查
+//	*/
+//	var diffColumn struct {
+//		TableName       string `db:"TABLE_NAME"`
+//		ColumnName      string `db:"COLUMN_NAME"`
+//		OrdinalPosition int    `db:"ORDINAL_POSITION"`
+//		DataType        string `db:"DATA_TYPE"`
+//		ColumnType      string `db:"COLUMN_TYPE"`
+//		RowCount        int    `db:"ROW_COUNT"`
+//	}
+//	err = r.db.Get(
+//		&diffColumn,
+//		fmt.Sprintf(
+//			`SELECT `+
+//				`TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, DATA_TYPE, COLUMN_TYPE, COUNT(1) as ROW_COUNT `+
+//				`FROM INFORMATION_SCHEMA.COLUMNS WHERE `+
+//				`TABLE_SCHEMA = '%s' AND TABLE_NAME in ('%s', '%s') `+
+//				`GROUP BY TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, DATA_TYPE, COLUMN_TYPE HAVING ROW_COUNT <> 2`,
+//			r.resultDB,
+//			r.resultTbl,
+//			r.resultHistoryTable,
+//		),
+//	)
+//	if err != nil {
+//		slog.Error("compare result table column", slog.String("error", err.Error()))
+//		return err
+//	}
+//
+//	if diffColumn.TableName != r.resultHistoryTable ||
+//		diffColumn.ColumnName != "reported" ||
+//		diffColumn.DataType != "int" {
+//		err = fmt.Errorf("%s need column as 'reported int default 0'", r.resultHistoryTable)
+//		slog.Error("check history table reported column", slog.String("error", err.Error()))
+//		return nil
+//	}
+//
+//	var pkColumns []string
+//	err = r.db.Select(
+//		&pkColumns,
+//		fmt.Sprintf(
+//			`SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS `+
+//				`WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND INDEX_NAME = 'PRIMARY' `+
+//				`ORDER BY SEQ_IN_INDEX`,
+//			r.resultDB,
+//			r.resultHistoryTable,
+//		),
+//	)
+//	if err != nil {
+//		slog.Error("check history table primary key", slog.String("error", err.Error()))
+//		return err
+//	}
+//
+//	if slices.Compare(pkColumns, []string{"master_ip", "master_port", "db", "tbl", "chunk", "ts"}) != 0 {
+//		err = fmt.Errorf("history table must has primary as (master_ip, master_port, db, tbl, chunk, ts])")
+//		slog.Error("check history table primary key", slog.String("error", err.Error()))
+//		return err
+//	}
+//
+//	return nil
+//}

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/define.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/define.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"dbm-services/mysql/db-tools/mysql-table-checksum/pkg/config"
-	"dbm-services/mysql/db-tools/mysql-table-checksum/pkg/reporter"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -28,7 +27,7 @@ type Checker struct {
 	resultDB           string
 	resultTbl          string
 	hasHistoryTable    bool
-	reporter           *reporter.Reporter
+	//reporter           *reporter.Reporter
 }
 
 // ChecksumSummary 结果汇总报表

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/move_result.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/move_result.go
@@ -35,12 +35,12 @@ func (r *Checker) moveResult() error {
 		columns = append(columns, col)
 	}
 
-	err = r.validateHistoryTable()
-	if err != nil {
-		slog.Error("move result validate history table again", slog.String("error", err.Error()))
-		return err
-	}
-	slog.Info("move result validate history table again success")
+	//err = r.validateHistoryTable()
+	//if err != nil {
+	//	slog.Error("move result validate history table again", slog.String("error", err.Error()))
+	//	return err
+	//}
+	//slog.Info("move result validate history table success")
 
 	//conn, err := r.db.Conn(context.Background())
 	//if err != nil {

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/report.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/report.go
@@ -1,8 +1,6 @@
 package checker
 
 import (
-	"context"
-	"dbm-services/mysql/db-tools/mysql-table-checksum/pkg/reporter"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -50,87 +48,87 @@ func (r *Checker) masterHosts() (ip string, port int, err error) {
 	return
 }
 
-// Report 只在 repeater, slave 的例行校验做上报
-func (r *Checker) Report() error {
-	if !r.hasHistoryTable {
-		slog.Info("report history table not found")
-		return nil
-	}
-
-	masterIP, masterPort, err := r.masterHosts()
-	if err != nil {
-		slog.Error("get master hosts: ", slog.String("error", err.Error()))
-		return err
-	}
-	slog.Info(
-		"query master info",
-		slog.String("master ip", masterIP), slog.Int("master port", masterPort),
-	)
-
-	tx, err := r.conn.BeginTxx(context.Background(), nil)
-	if err != nil {
-		slog.Error("start transaction: ", slog.String("error", err.Error()))
-		return err
-	}
-	defer func() {
-		_ = tx.Commit()
-	}()
-
-	rows, err := tx.Queryx(
-		fmt.Sprintf(
-			`SELECT master_ip, master_port,
-									db, tbl,
-									chunk, chunk_time, chunk_index,
-									lower_boundary, upper_boundary,
-									this_crc, this_cnt, master_crc, master_cnt, ts
-							FROM %s WHERE master_ip = ? AND master_port = ? AND reported = 0
-										AND (this_crc <> master_crc or this_cnt <> master_cnt)
-							UNION
-							SELECT master_ip, master_port,
-							       db, tbl,
-							       chunk, chunk_time, chunk_index,
-							       lower_boundary, upper_boundary,
-							       this_crc, this_cnt, master_crc, master_cnt, ts
-							FROM %s WHERE master_ip = ? AND master_port = ? AND reported = 0
-										AND (db = ? OR db = ?)`, r.resultHistoryTable, r.resultHistoryTable,
-		),
-		masterIP, masterPort, masterIP, masterPort,
-		dailyStr, roundStartStr,
-	)
-	if err != nil {
-		slog.Error("query unreported result", slog.String("error", err.Error()))
-		return err
-	}
-
-	for rows.Next() {
-		var cs reporter.ChecksumResult
-		err := rows.StructScan(&cs)
-		if err != nil {
-			slog.Error("scan unreported result", slog.String("error", err.Error()))
-			return err
-		}
-
-		slog.Debug("scan checksum history", slog.Any("checksum result", cs))
-
-		err = r.reporter.Report(&cs)
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err = tx.ExecContext(
-		context.Background(),
-		fmt.Sprintf(
-			`UPDATE %s.%s SET reported = 1
-								WHERE master_ip = ? AND master_port = ? AND reported = 0`,
-			r.resultDB, r.resultHistoryTable,
-		), masterIP, masterPort,
-	)
-	if err != nil {
-		slog.Error("update reported", slog.String("error", err.Error()))
-		return err
-	}
-	slog.Info("update reported")
-
-	return nil
-}
+//// Report 只在 repeater, slave 的例行校验做上报
+//func (r *Checker) Report() error {
+//	if !r.hasHistoryTable {
+//		slog.Info("report history table not found")
+//		return nil
+//	}
+//
+//	masterIP, masterPort, err := r.masterHosts()
+//	if err != nil {
+//		slog.Error("get master hosts: ", slog.String("error", err.Error()))
+//		return err
+//	}
+//	slog.Info(
+//		"query master info",
+//		slog.String("master ip", masterIP), slog.Int("master port", masterPort),
+//	)
+//
+//	tx, err := r.conn.BeginTxx(context.Background(), nil)
+//	if err != nil {
+//		slog.Error("start transaction: ", slog.String("error", err.Error()))
+//		return err
+//	}
+//	defer func() {
+//		_ = tx.Commit()
+//	}()
+//
+//	rows, err := tx.Queryx(
+//		fmt.Sprintf(
+//			`SELECT master_ip, master_port,
+//									db, tbl,
+//									chunk, chunk_time, chunk_index,
+//									lower_boundary, upper_boundary,
+//									this_crc, this_cnt, master_crc, master_cnt, ts
+//							FROM %s WHERE master_ip = ? AND master_port = ? AND reported = 0
+//										AND (this_crc <> master_crc or this_cnt <> master_cnt)
+//							UNION
+//							SELECT master_ip, master_port,
+//							       db, tbl,
+//							       chunk, chunk_time, chunk_index,
+//							       lower_boundary, upper_boundary,
+//							       this_crc, this_cnt, master_crc, master_cnt, ts
+//							FROM %s WHERE master_ip = ? AND master_port = ? AND reported = 0
+//										AND (db = ? OR db = ?)`, r.resultHistoryTable, r.resultHistoryTable,
+//		),
+//		masterIP, masterPort, masterIP, masterPort,
+//		dailyStr, roundStartStr,
+//	)
+//	if err != nil {
+//		slog.Error("query unreported result", slog.String("error", err.Error()))
+//		return err
+//	}
+//
+//	for rows.Next() {
+//		var cs reporter.ChecksumResult
+//		err := rows.StructScan(&cs)
+//		if err != nil {
+//			slog.Error("scan unreported result", slog.String("error", err.Error()))
+//			return err
+//		}
+//
+//		slog.Debug("scan checksum history", slog.Any("checksum result", cs))
+//
+//		err = r.reporter.Report(&cs)
+//		if err != nil {
+//			return err
+//		}
+//	}
+//
+//	_, err = tx.ExecContext(
+//		context.Background(),
+//		fmt.Sprintf(
+//			`UPDATE %s.%s SET reported = 1
+//								WHERE master_ip = ? AND master_port = ? AND reported = 0`,
+//			r.resultDB, r.resultHistoryTable,
+//		), masterIP, masterPort,
+//	)
+//	if err != nil {
+//		slog.Error("update reported", slog.String("error", err.Error()))
+//		return err
+//	}
+//	slog.Info("update reported")
+//
+//	return nil
+//}

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/run_command.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/run_command.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,6 +15,8 @@ import (
 	"time"
 
 	"dbm-services/mysql/db-tools/mysql-table-checksum/pkg/config"
+
+	"github.com/avast/retry-go/v5"
 )
 
 var roundStartStr = "_dba_fake_round_start"
@@ -21,6 +24,25 @@ var dailyStr = "_dba_fake_daily"
 
 // var demandStartStr = "_dba_fake_demand_start"
 var demandEndStr = "_dba_fake_demand_end"
+
+// EmptySummaryError 表示校验摘要为空的错误，用于 RetryIf 判断是否需要重试
+// 当 pt-table-checksum 执行完成但没有返回校验摘要时，返回此错误触发重试
+type EmptySummaryError struct {
+	Message string
+}
+
+func (e *EmptySummaryError) Error() string {
+	if e.Message == "" {
+		return "checksum summary is empty, need retry"
+	}
+	return e.Message
+}
+
+// IsEmptySummaryError 判断错误是否为 EmptySummaryError 类型
+func IsEmptySummaryError(err error) bool {
+	var emptySummaryErr *EmptySummaryError
+	return errors.As(err, &emptySummaryErr)
+}
 
 func (r *Checker) Run() error {
 	slog.Info("run mode", slog.String("mode", string(r.Mode)))
@@ -37,7 +59,7 @@ func (r *Checker) Run() error {
 			return nil
 		}
 
-		err = r.runGeneral(1)
+		err = r.runGeneral()
 		if err != nil {
 			slog.Error("run checksum", slog.String("error", err.Error()))
 			return err
@@ -49,10 +71,7 @@ func (r *Checker) Run() error {
 		}
 		return nil
 	case config.DemandMode:
-		//err := r.preRunDemand()
-		//if err != nil {
-		//	return err
-		//}
+
 		err := r.runDemand()
 		if err != nil {
 			return err
@@ -62,10 +81,7 @@ func (r *Checker) Run() error {
 		if err != nil {
 			return err
 		}
-		//err = r.moveResult()
-		//if err != nil {
-		//	return err
-		//}
+
 		return nil
 	default:
 		err := fmt.Errorf("run mode %s not supported", r.Mode)
@@ -74,14 +90,6 @@ func (r *Checker) Run() error {
 	}
 }
 
-//	func (r *Checker) preRunDemand() error {
-//		err := r.writeFakeResult(demandStartStr, demandStartStr)
-//		if err != nil {
-//			slog.Error("run demand checksum", slog.String("error", err.Error()))
-//			return err
-//		}
-//		return nil
-//	}
 func (r *Checker) postRunDemand(demand bool) error {
 	err := r.writeFakeResult(demandEndStr, demandEndStr, demand)
 	if err != nil {
@@ -111,72 +119,77 @@ func (r *Checker) preRunGeneral() error {
 	return nil
 }
 
-func (r *Checker) runGeneral(guard int) error {
-	// 重试保护, 防止任何意外情况的无限递归
-	if guard < 0 {
-		err := fmt.Errorf("guard must be greater than zero")
-		slog.Error("run checksum", slog.String("error", err.Error()))
-		return err
-	}
+func (r *Checker) runGeneral() error {
+	var cleanUpErr error
 
-	isEmptyResultTbl, err := r.isEmptyResultTbl()
-	if err != nil {
-		slog.Error("run checksum", slog.String("error", err.Error()))
-		return err
-	}
-	if isEmptyResultTbl {
-		err := r.writeFakeResult(roundStartStr, roundStartStr, false)
-		if err != nil {
-			slog.Error("run checksum", slog.String("error", err.Error()))
-			return err
-		}
-	}
+	err := retry.New(
+		retry.Attempts(2),
+		retry.Delay(2*time.Second),
+		retry.RetryIf(
+			func(err error) bool {
+				// 只有当错误是 EmptySummaryError 时才重试
+				isEmptySummary := IsEmptySummaryError(err)
+				shouldRetry := isEmptySummary && cleanUpErr == nil
+				slog.Info(
+					"RetryIf check",
+					slog.Bool("isEmptySummaryError", isEmptySummary),
+					slog.Any("cleanUpErr", cleanUpErr),
+					slog.Bool("shouldRetry", shouldRetry),
+					slog.Any("originalErr", err),
+				)
+				return shouldRetry
+			},
+		),
+		retry.OnRetry(
+			func(_ uint, _ error) {
+				_, cleanUpErr = r.db.Exec(
+					fmt.Sprintf("TRUNCATE TABLE `%s`.`%s`", r.resultDB, r.resultTbl),
+				)
+				if cleanUpErr != nil {
+					slog.Error("clean up retry run checksum", slog.String("error", cleanUpErr.Error()))
+					return
+				}
+				slog.Info("clean up retry run checksum success")
+			},
+		),
+	).Do(
+		func() error {
+			isEmptyResultTbl, err := r.isEmptyResultTbl()
+			if err != nil {
+				slog.Error("run checksum", slog.String("error", err.Error()))
+				return err
+			}
+			if isEmptyResultTbl {
+				err := r.writeFakeResult(roundStartStr, roundStartStr, false)
+				if err != nil {
+					slog.Error("run checksum", slog.String("error", err.Error()))
+					return err
+				}
+			}
 
-	output, err, pterr := r.run()
-	if err != nil {
-		slog.Error("run checksum", slog.String("error", err.Error()))
-		return err
-	}
-	if pterr != nil {
-		slog.Error("run checksum", slog.String("error", pterr.Error()))
-		return pterr
-	}
-	if output == nil {
-		err := fmt.Errorf("output nil")
-		slog.Error("run checksum", slog.String("error", err.Error()))
-		return err
-	}
+			output, err, pterr := r.run()
+			if err != nil {
+				slog.Error("run checksum", slog.String("error", err.Error()))
+				return err
+			}
+			if pterr != nil {
+				slog.Error("run checksum", slog.String("error", pterr.Error()))
+				return pterr
+			}
+			if output == nil {
+				err := fmt.Errorf("output nil")
+				slog.Error("run checksum", slog.String("error", err.Error()))
+				return err
+			}
 
-	if len(output.Summaries) == 0 {
-		var cnt int
-		querySql := fmt.Sprintf(
-			"SELECT COUNT(*) FROM `%s`.`%s` WHERE master_ip = ? AND master_port = ? AND db NOT LIKE ?",
-			r.resultDB, r.resultTbl,
-		)
-		err := r.db.QueryRowx(querySql, r.Config.Ip, r.Config.Port, "_dba_fake_%").Scan(&cnt)
-		if err != nil {
-			slog.Error("run checksum", slog.String("error", err.Error()))
-			return err
-		}
-		slog.Info("run checksum", slog.Int("result table count", cnt))
-		if cnt == 0 {
+			if len(output.Summaries) == 0 {
+				return &EmptySummaryError{}
+			}
 			return nil
-		}
+		},
+	)
 
-		_, err = r.db.Exec(
-			fmt.Sprintf("TRUNCATE TABLE `%s`.`%s`", r.resultDB, r.resultTbl),
-		)
-		if err != nil {
-			slog.Error("run checksum", slog.String("error", err.Error()))
-			return err
-		}
-
-		slog.Info("retry run checksum")
-		return r.runGeneral(guard - 1)
-	}
-
-	slog.Info("run checksum", slog.String("output", output.String()))
-	return nil
+	return err
 }
 
 func (r *Checker) runDemand() error {
@@ -204,126 +217,6 @@ func (r *Checker) runDemand() error {
 	fmt.Println(zipOutput)
 	return nil
 }
-
-//func (r *Checker) Run() error {
-//	slog.Info("run mode", slog.String("mode", string(r.Mode)))
-//	stackDepth := 0
-//
-//RunCheckLabel:
-//	slog.Info("run", slog.Int("stack depth", stackDepth))
-//	stackDepth += 1
-//	if stackDepth > 2 {
-//		err := fmt.Errorf("retry stack too deep: %d", stackDepth)
-//		slog.Error("run stack check", slog.String("error", err.Error()))
-//		return err
-//	}
-//
-//	if r.Mode == config.GeneralMode {
-//		if stackDepth == 1 {
-//			err := r.writeFakeResult(dailyStr, dailyStr)
-//			if err != nil {
-//				slog.Error("write daily fake", slog.String("error", err.Error()))
-//				return err
-//			}
-//			slog.Info("write daily fake success")
-//		}
-//
-//		if !config.ChecksumConfig.Enable {
-//			slog.Info("general checksum disabled")
-//			return nil
-//		}
-//	}
-//
-//	isEmptyResultTbl, err := r.isEmptyResultTbl()
-//	if err != nil {
-//		return err
-//	}
-//	if r.Mode == config.GeneralMode && isEmptyResultTbl {
-//		slog.Info("result table is empty")
-//		err := r.writeFakeResult(roundStartStr, roundStartStr)
-//		if err != nil {
-//			slog.Error("write round start", slog.String("error", err.Error()))
-//			return err
-//		}
-//		slog.Info("round start")
-//	}
-//
-//	// ------- 跑校验 -------
-//	output, err, pterr := r.run()
-//	if err != nil {
-//		return err
-//	}
-//	if output == nil {
-//		return fmt.Errorf("output is nil")
-//	}
-//
-//	if r.Mode == config.GeneralMode {
-//		slog.Info("run in general mode")
-//
-//		// 清理太老的 history
-//		_, err := r.conn.ExecContext(
-//			context.Background(),
-//			fmt.Sprintf(`DELETE FROM %s WHERE ts < NOW() - INTERVAL 10 DAY`, r.resultHistoryTable),
-//		)
-//		if err != nil {
-//			slog.Error("run in general mode delete 10 days ago history", slog.String("error", err.Error()))
-//		}
-//		slog.Info("run in general mode delete 10 days ago history")
-//
-//		// 校验摘要是空的, 有两种可能
-//		// 1. 应用过滤器后, 没有库表需要校验
-//		// 2. checksum 中有所有库表的校验结果, 这一轮轮空了
-//		if len(output.Summaries) == 0 {
-//			var cnt int
-//			err = r.db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s.%s", r.resultDB, r.resultTbl)).Scan(&cnt)
-//			if err != nil {
-//				slog.Error("query result table rows count", slog.String("error", err.Error()))
-//				return err
-//			}
-//			slog.Info("query result table rows count", slog.Int("rows count", cnt))
-//			/*
-//				由于会写入 round start 假数据
-//				所以如果行数大于 1, 则说明有真实的校验结果
-//				完成了一轮
-//			*/
-//			if cnt > 1 {
-//				//Replicate 是带有库前缀的字符串
-//				_, err := r.db.Exec(fmt.Sprintf(`TRUNCATE TABLE %s`, r.Config.PtChecksum.Replicate))
-//				if err != nil {
-//					slog.Error(
-//						"truncate regular result table",
-//						slog.String("error", err.Error()),
-//						slog.String("table name", r.Config.PtChecksum.Replicate),
-//					)
-//					return err
-//				}
-//
-//				// 清掉上一轮的结构后再跑一次
-//				slog.Info("clear last round result and run again")
-//				goto RunCheckLabel
-//			} else {
-//				// 什么都没干, 又没有库表需要校验
-//				// 直接返回
-//				return nil
-//			}
-//		}
-//
-//		err = r.moveResult()
-//		if err != nil {
-//			return err
-//		}
-//	} else {
-//		slog.Info("run in demand mode")
-//	}
-//
-//	fmt.Println(output.String())
-//
-//	if pterr != nil {
-//		return pterr
-//	}
-//
-//	return nil
-//}
 
 func (r *Checker) isEmptyResultTbl() (bool, error) {
 	var resultCnt int

--- a/dbm-ui/backend/dbm_aiagent/init/ticket-schema.json
+++ b/dbm-ui/backend/dbm_aiagent/init/ticket-schema.json
@@ -1,0 +1,12151 @@
+{
+  "RECYCLE_OLD_HOST": {
+    "type": "object",
+    "title": "RECYCLE_OLD_HOST",
+    "description": "单据类型: RECYCLE_OLD_HOST",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "group": {
+            "type": "string",
+            "description": "group"
+          },
+          "recycle_hosts": {
+            "type": "string",
+            "description": "recycle_hosts"
+          },
+          "parent_ticket": {
+            "type": "string",
+            "description": "parent_ticket"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/RecycleOldHost.vue",
+      "props_type": "ResourcePool.ResourcePoolRecycle",
+      "labels": [
+        "DB类型",
+        "前置单据",
+        "已下架主机",
+        "管控区域",
+        "Agent 状态",
+        "地域",
+        "园区",
+        "机架",
+        "操作系统",
+        "机型"
+      ],
+      "fields": [
+        "group",
+        "recycle_hosts",
+        "parent_ticket"
+      ]
+    }
+  },
+  "RESOURCE_HCM_REPLENISH": {
+    "type": "object",
+    "title": "RESOURCE_HCM_REPLENISH",
+    "description": "单据类型: RESOURCE_HCM_REPLENISH",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/ResourceReplenish.vue",
+      "props_type": "ResourcePool.ResourcePoolReplenish",
+      "labels": [
+        "DB 类型",
+        "规格类型",
+        "规格",
+        "地域",
+        "园区",
+        "操作系统",
+        "申请数量"
+      ],
+      "fields": []
+    }
+  },
+  "RESOURCE_IMPORT": {
+    "type": "object",
+    "title": "RESOURCE_IMPORT",
+    "description": "单据类型: RESOURCE_IMPORT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "os_type": {
+            "type": "string",
+            "description": "操作系统类型"
+          },
+          "operator": {
+            "type": "string",
+            "description": "操作人"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "ResourceImportSerializer",
+      "builder_class": "ResourceImportFlowBuilder",
+      "source_file": "ticket/builders/common/resource.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/ImportResource.vue",
+      "props_type": "ResourcePool.ImportResource",
+      "labels": [
+        "导入主机",
+        "所属业务",
+        "所属 DB 类型",
+        "资源标签",
+        "管控区域",
+        "Agent 状态",
+        "地域",
+        "园区",
+        "机架",
+        "操作系统",
+        "机型"
+      ],
+      "fields": [
+        "label_names",
+        "for_biz",
+        "hosts"
+      ]
+    }
+  },
+  "REDIS_CLUSTER_REINSTALL_DBMON": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_REINSTALL_DBMON",
+    "description": "单据类型: REDIS_CLUSTER_REINSTALL_DBMON",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_biz_id": {
+            "type": "integer",
+            "description": "业务ID"
+          },
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "is_stop": {
+            "type": "boolean"
+          },
+          "restart_exporter": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisClusterStandardizeDetailSerializer",
+      "builder_class": "RedisClusterStandardizeFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_cluster_standardize.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ClusterReinstallDbmon.vue",
+      "props_type": "Redis.ClusterReinstallDbmon",
+      "labels": [
+        "重新下发GSE配置"
+      ],
+      "fields": [
+        "cluster_ids.map",
+        "restart_exporter",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_PROXY_CLOSE": {
+    "type": "object",
+    "title": "REDIS_PROXY_CLOSE",
+    "description": "单据类型: REDIS_PROXY_CLOSE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ProxyClose.vue",
+      "props_type": "Redis.ProxyClose",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_PLUGIN_DNS_UNBIND_CLB": {
+    "type": "object",
+    "title": "REDIS_PLUGIN_DNS_UNBIND_CLB",
+    "description": "单据类型: REDIS_PLUGIN_DNS_UNBIND_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPluginDnsUnBindCLBDetailSerializer",
+      "builder_class": "RedisPluginDnsUnBindCLBFlowBuilder",
+      "source_file": "ticket/builders/redis/plugin_dns_unbind_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/PluginDnsUnbindClb.vue",
+      "props_type": "Redis.PluginDnsUnbindClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_SHARD_REDUCE": {
+    "type": "object",
+    "title": "REDIS_SHARD_REDUCE",
+    "description": "单据类型: REDIS_SHARD_REDUCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ShardReduce.vue",
+      "props_type": "Redis.ShardReduce",
+      "labels": [
+        "架构版本",
+        "当前容量",
+        "减少机器组数",
+        "目标容量"
+      ],
+      "fields": [
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_PLUGIN_CREATE_CLB": {
+    "type": "object",
+    "title": "REDIS_PLUGIN_CREATE_CLB",
+    "description": "单据类型: REDIS_PLUGIN_CREATE_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPluginCreateCLBDetailSerializer",
+      "builder_class": "RedisPluginCreateCLBFlowBuilder",
+      "source_file": "ticket/builders/redis/plugin_create_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/pluginCreateClb.vue",
+      "props_type": "Redis.PluginCreateClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_CLUSTER_APPLY": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_APPLY",
+    "description": "单据类型: REDIS_CLUSTER_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "proxy": {
+                "type": "object",
+                "properties": {
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  },
+                  "spec_name": {
+                    "type": "string",
+                    "description": "spec_name"
+                  },
+                  "count": {
+                    "type": "string",
+                    "description": "count"
+                  }
+                },
+                "description": "proxy (也可能是叶子节点)"
+              },
+              "backend_group": {
+                "type": "object",
+                "properties": {
+                  "spec_info": {
+                    "type": "string",
+                    "description": "spec_info"
+                  },
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  }
+                }
+              }
+            }
+          },
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "proxy_port": {
+            "type": "string",
+            "description": "proxy_port"
+          },
+          "cap_spec": {
+            "type": "object",
+            "properties": {
+              "split": {
+                "type": "string",
+                "description": "split"
+              }
+            },
+            "description": "cap_spec (也可能是叶子节点)"
+          },
+          "cluster_type": {
+            "type": "string",
+            "description": "cluster_type"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ClusterApply.vue",
+      "props_type": "Redis.ClusterApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "部署架构",
+        "版本",
+        "服务器",
+        "访问端口",
+        "申请容量",
+        "Proxy：",
+        "Master",
+        "Slave",
+        "Proxy 规格",
+        "Proxy 资源标签",
+        "后端存储",
+        "资源规格",
+        "资源标签",
+        "需机器组数",
+        "集群分片",
+        "集群容量G"
+      ],
+      "fields": [
+        "resource_spec.proxy.label_names",
+        "cluster_name",
+        "proxy_port",
+        "cap_spec",
+        "resource_spec.proxy",
+        "cluster_type",
+        "resource_spec.proxy.spec_name",
+        "resource_spec.proxy.count",
+        "resource_spec.backend_group.spec_info",
+        "resource_spec.backend_group.label_names",
+        "cluster_alias",
+        "cap_spec.split",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "REDIS_PLUGIN_DELETE_CLB": {
+    "type": "object",
+    "title": "REDIS_PLUGIN_DELETE_CLB",
+    "description": "单据类型: REDIS_PLUGIN_DELETE_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPluginDeleteCLBDetailSerializer",
+      "builder_class": "RedisPluginDeleteCLBFlowBuilder",
+      "source_file": "ticket/builders/redis/plugin_delete_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/PluginDeleteClb.vue",
+      "props_type": "Redis.PluginDeleteClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_PLUGIN_CREATE_POLARIS": {
+    "type": "object",
+    "title": "REDIS_PLUGIN_CREATE_POLARIS",
+    "description": "单据类型: REDIS_PLUGIN_CREATE_POLARIS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPluginCreatePolarisDetailSerializer",
+      "builder_class": "RedisPluginCreatePolarisFlowBuilder",
+      "source_file": "ticket/builders/redis/plugin_create_polaris.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/PluginCreatePolaris.vue",
+      "props_type": "Redis.PluginCreatePolaris",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_HOT_KEY_ANALYSIS": {
+    "type": "object",
+    "title": "REDIS_HOT_KEY_ANALYSIS",
+    "description": "单据类型: REDIS_HOT_KEY_ANALYSIS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "analysis_time": {
+            "type": "integer",
+            "description": "分析时长"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "ins": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "实例列表"
+                },
+                "immute_domain": {
+                  "type": "string",
+                  "description": "域名"
+                },
+                "cluster_type": {
+                  "type": "string",
+                  "description": "集群类型"
+                }
+              }
+            },
+            "description": "批量操作参数列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisHotKeyAnalysisDetailSerializer",
+      "builder_class": "RedisHotKeyAnalysisFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_toolbox_hot_key_analysis.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/HotKeyAnalyse.vue",
+      "props_type": "Redis.HotKeyAnalyse",
+      "labels": [
+        "分析时长",
+        "所属集群",
+        "架构版本"
+      ],
+      "fields": [
+        "infos.flatMap",
+        "analysis_time",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_DESTROY": {
+    "type": "object",
+    "title": "REDIS_DESTROY",
+    "description": "单据类型: REDIS_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/Destroy.vue",
+      "props_type": "Redis.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_DATA_STRUCTURE_TASK_DELETE": {
+    "type": "object",
+    "title": "REDIS_DATA_STRUCTURE_TASK_DELETE",
+    "description": "单据类型: REDIS_DATA_STRUCTURE_TASK_DELETE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/DataStructureTaskDelete.vue",
+      "props_type": "Redis.DataStructureTaskDelete",
+      "labels": [
+        "构造产物访问入口",
+        "源集群",
+        "关联单据"
+      ],
+      "fields": [
+        "infos"
+      ]
+    }
+  },
+  "REDIS_KEYS_EXTRACT": {
+    "type": "object",
+    "title": "REDIS_KEYS_EXTRACT",
+    "description": "单据类型: REDIS_KEYS_EXTRACT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisKeyExtractDetailSerializer",
+      "builder_class": "RedisKeyExtractFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_key_extract.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/KeysExtract.vue",
+      "props_type": "Redis.KeysExtract",
+      "labels": [
+        "架构版本",
+        "包含Key",
+        "排除Key"
+      ],
+      "fields": [
+        "rules",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_CLUSTER_LOAD_MODULES": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_LOAD_MODULES",
+    "description": "单据类型: REDIS_CLUSTER_LOAD_MODULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ClusterLoadModules.vue",
+      "props_type": "Redis.ClusterLoadModules",
+      "labels": [
+        "架构版本",
+        "版本",
+        "Module"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_BACKUP": {
+    "type": "object",
+    "title": "REDIS_BACKUP",
+    "description": "单据类型: REDIS_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisBackupDetailSerializer",
+      "builder_class": "RedisBackupFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/Backup.vue",
+      "props_type": "Redis.Backup",
+      "labels": [
+        "架构版本",
+        "备份目标",
+        "备份保存时间"
+      ],
+      "fields": [
+        "rules",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_CLUSTER_ROLLBACK_DATA_COPY": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_ROLLBACK_DATA_COPY",
+    "description": "单据类型: REDIS_CLUSTER_ROLLBACK_DATA_COPY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "dts_copy_type": {
+            "type": "string"
+          },
+          "write_mode": {
+            "type": "string"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "src_cluster": {
+                  "type": "string",
+                  "description": "构造产物访问入口（ip:port）"
+                },
+                "dst_cluster": {
+                  "type": "integer",
+                  "description": "目标集群ID"
+                },
+                "key_white_regex": {
+                  "type": "string",
+                  "description": "包含key"
+                },
+                "key_black_regex": {
+                  "type": "string",
+                  "description": "排除key"
+                },
+                "recovery_time_point": {
+                  "type": "string",
+                  "description": "待构造时间点"
+                }
+              }
+            },
+            "description": "批量操作参数列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisRollbackDataCopyDetailSerializer",
+      "builder_class": "RedisRollbackDataCopyFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_toolbox_rollback_data_copy.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ClusterRollbackDataCopy.vue",
+      "props_type": "Redis.ClusterRollbackDataCopy",
+      "labels": [
+        "写入类型",
+        "目标集群",
+        "架构版本",
+        "构造到指定时间",
+        "包含 Key",
+        "排除 Key"
+      ],
+      "fields": [
+        "infos",
+        "write_mode",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_PROXY_SCALE_DOWN": {
+    "type": "object",
+    "title": "REDIS_PROXY_SCALE_DOWN",
+    "description": "单据类型: REDIS_PROXY_SCALE_DOWN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "shrink_type": {
+            "type": "string",
+            "description": "shrink_type"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ProxyScaleDown.vue",
+      "props_type": "Redis.ProxyScaleDown",
+      "labels": [
+        "缩容方式",
+        "关联集群",
+        "切换模式",
+        "架构版本",
+        "当前数量(台",
+        "缩容数量(台",
+        "剩余数量(台"
+      ],
+      "fields": [
+        "clusters",
+        "infos",
+        "shrink_type"
+      ]
+    }
+  },
+  "REDIS_PLUGIN_DNS_BIND_CLB": {
+    "type": "object",
+    "title": "REDIS_PLUGIN_DNS_BIND_CLB",
+    "description": "单据类型: REDIS_PLUGIN_DNS_BIND_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPluginDnsBindCLBDetailSerializer",
+      "builder_class": "RedisPluginDnsBindCLBFlowBuilder",
+      "source_file": "ticket/builders/redis/plugin_dns_bind_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/PluginDnsBindClb.vue",
+      "props_type": "Redis.PluginDnsBindClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_CLUSTER_CUTOFF": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_CUTOFF",
+    "description": "单据类型: REDIS_CLUSTER_CUTOFF",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ClusterCutoff.vue",
+      "props_type": "Redis.ResourcePool.ClusterCutoff",
+      "labels": [
+        "角色类型",
+        "所属集群",
+        "规格需求",
+        "资源标签"
+      ],
+      "fields": []
+    }
+  },
+  "REDIS_KEYSTAT": {
+    "type": "object",
+    "title": "REDIS_KEYSTAT",
+    "description": "单据类型: REDIS_KEYSTAT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "analysis_time": {
+            "type": "integer",
+            "description": "分析时长",
+            "default": 0
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "check_last_visit": {
+                  "type": "boolean",
+                  "description": "是否上次访问",
+                  "default": true
+                },
+                "ins": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "实例列表"
+                },
+                "immute_domain": {
+                  "type": "string",
+                  "description": "域名"
+                },
+                "delimiter": {
+                  "type": "string",
+                  "description": "域名",
+                  "default": "#@_-"
+                },
+                "cluster_type": {
+                  "type": "string",
+                  "description": "集群类型"
+                }
+              }
+            },
+            "description": "批量操作参数列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisKeyStatSerializer",
+      "builder_class": "RedisKeyStatFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_toolbox_keystat.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/MemoryAnalyse.vue",
+      "props_type": "Redis.KeyStat",
+      "labels": [
+        "所属集群",
+        "架构版本",
+        "内存大小",
+        "Key 数量"
+      ],
+      "fields": [
+        "infos.flatMap",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_INSTANCE_DESTROY": {
+    "type": "object",
+    "title": "REDIS_INSTANCE_DESTROY",
+    "description": "单据类型: REDIS_INSTANCE_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/InstanceDestroy.vue",
+      "props_type": "Redis.InstanceDestroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_CLUSTER_DATA_COPY": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_DATA_COPY",
+    "description": "单据类型: REDIS_CLUSTER_DATA_COPY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "dts_copy_type": {
+            "type": "string"
+          },
+          "write_mode": {
+            "type": "string"
+          },
+          "sync_disconnect_setting": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "reminder_frequency": {
+                "type": "string"
+              }
+            }
+          },
+          "data_check_repair_setting": {
+            "type": "object"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "批量数据复制列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisDataCopyDetailSerializer",
+      "builder_class": "RedisDataCopyFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_toolbox_data_copy.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ClusterDataCopy.vue",
+      "props_type": "Redis.ClusterDataCopy",
+      "labels": [
+        "复制类型",
+        "写入类型",
+        "断开设置",
+        "提醒频率",
+        "校验与修复类型",
+        "校验与修复频率设置",
+        "集群类型",
+        "架构版本",
+        "目标业务",
+        "目标集群",
+        "包含 Key",
+        "排除 Key"
+      ],
+      "fields": [
+        "dts_copy_type",
+        "clusters",
+        "infos",
+        "write_mode",
+        "sync_disconnect_setting.reminder_frequency",
+        "data_check_repair_setting.type",
+        "sync_disconnect_setting.type",
+        "data_check_repair_setting.execution_frequency"
+      ]
+    }
+  },
+  "REDIS_INS_APPLY": {
+    "type": "object",
+    "title": "REDIS_INS_APPLY",
+    "description": "单据类型: REDIS_INS_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "port": {
+            "type": "string",
+            "description": "port"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          },
+          "append_apply": {
+            "type": "string",
+            "description": "append_apply"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/InsApply.vue",
+      "props_type": "Redis.InsApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "管控区域",
+        "部署方式",
+        "Redis 版本",
+        "Redis 起始端口",
+        "服务器选择",
+        "后端存储规格",
+        "资源标签",
+        "域名设置",
+        "主域名",
+        "Databases",
+        "待部署主库主机",
+        "待部署从库主机"
+      ],
+      "fields": [
+        "port",
+        "bk_cloud_name",
+        "db_version",
+        "append_apply"
+      ]
+    }
+  },
+  "REDIS_INSTANCE_CLOSE": {
+    "type": "object",
+    "title": "REDIS_INSTANCE_CLOSE",
+    "description": "单据类型: REDIS_INSTANCE_CLOSE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/InstanceProxyClose.vue",
+      "props_type": "Redis.InstanceProxyClose",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_DATA_STRUCTURE": {
+    "type": "object",
+    "title": "REDIS_DATA_STRUCTURE",
+    "description": "单据类型: REDIS_DATA_STRUCTURE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/DataStructure.vue",
+      "props_type": "Redis.DataStructure",
+      "labels": [
+        "架构版本",
+        "待构造的实例",
+        "规格需求",
+        "构造主机数量",
+        "构造到指定时间"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_MASTER_SLAVE_SWITCH": {
+    "type": "object",
+    "title": "REDIS_MASTER_SLAVE_SWITCH",
+    "description": "单据类型: REDIS_MASTER_SLAVE_SWITCH",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                },
+                "pairs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "主从切换对"
+                },
+                "online_switch_type": {
+                  "type": "string",
+                  "description": "切换类型"
+                }
+              }
+            },
+            "description": "批量操作参数列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisMasterSlaveSwitchDetailSerializer",
+      "builder_class": "RedisMasterSlaveSwitchFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_toolbox_master_slave_switch.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/masterSlaveSwitch.vue",
+      "props_type": "Redis.MasterSlaveSwitch",
+      "labels": [
+        "是否强制切换",
+        "所属集群",
+        "待切换的从库主机",
+        "切换模式"
+      ],
+      "fields": [
+        "infos",
+        "force",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_PROXY_OPEN": {
+    "type": "object",
+    "title": "REDIS_PROXY_OPEN",
+    "description": "单据类型: REDIS_PROXY_OPEN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/ProxyOpen.vue",
+      "props_type": "Redis.ProxyOpen",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_KEYS_DELETE": {
+    "type": "object",
+    "title": "REDIS_KEYS_DELETE",
+    "description": "单据类型: REDIS_KEYS_DELETE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "delete_type": {
+            "type": "string",
+            "description": "删除方式"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisKeyDeleteDetailSerializer",
+      "builder_class": "RedisKeyDeleteFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_key_delete.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/KeysDelete.vue",
+      "props_type": "Redis.KeysDelete",
+      "labels": [
+        "架构版本",
+        "包含Key",
+        "排除Key",
+        "每秒删除 Key 个数"
+      ],
+      "fields": [
+        "rules",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_INSTANCE_OPEN": {
+    "type": "object",
+    "title": "REDIS_INSTANCE_OPEN",
+    "description": "单据类型: REDIS_INSTANCE_OPEN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/InstanceProxyOpen.vue",
+      "props_type": "Redis.InstanceProxyOpen",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "REDIS_DATACOPY_CHECK_REPAIR": {
+    "type": "object",
+    "title": "REDIS_DATACOPY_CHECK_REPAIR",
+    "description": "单据类型: REDIS_DATACOPY_CHECK_REPAIR",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "execute_mode": {
+            "type": "string",
+            "description": "执行模式"
+          },
+          "specified_execution_time": {
+            "type": "string",
+            "description": "执行模式为定时执行时，需要设置执行时间"
+          },
+          "keep_check_and_repair": {
+            "type": "boolean",
+            "description": "是否保持校验"
+          },
+          "check_stop_time": {
+            "type": "string",
+            "description": "校验终止时间，当不保持校验时，需要设置该时间"
+          },
+          "data_repair_enabled": {
+            "type": "boolean",
+            "description": "是否修复数据"
+          },
+          "repair_mode": {
+            "type": "string",
+            "description": "数据修复模式"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "bill_id": {
+                  "type": "integer",
+                  "description": "任务ID"
+                },
+                "src_cluster": {
+                  "type": "string",
+                  "description": "源集群访问入口"
+                },
+                "dst_cluster": {
+                  "type": "string",
+                  "description": "目标集群访问入口"
+                },
+                "src_instances": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "源实例列表"
+                },
+                "key_white_regex": {
+                  "type": "string",
+                  "description": "包含key"
+                },
+                "key_black_regex": {
+                  "type": "string",
+                  "description": "排除key"
+                }
+              }
+            },
+            "description": "批量校验与修复列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisDataCheckRepairDetailSerializer",
+      "builder_class": "RedisDataCheckRepairFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_toolbox_data_check_repair.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/DatacopyCheckRepair.vue",
+      "props_type": "Redis.DatacopyCheckRepair",
+      "labels": [
+        "执行模式:",
+        "指定执行时间",
+        "指定停止时间",
+        "一直保持校验修复",
+        "修复数据",
+        "修复模式",
+        "关联单据",
+        "源集群",
+        "源实例",
+        "目标集群",
+        "包含 Key",
+        "排除 Key"
+      ],
+      "fields": [
+        "execute_mode",
+        "specified_execution_time",
+        "repair_mode",
+        "infos",
+        "check_stop_time",
+        "data_repair_enabled",
+        "keep_check_and_repair"
+      ]
+    }
+  },
+  "REDIS_PURGE": {
+    "type": "object",
+    "title": "REDIS_PURGE",
+    "description": "单据类型: REDIS_PURGE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPurgeDetailSerializer",
+      "builder_class": "RedisPurgeFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_purge.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/Purge.vue",
+      "props_type": "Redis.Purge",
+      "labels": [
+        "架构版本",
+        "清档前备份",
+        "强制清档"
+      ],
+      "fields": [
+        "rules",
+        "clusters"
+      ]
+    }
+  },
+  "DORIS_REBOOT": {
+    "type": "object",
+    "title": "DORIS_REBOOT",
+    "description": "单据类型: DORIS_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "DorisRebootDetailSerializer",
+      "builder_class": "DorisRebootFlowBuilder",
+      "source_file": "ticket/builders/doris/doris_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/doris/Reboot.vue",
+      "props_type": "Doris.Reboot",
+      "labels": [
+        "集群类型",
+        "节点IP"
+      ],
+      "fields": [
+        "clusters"
+      ]
+    }
+  },
+  "DORIS_DESTROY": {
+    "type": "object",
+    "title": "DORIS_DESTROY",
+    "description": "单据类型: DORIS_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/doris/Destroy.vue",
+      "props_type": "Doris.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "DORIS_ENABLE": {
+    "type": "object",
+    "title": "DORIS_ENABLE",
+    "description": "单据类型: DORIS_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/doris/Enable.vue",
+      "props_type": "Doris.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "DORIS_DISABLE": {
+    "type": "object",
+    "title": "DORIS_DISABLE",
+    "description": "单据类型: DORIS_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/doris/Disable.vue",
+      "props_type": "Doris.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "DORIS_APPLY": {
+    "type": "object",
+    "title": "DORIS_APPLY",
+    "description": "单据类型: DORIS_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "http_port": {
+            "type": "string",
+            "description": "http_port"
+          },
+          "enable_cold_storage": {
+            "type": "string",
+            "description": "enable_cold_storage"
+          },
+          "query_port": {
+            "type": "string",
+            "description": "query_port"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/doris/Apply.vue",
+      "props_type": "Doris.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "Doris版本",
+        "服务器选择方式",
+        "查询端口",
+        "http端口",
+        "Follower节点规格",
+        "Follower 节点资源标签",
+        "Observer 节点标签",
+        "Observer节点资源标签",
+        "热节点规格",
+        "热节点资源标签",
+        "温节点规格",
+        "温节点资源标签",
+        "启用低频存储",
+        "Follower节点IP",
+        "Observer节点IP",
+        "热节点IP",
+        "冷节点IP"
+      ],
+      "fields": [
+        "cluster_name",
+        "http_port",
+        "enable_cold_storage",
+        "query_port",
+        "cluster_alias",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "DORIS_SHRINK": {
+    "type": "object",
+    "title": "DORIS_SHRINK",
+    "description": "单据类型: DORIS_SHRINK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/doris/Shrink.vue",
+      "props_type": "Bigdata.ResourcePool.Shrink",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_SCALE_UP": {
+    "type": "object",
+    "title": "ES_SCALE_UP",
+    "description": "单据类型: ES_SCALE_UP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/elastic-search/ScaleUp.vue",
+      "props_type": "Bigdata.ResourcePool.ScaleUp",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "DORIS_REPLACE": {
+    "type": "object",
+    "title": "DORIS_REPLACE",
+    "description": "单据类型: DORIS_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/doris/Replace.vue",
+      "props_type": "Bigdata.ResourcePool.Replace",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ORACLE_EXEC_SCRIPT_APPLY": {
+    "type": "object",
+    "title": "ORACLE_EXEC_SCRIPT_APPLY",
+    "description": "单据类型: ORACLE_EXEC_SCRIPT_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群id"
+                },
+                "execute_db": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "执行的db"
+                }
+              }
+            },
+            "description": "集群执行列表"
+          },
+          "script_files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "脚本文件列表"
+          },
+          "import_mode": {
+            "type": "string",
+            "description": "sql导入模式"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "OracleScriptExecDetailSerializer",
+      "builder_class": "OracleScriptExecApplyFlowBuilder",
+      "source_file": "ticket/builders/oracle/oracle_script_exec.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/oracle/ImportSqlfile.vue",
+      "props_type": "Oracle.ImportSqlFile",
+      "labels": [
+        "SQL 来源",
+        "脚本执行内容",
+        "变更 DB"
+      ],
+      "fields": [
+        "clusters",
+        "cluster_info",
+        "script_files.map",
+        "path",
+        "import_mode",
+        "script_files"
+      ]
+    }
+  },
+  "MONGODB_PLUGIN_CREATE_CLB": {
+    "type": "object",
+    "title": "MONGODB_PLUGIN_CREATE_CLB",
+    "description": "单据类型: MONGODB_PLUGIN_CREATE_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBPluginCreateCLBDetailSerializer",
+      "builder_class": "MongoDBPluginCreateCLBFlowBuilder",
+      "source_file": "ticket/builders/mongodb/plugin_create_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/PluginCreateClb.vue",
+      "props_type": "Redis.PluginCreateClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MONGODB_PLUGIN_DELETE_CLB": {
+    "type": "object",
+    "title": "MONGODB_PLUGIN_DELETE_CLB",
+    "description": "单据类型: MONGODB_PLUGIN_DELETE_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBPluginDeleteCLBDetailSerializer",
+      "builder_class": "MongoDBPluginDeleteCLBFlowBuilder",
+      "source_file": "ticket/builders/mongodb/plugin_delete_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/PluginDeleteClb.vue",
+      "props_type": "Redis.PluginDeleteClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MONGODB_REDUCE_SHARD_NODES": {
+    "type": "object",
+    "title": "MONGODB_REDUCE_SHARD_NODES",
+    "description": "单据类型: MONGODB_REDUCE_SHARD_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "object",
+            "properties": {
+              "MongoShardedCluster": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "cluster_id": {
+                      "type": "integer",
+                      "description": "集群ID"
+                    },
+                    "current_shard_nodes_num": {
+                      "type": "integer",
+                      "description": "当前Shard节点数"
+                    },
+                    "reduce_shard_nodes": {
+                      "type": "integer",
+                      "description": "缩容节点数"
+                    }
+                  }
+                },
+                "description": "分片集群缩容信息"
+              },
+              "MongoReplicaSet": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "cluster_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "description": "集群ID列表"
+                    },
+                    "current_shard_nodes_num": {
+                      "type": "integer",
+                      "description": "当前Shard节点数"
+                    },
+                    "reduce_shard_nodes": {
+                      "type": "integer",
+                      "description": "缩容节点数"
+                    }
+                  }
+                },
+                "description": "副本集缩容信息"
+              }
+            }
+          },
+          "is_safe": {
+            "type": "boolean",
+            "description": "是否安全模式"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ReduceShardNodes.vue",
+      "props_type": "Mongodb.ResourcePool.ReduceShardNodes",
+      "labels": [
+        "忽略业务连接",
+        "集群类型",
+        "当前Shard的节点数",
+        "缩容至（节点数）"
+      ],
+      "fields": [
+        "infos.MongoShardedCluster.map",
+        "is_safe",
+        "clusters",
+        "infos.MongoReplicaSet.map"
+      ]
+    }
+  },
+  "MONGODB_DESTROY": {
+    "type": "object",
+    "title": "MONGODB_DESTROY",
+    "description": "单据类型: MONGODB_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/Destroy.vue",
+      "props_type": "Mongodb.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MONGODB_ENABLE": {
+    "type": "object",
+    "title": "MONGODB_ENABLE",
+    "description": "单据类型: MONGODB_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/Enable.vue",
+      "props_type": "Mongodb.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MONGODB_TEMPORARY_DESTROY": {
+    "type": "object",
+    "title": "MONGODB_TEMPORARY_DESTROY",
+    "description": "单据类型: MONGODB_TEMPORARY_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/TemporaryDestroy.vue",
+      "props_type": "Mongodb.TemporaryDestroy",
+      "labels": [
+        "临时集群名称"
+      ],
+      "fields": []
+    }
+  },
+  "MONGODB_BACKUP": {
+    "type": "object",
+    "title": "MONGODB_BACKUP",
+    "description": "单据类型: MONGODB_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "file_tag": {
+            "type": "string",
+            "description": "备份保存时间"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ns_filter": {
+                  "type": "object",
+                  "description": "库表选择器"
+                },
+                "cluster_type": {
+                  "type": "string",
+                  "description": "集群类型"
+                },
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                }
+              }
+            },
+            "description": "备份信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBBackupDetailSerializer",
+      "builder_class": "MongoDBBackupApplyFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/Backup.vue",
+      "props_type": "Mongodb.Backup",
+      "labels": [
+        "备份保存时间",
+        "集群类型",
+        "备份DB名",
+        "忽略DB名",
+        "备份表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "file_tag",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_SHARD_APPLY": {
+    "type": "object",
+    "title": "MONGODB_SHARD_APPLY",
+    "description": "单据类型: MONGODB_SHARD_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "mongodb": {
+                "type": "object",
+                "properties": {
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  }
+                }
+              }
+            },
+            "description": "resource_spec (也可能是叶子节点)"
+          },
+          "shard_num": {
+            "type": "string",
+            "description": "shard_num"
+          },
+          "oplog_percent": {
+            "type": "string",
+            "description": "oplog_percent"
+          },
+          "start_port": {
+            "type": "string",
+            "description": "start_port"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "shard_machine_group": {
+            "type": "string",
+            "description": "shard_machine_group"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/ShardApply.vue",
+      "props_type": "Mongodb.ShardApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "MongoDB版本",
+        "访问端口",
+        "Config Server资源规格",
+        "Config Server 资源标签",
+        "Mongos资源规格",
+        "Mongos 资源标签",
+        "ShardSvr 部署方案",
+        "每台主机 oplog 容量占比",
+        "规格",
+        "资源标签",
+        "每个 Shard 节点数",
+        "集群 Shard 数",
+        "机器组数"
+      ],
+      "fields": [
+        "cluster_name",
+        "resource_spec.mongodb.label_names",
+        "shard_num",
+        "resource_spec",
+        "oplog_percent",
+        "start_port",
+        "cluster_alias",
+        "shard_machine_group",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "MONGODB_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "MONGODB_AUTHORIZE_RULES",
+    "description": "单据类型: MONGODB_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "authorize_uid": {
+            "type": "string",
+            "description": "授权数据缓存uid"
+          },
+          "authorize_data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "username": {
+                  "type": "string",
+                  "description": "授权账号"
+                },
+                "access_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "准入DB"
+                },
+                "account_id": {
+                  "type": "string",
+                  "description": "账号ID"
+                },
+                "auth_db": {
+                  "type": "string",
+                  "description": "认证用户"
+                },
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "目标集群ID"
+                },
+                "password": {
+                  "type": "string",
+                  "description": "密码"
+                },
+                "rule_sets": {
+                  "type": "array",
+                  "items": {
+                    "type": "json"
+                  },
+                  "description": "规则集"
+                },
+                "target_instances": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标集群域名"
+                }
+              }
+            },
+            "description": "授权数据列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBAuthorizeRulesSerializer",
+      "builder_class": "MongoDBAuthorizeRulesFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_authorize.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/AuthorizeRules.vue",
+      "props_type": "Mongodb.AuthorizeRules",
+      "labels": [
+        "目标集群",
+        "权限明细",
+        "账号名称",
+        "访问 DB",
+        "权限"
+      ],
+      "fields": [
+        "authorize_data"
+      ]
+    }
+  },
+  "MONGODB_DISABLE": {
+    "type": "object",
+    "title": "MONGODB_DISABLE",
+    "description": "单据类型: MONGODB_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/Disable.vue",
+      "props_type": "Mongodb.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MONGODB_ADD_SHARD_NODES": {
+    "type": "object",
+    "title": "MONGODB_ADD_SHARD_NODES",
+    "description": "单据类型: MONGODB_ADD_SHARD_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/AddShardNodes.vue",
+      "props_type": "Mongodb.AddShardNodes",
+      "labels": [
+        "忽略业务连接",
+        "集群类型",
+        "当前Shard的节点数",
+        "扩容至（节点数）"
+      ],
+      "fields": [
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_REMOVE_NS": {
+    "type": "object",
+    "title": "MONGODB_REMOVE_NS",
+    "description": "单据类型: MONGODB_REMOVE_NS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                },
+                "drop_type": {
+                  "type": "string",
+                  "description": "删除类型",
+                  "default": ""
+                },
+                "drop_index": {
+                  "type": "boolean",
+                  "description": "是否删除索引",
+                  "default": true
+                },
+                "ns_filter": {
+                  "type": "object",
+                  "description": "库表选择器"
+                }
+              }
+            },
+            "description": "清档信息"
+          },
+          "is_safe": {
+            "type": "boolean",
+            "description": "是否做安全检测",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBClearDetailSerializer",
+      "builder_class": "MongoDBClearApplyFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_clear.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/RemoveNs.vue",
+      "props_type": "Mongodb.RemoveNs",
+      "labels": [
+        "忽略业务连接",
+        "集群类型",
+        "清档类型",
+        "索引处理",
+        "指定 DB 名",
+        "忽略 DB 名",
+        "指定表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_INSTANCE_DEINSTALL": {
+    "type": "object",
+    "title": "MONGODB_INSTANCE_DEINSTALL",
+    "description": "单据类型: MONGODB_INSTANCE_DEINSTALL",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/InstanceDeinstall.vue",
+      "props_type": "Mongodb.InstanceDeinstall",
+      "labels": [
+        "角色",
+        "实例"
+      ],
+      "fields": [
+        "infos"
+      ]
+    }
+  },
+  "MONGODB_REDUCE_MONGOS": {
+    "type": "object",
+    "title": "MONGODB_REDUCE_MONGOS",
+    "description": "单据类型: MONGODB_REDUCE_MONGOS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "mackine_infos": {
+            "type": "string",
+            "description": "mackine_infos"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ReduceMongos.vue",
+      "props_type": "Mongodb.ResourcePool.ReduceMongos",
+      "labels": [
+        "缩容节点类型",
+        "当前规格",
+        "缩容的IP"
+      ],
+      "fields": [
+        "infos",
+        "clusters",
+        "mackine_infos"
+      ]
+    }
+  },
+  "MONGODB_RESTORE": {
+    "type": "object",
+    "title": "MONGODB_RESTORE",
+    "description": "单据类型: MONGODB_RESTORE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/Restore.vue",
+      "props_type": "Mongodb.Restore",
+      "labels": [
+        "构造类型",
+        "备份文件",
+        "指定时间",
+        "备份DB名",
+        "备份表名",
+        "忽略表名"
+      ],
+      "fields": []
+    }
+  },
+  "MONGODB_FULL_BACKUP": {
+    "type": "object",
+    "title": "MONGODB_FULL_BACKUP",
+    "description": "单据类型: MONGODB_FULL_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "oplog": {
+            "type": "boolean",
+            "description": "是否需要oplog备份"
+          },
+          "file_tag": {
+            "type": "string",
+            "description": "备份保存时间"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                }
+              }
+            },
+            "description": "备份信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBFullBackupDetailSerializer",
+      "builder_class": "MongoDBFullBackupApplyFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_full_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/FullBackup.vue",
+      "props_type": "Mongodb.FullBackup",
+      "labels": [
+        "备份保存时间",
+        "是否备份 Oplog",
+        "集群类型"
+      ],
+      "fields": [
+        "oplog",
+        "file_tag",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_CUTOFF": {
+    "type": "object",
+    "title": "MONGODB_CUTOFF",
+    "description": "单据类型: MONGODB_CUTOFF",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/Cutoff.vue",
+      "props_type": "Mongodb.Cutoff",
+      "labels": [
+        "角色类型",
+        "所属集群",
+        "新机规格"
+      ],
+      "fields": []
+    }
+  },
+  "MONGODB_EXCEL_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "MONGODB_EXCEL_AUTHORIZE_RULES",
+    "description": "单据类型: MONGODB_EXCEL_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "authorize_data": {
+            "type": "string",
+            "description": "authorize_data"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/ExcelAuthorize.vue",
+      "props_type": "Mongodb.AuthorizeRules",
+      "labels": [
+        "目标集群",
+        "Excel 文件"
+      ],
+      "fields": [
+        "authorize_data"
+      ]
+    }
+  },
+  "MONGODB_EXEC_SCRIPT_APPLY": {
+    "type": "object",
+    "title": "MONGODB_EXEC_SCRIPT_APPLY",
+    "description": "单据类型: MONGODB_EXEC_SCRIPT_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "scripts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "文件名"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "脚本内容"
+                }
+              }
+            },
+            "description": "脚本内容列表"
+          },
+          "mode": {
+            "type": "string",
+            "description": "脚本导入类型"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBScriptExecDetailSerializer",
+      "builder_class": "MongoScriptExecApplyFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_script_exec.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/ExecScriptApply.vue",
+      "props_type": "Mongodb.ExecScriptApply",
+      "labels": [
+        "脚本来源",
+        "脚本执行内容",
+        "目标集群",
+        "类型"
+      ],
+      "fields": [
+        "cluster_ids.map",
+        "mode",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_PITR_RESTORE": {
+    "type": "object",
+    "title": "MONGODB_PITR_RESTORE",
+    "description": "单据类型: MONGODB_PITR_RESTORE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "cluster_type": {
+            "type": "string",
+            "description": "cluster_type"
+          },
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "mongodb": {
+                "type": "object",
+                "properties": {
+                  "spec_id": {
+                    "type": "string",
+                    "description": "spec_id"
+                  }
+                }
+              }
+            }
+          },
+          "rollback_time": {
+            "type": "string",
+            "description": "rollback_time"
+          },
+          "instance_per_host": {
+            "type": "string",
+            "description": "instance_per_host"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/PitrRestore.vue",
+      "props_type": "Mongodb.PitrRestore",
+      "labels": [
+        "集群类型:",
+        "目标集群与构造设置:",
+        "构造新主机规格:",
+        "每台主机构造 Shard 数量:",
+        "版本",
+        "指定时间"
+      ],
+      "fields": [
+        "clusters",
+        "specs",
+        "cluster_ids.map",
+        "cluster_type",
+        "resource_spec.mongodb.spec_id",
+        "rollback_time",
+        "instance_per_host"
+      ]
+    }
+  },
+  "MONGODB_REPLICASET_APPLY": {
+    "type": "object",
+    "title": "MONGODB_REPLICASET_APPLY",
+    "description": "单据类型: MONGODB_REPLICASET_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "node_count": {
+            "type": "string",
+            "description": "node_count"
+          },
+          "replica_count": {
+            "type": "string",
+            "description": "replica_count"
+          },
+          "oplog_percent": {
+            "type": "string",
+            "description": "oplog_percent"
+          },
+          "start_port": {
+            "type": "string",
+            "description": "start_port"
+          },
+          "node_replica_count": {
+            "type": "string",
+            "description": "node_replica_count"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/ReplicasetApply.vue",
+      "props_type": "Mongodb.ReplicasetApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "管控区域",
+        "MongoDB版本",
+        "访问端口",
+        "部署副本集数量",
+        "每组主机部署副本集数量",
+        "Shard 节点数",
+        "规格",
+        "资源标签",
+        "每台主机 oplog 容量占比",
+        "域名设置",
+        "集群ID",
+        "集群名称"
+      ],
+      "fields": [
+        "node_count",
+        "replica_count",
+        "oplog_percent",
+        "start_port",
+        "node_replica_count",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "MONGODB_INSTANCE_RELOAD": {
+    "type": "object",
+    "title": "MONGODB_INSTANCE_RELOAD",
+    "description": "单据类型: MONGODB_INSTANCE_RELOAD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "bk_host_id": {
+                  "type": "integer",
+                  "description": "实例主机ID"
+                },
+                "instance_id": {
+                  "type": "integer",
+                  "description": "实例ID"
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "实例Port"
+                },
+                "role": {
+                  "type": "string",
+                  "description": "角色"
+                }
+              }
+            },
+            "description": "重启信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBInstanceReloadDetailSerializer",
+      "builder_class": "MongoDBInstanceReloadApplyFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_instance_reload.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mongodb/InstanceReload.vue",
+      "props_type": "Mongodb.InstanceReload",
+      "labels": [
+        "角色",
+        "所属集群"
+      ],
+      "fields": [
+        "instances",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "ES_REBOOT": {
+    "type": "object",
+    "title": "ES_REBOOT",
+    "description": "单据类型: ES_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "EsRebootDetailSerializer",
+      "builder_class": "EsRebootFlowBuilder",
+      "source_file": "ticket/builders/es/es_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/Reboot.vue",
+      "props_type": "Es.Reboot",
+      "labels": [
+        "集群ID",
+        "集群名称",
+        "集群类型",
+        "节点IP"
+      ],
+      "fields": []
+    }
+  },
+  "ES_DESTROY": {
+    "type": "object",
+    "title": "ES_DESTROY",
+    "description": "单据类型: ES_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/Destroy.vue",
+      "props_type": "Es.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_ENABLE": {
+    "type": "object",
+    "title": "ES_ENABLE",
+    "description": "单据类型: ES_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/Enable.vue",
+      "props_type": "Es.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_DELETE_POLARIS": {
+    "type": "object",
+    "title": "ES_DELETE_POLARIS",
+    "description": "单据类型: ES_DELETE_POLARIS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "EsDeletePolarisDetailSerializer",
+      "builder_class": "EsDeletePolarisFlowBuilder",
+      "source_file": "ticket/builders/es/es_delete_polaris.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/DeletePolaris.vue",
+      "props_type": "Es.DeletePolaris",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_CREATE_CLB": {
+    "type": "object",
+    "title": "ES_CREATE_CLB",
+    "description": "单据类型: ES_CREATE_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "EsCreateCLBDetailSerializer",
+      "builder_class": "EsCreateCLBFlowBuilder",
+      "source_file": "ticket/builders/es/es_create_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/AddClb.vue",
+      "props_type": "Es.AddClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_DNS_BIND_CLB": {
+    "type": "object",
+    "title": "ES_DNS_BIND_CLB",
+    "description": "单据类型: ES_DNS_BIND_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "EsDnsBindCLBDetailSerializer",
+      "builder_class": "EsDnsBindCLBFlowBuilder",
+      "source_file": "ticket/builders/es/es_dns_bind_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/ClbBindDomain.vue",
+      "props_type": "Es.ClbBindDomain",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_DISABLE": {
+    "type": "object",
+    "title": "ES_DISABLE",
+    "description": "单据类型: ES_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/Disable.vue",
+      "props_type": "Es.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_APPLY": {
+    "type": "object",
+    "title": "ES_APPLY",
+    "description": "单据类型: ES_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "http_port": {
+            "type": "string",
+            "description": "http_port"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/Apply.vue",
+      "props_type": "Es.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "版本",
+        "Master节点规格",
+        "Master 节点资源标签",
+        "Client节点规格",
+        "Client 节点资源标签",
+        "热节点规格",
+        "热节点资源标签",
+        "冷节点规格",
+        "冷节点资源标签",
+        "热节点IP",
+        "冷节点IP",
+        "Client节点IP",
+        "Master节点IP",
+        "端口号"
+      ],
+      "fields": [
+        "cluster_name",
+        "http_port",
+        "cluster_alias",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "ES_SHRINK": {
+    "type": "object",
+    "title": "ES_SHRINK",
+    "description": "单据类型: ES_SHRINK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/elastic-search/Shrink.vue",
+      "props_type": "Bigdata.ResourcePool.Shrink",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "DORIS_SCALE_UP": {
+    "type": "object",
+    "title": "DORIS_SCALE_UP",
+    "description": "单据类型: DORIS_SCALE_UP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/doris/ScaleUp.vue",
+      "props_type": "Bigdata.ResourcePool.ScaleUp",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_DNS_UNBIND_CLB": {
+    "type": "object",
+    "title": "ES_DNS_UNBIND_CLB",
+    "description": "单据类型: ES_DNS_UNBIND_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "EsDnsUnBindCLBDetailSerializer",
+      "builder_class": "EsDnsUnBindCLBFlowBuilder",
+      "source_file": "ticket/builders/es/es_dns_unbind_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/ClbUnbindDomain.vue",
+      "props_type": "Es.ClbUnbindDomain",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_REPLACE": {
+    "type": "object",
+    "title": "ES_REPLACE",
+    "description": "单据类型: ES_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/elastic-search/Replace.vue",
+      "props_type": "Bigdata.ResourcePool.Replace",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_DELETE_CLB": {
+    "type": "object",
+    "title": "ES_DELETE_CLB",
+    "description": "单据类型: ES_DELETE_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/DeleteClb.vue",
+      "props_type": "Es.DeleteClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "ES_CREATE_POLARIS": {
+    "type": "object",
+    "title": "ES_CREATE_POLARIS",
+    "description": "单据类型: ES_CREATE_POLARIS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "EsCreatePolarisDetailSerializer",
+      "builder_class": "EsCreatePolarisFlowBuilder",
+      "source_file": "ticket/builders/es/es_create_polaris.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/elastic-search/AddPolaris.vue",
+      "props_type": "Es.AddPolaris",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "INFLUXDB_REBOOT": {
+    "type": "object",
+    "title": "INFLUXDB_REBOOT",
+    "description": "单据类型: INFLUXDB_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "InfluxDBRebootDetailSerializer",
+      "builder_class": "InfluxDBRebootFlowBuilder",
+      "source_file": "ticket/builders/influxdb/influxdb_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/influxdb/Reboot.vue",
+      "props_type": null,
+      "labels": [],
+      "fields": []
+    }
+  },
+  "INFLUXDB_DESTROY": {
+    "type": "object",
+    "title": "INFLUXDB_DESTROY",
+    "description": "单据类型: INFLUXDB_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/influxdb/Destroy.vue",
+      "props_type": null,
+      "labels": [],
+      "fields": []
+    }
+  },
+  "INFLUXDB_ENABLE": {
+    "type": "object",
+    "title": "INFLUXDB_ENABLE",
+    "description": "单据类型: INFLUXDB_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/influxdb/Enable.vue",
+      "props_type": null,
+      "labels": [],
+      "fields": []
+    }
+  },
+  "INFLUXDB_DISABLE": {
+    "type": "object",
+    "title": "INFLUXDB_DISABLE",
+    "description": "单据类型: INFLUXDB_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/influxdb/Disable.vue",
+      "props_type": null,
+      "labels": [],
+      "fields": []
+    }
+  },
+  "INFLUXDB_APPLY": {
+    "type": "object",
+    "title": "INFLUXDB_APPLY",
+    "description": "单据类型: INFLUXDB_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "port": {
+            "type": "string",
+            "description": "port"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "group_name": {
+            "type": "string",
+            "description": "group_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/influxdb/Apply.vue",
+      "props_type": "Influxdb.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "分组名",
+        "版本",
+        "规格",
+        "服务器",
+        "访问端口"
+      ],
+      "fields": [
+        "port",
+        "ip_source",
+        "group_name",
+        "db_version"
+      ]
+    }
+  },
+  "KAFKA_REBOOT": {
+    "type": "object",
+    "title": "KAFKA_REBOOT",
+    "description": "单据类型: KAFKA_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "KafkaRebootDetailSerializer",
+      "builder_class": "KafkaRebootFlowBuilder",
+      "source_file": "ticket/builders/kafka/kafka_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/kafka/Reboot.vue",
+      "props_type": "Kafka.Reboot",
+      "labels": [
+        "集群ID",
+        "集群名称",
+        "集群类型",
+        "节点IP"
+      ],
+      "fields": []
+    }
+  },
+  "KAFKA_REBALANCE": {
+    "type": "object",
+    "title": "KAFKA_REBALANCE",
+    "description": "单据类型: KAFKA_REBALANCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_id": {
+            "type": "integer",
+            "description": "集群ID"
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "topics"
+          },
+          "throttle_rate": {
+            "type": "integer",
+            "description": "要均衡的速率"
+          },
+          "instance_list": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "bk_cloud_id": {
+                  "type": "integer",
+                  "description": "云区域ID"
+                },
+                "ip": {
+                  "type": "string",
+                  "description": "IP地址"
+                },
+                "bk_host_id": {
+                  "type": "integer",
+                  "description": "主机ID"
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "端口"
+                }
+              }
+            },
+            "description": "broker 列表"
+          },
+          "instance_info": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "前端展示实例信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "KafkaRebalanceDetailSerializer",
+      "builder_class": "KafkaRebalanceFlowBuilder",
+      "source_file": "ticket/builders/kafka/kafka_rebalance.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/kafka/Rebalance.vue",
+      "props_type": "Kafka.Rebalance",
+      "labels": [
+        "集群",
+        "Topic",
+        "速率",
+        "主机 Agent 状态",
+        "部署时间"
+      ],
+      "fields": [
+        "clusters",
+        "topics",
+        "throttle_rate",
+        "cluster_id",
+        "instance_list",
+        "instance_info"
+      ]
+    }
+  },
+  "KAFKA_DESTROY": {
+    "type": "object",
+    "title": "KAFKA_DESTROY",
+    "description": "单据类型: KAFKA_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/kafka/Destroy.vue",
+      "props_type": "Kafka.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "KAFKA_ENABLE": {
+    "type": "object",
+    "title": "KAFKA_ENABLE",
+    "description": "单据类型: KAFKA_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/kafka/Enable.vue",
+      "props_type": "Kafka.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "KAFKA_DISABLE": {
+    "type": "object",
+    "title": "KAFKA_DISABLE",
+    "description": "单据类型: KAFKA_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/kafka/Disable.vue",
+      "props_type": "Kafka.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "KAFKA_APPLY": {
+    "type": "object",
+    "title": "KAFKA_APPLY",
+    "description": "单据类型: KAFKA_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "retention_hours": {
+            "type": "string",
+            "description": "retention_hours"
+          },
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "no_security": {
+            "type": "string",
+            "description": "no_security"
+          },
+          "replication_num": {
+            "type": "string",
+            "description": "replication_num"
+          },
+          "partition_num": {
+            "type": "string",
+            "description": "partition_num"
+          },
+          "retention_bytes": {
+            "type": "string",
+            "description": "retention_bytes"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "port": {
+            "type": "string",
+            "description": "port"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/kafka/Apply.vue",
+      "props_type": "Kafka.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "版本",
+        "Broker节点规格",
+        "Broker 节点资源标签",
+        "Zookeeper节点规格",
+        "Zookeeper 节点资源标签",
+        "Broker节点IP",
+        "Zookeeper节点IP",
+        "开启认证",
+        "总容量",
+        "访问端口",
+        "Partition数量",
+        "消息保留时间",
+        "消息保留大小",
+        "副本数量"
+      ],
+      "fields": [
+        "retention_hours",
+        "cluster_name",
+        "no_security",
+        "replication_num",
+        "partition_num",
+        "retention_bytes",
+        "cluster_alias",
+        "port",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "KAFKA_SHRINK": {
+    "type": "object",
+    "title": "KAFKA_SHRINK",
+    "description": "单据类型: KAFKA_SHRINK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/kafka/Shrink.vue",
+      "props_type": "Bigdata.ResourcePool.Shrink",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "KAFKA_SCALE_UP": {
+    "type": "object",
+    "title": "KAFKA_SCALE_UP",
+    "description": "单据类型: KAFKA_SCALE_UP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/kafka/ScaleUp.vue",
+      "props_type": "Bigdata.ResourcePool.ScaleUp",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "KAFKA_REPLACE": {
+    "type": "object",
+    "title": "KAFKA_REPLACE",
+    "description": "单据类型: KAFKA_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/kafka/Replace.vue",
+      "props_type": "Bigdata.ResourcePool.Replace",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_CHECKSUM_CRON": {
+    "type": "object",
+    "title": "MYSQL_CHECKSUM_CRON",
+    "description": "单据类型: MYSQL_CHECKSUM_CRON",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "skip_timer": {
+            "type": "boolean",
+            "description": "是否是定时"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLChecksumCronDetailSerializer",
+      "builder_class": "MySQLChecksumCronFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_checksum_cron.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/CheckSumCron.vue",
+      "props_type": "Mysql.CheckSum",
+      "labels": [
+        "执行模式",
+        "全局超时时间（h）",
+        "修复数据",
+        "修复模式",
+        "校验从库",
+        "校验主库",
+        "校验 DB 名",
+        "忽略 DB 名",
+        "校验表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "runtime_hour",
+        "data_repair.mode",
+        "data_repair.is_repair",
+        "need_manual_confirm",
+        "clusters",
+        "infos.map",
+        "infos",
+        "timing",
+        "infos.reduce"
+      ]
+    }
+  },
+  "MYSQL_PROXY_UPGRADE": {
+    "type": "object",
+    "title": "MYSQL_PROXY_UPGRADE",
+    "description": "单据类型: MYSQL_PROXY_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                },
+                "pkg_id": {
+                  "type": "integer",
+                  "description": "目标版本包ID"
+                }
+              }
+            },
+            "description": "单据信息"
+          },
+          "is_check_process": {
+            "type": "boolean",
+            "description": "是否做安全检测",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlProxyUpgradeDetailSerializer",
+      "builder_class": "MysqlProxyUpgradeFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_proxy_upgrade.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ProxyUpgrade.vue",
+      "props_type": "Mysql.ProxyUpgrade",
+      "labels": [
+        "检查业务连接",
+        "当前版本",
+        "目标版本"
+      ],
+      "fields": [
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_MIGRATE_UPGRADE": {
+    "type": "object",
+    "title": "MYSQL_MIGRATE_UPGRADE",
+    "description": "单据类型: MYSQL_MIGRATE_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "need_checksum": {
+            "type": "string",
+            "description": "need_checksum"
+          },
+          "is_check_process": {
+            "type": "string",
+            "description": "is_check_process"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "backup_source"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/MigrateUpgrade.vue",
+      "props_type": "Mysql.ResourcePool.MigrateUpgrade",
+      "labels": [
+        "检查业务连接",
+        "数据校验",
+        "备份源：",
+        "当前版本",
+        "目标版本",
+        "规格",
+        "资源标签",
+        "只读主机（旧 -"
+      ],
+      "fields": [
+        "need_checksum",
+        "is_check_process",
+        "clusters",
+        "specs",
+        "infos",
+        "backup_source"
+      ]
+    }
+  },
+  "MYSQL_PROXY_SWITCH": {
+    "type": "object",
+    "title": "MYSQL_PROXY_SWITCH",
+    "description": "单据类型: MYSQL_PROXY_SWITCH",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/ProxySwitch.vue",
+      "props_type": "Mysql.ResourcePool.ProxySwitch",
+      "labels": [
+        "检查业务连接",
+        "目标Proxy主机",
+        "关联集群",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_HA_DESTROY": {
+    "type": "object",
+    "title": "MYSQL_HA_DESTROY",
+    "description": "单据类型: MYSQL_HA_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaDestroy.vue",
+      "props_type": "Mysql.HaDestroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_SINGLE_ENABLE": {
+    "type": "object",
+    "title": "MYSQL_SINGLE_ENABLE",
+    "description": "单据类型: MYSQL_SINGLE_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/SingleEnable.vue",
+      "props_type": "Mysql.SingleEnable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_RESTORE_SLAVE": {
+    "type": "object",
+    "title": "MYSQL_RESTORE_SLAVE",
+    "description": "单据类型: MYSQL_RESTORE_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "source_type": {
+            "type": "string",
+            "description": "source_type"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "backup_source"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/RestoreSlave.vue",
+      "props_type": "Mysql.ResourcePool.RestoreSlave",
+      "labels": [
+        "主机选择方式",
+        "备份源",
+        "同机关联集群",
+        "规格",
+        "资源标签",
+        "新从库主机"
+      ],
+      "fields": [
+        "source_type",
+        "clusters",
+        "specs",
+        "infos",
+        "backup_source"
+      ]
+    }
+  },
+  "MYSQL_MASTER_FAIL_OVER": {
+    "type": "object",
+    "title": "MYSQL_MASTER_FAIL_OVER",
+    "description": "单据类型: MYSQL_MASTER_FAIL_OVER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlMasterFailOverDetailSerializer",
+      "builder_class": "MysqlMasterFailOverFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_master_fail_over.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/MasterFailOver.vue",
+      "props_type": "Mysql.MasterFailOver",
+      "labels": [
+        "检查业务来源的连接",
+        "检查主从数据校验结果",
+        "从库主机",
+        "同机关联的集群"
+      ],
+      "fields": [
+        "is_verify_checksum",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_ACCOUNT_RULE_CHANGE": {
+    "type": "object",
+    "title": "MYSQL_ACCOUNT_RULE_CHANGE",
+    "description": "单据类型: MYSQL_ACCOUNT_RULE_CHANGE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/AccountRuleChange.vue",
+      "props_type": "Mysql.AccountRuleChange",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "MYSQL_AUTHORIZE_RULES",
+    "description": "单据类型: MYSQL_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "authorize_uid": {
+            "type": "string",
+            "description": "授权数据缓存uid"
+          },
+          "authorize_data": {
+            "type": "object",
+            "description": "授权数据信息",
+            "properties": {
+              "privileges": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "授权详情"
+              }
+            }
+          },
+          "authorize_plugin_infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "bk_biz_id": {
+                  "type": "integer",
+                  "description": "业务ID"
+                },
+                "user": {
+                  "type": "string",
+                  "description": "授权账号"
+                },
+                "access_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "准入DB"
+                },
+                "source_ips": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "源IP列表"
+                },
+                "target_instances": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标集群域名"
+                },
+                "cluster_type": {
+                  "type": "string",
+                  "description": "集群类型"
+                }
+              }
+            },
+            "description": "第三方接口/插件授权信息"
+          },
+          "need_itsm": {
+            "type": "boolean",
+            "description": "是否需要审批",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLAuthorizeRulesSerializer",
+      "builder_class": "MySQLAuthorizeRulesFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_authorize_rules.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/AuthorizeRule.vue",
+      "props_type": "Mysql.AuthorizeRules",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_ROLLBACK_CLUSTER": {
+    "type": "object",
+    "title": "MYSQL_ROLLBACK_CLUSTER",
+    "description": "单据类型: MYSQL_ROLLBACK_CLUSTER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "rollback_cluster_type": {
+            "type": "string",
+            "description": "rollback_cluster_type"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/RollbackCluster.vue",
+      "props_type": "Mysql.ResourcePool.RollbackCluster",
+      "labels": [
+        "构造类型",
+        "目标集群",
+        "回档到新主机",
+        "备份源",
+        "回档类型",
+        "回档DB",
+        "忽略 DB",
+        "回档表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "infos",
+        "rollback_cluster_type",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_RESTORE_LOCAL_SLAVE": {
+    "type": "object",
+    "title": "MYSQL_RESTORE_LOCAL_SLAVE",
+    "description": "单据类型: MYSQL_RESTORE_LOCAL_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "slave": {
+                  "type": "object",
+                  "description": "从库实例信息"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                }
+              }
+            },
+            "description": "重建从库列表"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "备份源"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlRestoreLocalSlaveDetailSerializer",
+      "builder_class": "MysqlRestoreLocalSlaveFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_restore_local_slave.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/RestoreLocalSlave.vue",
+      "props_type": "Mysql.RestoreLocalSlave",
+      "labels": [
+        "目标从库实例",
+        "备份源"
+      ],
+      "fields": [
+        "backup_source",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_SINGLE_DISABLE": {
+    "type": "object",
+    "title": "MYSQL_SINGLE_DISABLE",
+    "description": "单据类型: MYSQL_SINGLE_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/SingleDisable.vue",
+      "props_type": "Mysql.SingleDisable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_ADD_CLB": {
+    "type": "object",
+    "title": "MYSQL_ADD_CLB",
+    "description": "单据类型: MYSQL_ADD_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlAddCLBDetailSerializer",
+      "builder_class": "MysqlAddCLBFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_add_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/AddClb.vue",
+      "props_type": "Mysql.AddClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_HA_ENABLE": {
+    "type": "object",
+    "title": "MYSQL_HA_ENABLE",
+    "description": "单据类型: MYSQL_HA_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaEnable.vue",
+      "props_type": "Mysql.HaEnable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_CLIENT_CLONE_RULES": {
+    "type": "object",
+    "title": "MYSQL_CLIENT_CLONE_RULES",
+    "description": "单据类型: MYSQL_CLIENT_CLONE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clone_plugin_infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "description": "源IP"
+                },
+                "target": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标IP列表"
+                },
+                "bk_cloud_id": {
+                  "type": "integer",
+                  "description": "云区域ID"
+                },
+                "user": {
+                  "type": "string",
+                  "description": "用户名"
+                },
+                "target_instances": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标域名"
+                }
+              }
+            },
+            "description": "插件的权限克隆信息"
+          },
+          "clone_uid": {
+            "type": "string",
+            "description": "权限克隆数据缓存uid"
+          },
+          "clone_type": {
+            "type": "string",
+            "description": "权限克隆类型"
+          },
+          "clone_cluster_type": {
+            "type": "string",
+            "description": "克隆集群类型"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLCloneRulesSerializer",
+      "builder_class": "MySQLClientCloneRulesFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_clone_rules.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ClientCloneRules.vue",
+      "props_type": "Mysql.ClientCloneRules",
+      "labels": [
+        "所属模块"
+      ],
+      "fields": [
+        "clone_data"
+      ]
+    }
+  },
+  "MYSQL_SINGLE_APPLY": {
+    "type": "object",
+    "title": "MYSQL_SINGLE_APPLY",
+    "description": "单据类型: MYSQL_SINGLE_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "domains": {
+            "type": "string",
+            "description": "domains"
+          },
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "backend": {
+                "type": "object",
+                "properties": {
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  },
+                  "spec_name": {
+                    "type": "string",
+                    "description": "spec_name"
+                  },
+                  "count": {
+                    "type": "string",
+                    "description": "count"
+                  }
+                },
+                "description": "backend (也可能是叶子节点)"
+              }
+            },
+            "description": "resource_spec (也可能是叶子节点)"
+          },
+          "charset": {
+            "type": "string",
+            "description": "charset"
+          },
+          "db_module_name": {
+            "type": "string",
+            "description": "db_module_name"
+          },
+          "nodes": {
+            "type": "object",
+            "properties": {
+              "backend": {
+                "type": "string",
+                "description": "backend"
+              }
+            },
+            "description": "nodes (也可能是叶子节点)"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/SingleApply.vue",
+      "props_type": "Mysql.SingleApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "DB模块名",
+        "管控区域",
+        "MySQL起始端口",
+        "后端存储资源规格",
+        "后端存储资源标签",
+        "域名设置",
+        "部署架构",
+        "数据库版本",
+        "字符集",
+        "服务器"
+      ],
+      "fields": [
+        "domains",
+        "resource_spec.backend",
+        "resource_spec.backend.label_names",
+        "charset",
+        "db_module_name",
+        "nodes.backend",
+        "resource_spec.backend.spec_name",
+        "resource_spec.backend.count",
+        "resource_spec",
+        "nodes",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "MYSQL_ADD_SLAVE": {
+    "type": "object",
+    "title": "MYSQL_ADD_SLAVE",
+    "description": "单据类型: MYSQL_ADD_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "backup_source": {
+            "type": "string",
+            "description": "backup_source"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/AddSlave.vue",
+      "props_type": "Mysql.ResourcePool.AddSlave",
+      "labels": [
+        "备份源",
+        "新从库主机"
+      ],
+      "fields": [
+        "backup_source",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_CLB_BIND_DOMAIN": {
+    "type": "object",
+    "title": "MYSQL_CLB_BIND_DOMAIN",
+    "description": "单据类型: MYSQL_CLB_BIND_DOMAIN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlCLBBindDomainDetailSerializer",
+      "builder_class": "MysqlCLBBindDomainFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_clb_bind_domain.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ClbBindDomain.vue",
+      "props_type": "Mysql.ClbBindDomain",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_PROXY_ADD": {
+    "type": "object",
+    "title": "MYSQL_PROXY_ADD",
+    "description": "单据类型: MYSQL_PROXY_ADD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/ProxyAdd.vue",
+      "props_type": "Mysql.ResourcePool.ProxyAdd",
+      "labels": [
+        "当前数量（台）",
+        "扩容数量（台）",
+        "最终数量（台）",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_ROLLBACK": {
+    "type": "object",
+    "title": "MYSQL_ROLLBACK",
+    "description": "单据类型: MYSQL_ROLLBACK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/Rollback.vue",
+      "props_type": "Mysql.ResourcePool.RollbackCluster",
+      "labels": [
+        "回档类型",
+        "回档方式",
+        "备份源",
+        "指定时间",
+        "备份记录",
+        "源 DB",
+        "源表",
+        "受影响的 DB"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_HA_TRUNCATE_DATA": {
+    "type": "object",
+    "title": "MYSQL_HA_TRUNCATE_DATA",
+    "description": "单据类型: MYSQL_HA_TRUNCATE_DATA",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "db_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配DB列表"
+                },
+                "ignore_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略DB列表"
+                },
+                "table_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配Table列表"
+                },
+                "ignore_tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略Table列表"
+                },
+                "truncate_data_type": {
+                  "type": "string",
+                  "description": "清档类型"
+                },
+                "force": {
+                  "type": "boolean",
+                  "description": "是否强制执行",
+                  "default": false
+                }
+              }
+            },
+            "description": "清档信息列表"
+          },
+          "clear_mode": {
+            "type": "object",
+            "description": "删除备份库模式",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "单据执行模式"
+              },
+              "days": {
+                "type": "integer",
+                "description": "执行删除延迟天数",
+                "default": 15
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLHaClearDetailSerializer",
+      "builder_class": "MySQLHaClearFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_ha_clear.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaTruncateData.vue",
+      "props_type": "Mysql.TruncateData",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_IMPORT_SQLFILE": {
+    "type": "object",
+    "title": "MYSQL_IMPORT_SQLFILE",
+    "description": "单据类型: MYSQL_IMPORT_SQLFILE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "root_id": {
+            "type": "string",
+            "description": "语义执行的流程ID"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlSqlImportDetailSerializer",
+      "builder_class": "MysqlSqlImportFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_import_sqlfile.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ImportSqlfile.vue",
+      "props_type": "Mysql.ImportSqlFile",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_FIXPOINT_EXIST_CLUSTER": {
+    "type": "object",
+    "title": "MYSQL_FIXPOINT_EXIST_CLUSTER",
+    "description": "单据类型: MYSQL_FIXPOINT_EXIST_CLUSTER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/FixpointExistCluster.vue",
+      "props_type": "Mysql.RollbackCluster",
+      "labels": [
+        "构造类型",
+        "构造方式",
+        "备份源",
+        "指定时间",
+        "备份记录",
+        "源 DB",
+        "源表",
+        "目标集群",
+        "受影响的 DB"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_HA_DISABLE": {
+    "type": "object",
+    "title": "MYSQL_HA_DISABLE",
+    "description": "单据类型: MYSQL_HA_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaDisable.vue",
+      "props_type": "Mysql.HaDisable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_PARTITION": {
+    "type": "object",
+    "title": "MYSQL_PARTITION",
+    "description": "单据类型: MYSQL_PARTITION",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "config_id": {
+                  "type": "integer",
+                  "description": "配置ID列表"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "bk_cloud_id": {
+                  "type": "integer",
+                  "description": "云区域ID"
+                },
+                "immute_domain": {
+                  "type": "string",
+                  "description": "集群域名"
+                },
+                "partition_objects": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "分区执行对象列表"
+                }
+              }
+            },
+            "description": "分区信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLPartitionDetailSerializer",
+      "builder_class": "MysqlPartitionFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_partition.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/Partition.vue",
+      "props_type": "Mysql.Partition",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_CLUSTER_STANDARDIZE": {
+    "type": "object",
+    "title": "MYSQL_CLUSTER_STANDARDIZE",
+    "description": "单据类型: MYSQL_CLUSTER_STANDARDIZE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_biz_id": {
+            "type": "integer",
+            "description": "业务ID"
+          },
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "with_deploy_binary": {
+            "type": "boolean",
+            "description": "是否推送二进制",
+            "default": true
+          },
+          "with_push_config": {
+            "type": "boolean",
+            "description": "是否推送配置",
+            "default": true
+          },
+          "with_cc_standardize": {
+            "type": "boolean",
+            "description": "是否CC模块标准",
+            "default": false
+          },
+          "with_instance_standardize": {
+            "type": "boolean",
+            "description": "是否实例标准化. 高危",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLClusterStandardizeDetailSerializer",
+      "builder_class": "MySQLClusterStandardizeFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_cluster_standardize.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ClusterStandardize.vue",
+      "props_type": "Mysql.ClusterStandardize",
+      "labels": [
+        "下发配置",
+        "推送二进制文件",
+        "CC 标准化",
+        "集群类型"
+      ],
+      "fields": [
+        "clusters",
+        "with_push_config",
+        "cluster_ids.map",
+        "with_cc_standardize",
+        "with_deploy_binary"
+      ]
+    }
+  },
+  "MYSQL_DATA_MIGRATE": {
+    "type": "object",
+    "title": "MYSQL_DATA_MIGRATE",
+    "description": "单据类型: MYSQL_DATA_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source_cluster": {
+                  "type": "integer",
+                  "description": "源集群ID"
+                },
+                "target_clusters": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "目标集群列表"
+                },
+                "db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "最终库列表"
+                },
+                "data_schema_grant": {
+                  "type": "string",
+                  "description": "克隆类型",
+                  "default": "data,schema"
+                },
+                "clone_db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "克隆库列表"
+                },
+                "ignore_db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略db列表"
+                }
+              }
+            },
+            "description": "数据迁移信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLDataMigrateDetailSerializer",
+      "builder_class": "MySQLDataMigrateFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_data_migrate.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/DataMigrate.vue",
+      "props_type": "Mysql.DataMigrate",
+      "labels": [
+        "克隆类型",
+        "克隆 DB 名",
+        "忽略 DB",
+        "目标集群"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_SINGLE_DESTROY": {
+    "type": "object",
+    "title": "MYSQL_SINGLE_DESTROY",
+    "description": "单据类型: MYSQL_SINGLE_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/SingleDestroy.vue",
+      "props_type": "Mysql.SingleDestroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_EXCEL_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "MYSQL_EXCEL_AUTHORIZE_RULES",
+    "description": "单据类型: MYSQL_EXCEL_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ExcelAuthrizeRule.vue",
+      "props_type": "Mysql.AuthorizeRules",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_HA_RENAME_DATABASE": {
+    "type": "object",
+    "title": "MYSQL_HA_RENAME_DATABASE",
+    "description": "单据类型: MYSQL_HA_RENAME_DATABASE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "from_database": {
+                  "type": "string",
+                  "description": "源数据库名"
+                },
+                "to_database": {
+                  "type": "string",
+                  "description": "目标数据库名"
+                }
+              }
+            },
+            "description": "重命名数据库列表"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLHaRenameSerializer",
+      "builder_class": "MySQLHaRenameFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_ha_rename.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaDbRename.vue",
+      "props_type": "Mysql.RenameDataBase",
+      "labels": [
+        "检查业务连接",
+        "源DB名",
+        "新DB名"
+      ],
+      "fields": [
+        "infos",
+        "force",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_MIGRATE_CLUSTER": {
+    "type": "object",
+    "title": "MYSQL_MIGRATE_CLUSTER",
+    "description": "单据类型: MYSQL_MIGRATE_CLUSTER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "source_type": {
+            "type": "string",
+            "description": "source_type"
+          },
+          "need_checksum": {
+            "type": "string",
+            "description": "need_checksum"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "machine_infos": {
+            "type": "string",
+            "description": "machine_infos"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "opera_object": {
+            "type": "string",
+            "description": "opera_object"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "backup_source"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/MigrateCluster.vue",
+      "props_type": "Mysql.ResourcePool.MigrateCluster",
+      "labels": [
+        "迁移类型",
+        "主机选择方式",
+        "备份源",
+        "数据校验",
+        "同机关联实例",
+        "同机关联集群",
+        "规格",
+        "资源标签",
+        "新主从主机"
+      ],
+      "fields": [
+        "source_type",
+        "need_checksum",
+        "clusters",
+        "specs",
+        "machine_infos",
+        "infos",
+        "opera_object",
+        "backup_source"
+      ]
+    }
+  },
+  "MYSQL_HA_FULL_BACKUP": {
+    "type": "object",
+    "title": "MYSQL_HA_FULL_BACKUP",
+    "description": "单据类型: MYSQL_HA_FULL_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "backup_type": {
+            "type": "string",
+            "description": "备份类型"
+          },
+          "file_tag": {
+            "type": "string",
+            "description": "备份文件tag"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "backup_local": {
+                  "type": "string",
+                  "description": "备份位置"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLFullBackupDetailSerializer",
+      "builder_class": "TenDBHAFullBackupFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_full_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaFullBackup.vue",
+      "props_type": "Mysql.HaFullBackup",
+      "labels": [
+        "备份类型",
+        "备份保存时间",
+        "备份位置"
+      ],
+      "fields": [
+        "file_tag",
+        "backup_type",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_LOCAL_UPGRADE": {
+    "type": "object",
+    "title": "MYSQL_LOCAL_UPGRADE",
+    "description": "单据类型: MYSQL_LOCAL_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                },
+                "pkg_id": {
+                  "type": "integer",
+                  "description": "目标版本包ID"
+                },
+                "new_db_module_id": {
+                  "type": "integer",
+                  "description": "数据库模块ID"
+                }
+              }
+            },
+            "description": "单据信息"
+          },
+          "is_check_process": {
+            "type": "boolean",
+            "description": "是否做安全检测",
+            "default": true
+          },
+          "is_verify_checksum": {
+            "type": "boolean",
+            "description": "是否检查主从数据校验结果",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlLocalUpgradeDetailSerializer",
+      "builder_class": "MysqlLocalUpgradeFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_local_upgrade.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/LocalUpgrade.vue",
+      "props_type": "Mysql.LocalUpgrade",
+      "labels": [
+        "检查业务连接",
+        "当前版本",
+        "目标版本"
+      ],
+      "fields": [
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_SINGLE_TRUNCATE_DATA": {
+    "type": "object",
+    "title": "MYSQL_SINGLE_TRUNCATE_DATA",
+    "description": "单据类型: MYSQL_SINGLE_TRUNCATE_DATA",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLSingleClearDetailSerializer",
+      "builder_class": "MySQLSingleClearFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_single_clear.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/SingleTruncateData.vue",
+      "props_type": "Mysql.TruncateData",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_FORCE_IMPORT_SQLFILE": {
+    "type": "object",
+    "title": "MYSQL_FORCE_IMPORT_SQLFILE",
+    "description": "单据类型: MYSQL_FORCE_IMPORT_SQLFILE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ForceImportSqlfile.vue",
+      "props_type": "Mysql.ImportSqlFile",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_DELETE_CLEAR_DB": {
+    "type": "object",
+    "title": "MYSQL_DELETE_CLEAR_DB",
+    "description": "单据类型: MYSQL_DELETE_CLEAR_DB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/DeleteClearDb.vue",
+      "props_type": "Mysql.DeleteClearDb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_CLB_UNBIND_DOMAIN": {
+    "type": "object",
+    "title": "MYSQL_CLB_UNBIND_DOMAIN",
+    "description": "单据类型: MYSQL_CLB_UNBIND_DOMAIN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlCLBUnBindDomainDetailSerializer",
+      "builder_class": "MysqlCLBUnBindDomainFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_clb_unbind_domain.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ClbUnbindDomain.vue",
+      "props_type": "Mysql.ClbUnbindDomain",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_HA_DB_TABLE_BACKUP": {
+    "type": "object",
+    "title": "MYSQL_HA_DB_TABLE_BACKUP",
+    "description": "单据类型: MYSQL_HA_DB_TABLE_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "db_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配DB列表"
+                },
+                "ignore_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略DB列表"
+                },
+                "table_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配Table列表"
+                },
+                "ignore_tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略Table列表"
+                }
+              }
+            },
+            "description": "备份信息列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLDBTableBackupDetailSerializer",
+      "builder_class": "TenDBHADBTableBackupFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_db_table_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaDBTableBackup.vue",
+      "props_type": "Mysql.HaDBTableBackup",
+      "labels": [
+        "备份位置",
+        "备份DB名",
+        "忽略DB名",
+        "备份表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_MASTER_SLAVE_SWITCH": {
+    "type": "object",
+    "title": "MYSQL_MASTER_SLAVE_SWITCH",
+    "description": "单据类型: MYSQL_MASTER_SLAVE_SWITCH",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "master_ip": {
+                  "type": "object",
+                  "description": "主库 IP"
+                },
+                "slave_ip": {
+                  "type": "object",
+                  "description": "从库 IP"
+                },
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                }
+              }
+            },
+            "description": "单据信息"
+          },
+          "is_check_process": {
+            "type": "boolean",
+            "description": "是否检测连接",
+            "default": false
+          },
+          "is_check_delay": {
+            "type": "boolean",
+            "description": "是否检测数据同步延时情况(互切单据延时属于强制检测，故必须传True)",
+            "default": false
+          },
+          "is_verify_checksum": {
+            "type": "boolean",
+            "description": "是否检测历史数据检验结果",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlMasterSlaveSwitchDetailSerializer",
+      "builder_class": "MysqlMasterSlaveSwitchFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_master_slave_switch.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/MasterSlaveSwitch.vue",
+      "props_type": "Mysql.MasterSlaveSwitch",
+      "labels": [
+        "检查业务来源的连接",
+        "检查主从数据校验结果",
+        "目标从库",
+        "同机关联的集群"
+      ],
+      "fields": [
+        "is_verify_checksum",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_DUMP_DATA": {
+    "type": "object",
+    "title": "MYSQL_DUMP_DATA",
+    "description": "单据类型: MYSQL_DUMP_DATA",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_id": {
+            "type": "integer",
+            "description": "集群ID"
+          },
+          "charset": {
+            "type": "string",
+            "description": "字符集"
+          },
+          "where": {
+            "type": "string",
+            "description": "where条件"
+          },
+          "databases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "导出库列表"
+          },
+          "tables": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "目标table列表"
+          },
+          "tables_ignore": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "忽略table列表"
+          },
+          "dump_schema": {
+            "type": "boolean",
+            "description": "是否导出表结构"
+          },
+          "dump_data": {
+            "type": "boolean",
+            "description": "是否导出表数据"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLDumpDataDetailSerializer",
+      "builder_class": "MySQLDumpDataFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_dump_data.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/DumpData.vue",
+      "props_type": "Mysql.DumpData",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_HA_APPLY": {
+    "type": "object",
+    "title": "MYSQL_HA_APPLY",
+    "description": "单据类型: MYSQL_HA_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "proxy": {
+                "type": "object",
+                "properties": {
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  },
+                  "count": {
+                    "type": "string",
+                    "description": "count"
+                  },
+                  "spec_name": {
+                    "type": "string",
+                    "description": "spec_name"
+                  }
+                },
+                "description": "proxy (也可能是叶子节点)"
+              },
+              "backend_group": {
+                "type": "object",
+                "properties": {
+                  "count": {
+                    "type": "string",
+                    "description": "count"
+                  },
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  },
+                  "spec_name": {
+                    "type": "string",
+                    "description": "spec_name"
+                  }
+                },
+                "description": "backend_group (也可能是叶子节点)"
+              }
+            },
+            "description": "resource_spec (也可能是叶子节点)"
+          },
+          "domains": {
+            "type": "string",
+            "description": "domains"
+          },
+          "cluster_count": {
+            "type": "string",
+            "description": "cluster_count"
+          },
+          "charset": {
+            "type": "string",
+            "description": "charset"
+          },
+          "db_module_name": {
+            "type": "string",
+            "description": "db_module_name"
+          },
+          "start_proxy_port": {
+            "type": "string",
+            "description": "start_proxy_port"
+          },
+          "start_mysql_port": {
+            "type": "string",
+            "description": "start_mysql_port"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/HaApply.vue",
+      "props_type": "Mysql.HaApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "DB模块名",
+        "管控区域",
+        "Proxy起始端口",
+        "MySQL起始端口",
+        "数量",
+        "Proxy 存储资源规格",
+        "Proxy 存储资源标签",
+        "后端存储资源规格",
+        "后端存储资源标签",
+        "域名设置",
+        "从访问入口",
+        "部署架构",
+        "数据库版本",
+        "字符集"
+      ],
+      "fields": [
+        "resource_spec.proxy.label_names",
+        "domains",
+        "cluster_count",
+        "charset",
+        "resource_spec.backend_group.count",
+        "db_module_name",
+        "start_proxy_port",
+        "start_mysql_port",
+        "resource_spec",
+        "resource_spec.proxy",
+        "resource_spec.backend_group.label_names",
+        "resource_spec.proxy.count",
+        "resource_spec.backend_group",
+        "resource_spec.backend_group.spec_name",
+        "db_version",
+        "bk_cloud_name",
+        "resource_spec.proxy.spec_name"
+      ]
+    }
+  },
+  "MYSQL_PROXY_REDUCE": {
+    "type": "object",
+    "title": "MYSQL_PROXY_REDUCE",
+    "description": "单据类型: MYSQL_PROXY_REDUCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/ProxyReduce.vue",
+      "props_type": "Mysql.ProxyReduce",
+      "labels": [
+        "检查业务连接",
+        "关联集群实例"
+      ],
+      "fields": [
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_FLASHBACK": {
+    "type": "object",
+    "title": "MYSQL_FLASHBACK",
+    "description": "单据类型: MYSQL_FLASHBACK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "start_time": {
+                  "type": "string",
+                  "description": "开始时间"
+                },
+                "end_time": {
+                  "type": "string",
+                  "description": "结束时间",
+                  "default": ""
+                },
+                "databases": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标库列表"
+                },
+                "databases_ignore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略库列表"
+                },
+                "tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标table列表"
+                },
+                "tables_ignore": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略table列表"
+                },
+                "mysqlbinlog_rollback": {
+                  "type": "string",
+                  "description": "flashback工具地址"
+                },
+                "recored_file": {
+                  "type": "string",
+                  "description": "记录文件",
+                  "default": ""
+                },
+                "rows_filter": {
+                  "type": "string",
+                  "description": "待闪回记录",
+                  "default": ""
+                },
+                "direct_write_back": {
+                  "type": "boolean",
+                  "description": "是否覆盖原始数据",
+                  "default": false
+                },
+                "conv_rows_update_to_write": {
+                  "type": "boolean",
+                  "description": "update转replace",
+                  "default": false
+                },
+                "filter_delete_rows_only": {
+                  "type": "boolean",
+                  "description": "仅回滚delete",
+                  "default": false
+                }
+              }
+            },
+            "description": "flashback信息"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          },
+          "flashback_type": {
+            "type": "string",
+            "description": "闪回方式"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLFlashbackDetailSerializer",
+      "builder_class": "MySQLFlashbackFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_flashback.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/Flashback.vue",
+      "props_type": "Mysql.FlashBack",
+      "labels": [
+        "回档类型",
+        "日志追溯截止",
+        "覆盖原始数据",
+        "update 转 replace",
+        "仅回滚 delete",
+        "回档时间",
+        "目标库",
+        "忽略库",
+        "目标表",
+        "忽略表",
+        "待闪回记录"
+      ],
+      "fields": [
+        "flashback_type",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_RENAME_DATABASE": {
+    "type": "object",
+    "title": "MYSQL_RENAME_DATABASE",
+    "description": "单据类型: MYSQL_RENAME_DATABASE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "重命名数据库列表"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "强制执行",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLRenameDatabaseSerializer",
+      "builder_class": "MySQLRenameDatabaseFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_rename_database.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/RenameDataBase.vue",
+      "props_type": "Mysql.RenameDataBase",
+      "labels": [
+        "检查业务连接",
+        "源DB名",
+        "新DB名"
+      ],
+      "fields": [
+        "infos",
+        "force",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_CHECKSUM": {
+    "type": "object",
+    "title": "MYSQL_CHECKSUM",
+    "description": "单据类型: MYSQL_CHECKSUM",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "runtime_hour": {
+            "type": "integer",
+            "description": "超时时间"
+          },
+          "timing": {
+            "type": "string",
+            "description": "定时触发时间"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "slaves": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "slave信息列表"
+                },
+                "db_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配DB列表"
+                },
+                "ignore_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略DB列表"
+                },
+                "table_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配Table列表"
+                },
+                "ignore_tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略Table列表"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "repl_table": {
+                  "type": "string",
+                  "description": "校验结果表名"
+                }
+              }
+            },
+            "description": "数据校验信息列表"
+          },
+          "data_repair": {
+            "type": "object",
+            "description": "数据修复信息"
+          },
+          "is_sync_non_innodb": {
+            "type": "boolean",
+            "description": "非innodb表是否修复",
+            "default": false
+          },
+          "need_manual_confirm": {
+            "type": "boolean",
+            "description": "是否需要人工确认",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLChecksumDetailSerializer",
+      "builder_class": "MySQLChecksumFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_checksum.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/Checksum.vue",
+      "props_type": "Mysql.CheckSum",
+      "labels": [
+        "执行模式",
+        "全局超时时间（h）",
+        "修复数据",
+        "修复模式",
+        "目标集群",
+        "校验从库",
+        "校验主库",
+        "校验 DB 名",
+        "忽略 DB 名",
+        "校验表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "need_manual_confirm",
+        "timing",
+        "runtime_hour",
+        "data_repair.is_repair",
+        "data_repair.mode",
+        "clusters",
+        "infos[].cluster_id",
+        "infos[].master",
+        "infos[].slaves",
+        "infos[].db_patterns",
+        "infos[].ignore_dbs",
+        "infos[].table_patterns",
+        "infos[].ignore_tables"
+      ]
+    }
+  },
+  "MYSQL_SINGLE_RENAME_DATABASE": {
+    "type": "object",
+    "title": "MYSQL_SINGLE_RENAME_DATABASE",
+    "description": "单据类型: MYSQL_SINGLE_RENAME_DATABASE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLSingleRenameDetailSerializer",
+      "builder_class": "MySQLSingleClearFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_single_rename.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/SingleDbRename.vue",
+      "props_type": "Mysql.RenameDataBase",
+      "labels": [
+        "检查业务连接",
+        "源DB名",
+        "新DB名"
+      ],
+      "fields": [
+        "infos",
+        "force",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_DATA_REPAIR": {
+    "type": "object",
+    "title": "MYSQL_DATA_REPAIR",
+    "description": "单据类型: MYSQL_DATA_REPAIR",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "master": {
+                  "type": "object",
+                  "description": "master信息"
+                },
+                "slaves": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "slaves信息"
+                }
+              }
+            },
+            "description": "数据修复信息"
+          },
+          "checksum_table": {
+            "type": "string",
+            "description": "校验单据结果表名"
+          },
+          "is_sync_non_innodb": {
+            "type": "boolean",
+            "description": "非innodb表是否修复",
+            "default": false
+          },
+          "is_ticket_consistent": {
+            "type": "boolean",
+            "description": "校验结果是否一致",
+            "default": false
+          },
+          "start_time": {
+            "type": "string",
+            "description": "开始时间",
+            "default": ""
+          },
+          "end_time": {
+            "type": "string",
+            "description": "结束时间",
+            "default": ""
+          },
+          "trigger_type": {
+            "type": "string",
+            "description": "数据修复触发类型"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLDataRepairDetailSerializer",
+      "builder_class": "MySQLDataRepairFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_data_repair.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/DataRepair.vue",
+      "props_type": "Mysql.DataRepair",
+      "labels": [
+        "不一致时间范围",
+        "修复主库",
+        "修复从库"
+      ],
+      "fields": [
+        "end_time",
+        "infos",
+        "clusters",
+        "start_time"
+      ]
+    }
+  },
+  "MYSQL_OPEN_AREA": {
+    "type": "object",
+    "title": "MYSQL_OPEN_AREA",
+    "description": "单据类型: MYSQL_OPEN_AREA",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_id": {
+            "type": "integer",
+            "description": "源集群ID"
+          },
+          "config_id": {
+            "type": "integer",
+            "description": "模板ID"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          },
+          "config_data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "目标集群ID"
+                },
+                "execute_objects": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "分区执行信息"
+                }
+              }
+            },
+            "description": "分区信息"
+          },
+          "rules_set": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "bk_biz_id": {
+                  "type": "integer",
+                  "description": "业务ID"
+                },
+                "operator": {
+                  "type": "string",
+                  "description": "操作人"
+                },
+                "user": {
+                  "type": "string",
+                  "description": "用户"
+                },
+                "source_ips": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "IP列表"
+                },
+                "target_instances": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "目标集群列表"
+                },
+                "account_rules": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "授权DB列表"
+                },
+                "cluster_type": {
+                  "type": "string",
+                  "description": "集群类型"
+                },
+                "privileges": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "授权详情"
+                },
+                "access_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "准入DB列表"
+                }
+              }
+            },
+            "description": "授权信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlOpenAreaDetailSerializer",
+      "builder_class": "MysqlOpenAreaFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_openarea.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/OpenArea.vue",
+      "props_type": "Mysql.OpenArea",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "MYSQL_INSTANCE_FAIL_OVER": {
+    "type": "object",
+    "title": "MYSQL_INSTANCE_FAIL_OVER",
+    "description": "单据类型: MYSQL_INSTANCE_FAIL_OVER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "is_verify_checksum": {
+            "type": "string",
+            "description": "is_verify_checksum"
+          },
+          "is_check_process": {
+            "type": "string",
+            "description": "is_check_process"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/InstanceFailOver.vue",
+      "props_type": "Mysql.InstanceFailOver",
+      "labels": [
+        "检查业务来源的连接",
+        "检查主从数据校验结果",
+        "从库实例",
+        "同机关联的集群"
+      ],
+      "fields": [
+        "is_verify_checksum",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_INSTANCE_CLONE_RULES": {
+    "type": "object",
+    "title": "MYSQL_INSTANCE_CLONE_RULES",
+    "description": "单据类型: MYSQL_INSTANCE_CLONE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clone_data": {
+            "type": "string",
+            "description": "clone_data"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/mysql/InstanceCloneRules.vue",
+      "props_type": "Mysql.InstanceCloneRules",
+      "labels": [
+        "所属集群",
+        "新实例"
+      ],
+      "fields": [
+        "clone_data"
+      ]
+    }
+  },
+  "SQLSERVER_FULL_MIGRATE": {
+    "type": "object",
+    "title": "SQLSERVER_FULL_MIGRATE",
+    "description": "单据类型: SQLSERVER_FULL_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "need_auto_rename": {
+            "type": "boolean",
+            "description": "迁移后，系统是否对源DB进行重命名"
+          },
+          "manual_terminate": {
+            "type": "boolean",
+            "description": "手动终止迁移",
+            "default": false
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "src_cluster": {
+                  "type": "integer",
+                  "description": "源集群ID"
+                },
+                "dst_cluster_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "目标集群ID列表"
+                },
+                "db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "库正则"
+                },
+                "ignore_db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略库正则"
+                },
+                "rename_infos": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "迁移DB信息"
+                },
+                "dts_id": {
+                  "type": "integer",
+                  "description": "迁移记录ID"
+                }
+              }
+            },
+            "description": "迁移信息列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerDataMigrateDetailSerializer",
+      "builder_class": "SQLServerDataMigrateFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_data_migrate.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/fullMigrate.vue",
+      "props_type": "Sqlserver.DataMigrate",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "SQLSERVER_INCR_MIGRATE": {
+    "type": "object",
+    "title": "SQLSERVER_INCR_MIGRATE",
+    "description": "单据类型: SQLSERVER_INCR_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/incrMigrate.vue",
+      "props_type": "Sqlserver.DataMigrate",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "SQLSERVER_BUILD_DB_SYNC": {
+    "type": "object",
+    "title": "SQLSERVER_BUILD_DB_SYNC",
+    "description": "单据类型: SQLSERVER_BUILD_DB_SYNC",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/BuildDbSync.vue",
+      "props_type": "Sqlserver.BuildDbSync",
+      "labels": [
+        "同步 DB"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_RESTORE_SLAVE": {
+    "type": "object",
+    "title": "SQLSERVER_RESTORE_SLAVE",
+    "description": "单据类型: SQLSERVER_RESTORE_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/sqlserver/RestoreSlave.vue",
+      "props_type": "Sqlserver.ResourcePool.RestoreSlave",
+      "labels": [
+        "同机关联集群",
+        "规格",
+        "资源标签",
+        "新从库主机"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_MASTER_FAIL_OVER": {
+    "type": "object",
+    "title": "SQLSERVER_MASTER_FAIL_OVER",
+    "description": "单据类型: SQLSERVER_MASTER_FAIL_OVER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "force": {
+            "type": "boolean",
+            "description": "是否强制切换(强切固定为true)",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerMasterFailOverDetailSerializer",
+      "builder_class": "SQLServerMasterSlaveSwitchFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_master_fail_over.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/MasterFailOver.vue",
+      "props_type": "Sqlserver.MasterFailOver",
+      "labels": [
+        "从库主机",
+        "同机关联的集群"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_RESTORE_LOCAL_SLAVE": {
+    "type": "object",
+    "title": "SQLSERVER_RESTORE_LOCAL_SLAVE",
+    "description": "单据类型: SQLSERVER_RESTORE_LOCAL_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "slave": {
+                  "type": "object",
+                  "description": "从库实例信息"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                }
+              }
+            },
+            "description": "重建从库列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerRestoreLocalSlaveDetailSerializer",
+      "builder_class": "SQLServerRestoreLocalSlaveFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_restore_local_slave.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/RestoreLocalSlave.vue",
+      "props_type": "Sqlserver.RestoreLocalSlave",
+      "labels": [
+        "所属集群"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_DESTROY": {
+    "type": "object",
+    "title": "SQLSERVER_DESTROY",
+    "description": "单据类型: SQLSERVER_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/ClusterDestroy.vue",
+      "props_type": "Sqlserver.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "SQLSERVER_SINGLE_APPLY": {
+    "type": "object",
+    "title": "SQLSERVER_SINGLE_APPLY",
+    "description": "单据类型: SQLSERVER_SINGLE_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "domains": {
+            "type": "string",
+            "description": "domains"
+          },
+          "cluster_count": {
+            "type": "string",
+            "description": "cluster_count"
+          },
+          "start_mssql_port": {
+            "type": "string",
+            "description": "start_mssql_port"
+          },
+          "charset": {
+            "type": "string",
+            "description": "charset"
+          },
+          "db_module_name": {
+            "type": "string",
+            "description": "db_module_name"
+          },
+          "nodes": {
+            "type": "object",
+            "properties": {
+              "backend": {
+                "type": "string",
+                "description": "backend"
+              }
+            },
+            "description": "nodes (也可能是叶子节点)"
+          },
+          "inst_num": {
+            "type": "string",
+            "description": "inst_num"
+          },
+          "resource_spec": {
+            "type": "string",
+            "description": "resource_spec"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/SingleApply.vue",
+      "props_type": "Sqlserver.SingleApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "DB模块名",
+        "管控区域",
+        "SQLServer 起始端口",
+        "集群数量",
+        "每组主机部署集群",
+        "服务器选择",
+        "后端存储规格",
+        "域名设置",
+        "部署架构",
+        "数据库版本",
+        "字符集",
+        "服务器"
+      ],
+      "fields": [
+        "domains",
+        "cluster_count",
+        "start_mssql_port",
+        "charset",
+        "db_module_name",
+        "nodes.backend",
+        "inst_num",
+        "resource_spec",
+        "nodes",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "SQLSERVER_ADD_SLAVE": {
+    "type": "object",
+    "title": "SQLSERVER_ADD_SLAVE",
+    "description": "单据类型: SQLSERVER_ADD_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/sqlserver/AddSlave.vue",
+      "props_type": "Sqlserver.ResourcePool.AddSlave",
+      "labels": [
+        "新从库主机"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_RESET": {
+    "type": "object",
+    "title": "SQLSERVER_RESET",
+    "description": "单据类型: SQLSERVER_RESET",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "new_cluster_name": {
+                  "type": "string",
+                  "description": "重置集群名"
+                },
+                "new_immutable_domain": {
+                  "type": "string",
+                  "description": "重置集群主域名"
+                },
+                "new_slave_domain": {
+                  "type": "string",
+                  "description": "重置集群从域名"
+                }
+              }
+            },
+            "description": "集群重置信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerResetDetailSerializer",
+      "builder_class": "SQLServerResetFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_reset.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/Reset.vue",
+      "props_type": "Sqlserver.Reset",
+      "labels": [
+        "集群ID",
+        "新集群",
+        "主域名",
+        "从域名"
+      ],
+      "fields": [
+        "infos"
+      ]
+    }
+  },
+  "SQLSERVER_BACKUP_DBS": {
+    "type": "object",
+    "title": "SQLSERVER_BACKUP_DBS",
+    "description": "单据类型: SQLSERVER_BACKUP_DBS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "backup_place": {
+            "type": "string",
+            "description": "备份位置(先固定为master)",
+            "default": "master"
+          },
+          "backup_type": {
+            "type": "string",
+            "description": "备份方式"
+          },
+          "file_tag": {
+            "type": "string",
+            "description": "备份保存时间"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "backup_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "备份db列表"
+                },
+                "db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "库正则"
+                },
+                "ignore_db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略库正则"
+                }
+              }
+            },
+            "description": "备份信息列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerBackupDetailSerializer",
+      "builder_class": "SQLServerBackupFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/BackupDbs.vue",
+      "props_type": "Sqlserver.BackupDb",
+      "labels": [
+        "备份方式",
+        "备份位置",
+        "备份保存时间",
+        "备份 DB 名",
+        "忽略 DB 名",
+        "最终 DB"
+      ],
+      "fields": [
+        "clusters",
+        "file_tag",
+        "infos",
+        "backup_place",
+        "backup_type"
+      ]
+    }
+  },
+  "SQLSERVER_ROLLBACK": {
+    "type": "object",
+    "title": "SQLSERVER_ROLLBACK",
+    "description": "单据类型: SQLSERVER_ROLLBACK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "src_cluster": {
+                  "type": "integer",
+                  "description": "源集群ID"
+                },
+                "dst_cluster": {
+                  "type": "integer",
+                  "description": "目标集群ID"
+                },
+                "db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "库正则"
+                },
+                "ignore_db_list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略库正则"
+                },
+                "rename_infos": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "迁移DB信息"
+                },
+                "restore_backup_file": {
+                  "type": "object",
+                  "description": "备份记录"
+                },
+                "restore_time": {
+                  "type": "string",
+                  "description": "回档时间"
+                }
+              }
+            },
+            "description": "迁移信息列表"
+          },
+          "is_local": {
+            "type": "boolean",
+            "description": "是否原地构造"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerRollbackDetailSerializer",
+      "builder_class": "SQLServerDataMigrateFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_rollback.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/Rollback.vue",
+      "props_type": "Sqlserver.Rollback",
+      "labels": [
+        "构造类型",
+        "目标集群",
+        "回档类型",
+        "构造 DB",
+        "忽略 DB",
+        "构造后 DB 名"
+      ],
+      "fields": [
+        "clusters",
+        "infos",
+        "is_local"
+      ]
+    }
+  },
+  "SQLSERVER_EXCEL_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "SQLSERVER_EXCEL_AUTHORIZE_RULES",
+    "description": "单据类型: SQLSERVER_EXCEL_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "authorize_data": {
+            "type": "string",
+            "description": "authorize_data"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/ExcelAuthorizeRules.vue",
+      "props_type": "Sqlserver.authorizeRules",
+      "labels": [
+        "目标集群",
+        "Excel 文件"
+      ],
+      "fields": [
+        "authorize_data"
+      ]
+    }
+  },
+  "SQLSERVER_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "SQLSERVER_AUTHORIZE_RULES",
+    "description": "单据类型: SQLSERVER_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "authorize_uid": {
+            "type": "string",
+            "description": "授权数据缓存uid"
+          },
+          "authorize_data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "授权数据信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerAuthorizeRulesSerializer",
+      "builder_class": "SQLServerRulesFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_authorize.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/AuthorizeRules.vue",
+      "props_type": "Sqlserver.authorizeRules",
+      "labels": [
+        "目标集群",
+        "权限明细",
+        "账号名称",
+        "访问 DB"
+      ],
+      "fields": [
+        "authorize_data"
+      ]
+    }
+  },
+  "SQLSERVER_CLEAR_DBS": {
+    "type": "object",
+    "title": "SQLSERVER_CLEAR_DBS",
+    "description": "单据类型: SQLSERVER_CLEAR_DBS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "is_safe": {
+            "type": "boolean",
+            "description": "安全模式",
+            "default": true
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "clean_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "清档db列表"
+                },
+                "clean_dbs_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "清档db正则列表"
+                },
+                "clean_ignore_dbs_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略db正则列表"
+                },
+                "clean_tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "清档表"
+                },
+                "ignore_clean_tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "忽略表"
+                },
+                "clean_mode": {
+                  "type": "string",
+                  "description": "清档类型"
+                }
+              }
+            },
+            "description": "清档信息列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerClearDetailSerializer",
+      "builder_class": "SQLServerClearFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_clear.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/ClearDbs.vue",
+      "props_type": "Sqlserver.ClearDbs",
+      "labels": [
+        "清档类型",
+        "指定 DB 名",
+        "忽略 DB 名",
+        "指定表名",
+        "忽略表名",
+        "最终 DB"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_DATA_MIGRATE": {
+    "type": "object",
+    "title": "SQLSERVER_DATA_MIGRATE",
+    "description": "单据类型: SQLSERVER_DATA_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/DataMigrate.vue",
+      "props_type": "Sqlserver.DataMigrate",
+      "labels": [
+        "目标集群",
+        "迁移 DB 名",
+        "忽略 DB 名",
+        "迁移后 DB 名"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_DISABLE": {
+    "type": "object",
+    "title": "SQLSERVER_DISABLE",
+    "description": "单据类型: SQLSERVER_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/ClusterDisable.vue",
+      "props_type": "Sqlserver.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "SQLSERVER_DBRENAME": {
+    "type": "object",
+    "title": "SQLSERVER_DBRENAME",
+    "description": "单据类型: SQLSERVER_DBRENAME",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "from_database": {
+                  "type": "string",
+                  "description": "源数据库名"
+                },
+                "to_database": {
+                  "type": "string",
+                  "description": "目标数据库名"
+                }
+              }
+            },
+            "description": "重命名数据库列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerRenameSerializer",
+      "builder_class": "SQLServerRenameFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_dbrename.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/DbRename.vue",
+      "props_type": "Sqlserver.DbRename",
+      "labels": [
+        "原 DB 名",
+        "新 DB 名"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_MODIFY_STATUS": {
+    "type": "object",
+    "title": "SQLSERVER_MODIFY_STATUS",
+    "description": "单据类型: SQLSERVER_MODIFY_STATUS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/ModifyStatus.vue",
+      "props_type": "Sqlserver.ModifyStatus",
+      "labels": [
+        "故障实例IP"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_MASTER_SLAVE_SWITCH": {
+    "type": "object",
+    "title": "SQLSERVER_MASTER_SLAVE_SWITCH",
+    "description": "单据类型: SQLSERVER_MASTER_SLAVE_SWITCH",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "master": {
+                  "type": "object",
+                  "description": "主库 IP"
+                },
+                "slave": {
+                  "type": "object",
+                  "description": "从库 IP"
+                },
+                "cluster_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "集群ID列表"
+                }
+              }
+            },
+            "description": "单据信息"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制切换(互切固定为false)",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerMasterSlaveSwitchDetailSerializer",
+      "builder_class": "SQLServerMasterSlaveSwitchFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_master_slave_switch.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/MasterSlaveSwitch.vue",
+      "props_type": "Sqlserver.MasterSlaveSwitch",
+      "labels": [
+        "从库主机",
+        "同机关联的集群"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_HA_APPLY": {
+    "type": "object",
+    "title": "SQLSERVER_HA_APPLY",
+    "description": "单据类型: SQLSERVER_HA_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "domains": {
+            "type": "string",
+            "description": "domains"
+          },
+          "cluster_count": {
+            "type": "string",
+            "description": "cluster_count"
+          },
+          "start_mssql_port": {
+            "type": "string",
+            "description": "start_mssql_port"
+          },
+          "charset": {
+            "type": "string",
+            "description": "charset"
+          },
+          "db_module_name": {
+            "type": "string",
+            "description": "db_module_name"
+          },
+          "nodes": {
+            "type": "object",
+            "properties": {
+              "backend": {
+                "type": "string",
+                "description": "backend"
+              }
+            },
+            "description": "nodes (也可能是叶子节点)"
+          },
+          "inst_num": {
+            "type": "string",
+            "description": "inst_num"
+          },
+          "resource_spec": {
+            "type": "string",
+            "description": "resource_spec"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/HaApply.vue",
+      "props_type": "Sqlserver.HaApply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "DB模块名",
+        "管控区域",
+        "SQLServer 起始端口",
+        "集群数量",
+        "每组主机部署集群",
+        "服务器选择",
+        "后端存储规格",
+        "Proxy 资源标签",
+        "域名设置",
+        "部署架构",
+        "数据库版本",
+        "字符集",
+        "Master / Slave IP"
+      ],
+      "fields": [
+        "domains",
+        "cluster_count",
+        "start_mssql_port",
+        "charset",
+        "db_module_name",
+        "nodes.backend",
+        "inst_num",
+        "resource_spec",
+        "nodes",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "SQLSERVER_ENABLE": {
+    "type": "object",
+    "title": "SQLSERVER_ENABLE",
+    "description": "单据类型: SQLSERVER_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/ClusterEnable.vue",
+      "props_type": "Sqlserver.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "HDFS_REBOOT": {
+    "type": "object",
+    "title": "HDFS_REBOOT",
+    "description": "单据类型: HDFS_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "HdfsRebootDetailSerializer",
+      "builder_class": "HdfsRebootFlowBuilder",
+      "source_file": "ticket/builders/hdfs/hdfs_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/hdfs/Reboot.vue",
+      "props_type": "Hdfs.Reboot",
+      "labels": [
+        "集群ID",
+        "集群名称",
+        "集群类型",
+        "节点IP"
+      ],
+      "fields": []
+    }
+  },
+  "HDFS_DESTROY": {
+    "type": "object",
+    "title": "HDFS_DESTROY",
+    "description": "单据类型: HDFS_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/hdfs/Destroy.vue",
+      "props_type": "Hdfs.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "HDFS_ENABLE": {
+    "type": "object",
+    "title": "HDFS_ENABLE",
+    "description": "单据类型: HDFS_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/hdfs/Enable.vue",
+      "props_type": "Hdfs.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "HDFS_DISABLE": {
+    "type": "object",
+    "title": "HDFS_DISABLE",
+    "description": "单据类型: HDFS_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/hdfs/Disable.vue",
+      "props_type": "Hdfs.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "HDFS_APPLY": {
+    "type": "object",
+    "title": "HDFS_APPLY",
+    "description": "单据类型: HDFS_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/hdfs/Apply.vue",
+      "props_type": "Hdfs.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "版本",
+        "NameNode",
+        "NameNode 资源标签",
+        "Zookeepers/JournalNodes",
+        "Zookeepers/JournalNodes 资源标签",
+        "DataNodes",
+        "DataNodes 资源标签",
+        "DataNode节点IP",
+        "Zookeeper节点IP",
+        "NameNode节点IP"
+      ],
+      "fields": [
+        "cluster_name",
+        "cluster_alias",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "HDFS_SHRINK": {
+    "type": "object",
+    "title": "HDFS_SHRINK",
+    "description": "单据类型: HDFS_SHRINK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/hdfs/Shrink.vue",
+      "props_type": "Bigdata.ResourcePool.Shrink",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "HDFS_SCALE_UP": {
+    "type": "object",
+    "title": "HDFS_SCALE_UP",
+    "description": "单据类型: HDFS_SCALE_UP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/hdfs/ScaleUp.vue",
+      "props_type": "Bigdata.ResourcePool.ScaleUp",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "HDFS_REPLACE": {
+    "type": "object",
+    "title": "HDFS_REPLACE",
+    "description": "单据类型: HDFS_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/hdfs/Replace.vue",
+      "props_type": "Bigdata.ResourcePool.Replace",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "PULSAR_REBOOT": {
+    "type": "object",
+    "title": "PULSAR_REBOOT",
+    "description": "单据类型: PULSAR_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "PulsarRebootDetailSerializer",
+      "builder_class": "PulsarRebootFlowBuilder",
+      "source_file": "ticket/builders/pulsar/pulsar_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/pulsar/Reboot.vue",
+      "props_type": "Pulsar.Reboot",
+      "labels": [
+        "集群ID",
+        "集群名称",
+        "集群类型",
+        "节点IP"
+      ],
+      "fields": []
+    }
+  },
+  "PULSAR_DESTROY": {
+    "type": "object",
+    "title": "PULSAR_DESTROY",
+    "description": "单据类型: PULSAR_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/pulsar/Destroy.vue",
+      "props_type": "Pulsar.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "PULSAR_ENABLE": {
+    "type": "object",
+    "title": "PULSAR_ENABLE",
+    "description": "单据类型: PULSAR_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/pulsar/Enable.vue",
+      "props_type": "Pulsar.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "PULSAR_DISABLE": {
+    "type": "object",
+    "title": "PULSAR_DISABLE",
+    "description": "单据类型: PULSAR_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/pulsar/Disable.vue",
+      "props_type": "Pulsar.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "PULSAR_APPLY": {
+    "type": "object",
+    "title": "PULSAR_APPLY",
+    "description": "单据类型: PULSAR_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "retention_hours": {
+            "type": "string",
+            "description": "retention_hours"
+          },
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "replication_num": {
+            "type": "string",
+            "description": "replication_num"
+          },
+          "partition_num": {
+            "type": "string",
+            "description": "partition_num"
+          },
+          "resource_spec": {
+            "type": "string",
+            "description": "resource_spec"
+          },
+          "ack_quorum": {
+            "type": "string",
+            "description": "ack_quorum"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "port": {
+            "type": "string",
+            "description": "port"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/pulsar/Apply.vue",
+      "props_type": "Pulsar.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "版本",
+        "Bookkeeper节点规格",
+        "Bookkeeper 节点资源标签",
+        "Zookeeper节点规格",
+        "Zookeeper 节点资源标签",
+        "Broker节点规格",
+        "Broker 节点资源标签",
+        "Bookkeeper节点",
+        "Zookeeper节点",
+        "Broker节点",
+        "Partition数量",
+        "消息保留",
+        "副本数量",
+        "至少写入成功副本数量",
+        "访问端口"
+      ],
+      "fields": [
+        "retention_hours",
+        "cluster_name",
+        "replication_num",
+        "partition_num",
+        "resource_spec",
+        "ack_quorum",
+        "cluster_alias",
+        "port",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "PULSAR_SHRINK": {
+    "type": "object",
+    "title": "PULSAR_SHRINK",
+    "description": "单据类型: PULSAR_SHRINK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/pulsar/Shrink.vue",
+      "props_type": "Bigdata.ResourcePool.Shrink",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "PULSAR_SCALE_UP": {
+    "type": "object",
+    "title": "PULSAR_SCALE_UP",
+    "description": "单据类型: PULSAR_SCALE_UP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/pulsar/ScaleUp.vue",
+      "props_type": "Bigdata.ResourcePool.ScaleUp",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "PULSAR_REPLACE": {
+    "type": "object",
+    "title": "PULSAR_REPLACE",
+    "description": "单据类型: PULSAR_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/pulsar/Replace.vue",
+      "props_type": "Bigdata.ResourcePool.Replace",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_CHECKSUM_CRON": {
+    "type": "object",
+    "title": "TENDBCLUSTER_CHECKSUM_CRON",
+    "description": "单据类型: TENDBCLUSTER_CHECKSUM_CRON",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "skip_timer": {
+            "type": "boolean",
+            "description": "是否是定时"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbChecksumCronDetailSerializer",
+      "builder_class": "TendbChecksumCronFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_checksum_cron.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/CheckSumCron.vue",
+      "props_type": "TendbCluster.CheckSum",
+      "labels": [
+        "执行模式",
+        "全局超时时间（h）",
+        "修复数据",
+        "修复模式",
+        "校验范围",
+        "校验从库",
+        "校验主库",
+        "校验DB名",
+        "忽略DB名",
+        "校验表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "runtime_hour",
+        "data_repair.mode",
+        "data_repair.is_repair",
+        "need_manual_confirm",
+        "clusters",
+        "infos",
+        "timing"
+      ]
+    }
+  },
+  "TENDBCLUSTER_SPIDER_UPGRADE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_UPGRADE",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "is_check_process": {
+            "type": "string",
+            "description": "is_check_process"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/SpiderUpgrade.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderUpgrade",
+      "labels": [
+        "检查业务连接",
+        "当前版本",
+        "目标版本",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_DB_TABLE_BACKUP": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DB_TABLE_BACKUP",
+    "description": "单据类型: TENDBCLUSTER_DB_TABLE_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "backup_local": {
+                  "type": "string",
+                  "description": "备份位置"
+                },
+                "spider_mnt_address": {
+                  "type": "string",
+                  "description": "运维节点地址"
+                },
+                "db_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配DB列表"
+                },
+                "ignore_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略DB列表"
+                },
+                "table_patterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "匹配Table列表"
+                },
+                "ignore_tables": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略Table列表"
+                }
+              }
+            },
+            "description": "库表备份信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBClusterDBTableBackUpDetailSerializer",
+      "builder_class": "TendDBClusterDBTableBackUpFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/db_table_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/DBTableBackup.vue",
+      "props_type": "TendbCluster.DbTableBackup",
+      "labels": [
+        "备份位置",
+        "备份DB名",
+        "忽略DB名",
+        "备份表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_MIGRATE_UPGRADE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_MIGRATE_UPGRADE",
+    "description": "单据类型: TENDBCLUSTER_MIGRATE_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "is_check_process": {
+            "type": "string",
+            "description": "is_check_process"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/MigrateUpgrade.vue",
+      "props_type": "TendbCluster.ResourcePool.MigrateUpgrade",
+      "labels": [
+        "检查业务连接",
+        "当前版本",
+        "目标版本",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_SPIDER_REDUCE_NODES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_REDUCE_NODES",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_REDUCE_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "shrink_type": {
+            "type": "string",
+            "description": "shrink_type"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderReduceNodes.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderReduceNodes",
+      "labels": [
+        "缩容方式",
+        "检查业务连接",
+        "缩容节点类型",
+        "关联集群",
+        "目标集群",
+        "当前数量(台",
+        "缩容数量(台",
+        "剩余数量(台"
+      ],
+      "fields": [
+        "clusters",
+        "infos",
+        "is_safe",
+        "shrink_type"
+      ]
+    }
+  },
+  "TENDBCLUSTER_RESTORE_SLAVE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_RESTORE_SLAVE",
+    "description": "单据类型: TENDBCLUSTER_RESTORE_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "machine_infos": {
+            "type": "string",
+            "description": "machine_infos"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "backup_source"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/RestoreSlave.vue",
+      "props_type": "TendbCluster.ResourcePool.RestoreSlave",
+      "labels": [
+        "备份源",
+        "从库主机关联实例",
+        "同机关联集群",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "clusters",
+        "specs",
+        "machine_infos",
+        "infos",
+        "backup_source"
+      ]
+    }
+  },
+  "TENDBCLUSTER_MASTER_FAIL_OVER": {
+    "type": "object",
+    "title": "TENDBCLUSTER_MASTER_FAIL_OVER",
+    "description": "单据类型: TENDBCLUSTER_MASTER_FAIL_OVER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行(互切不强制，故障切强制)",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbMasterFailOverDetailSerializer",
+      "builder_class": "TendbMasterFailOverFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_master_fail_over.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/MasterFailOver.vue",
+      "props_type": "TendbCluster.MasterFailOver",
+      "labels": [
+        "检查业务来源的连接",
+        "检查主从数据校验结果",
+        "从库主机",
+        "所属集群"
+      ],
+      "fields": [
+        "is_verify_checksum",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_ACCOUNT_RULE_CHANGE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_ACCOUNT_RULE_CHANGE",
+    "description": "单据类型: TENDBCLUSTER_ACCOUNT_RULE_CHANGE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/AccountRuleChange.vue",
+      "props_type": "TendbCluster.AccountRuleChange",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_AUTHORIZE_RULES",
+    "description": "单据类型: TENDBCLUSTER_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/AuthorizeRule.vue",
+      "props_type": "TendbCluster.AuthorizeRules",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_ROLLBACK_CLUSTER": {
+    "type": "object",
+    "title": "TENDBCLUSTER_ROLLBACK_CLUSTER",
+    "description": "单据类型: TENDBCLUSTER_ROLLBACK_CLUSTER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "description": "回档信息列表",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "target_cluster_id": {
+                  "type": "integer",
+                  "description": "目标集群ID"
+                },
+                "rollback_time": {
+                  "type": "string",
+                  "description": "回档时间"
+                },
+                "rollback_type": {
+                  "type": "string",
+                  "description": "回档类型"
+                },
+                "backupinfo": {
+                  "type": "object",
+                  "description": "备份记录信息",
+                  "properties": {
+                    "backup_id": {
+                      "type": "string",
+                      "description": "备份ID"
+                    },
+                    "backup_time": {
+                      "type": "string",
+                      "description": "备份时间"
+                    }
+                  }
+                },
+                "databases": {
+                  "type": "array",
+                  "items": {"type": "string"},
+                  "description": "回档DB列表"
+                },
+                "databases_ignore": {
+                  "type": "array",
+                  "items": {"type": "string"},
+                  "description": "忽略DB列表"
+                },
+                "tables": {
+                  "type": "array",
+                  "items": {"type": "string"},
+                  "description": "回档表名列表"
+                },
+                "tables_ignore": {
+                  "type": "array",
+                  "items": {"type": "string"},
+                  "description": "忽略表名列表"
+                },
+                "resource_spec": {
+                  "type": "object",
+                  "description": "资源规格"
+                }
+              }
+            }
+          },
+          "rollback_cluster_type": {
+            "type": "string",
+            "description": "构造类型(BUILD_INTO_NEW_CLUSTER/BUILD_INTO_EXIST_CLUSTER/BUILD_INTO_METACLUSTER)"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/RollbackCluster.vue",
+      "props_type": "TendbCluster.ResourcePool.RollbackCluster",
+      "labels": [
+        "构造类型",
+        "目标集群",
+        "存储层主机",
+        "接入层主机",
+        "回档类型",
+        "回档DB",
+        "忽略 DB",
+        "回档表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "infos",
+        "rollback_cluster_type",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_RESTORE_LOCAL_SLAVE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_RESTORE_LOCAL_SLAVE",
+    "description": "单据类型: TENDBCLUSTER_RESTORE_LOCAL_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "slave": {
+                  "type": "object",
+                  "description": "从库实例信息"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                }
+              }
+            },
+            "description": "重建从库列表"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "备份源"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbClusterRestoreLocalSlaveDetailSerializer",
+      "builder_class": "TendbClusterRestoreLocalSlaveFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_restore_local_slave.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/RestoreLocalSlave.vue",
+      "props_type": "TendbCluster.RestoreLocalSlave",
+      "labels": [
+        "备份源",
+        "所属集群"
+      ],
+      "fields": [
+        "backup_source",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_DESTROY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DESTROY",
+    "description": "单据类型: TENDBCLUSTER_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClusterDestroy.vue",
+      "props_type": "TendbCluster.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_ADD_CLB": {
+    "type": "object",
+    "title": "TENDBCLUSTER_ADD_CLB",
+    "description": "单据类型: TENDBCLUSTER_ADD_CLB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbAddCLBDetailSerializer",
+      "builder_class": "TendbAddCLBFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_add_clb.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/AddClb.vue",
+      "props_type": "TendbCluster.AddClb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_SPIDER_SLAVE_APPLY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_SLAVE_APPLY",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_SLAVE_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderSlaveApply.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderSlaveApply",
+      "labels": [
+        "规格",
+        "部署台数",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_CLIENT_CLONE_RULES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_CLIENT_CLONE_RULES",
+    "description": "单据类型: TENDBCLUSTER_CLIENT_CLONE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clone_cluster_type": {
+            "type": "string",
+            "description": "集群类型"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbClusterCloneRulesSerializer",
+      "builder_class": "TendbClusterClientCloneRulesFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_clone_rules.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClientCloneRules.vue",
+      "props_type": "TendbCluster.ClientCloneRules",
+      "labels": [
+        "所属模块"
+      ],
+      "fields": [
+        "clone_data"
+      ]
+    }
+  },
+  "TENDBCLUSTER_TEMPORARY_DESTROY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_TEMPORARY_DESTROY",
+    "description": "单据类型: TENDBCLUSTER_TEMPORARY_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/TemporaryDestroy.vue",
+      "props_type": "TendbCluster.TemporaryDestroy",
+      "labels": [],
+      "fields": [
+        "cluster_ids.map",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_CLB_BIND_DOMAIN": {
+    "type": "object",
+    "title": "TENDBCLUSTER_CLB_BIND_DOMAIN",
+    "description": "单据类型: TENDBCLUSTER_CLB_BIND_DOMAIN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbCLBBindDomainDetailSerializer",
+      "builder_class": "TendbCLBBindDomainFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_clb_bind_domain.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClbBindDomain.vue",
+      "props_type": "TendbCluster.ClbBindDomain",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_SPIDER_MNT_APPLY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_MNT_APPLY",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_MNT_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderMntApply.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderMntApply",
+      "labels": [
+        "所属管控区域",
+        "运维节点 IP"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_ROLLBACK": {
+    "type": "object",
+    "title": "TENDBCLUSTER_ROLLBACK",
+    "description": "单据类型: TENDBCLUSTER_ROLLBACK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/Rollback.vue",
+      "props_type": "TendbCluster.ResourcePool.RollbackCluster",
+      "labels": [
+        "回档类型",
+        "回档方式",
+        "指定时间",
+        "备份记录",
+        "源 DB",
+        "源表",
+        "受影响的 DB"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_IMPORT_SQLFILE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_IMPORT_SQLFILE",
+    "description": "单据类型: TENDBCLUSTER_IMPORT_SQLFILE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBClusterSqlImportDetailSerializer",
+      "builder_class": "TenDBClusterSqlImportFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_import_sqlfile.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ImportSqlfile.vue",
+      "props_type": "TendbCluster.ImportSqlFile",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_FIXPOINT_EXIST": {
+    "type": "object",
+    "title": "TENDBCLUSTER_FIXPOINT_EXIST",
+    "description": "单据类型: TENDBCLUSTER_FIXPOINT_EXIST",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/FixpointExistCluster.vue",
+      "props_type": "TendbCluster.RollbackCluster",
+      "labels": [
+        "构造类型",
+        "构造方式",
+        "指定时间",
+        "备份记录",
+        "源 DB",
+        "源表",
+        "目标集群",
+        "受影响的 DB"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_SPIDER_SLAVE_DESTROY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_SLAVE_DESTROY",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_SLAVE_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/SpiderSlaveDestroy.vue",
+      "props_type": "TendbCluster.SpiderSlaveDestroy",
+      "labels": [],
+      "fields": [
+        "cluster_ids.map",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_PARTITION": {
+    "type": "object",
+    "title": "TENDBCLUSTER_PARTITION",
+    "description": "单据类型: TENDBCLUSTER_PARTITION",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "SpiderPartitionDetailSerializer",
+      "builder_class": "SpiderPartitionFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_partition.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/Partition.vue",
+      "props_type": "Mysql.Partition",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_TRUNCATE_DATABASE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_TRUNCATE_DATABASE",
+    "description": "单据类型: TENDBCLUSTER_TRUNCATE_DATABASE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbClearDetailSerializer",
+      "builder_class": "TendbClearFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_clear.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/TruncateDatabase.vue",
+      "props_type": "TendbCluster.TruncateData",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_CLUSTER_STANDARDIZE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_CLUSTER_STANDARDIZE",
+    "description": "单据类型: TENDBCLUSTER_CLUSTER_STANDARDIZE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_biz_id": {
+            "type": "integer",
+            "description": "业务ID"
+          },
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "with_deploy_binary": {
+            "type": "boolean",
+            "description": "是否推送二进制",
+            "default": true
+          },
+          "with_push_config": {
+            "type": "boolean",
+            "description": "是否推送配置",
+            "default": true
+          },
+          "with_cc_standardize": {
+            "type": "boolean",
+            "description": "是否CC模块标准",
+            "default": false
+          },
+          "with_instance_standardize": {
+            "type": "boolean",
+            "description": "是否实例标准化. 高危",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBClusterStandardizeDetailSerializer",
+      "builder_class": "TenDBClusterStandardizeFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_cluster_standardize.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClusterStandardize.vue",
+      "props_type": "TendbCluster.ClusterStandardize",
+      "labels": [
+        "下发配置",
+        "推送二进制文件",
+        "CC 标准化",
+        "集群类型"
+      ],
+      "fields": [
+        "clusters",
+        "with_push_config",
+        "cluster_ids.map",
+        "with_cc_standardize",
+        "with_deploy_binary"
+      ]
+    }
+  },
+  "TENDBCLUSTER_DISABLE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DISABLE",
+    "description": "单据类型: TENDBCLUSTER_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClusterDisable.vue",
+      "props_type": "TendbCluster.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_EXCEL_AUTHORIZE_RULES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_EXCEL_AUTHORIZE_RULES",
+    "description": "单据类型: TENDBCLUSTER_EXCEL_AUTHORIZE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ExcelAuthrizeRule.vue",
+      "props_type": "TendbCluster.AuthorizeRules",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_SPIDER_MNT_DESTROY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_MNT_DESTROY",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_MNT_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderMntDestroy.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderMntDestroy",
+      "labels": [
+        "节点IP"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_APPLY": {
+    "type": "object",
+    "title": "TENDBCLUSTER_APPLY",
+    "description": "单据类型: TENDBCLUSTER_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "spider": {
+                "type": "object",
+                "properties": {
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  },
+                  "count": {
+                    "type": "string",
+                    "description": "count"
+                  },
+                  "spec_name": {
+                    "type": "string",
+                    "description": "spec_name"
+                  }
+                },
+                "description": "spider (也可能是叶子节点)"
+              },
+              "backend_group": {
+                "type": "object",
+                "properties": {
+                  "label_names": {
+                    "type": "string",
+                    "description": "label_names"
+                  },
+                  "spec_info": {
+                    "type": "string",
+                    "description": "spec_info"
+                  }
+                }
+              }
+            }
+          },
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "db_module_name": {
+            "type": "string",
+            "description": "db_module_name"
+          },
+          "spider_port": {
+            "type": "string",
+            "description": "spider_port"
+          },
+          "version": {
+            "type": "object",
+            "properties": {
+              "db_version": {
+                "type": "string",
+                "description": "db_version"
+              },
+              "spider_version": {
+                "type": "string",
+                "description": "spider_version"
+              }
+            }
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/Apply.vue",
+      "props_type": "TendbCluster.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "DB模块",
+        "MySQL版本",
+        "Spider版本",
+        "访问端口",
+        "Spider Master 规格",
+        "Spider Master 资源标签",
+        "后端存储",
+        "资源规格",
+        "资源标签",
+        "需机器组数",
+        "集群分片",
+        "集群QPS每秒"
+      ],
+      "fields": [
+        "resource_spec.spider",
+        "resource_spec.spider.label_names",
+        "cluster_name",
+        "db_module_name",
+        "spider_port",
+        "version.db_version",
+        "resource_spec.backend_group.label_names",
+        "resource_spec.spider.count",
+        "resource_spec.backend_group.spec_info",
+        "cluster_alias",
+        "version.spider_version",
+        "resource_spec.spider.spec_name",
+        "bk_cloud_name"
+      ]
+    }
+  },
+  "TENDBCLUSTER_MIGRATE_CLUSTER": {
+    "type": "object",
+    "title": "TENDBCLUSTER_MIGRATE_CLUSTER",
+    "description": "单据类型: TENDBCLUSTER_MIGRATE_CLUSTER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "need_checksum": {
+            "type": "string",
+            "description": "need_checksum"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "machine_infos": {
+            "type": "string",
+            "description": "machine_infos"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "backup_source": {
+            "type": "string",
+            "description": "backup_source"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/MigrateCluster.vue",
+      "props_type": "TendbCluster.ResourcePool.MigrateCluster",
+      "labels": [
+        "备份源",
+        "数据校验",
+        "主库主机关联实例",
+        "目标从库主机",
+        "从库主机关联实例",
+        "所属集群",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "need_checksum",
+        "clusters",
+        "specs",
+        "machine_infos",
+        "infos",
+        "backup_source"
+      ]
+    }
+  },
+  "TENDBCLUSTER_LOCAL_UPGRADE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_LOCAL_UPGRADE",
+    "description": "单据类型: TENDBCLUSTER_LOCAL_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "pkg_id": {
+                  "type": "integer",
+                  "description": "目标版本包ID"
+                },
+                "new_db_module_id": {
+                  "type": "integer",
+                  "description": "数据库模块ID"
+                },
+                "current_version": {
+                  "type": "object",
+                  "description": "当前版本信息"
+                },
+                "target_version": {
+                  "type": "object",
+                  "description": "目标版本信息"
+                }
+              }
+            },
+            "description": "单据信息"
+          },
+          "is_check_process": {
+            "type": "boolean",
+            "description": "是否做安全检测",
+            "default": true
+          },
+          "upgrade_local": {
+            "type": "boolean",
+            "description": "是否本地升级",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBLocalUpgradeSerializer",
+      "builder_class": "TenDBLocalUpgradeFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_local_upgrade.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/LocalUpgrade.vue",
+      "props_type": "TendbCluster.LocalUpgrade",
+      "labels": [
+        "检查业务连接",
+        "当前版本",
+        "目标版本"
+      ],
+      "fields": [
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_REMOTE_UPGRADE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_REMOTE_UPGRADE",
+    "description": "单据类型: TENDBCLUSTER_REMOTE_UPGRADE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "is_verify_checksum": {
+            "type": "boolean",
+            "description": "是否检查主从数据校验结果",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBBackendLocalUpgradeSerializer",
+      "builder_class": "TenDBBackendLocalUpgradeFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_backend_local_upgrade.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/RemoteUpgrade.vue",
+      "props_type": "TendbCluster.RemoteUpgrade",
+      "labels": [
+        "检查业务连接",
+        "当前版本",
+        "目标版本"
+      ],
+      "fields": [
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_FORCE_IMPORT_SQLFILE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_FORCE_IMPORT_SQLFILE",
+    "description": "单据类型: TENDBCLUSTER_FORCE_IMPORT_SQLFILE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ForceImportSqlfile.vue",
+      "props_type": "TendbCluster.ImportSqlFile",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_DELETE_CLEAR_DB": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DELETE_CLEAR_DB",
+    "description": "单据类型: TENDBCLUSTER_DELETE_CLEAR_DB",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/DeleteClearDb.vue",
+      "props_type": "TendbCluster.DeleteClearDb",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_FULL_BACKUP": {
+    "type": "object",
+    "title": "TENDBCLUSTER_FULL_BACKUP",
+    "description": "单据类型: TENDBCLUSTER_FULL_BACKUP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "backup_type": {
+            "type": "string",
+            "description": "备份选项"
+          },
+          "file_tag": {
+            "type": "string",
+            "description": "备份保存时间"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "backup_local": {
+                  "type": "string",
+                  "description": "备份位置信息"
+                },
+                "spider_mnt_address": {
+                  "type": "string",
+                  "description": "运维节点地址"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBClusterFullBackUpDetailSerializer",
+      "builder_class": "TenDBClusterFullBackUpFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/full_backup.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/FullBackup.vue",
+      "props_type": "TendbCluster.FullBackup",
+      "labels": [
+        "备份类型",
+        "备份保存时间",
+        "备份位置"
+      ],
+      "fields": [
+        "file_tag",
+        "backup_type",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_CLB_UNBIND_DOMAIN": {
+    "type": "object",
+    "title": "TENDBCLUSTER_CLB_UNBIND_DOMAIN",
+    "description": "单据类型: TENDBCLUSTER_CLB_UNBIND_DOMAIN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbCLBUnBindDomainDetailSerializer",
+      "builder_class": "TendbCLBUnBindDomainFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_clb_unbind_domain.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClbUnbindDomain.vue",
+      "props_type": "TendbCluster.ClbUnbindDomain",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_MASTER_SLAVE_SWITCH": {
+    "type": "object",
+    "title": "TENDBCLUSTER_MASTER_SLAVE_SWITCH",
+    "description": "单据类型: TENDBCLUSTER_MASTER_SLAVE_SWITCH",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "switch_tuples": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "切换的主从组"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                }
+              }
+            },
+            "description": "单据信息"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行(互切不强制，故障切强制)",
+            "default": false
+          },
+          "is_check_process": {
+            "type": "boolean",
+            "description": "是否检测连接"
+          },
+          "is_check_delay": {
+            "type": "boolean",
+            "description": "是否检测数据同步延时情况(互切单据延时属于强制检测，故必须传True)",
+            "default": true
+          },
+          "is_verify_checksum": {
+            "type": "boolean",
+            "description": "是否检测历史数据检验结果"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbMasterSlaveSwitchDetailSerializer",
+      "builder_class": "TendbMasterSlaveSwitchFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_master_slave_switch.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/MasterSlaveSwitch.vue",
+      "props_type": "TendbCluster.MasterSlaveSwitch",
+      "labels": [
+        "检查业务来源的连接",
+        "检查主从数据校验结果",
+        "从库主机",
+        "所属集群"
+      ],
+      "fields": [
+        "is_verify_checksum",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_DUMP_DATA": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DUMP_DATA",
+    "description": "单据类型: TENDBCLUSTER_DUMP_DATA",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbClusterDumpDataDetailSerializer",
+      "builder_class": "TendbClusterDumpDataFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_dump_data.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/DumpData.vue",
+      "props_type": "TendbCluster.DumpData",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_FLASHBACK": {
+    "type": "object",
+    "title": "TENDBCLUSTER_FLASHBACK",
+    "description": "单据类型: TENDBCLUSTER_FLASHBACK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbFlashbackDetailSerializer",
+      "builder_class": "TendbFlashbackFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_flashback.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/Flashback.vue",
+      "props_type": "TendbCluster.FlashBack",
+      "labels": [
+        "闪回方式",
+        "日志追溯截止",
+        "覆盖原始数据",
+        "update 转 replace",
+        "仅回滚 delete",
+        "回档时间",
+        "目标库",
+        "忽略库",
+        "目标表",
+        "忽略表",
+        "待闪回记录"
+      ],
+      "fields": [
+        "flashback_type",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_RENAME_DATABASE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_RENAME_DATABASE",
+    "description": "单据类型: TENDBCLUSTER_RENAME_DATABASE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbRenameSerializer",
+      "builder_class": "MySQLHaRenameFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_rename.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/RenameDataBase.vue",
+      "props_type": "TendbCluster.RenameDataBase",
+      "labels": [
+        "检查业务连接",
+        "源DB名",
+        "新DB名"
+      ],
+      "fields": [
+        "infos",
+        "force",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_NODE_REBALANCE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_NODE_REBALANCE",
+    "description": "单据类型: TENDBCLUSTER_NODE_REBALANCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "need_checksum": {
+            "type": "string",
+            "description": "need_checksum"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/NodeRebalance.vue",
+      "props_type": "TendbCluster.ResourcePool.NodeRebalance",
+      "labels": [
+        "数据校验",
+        "当前容量",
+        "目标容量",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "need_checksum",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_CHECKSUM": {
+    "type": "object",
+    "title": "TENDBCLUSTER_CHECKSUM",
+    "description": "单据类型: TENDBCLUSTER_CHECKSUM",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "data_repair": {
+            "type": "object",
+            "description": "数据修复信息",
+            "properties": {
+              "is_repair": {
+                "type": "boolean",
+                "description": "是否修复"
+              },
+              "mode": {
+                "type": "string",
+                "description": "数据校验后修复执行类型"
+              }
+            }
+          },
+          "runtime_hour": {
+            "type": "integer",
+            "description": "超时时间"
+          },
+          "timing": {
+            "type": "string",
+            "description": "定时触发时间"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "checksum_scope": {
+                  "type": "string",
+                  "description": "校验范围"
+                },
+                "backup_infos": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "备份信息"
+                },
+                "repl_table": {
+                  "type": "string",
+                  "description": "校验结果表名"
+                }
+              }
+            },
+            "description": "全备信息列表"
+          },
+          "is_sync_non_innodb": {
+            "type": "boolean",
+            "description": "非innodb表是否修复",
+            "default": false
+          },
+          "need_manual_confirm": {
+            "type": "boolean",
+            "description": "是否需要人工确认",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbChecksumDetailSerializer",
+      "builder_class": "TendbChecksumFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_checksum.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/CheckSum.vue",
+      "props_type": "TendbCluster.CheckSum",
+      "labels": [
+        "执行模式",
+        "全局超时时间（h）",
+        "修复数据",
+        "修复模式",
+        "校验范围",
+        "校验从库",
+        "校验主库",
+        "校验DB名",
+        "忽略DB名",
+        "校验表名",
+        "忽略表名"
+      ],
+      "fields": [
+        "runtime_hour",
+        "data_repair.mode",
+        "data_repair.is_repair",
+        "need_manual_confirm",
+        "clusters",
+        "infos",
+        "timing"
+      ]
+    }
+  },
+  "TENDBCLUSTER_SPIDER_ADD_NODES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_ADD_NODES",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_ADD_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderAddNodes.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderAddNodes",
+      "labels": [
+        "扩容节点类型",
+        "当前数量（台）",
+        "扩容数量（台）",
+        "最终数量（台）",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_DATA_REPAIR": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DATA_REPAIR",
+    "description": "单据类型: TENDBCLUSTER_DATA_REPAIR",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbDataRepairDetailSerializer",
+      "builder_class": "TendbDataRepairFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_data_repair.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/DataRepair.vue",
+      "props_type": "TendbCluster.DataRepair",
+      "labels": [
+        "不一致时间范围",
+        "修复主库",
+        "修复从库"
+      ],
+      "fields": [
+        "end_time",
+        "infos",
+        "clusters",
+        "start_time"
+      ]
+    }
+  },
+  "TENDBCLUSTER_ENABLE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_ENABLE",
+    "description": "单据类型: TENDBCLUSTER_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/ClusterEnable.vue",
+      "props_type": "TendbCluster.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_OPEN_AREA": {
+    "type": "object",
+    "title": "TENDBCLUSTER_OPEN_AREA",
+    "description": "单据类型: TENDBCLUSTER_OPEN_AREA",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TendbOpenAreaDetailSerializer",
+      "builder_class": "TendbOpenAreaFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_openarea.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/OpenArea.vue",
+      "props_type": "TendbCluster.OpenArea",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TENDBCLUSTER_INSTANCE_FAIL_OVER": {
+    "type": "object",
+    "title": "TENDBCLUSTER_INSTANCE_FAIL_OVER",
+    "description": "单据类型: TENDBCLUSTER_INSTANCE_FAIL_OVER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "is_verify_checksum": {
+            "type": "string",
+            "description": "is_verify_checksum"
+          },
+          "is_check_process": {
+            "type": "string",
+            "description": "is_check_process"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/InstanceFailOver.vue",
+      "props_type": "TendbCluster.InstanceFailOver",
+      "labels": [
+        "检查业务来源的连接",
+        "检查主从数据校验结果",
+        "从库实例",
+        "所属集群"
+      ],
+      "fields": [
+        "is_verify_checksum",
+        "is_check_process",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_INSTANCE_CLONE_RULES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_INSTANCE_CLONE_RULES",
+    "description": "单据类型: TENDBCLUSTER_INSTANCE_CLONE_RULES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clone_data": {
+            "type": "string",
+            "description": "clone_data"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/tendbCluster/InstanceCloneRules.vue",
+      "props_type": "TendbCluster.InstanceCloneRules",
+      "labels": [
+        "所属集群",
+        "新实例"
+      ],
+      "fields": [
+        "clone_data"
+      ]
+    }
+  },
+  "RIAK_CLUSTER_REBOOT": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_REBOOT",
+    "description": "单据类型: RIAK_CLUSTER_REBOOT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_host_id": {
+            "type": "integer",
+            "description": "重启主机ID"
+          },
+          "cluster_id": {
+            "type": "integer",
+            "description": "集群ID"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RiakRebootDetailSerializer",
+      "builder_class": "RiakRebootFlowBuilder",
+      "source_file": "ticket/builders/riak/riak_reboot.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/riak/Reboot.vue",
+      "props_type": "Riak.Reboot",
+      "labels": [
+        "集群ID",
+        "集群名称",
+        "集群类型"
+      ],
+      "fields": []
+    }
+  },
+  "RIAK_CLUSTER_DESTROY": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_DESTROY",
+    "description": "单据类型: RIAK_CLUSTER_DESTROY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/riak/Destroy.vue",
+      "props_type": "Riak.Destroy",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "RIAK_CLUSTER_ENABLE": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_ENABLE",
+    "description": "单据类型: RIAK_CLUSTER_ENABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/riak/Enable.vue",
+      "props_type": "Riak.Enable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "RIAK_CLUSTER_DISABLE": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_DISABLE",
+    "description": "单据类型: RIAK_CLUSTER_DISABLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/riak/Disable.vue",
+      "props_type": "Riak.Disable",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "RIAK_CLUSTER_APPLY": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_APPLY",
+    "description": "单据类型: RIAK_CLUSTER_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "cluster_name": {
+            "type": "string",
+            "description": "cluster_name"
+          },
+          "db_module_name": {
+            "type": "string",
+            "description": "db_module_name"
+          },
+          "cluster_alias": {
+            "type": "string",
+            "description": "cluster_alias"
+          },
+          "ip_source": {
+            "type": "string",
+            "description": "ip_source"
+          },
+          "bk_cloud_name": {
+            "type": "string",
+            "description": "bk_cloud_name"
+          },
+          "db_version": {
+            "type": "string",
+            "description": "db_version"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/riak/Apply.vue",
+      "props_type": "Riak.Apply",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "DB模块名",
+        "集群名称",
+        "集群别名",
+        "管控区域",
+        "Riak版本",
+        "服务器选择方式",
+        "资源规格",
+        "资源标签",
+        "节点数量",
+        "Riak节点IP"
+      ],
+      "fields": [
+        "cluster_name",
+        "db_module_name",
+        "cluster_alias",
+        "ip_source",
+        "bk_cloud_name",
+        "db_version"
+      ]
+    }
+  },
+  "RIAK_CLUSTER_SCALE_OUT": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_SCALE_OUT",
+    "description": "单据类型: RIAK_CLUSTER_SCALE_OUT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "resource_spec": {
+            "type": "object",
+            "properties": {
+              "riak": {
+                "type": "object",
+                "properties": {
+                  "hosts": {
+                    "type": "object",
+                    "properties": {
+                      "length": {
+                        "type": "string",
+                        "description": "length"
+                      }
+                    },
+                    "description": "hosts (也可能是叶子节点)"
+                  },
+                  "count": {
+                    "type": "string",
+                    "description": "count"
+                  },
+                  "spec_id": {
+                    "type": "string",
+                    "description": "spec_id"
+                  }
+                }
+              }
+            }
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "cluster_id": {
+            "type": "string",
+            "description": "cluster_id"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/riak/ScaleOut.vue",
+      "props_type": "Riak.ResourcePool.ScaleOut",
+      "labels": [
+        "集群",
+        "集群ID",
+        "服务器选择方式",
+        "扩容规格",
+        "扩容数量",
+        "已选IP",
+        "Agent状态",
+        "磁盘容量(G"
+      ],
+      "fields": [
+        "resource_spec.riak.hosts",
+        "clusters",
+        "resource_spec.riak.hosts.length",
+        "specs",
+        "cluster_id",
+        "resource_spec.riak.count",
+        "resource_spec.riak.spec_id"
+      ]
+    }
+  },
+  "RIAK_CLUSTER_SCALE_IN": {
+    "type": "object",
+    "title": "RIAK_CLUSTER_SCALE_IN",
+    "description": "单据类型: RIAK_CLUSTER_SCALE_IN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "recycle_hosts": {
+            "type": "string",
+            "description": "recycle_hosts"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "cluster_id": {
+            "type": "string",
+            "description": "cluster_id"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/riak/ScaleIn.vue",
+      "props_type": "Riak.ResourcePool.ScaleIn",
+      "labels": [
+        "集群",
+        "集群ID",
+        "缩容主机：",
+        "Agent状态",
+        "磁盘容量(G"
+      ],
+      "fields": [
+        "recycle_hosts",
+        "clusters",
+        "cluster_id"
+      ]
+    }
+  },
+  "TBINLOGDUMPER_INSTALL": {
+    "type": "object",
+    "title": "TBINLOGDUMPER_INSTALL",
+    "description": "单据类型: TBINLOGDUMPER_INSTALL",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "订阅名称"
+          },
+          "add_type": {
+            "type": "string",
+            "description": "数据同步方式"
+          },
+          "repl_tables": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "订阅库表(格式: db_name.table_name)"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "数据库原源群"
+                },
+                "db_module_id": {
+                  "type": "integer",
+                  "description": "集群module id"
+                },
+                "dumper_id": {
+                  "type": "integer",
+                  "description": "部署的dumper id"
+                },
+                "protocol_type": {
+                  "type": "string",
+                  "description": "接收端类型"
+                },
+                "target_address": {
+                  "type": "string",
+                  "description": "接收端集群域名/IP"
+                },
+                "target_port": {
+                  "type": "integer",
+                  "description": "接收端端口"
+                },
+                "l5_modid": {
+                  "type": "integer",
+                  "description": "l5_modid配置"
+                },
+                "l5_cmdid": {
+                  "type": "integer",
+                  "description": "l5_cmdid配置"
+                },
+                "kafka_user": {
+                  "type": "string",
+                  "description": "kafka用户名"
+                },
+                "kafka_pwd": {
+                  "type": "string",
+                  "description": "kafka密码"
+                }
+              }
+            },
+            "description": "dumper配置信息"
+          },
+          "dumper_config_id": {
+            "type": "integer",
+            "description": "dumper配置ID"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TbinlogdumperApplyDetailSerializer",
+      "builder_class": "TbinlogdumperApplyFlowBuilder",
+      "source_file": "ticket/builders/tbinlogdumper/dumper_apply.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/dumper/Install.vue",
+      "props_type": "Dumper.Install",
+      "labels": [
+        "订阅的库表",
+        "数据源与接收端",
+        "订阅名称",
+        "Dumper部署位置",
+        "数据同步方式",
+        "DB 名",
+        "表名",
+        "数据源集群",
+        "部署dumper实例ID",
+        "接收端类型",
+        "接收端集群与端口",
+        "l5_modid",
+        "l5_cmdid",
+        "账号",
+        "密码"
+      ],
+      "fields": [
+        "repl_tables.reduce"
+      ]
+    }
+  },
+  "TBINLOGDUMPER_ENABLE_NODES": {
+    "type": "object",
+    "title": "TBINLOGDUMPER_ENABLE_NODES",
+    "description": "单据类型: TBINLOGDUMPER_ENABLE_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/dumper/EnableNodes.vue",
+      "props_type": "Dumper.EnableNodes",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "TBINLOGDUMPER_SWITCH_NODES": {
+    "type": "object",
+    "title": "TBINLOGDUMPER_SWITCH_NODES",
+    "description": "单据类型: TBINLOGDUMPER_SWITCH_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "switch_instances": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "dumper切换信息"
+                }
+              }
+            }
+          },
+          "is_safe": {
+            "type": "boolean",
+            "description": "是否安全切换",
+            "default": true
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TbinlogdumperSwitchNodesDetailSerializer",
+      "builder_class": "TbinlogdumperSwitchNodesFlowBuilder",
+      "source_file": "ticket/builders/tbinlogdumper/dumper_switch.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/dumper/SwitchNodes.vue",
+      "props_type": "Dumper.SwitchNodes",
+      "labels": [
+        "迁移目标位置",
+        "binlog file",
+        "binlog pos"
+      ],
+      "fields": []
+    }
+  },
+  "TBINLOGDUMPER_DISABLE_NODES": {
+    "type": "object",
+    "title": "TBINLOGDUMPER_DISABLE_NODES",
+    "description": "单据类型: TBINLOGDUMPER_DISABLE_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/dumper/DisableNodes.vue",
+      "props_type": "Dumper.DisableNodes",
+      "labels": [],
+      "fields": []
+    }
+  },
+  "SQLSERVER_IMPORT_SQLFILE": {
+    "type": "object",
+    "title": "SQLSERVER_IMPORT_SQLFILE",
+    "description": "单据类型: SQLSERVER_IMPORT_SQLFILE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "charset": {
+            "type": "string",
+            "description": "字符集"
+          },
+          "force": {
+            "type": "boolean",
+            "description": "是否强制执行",
+            "default": false
+          },
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "execute_objects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dbnames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "执行DB"
+                },
+                "ignore_dbnames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略DB"
+                },
+                "sql_files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "sql执行文件"
+                },
+                "import_mode": {
+                  "type": "string",
+                  "description": "sql导入模式"
+                }
+              }
+            },
+            "description": "sql执行体信息"
+          },
+          "ticket_mode": {
+            "type": "object",
+            "description": "执行模式",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "单据执行模式"
+              },
+              "trigger_time": {
+                "type": "string",
+                "description": "定时任务触发时间"
+              }
+            }
+          },
+          "backup": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "backup_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "备份db列表"
+                },
+                "ignore_backup_dbs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "忽略备份db列表"
+                }
+              }
+            },
+            "description": "备份信息"
+          },
+          "backup_place": {
+            "type": "string",
+            "description": "备份位置(先固定为master)",
+            "default": "master"
+          },
+          "file_tag": {
+            "type": "string",
+            "description": "备份保存时间"
+          },
+          "backup_type": {
+            "type": "string",
+            "description": "备份方式"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SQLServerImportDetailSerializer",
+      "builder_class": "SQLServerSingleApplyFlowBuilder",
+      "source_file": "ticket/builders/sqlserver/sqlserver_import_sqlfile.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/sqlserver/import-sql-file/Index.vue",
+      "props_type": "Sqlserver.ImportSqlFile",
+      "labels": [
+        "所属业务",
+        "业务英文名",
+        "字符集",
+        "执行模式",
+        "执行时间",
+        "目标集群",
+        "变更内容",
+        "集群类型",
+        "版本",
+        "状态",
+        "变更的 DB",
+        "忽略的 DB",
+        "执行的 SQL",
+        "备份 DB",
+        "备份源",
+        "备份表名"
+      ],
+      "fields": [
+        "charset",
+        "execute_objects",
+        "clusters",
+        "backup",
+        "execute_objects.map",
+        "ticket_mode.trigger_time",
+        "ticket_mode.mode",
+        "cluster_ids.map",
+        "path"
+      ]
+    }
+  },
+  "REDIS_VERSION_UPDATE_ONLINE": {
+    "type": "object",
+    "title": "REDIS_VERSION_UPDATE_ONLINE",
+    "description": "单据类型: REDIS_VERSION_UPDATE_ONLINE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "slave_current_versions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "当前从节点版本信息"
+                },
+                "node_type": {
+                  "type": "string",
+                  "description": "节点类型"
+                },
+                "current_versions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "当前版本列表"
+                },
+                "target_versions": {
+                  "type": "array",
+                  "items": {
+                    "type": "json"
+                  },
+                  "description": "目标版本信息"
+                }
+              }
+            },
+            "description": "版本升级信息"
+          },
+          "update_type": {
+            "type": "string",
+            "description": "更新类型"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisVersionUpdateDetailSerializer",
+      "builder_class": "RedisVersionUpdateFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_cluster_version_update.py",
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/redis/version-update-online/Index.vue",
+      "props_type": "Redis.VersionUpdateOnline",
+      "labels": [
+        "角色类型",
+        "升级类型"
+      ],
+      "fields": []
+    }
+  },
+  "REDIS_CLUSTER_ADD_SLAVE": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_ADD_SLAVE",
+    "description": "单据类型: REDIS_CLUSTER_ADD_SLAVE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ClusterAddSlave.vue",
+      "props_type": "Redis.ResourcePool.ClusterAddSlave",
+      "labels": [
+        "关联主库主机",
+        "所属集群",
+        "规格需求",
+        "资源标签",
+        "新增从库主机数量"
+      ],
+      "fields": []
+    }
+  },
+  "REDIS_CLUSTER_TYPE_UPDATE": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_TYPE_UPDATE",
+    "description": "单据类型: REDIS_CLUSTER_TYPE_UPDATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "data_check_repair_setting": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "type"
+              },
+              "execution_frequency": {
+                "type": "string",
+                "description": "execution_frequency"
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ClusterTypeUpdate.vue",
+      "props_type": "Redis.ResourcePool.ClusterTypeUpdate",
+      "labels": [
+        "校验与修复类型",
+        "校验与修复频率设置",
+        "源集群类型",
+        "源集群容量",
+        "新集群类型",
+        "当前容量需求",
+        "未来容量需求",
+        "新集群版本",
+        "新集群部署方案",
+        "资源标签",
+        "切换模式"
+      ],
+      "fields": [
+        "clusters",
+        "specs",
+        "infos",
+        "data_check_repair_setting.type",
+        "data_check_repair_setting.execution_frequency"
+      ]
+    }
+  },
+  "REDIS_PROXY_SCALE_UP": {
+    "type": "object",
+    "title": "REDIS_PROXY_SCALE_UP",
+    "description": "单据类型: REDIS_PROXY_SCALE_UP",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ProxyScaleUp.vue",
+      "props_type": "Redis.ResourcePool.ProxyScaleUp",
+      "labels": [
+        "架构版本",
+        "当前数量（台）",
+        "扩容数量（台）",
+        "最终数量（台）",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_SHARD_ADD": {
+    "type": "object",
+    "title": "REDIS_SHARD_ADD",
+    "description": "单据类型: REDIS_SHARD_ADD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ShardAdd.vue",
+      "props_type": "Redis.ResourcePool.ShardAdd",
+      "labels": [
+        "架构版本",
+        "当前容量",
+        "增加机器组数",
+        "目标容量",
+        "资源标签"
+      ],
+      "fields": [
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_CLUSTER_INS_MIGRATE": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_INS_MIGRATE",
+    "description": "单据类型: REDIS_CLUSTER_INS_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/MigrateCluster.vue",
+      "props_type": "Redis.ResourcePool.MigrateCluster",
+      "labels": [
+        "所属集群",
+        "规格",
+        "资源标签",
+        "版本"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "REDIS_SINGLE_INS_MIGRATE": {
+    "type": "object",
+    "title": "REDIS_SINGLE_INS_MIGRATE",
+    "description": "单据类型: REDIS_SINGLE_INS_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "db_version": {
+                  "type": "string",
+                  "description": "版本"
+                },
+                "migrate_type": {
+                  "type": "string",
+                  "description": "迁移类型"
+                },
+                "resource_spec": {
+                  "type": "object",
+                  "properties": {
+                    "backend_group": {
+                      "type": "object",
+                      "properties": {
+                        "spec_id": {
+                          "type": "integer",
+                          "description": "规格ID"
+                        },
+                        "label_names": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "标签名列表"
+                        }
+                      }
+                    }
+                  }
+                },
+                "src_cluster": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "cluster_id": {
+                        "type": "integer",
+                        "description": "集群ID"
+                      },
+                      "master_ins": {
+                        "type": "string",
+                        "description": "主实例"
+                      },
+                      "slave_ins": {
+                        "type": "string",
+                        "description": "从实例"
+                      }
+                    }
+                  },
+                  "description": "源集群列表"
+                }
+              }
+            },
+            "description": "迁移信息列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/MigrateSingle.vue",
+      "props_type": "Redis.ResourcePool.MigrateSingle",
+      "labels": [
+        "关联的主从实例",
+        "规格",
+        "资源标签",
+        "版本"
+      ],
+      "fields": [
+        "infos.map"
+      ]
+    }
+  },
+  "REDIS_CLUSTER_SHARD_NUM_UPDATE": {
+    "type": "object",
+    "title": "REDIS_CLUSTER_SHARD_NUM_UPDATE",
+    "description": "单据类型: REDIS_CLUSTER_SHARD_NUM_UPDATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          },
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "data_check_repair_setting": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "type"
+              },
+              "execution_frequency": {
+                "type": "string",
+                "description": "execution_frequency"
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ClusterShardNumUpdate.vue",
+      "props_type": "Redis.ResourcePool.ClusterShardNumUpdate",
+      "labels": [
+        "校验与修复类型",
+        "校验与修复频率设置",
+        "架构版本",
+        "Redis 版本",
+        "当前方案",
+        "新部署方案",
+        "切换模式"
+      ],
+      "fields": [
+        "clusters",
+        "specs",
+        "infos",
+        "data_check_repair_setting.type",
+        "data_check_repair_setting.execution_frequency"
+      ]
+    }
+  },
+  "REDIS_SCALE_UPDOWN": {
+    "type": "object",
+    "title": "REDIS_SCALE_UPDOWN",
+    "description": "单据类型: REDIS_SCALE_UPDOWN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/redis/ScaleUpdown.vue",
+      "props_type": "Redis.ResourcePool.ScaleUpdown",
+      "labels": [
+        "架构版本",
+        "Redis版本",
+        "当前容量",
+        "目标容量",
+        "切换模式"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_REPLICASET_CUTOFF": {
+    "type": "object",
+    "title": "MONGODB_REPLICASET_CUTOFF",
+    "description": "单据类型: MONGODB_REPLICASET_CUTOFF",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ReplicaCutoff.vue",
+      "props_type": "Mongodb.ResourcePool.ReplicaCutoff",
+      "labels": [
+        "角色类型",
+        "所属集群",
+        "新机规格",
+        "资源标签"
+      ],
+      "fields": []
+    }
+  },
+  "MONGODB_REPLICA_ADD_SHARD_NODES": {
+    "type": "object",
+    "title": "MONGODB_REPLICA_ADD_SHARD_NODES",
+    "description": "单据类型: MONGODB_REPLICA_ADD_SHARD_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ReplicaAddShardNodes.vue",
+      "props_type": "Mongodb.ResourcePool.ReplicaAddShardNodes",
+      "labels": [
+        "忽略业务连接",
+        "集群类型",
+        "当前节点数",
+        "扩容节点数",
+        "最终节点数",
+        "资源标签"
+      ],
+      "fields": [
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_SHARD_MIGRATE": {
+    "type": "object",
+    "title": "MONGODB_SHARD_MIGRATE",
+    "description": "单据类型: MONGODB_SHARD_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ShardMigrate.vue",
+      "props_type": "Mongodb.ResourcePool.ShardMigrate",
+      "labels": [
+        "关联集群",
+        "关联集群实例",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_ADD_MONGOS": {
+    "type": "object",
+    "title": "MONGODB_ADD_MONGOS",
+    "description": "单据类型: MONGODB_ADD_MONGOS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/AddMongos.vue",
+      "props_type": "Mongodb.ResourcePool.AddMongos",
+      "labels": [
+        "当前数量（台）",
+        "扩容数量（台）",
+        "最终数量（台）",
+        "扩容规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_SHARD_CUTOFF": {
+    "type": "object",
+    "title": "MONGODB_SHARD_CUTOFF",
+    "description": "单据类型: MONGODB_SHARD_CUTOFF",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ShardCutoff.vue",
+      "props_type": "Mongodb.ResourcePool.ShardCutoff",
+      "labels": [
+        "角色类型",
+        "所属集群",
+        "新机规格",
+        "资源标签"
+      ],
+      "fields": []
+    }
+  },
+  "MONGODB_SHARD_ADD_SHARD_NODES": {
+    "type": "object",
+    "title": "MONGODB_SHARD_ADD_SHARD_NODES",
+    "description": "单据类型: MONGODB_SHARD_ADD_SHARD_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ShardAddShardNodes.vue",
+      "props_type": "Mongodb.ResourcePool.ShardAddShardNodes",
+      "labels": [
+        "忽略业务连接",
+        "集群类型",
+        "当前节点数",
+        "扩容节点数",
+        "最终节点数",
+        "资源标签"
+      ],
+      "fields": [
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_REPLICASET_MIGRATE": {
+    "type": "object",
+    "title": "MONGODB_REPLICASET_MIGRATE",
+    "description": "单据类型: MONGODB_REPLICASET_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ReplicasetMigrate.vue",
+      "props_type": "Mongodb.ResourcePool.ReplicasetMigrate",
+      "labels": [
+        "关联实例",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_ADD_SHARD": {
+    "type": "object",
+    "title": "MONGODB_ADD_SHARD",
+    "description": "单据类型: MONGODB_ADD_SHARD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/AddShard.vue",
+      "props_type": "Mongodb.ResourcePool.AddShard",
+      "labels": [
+        "当前集群分片数",
+        "新增集群分片数",
+        "最终集群分片数",
+        "单机分片数",
+        "每片节点数",
+        "规格",
+        "新增机器（组）",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MONGODB_SCALE_UPDOWN": {
+    "type": "object",
+    "title": "MONGODB_SCALE_UPDOWN",
+    "description": "单据类型: MONGODB_SCALE_UPDOWN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mongodb/ScaleUpdown.vue",
+      "props_type": "Mongodb.ResourcePool.ScaleUpdown",
+      "labels": [
+        "目标资源规格",
+        "目标 Shard 节点数",
+        "目标机器组数",
+        "分片数"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_FIXPOINT_NEW_CLUSTER": {
+    "type": "object",
+    "title": "MYSQL_FIXPOINT_NEW_CLUSTER",
+    "description": "单据类型: MYSQL_FIXPOINT_NEW_CLUSTER",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/FixpointNewCluster.vue",
+      "props_type": "Mysql.ResourcePool.RollbackCluster",
+      "labels": [
+        "构造类型",
+        "构造方式",
+        "备份源",
+        "指定时间",
+        "备份记录",
+        "源 DB",
+        "源表",
+        "新集群主机"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_PROXY_MIGRATE_INS": {
+    "type": "object",
+    "title": "MYSQL_PROXY_MIGRATE_INS",
+    "description": "单据类型: MYSQL_PROXY_MIGRATE_INS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/ProxyMigrateIns.vue",
+      "props_type": "Mysql.ResourcePool.ProxyMigrateIns",
+      "labels": [
+        "检查业务连接",
+        "关联集群",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_PROXY_CONF_CHANGE": {
+    "type": "object",
+    "title": "MYSQL_PROXY_CONF_CHANGE",
+    "description": "单据类型: MYSQL_PROXY_CONF_CHANGE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/ProxyConfChange.vue",
+      "props_type": "Mysql.ResourcePool.ProxyConfChange",
+      "labels": [
+        "当前规格",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_PROXY_MIGRATE": {
+    "type": "object",
+    "title": "MYSQL_PROXY_MIGRATE",
+    "description": "单据类型: MYSQL_PROXY_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/ProxyMigrate.vue",
+      "props_type": "Mysql.ResourcePool.ProxyMigrate",
+      "labels": [
+        "关联实例",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_CLUSTER_MIGRATE": {
+    "type": "object",
+    "title": "SQLSERVER_CLUSTER_MIGRATE",
+    "description": "单据类型: SQLSERVER_CLUSTER_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/sqlserver/ClusterMigrate.vue",
+      "props_type": "Sqlserver.ResourcePool.ClusterMigrate",
+      "labels": [
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "SQLSERVER_HOST_MIGRATE": {
+    "type": "object",
+    "title": "SQLSERVER_HOST_MIGRATE",
+    "description": "单据类型: SQLSERVER_HOST_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/sqlserver/HostMigrate.vue",
+      "props_type": "Sqlserver.ResourcePool.HostMigrate",
+      "labels": [
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_FIXPOINT_NEW": {
+    "type": "object",
+    "title": "TENDBCLUSTER_FIXPOINT_NEW",
+    "description": "单据类型: TENDBCLUSTER_FIXPOINT_NEW",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/FixpointNewCluster.vue",
+      "props_type": "TendbCluster.ResourcePool.RollbackCluster",
+      "labels": [
+        "构造类型",
+        "构造方式",
+        "指定时间",
+        "备份记录",
+        "源 DB",
+        "源表",
+        "存储层主机",
+        "接入层主机"
+      ],
+      "fields": [
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_SPIDER_CONF_UP_DOWN": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_CONF_UP_DOWN",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_CONF_UP_DOWN",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderConfUpDown.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderConfUpDown",
+      "labels": [
+        "节点类型",
+        "当前规格",
+        "目标规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "clusters"
+      ]
+    }
+  },
+  "TENDBCLUSTER_SPIDER_SWITCH_NODES": {
+    "type": "object",
+    "title": "TENDBCLUSTER_SPIDER_SWITCH_NODES",
+    "description": "单据类型: TENDBCLUSTER_SPIDER_SWITCH_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "specs": {
+            "type": "string",
+            "description": "specs"
+          },
+          "infos": {
+            "type": "string",
+            "description": "infos"
+          },
+          "is_safe": {
+            "type": "string",
+            "description": "is_safe"
+          },
+          "clusters": {
+            "type": "string",
+            "description": "clusters"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/tendbCluster/SpiderSwitchNodes.vue",
+      "props_type": "TendbCluster.ResourcePool.SpiderSwitchNodes",
+      "labels": [
+        "检查业务连接",
+        "实例角色",
+        "关联集群",
+        "规格",
+        "资源标签"
+      ],
+      "fields": [
+        "specs",
+        "infos",
+        "is_safe",
+        "clusters"
+      ]
+    }
+  },
+  "MYSQL_MIGRATE_SINGLE": {
+    "type": "object",
+    "title": "MYSQL_MIGRATE_SINGLE",
+    "description": "单据类型: MYSQL_MIGRATE_SINGLE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "migrate_type": {
+            "type": "string",
+            "description": "migrate_type"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "vue_file": "frontend/src/views/ticket-center/common/ticket-detail/components/task-info/com-factory/resource-pool-strategy/mysql/migrate-single/Index.vue",
+      "props_type": "Mysql.ResourcePool.MigrateSingle",
+      "labels": [],
+      "fields": [
+        "migrate_type"
+      ]
+    }
+  },
+  "REDIS_FAILOVER_DRILL": {
+    "type": "object",
+    "title": "REDIS_FAILOVER_DRILL",
+    "description": "单据类型: REDIS_FAILOVER_DRILL",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "drill_infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群id"
+                }
+              }
+            },
+            "description": "容灾演练信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisFailoverDrillDetailSerializer",
+      "builder_class": "RedisFailoverDrillFlowBuilder",
+      "source_file": "ticket/builders/redis/redis_failover_drill.py"
+    }
+  },
+  "REDIS_PLUGIN_DELETE_POLARIS": {
+    "type": "object",
+    "title": "REDIS_PLUGIN_DELETE_POLARIS",
+    "description": "单据类型: REDIS_PLUGIN_DELETE_POLARIS",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "RedisPluginCreatePolarisDetailSerializer",
+      "builder_class": "RedisPluginCreatePolarisFlowBuilder",
+      "source_file": "ticket/builders/redis/plugin_delete_polaris.py"
+    }
+  },
+  "TBINLOGDUMPER_REDUCE_NODES": {
+    "type": "object",
+    "title": "TBINLOGDUMPER_REDUCE_NODES",
+    "description": "单据类型: TBINLOGDUMPER_REDUCE_NODES",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "dumper_instance_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "dumper实例ID"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TbinlogdumperReduceNodesDetailSerializer",
+      "builder_class": "TbinlogdumperReduceNodesFlowBuilder",
+      "source_file": "ticket/builders/tbinlogdumper/dumper_reduce_nodes.py"
+    }
+  },
+  "MONGODB_DATA_EXPORT": {
+    "type": "object",
+    "title": "MONGODB_DATA_EXPORT",
+    "description": "单据类型: MONGODB_DATA_EXPORT",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ns_filter": {
+                  "type": "object",
+                  "description": "库表选择器"
+                },
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群ID"
+                },
+                "export_options": {
+                  "type": "object",
+                  "description": "导出选项配置"
+                }
+              }
+            },
+            "description": "数据导出信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MongoDBDataExportDetailSerializer",
+      "builder_class": "MongoDBDataExportApplyFlowBuilder",
+      "source_file": "ticket/builders/mongodb/mongo_data_export.py"
+    }
+  },
+  "VM_SHRINK": {
+    "type": "object",
+    "title": "VM_SHRINK",
+    "description": "单据类型: VM_SHRINK",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "nodes": {
+            "type": "object",
+            "description": "nodes节点列表",
+            "properties": {
+              "hot": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "hot信息列表"
+              },
+              "cold": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "cold信息列表"
+              },
+              "client": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "client信息列表"
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "VmShrinkDetailSerializer",
+      "builder_class": "EsShrinkFlowBuilder",
+      "source_file": "ticket/builders/vm/vm_shrink.py"
+    }
+  },
+  "MYSQL_PARTITION_CRON": {
+    "type": "object",
+    "title": "MYSQL_PARTITION_CRON",
+    "description": "单据类型: MYSQL_PARTITION_CRON",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ip": {
+                  "type": "string",
+                  "description": "服务器IP"
+                },
+                "bk_cloud_id": {
+                  "type": "integer",
+                  "description": "云区域ID"
+                },
+                "file_name": {
+                  "type": "string",
+                  "description": "分区文件名"
+                }
+              }
+            },
+            "description": "分区信息"
+          },
+          "immute_domain": {
+            "type": "string",
+            "description": "域名"
+          },
+          "cron_date": {
+            "type": "string",
+            "description": "定时任务执行日期"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlPartitionCronDetailSerializer",
+      "builder_class": "MysqlPartitionCronFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_partition_cron.py"
+    }
+  },
+  "MYSQL_FAILOVER_DRILL": {
+    "type": "object",
+    "title": "MYSQL_FAILOVER_DRILL",
+    "description": "单据类型: MYSQL_FAILOVER_DRILL",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "drill_infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "cluster_id": {
+                  "type": "integer",
+                  "description": "集群id"
+                },
+                "instance_role": {
+                  "type": "string",
+                  "description": "实例类型"
+                }
+              }
+            },
+            "description": "容灾演练信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MysqlFailoverDrillDetailSerializer",
+      "builder_class": "MysqlFailoverDrillFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_failover_drill.py"
+    }
+  },
+  "FAKE_TICKET": {
+    "type": "object",
+    "title": "FAKE_TICKET",
+    "description": "单据类型: FAKE_TICKET",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "params": {
+            "type": "object",
+            "description": "测试参数"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "MySQLFakeDetailSerializer",
+      "builder_class": "MySQLDataMigrateFlowBuilder",
+      "source_file": "ticket/builders/mysql/mysql_fake.py"
+    }
+  },
+  "CLOUD_DNS_RELOAD": {
+    "type": "object",
+    "title": "CLOUD_DNS_RELOAD",
+    "description": "单据类型: CLOUD_DNS_RELOAD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "dns_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "重装的DNSID列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDNSReloadDetailSerializer",
+      "builder_class": "CloudDNSReloadFlowBuilder",
+      "source_file": "ticket/builders/cloud/dns_reload.py"
+    }
+  },
+  "CLOUD_REDIS_DTS_SERVER_ADD": {
+    "type": "object",
+    "title": "CLOUD_REDIS_DTS_SERVER_ADD",
+    "description": "单据类型: CLOUD_REDIS_DTS_SERVER_ADD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "new_redis_dts": {
+            "type": "object",
+            "description": "新Redis Dts机器的部署信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudRedisDtsAddDetailSerializer",
+      "builder_class": "CloudRedisDtsAddFlowBuilder",
+      "source_file": "ticket/builders/cloud/redis_dts_add.py"
+    }
+  },
+  "CLOUD_DNS_REDUCE": {
+    "type": "object",
+    "title": "CLOUD_DNS_REDUCE",
+    "description": "单据类型: CLOUD_DNS_REDUCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_dns_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "裁撤的DNS列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDNSReduceDetailSerializer",
+      "builder_class": "CloudDNSReduceFlowBuilder",
+      "source_file": "ticket/builders/cloud/dns_reduce.py"
+    }
+  },
+  "CLOUD_DNS_REPLACE": {
+    "type": "object",
+    "title": "CLOUD_DNS_REPLACE",
+    "description": "单据类型: CLOUD_DNS_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_dns_id": {
+            "type": "integer",
+            "description": "被替换旧DNS服务ID"
+          },
+          "new_dns": {
+            "type": "object",
+            "description": "替换后的新的DNS服务信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDNSReplaceDetailSerializer",
+      "builder_class": "CloudDNSReplaceFlowBuilder",
+      "source_file": "ticket/builders/cloud/dns_replace.py"
+    }
+  },
+  "CLOUD_NGINX_REPLACE": {
+    "type": "object",
+    "title": "CLOUD_NGINX_REPLACE",
+    "description": "单据类型: CLOUD_NGINX_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_nginx_id": {
+            "type": "integer",
+            "description": "替换的nginx id"
+          },
+          "new_nginx": {
+            "type": "object",
+            "description": "nginx服务部署信息",
+            "properties": {
+              "host_infos": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "部署nginx服务主机信息"
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudNginxReplaceDetailSerializer",
+      "builder_class": "CloudNginxReplaceFlowBuilder",
+      "source_file": "ticket/builders/cloud/nginx_replace.py"
+    }
+  },
+  "CLOUD_DRS_REPLACE": {
+    "type": "object",
+    "title": "CLOUD_DRS_REPLACE",
+    "description": "单据类型: CLOUD_DRS_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_drs_id": {
+            "type": "integer",
+            "description": "被替换旧DRS服务ID"
+          },
+          "new_drs": {
+            "type": "object",
+            "description": "替换后的新的DRS服务信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDRSReplaceDetailSerializer",
+      "builder_class": "CloudDRSReplaceFlowBuilder",
+      "source_file": "ticket/builders/cloud/drs_replace.py"
+    }
+  },
+  "CLOUD_DRS_REDUCE": {
+    "type": "object",
+    "title": "CLOUD_DRS_REDUCE",
+    "description": "单据类型: CLOUD_DRS_REDUCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_drs_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "裁撤的drs列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDRSReduceDetailSerializer",
+      "builder_class": "CloudDRSReduceFlowBuilder",
+      "source_file": "ticket/builders/cloud/drs_reduce.py"
+    }
+  },
+  "CLOUD_DRS_RELOAD": {
+    "type": "object",
+    "title": "CLOUD_DRS_RELOAD",
+    "description": "单据类型: CLOUD_DRS_RELOAD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "drs_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "重装的drsID列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDRSReloadDetailSerializer",
+      "builder_class": "CloudDRSReloadFlowBuilder",
+      "source_file": "ticket/builders/cloud/drs_reload.py"
+    }
+  },
+  "CLOUD_DBHA_REPLACE": {
+    "type": "object",
+    "title": "CLOUD_DBHA_REPLACE",
+    "description": "单据类型: CLOUD_DBHA_REPLACE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_gm_id": {
+            "type": "integer",
+            "description": "被替换旧DBHA-GM服务ID"
+          },
+          "new_gm": {
+            "type": "object",
+            "description": "替换后的新的DBHA-GM服务信息"
+          },
+          "old_agent_id": {
+            "type": "integer",
+            "description": "被替换旧DBHA-AGENT服务ID"
+          },
+          "new_agent": {
+            "type": "object",
+            "description": "替换后的新的DBHA-AGENT服务信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDBHAReplaceDetailSerializer",
+      "builder_class": "CloudDBHAReplaceFlowBuilder",
+      "source_file": "ticket/builders/cloud/dbha_replace.py"
+    }
+  },
+  "CLOUD_DRS_ADD": {
+    "type": "object",
+    "title": "CLOUD_DRS_ADD",
+    "description": "单据类型: CLOUD_DRS_ADD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "new_drs": {
+            "type": "object",
+            "description": "新drs机器的部署信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDRSAddDetailSerializer",
+      "builder_class": "CloudDRSReloadFlowBuilder",
+      "source_file": "ticket/builders/cloud/drs_add.py"
+    }
+  },
+  "CLOUD_SERVICE_APPLY": {
+    "type": "object",
+    "title": "CLOUD_SERVICE_APPLY",
+    "description": "单据类型: CLOUD_SERVICE_APPLY",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "drs": {
+            "type": "string",
+            "description": "drs服务部署信息"
+          },
+          "nginx": {
+            "type": "object",
+            "description": "nginx服务部署信息",
+            "properties": {
+              "host_infos": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "部署nginx服务主机信息"
+              }
+            }
+          },
+          "dns": {
+            "type": "object",
+            "description": "dns服务部署信息",
+            "properties": {
+              "host_infos": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "部署dns服务主机信息"
+              }
+            }
+          },
+          "dbha": {
+            "type": "object",
+            "description": "dbha服务部署信息",
+            "properties": {
+              "agent": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "部署dbha-agent服务主机信息"
+              },
+              "gm": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "部署dbha-gm服务主机信息"
+              }
+            }
+          },
+          "redis_dts": {
+            "type": "object",
+            "description": "redis_dts服务部署信息",
+            "properties": {
+              "host_infos": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "部署dns服务主机信息"
+              }
+            }
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudServiceApplyDetailSerializer",
+      "builder_class": "CloudServiceApplyFlowBuilder",
+      "source_file": "ticket/builders/cloud/service_apply.py"
+    }
+  },
+  "CLOUD_DNS_ADD": {
+    "type": "object",
+    "title": "CLOUD_DNS_ADD",
+    "description": "单据类型: CLOUD_DNS_ADD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "new_dns": {
+            "type": "object",
+            "description": "新DNS机器的部署信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDNSAddDetailSerializer",
+      "builder_class": "CloudDNSReloadFlowBuilder",
+      "source_file": "ticket/builders/cloud/dns_add.py"
+    }
+  },
+  "CLOUD_REDIS_DTS_SERVER_REDUCE": {
+    "type": "object",
+    "title": "CLOUD_REDIS_DTS_SERVER_REDUCE",
+    "description": "单据类型: CLOUD_REDIS_DTS_SERVER_REDUCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_redis_dts_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "裁撤的redis_dts列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudRedisDtsReduceDetailSerializer",
+      "builder_class": "CloudRedisDtsReduceFlowBuilder",
+      "source_file": "ticket/builders/cloud/redis_dts_reduce.py"
+    }
+  },
+  "CLOUD_NGINX_RELOAD": {
+    "type": "object",
+    "title": "CLOUD_NGINX_RELOAD",
+    "description": "单据类型: CLOUD_NGINX_RELOAD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "nginx_id": {
+            "type": "integer",
+            "description": "重装的nginx id"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudNginxReloadDetailSerializer",
+      "builder_class": "CloudNginxReloadFlowBuilder",
+      "source_file": "ticket/builders/cloud/nginx_reload.py"
+    }
+  },
+  "CLOUD_DBHA_REDUCE": {
+    "type": "object",
+    "title": "CLOUD_DBHA_REDUCE",
+    "description": "单据类型: CLOUD_DBHA_REDUCE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "old_gm_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "裁撤的DBHA-GM列表"
+          },
+          "old_agent_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "裁撤的DBHA-AGENT列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDBHAReduceDetailSerializer",
+      "builder_class": "CloudDBHAReduceFlowBuilder",
+      "source_file": "ticket/builders/cloud/dbha_reduce.py"
+    }
+  },
+  "CLOUD_DBHA_RELOAD": {
+    "type": "object",
+    "title": "CLOUD_DBHA_RELOAD",
+    "description": "单据类型: CLOUD_DBHA_RELOAD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "gm_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "重装的GM ID列表"
+          },
+          "agent_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "重装的AGENT ID列表"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDBHAReloadDetailSerializer",
+      "builder_class": "CloudDBHAReloadFlowBuilder",
+      "source_file": "ticket/builders/cloud/dbha_reload.py"
+    }
+  },
+  "CLOUD_DBHA_ADD": {
+    "type": "object",
+    "title": "CLOUD_DBHA_ADD",
+    "description": "单据类型: CLOUD_DBHA_ADD",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID"
+          },
+          "new_gm": {
+            "type": "object",
+            "description": "新DBHA-GM机器的部署信息"
+          },
+          "new_agent": {
+            "type": "object",
+            "description": "新DBHA-AGENT机器的部署信息"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "CloudDBHAAddDetailSerializer",
+      "builder_class": "CloudDBHAAddFlowBuilder",
+      "source_file": "ticket/builders/cloud/dbha_add.py"
+    }
+  },
+  "TENDBCLUSTER_DATA_MIGRATE": {
+    "type": "object",
+    "title": "TENDBCLUSTER_DATA_MIGRATE",
+    "description": "单据类型: TENDBCLUSTER_DATA_MIGRATE",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {}
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBClusterDataMigrateDetailSerializer",
+      "builder_class": "TenDBClusterDataMigrateFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_data_migrate.py"
+    }
+  },
+  "TENDBCLUSTER_PARTITION_CRON": {
+    "type": "object",
+    "title": "TENDBCLUSTER_PARTITION_CRON",
+    "description": "单据类型: TENDBCLUSTER_PARTITION_CRON",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "infos": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ip": {
+                  "type": "string",
+                  "description": "服务器IP"
+                },
+                "bk_cloud_id": {
+                  "type": "integer",
+                  "description": "云区域ID"
+                },
+                "file_name": {
+                  "type": "string",
+                  "description": "分区文件名"
+                }
+              }
+            },
+            "description": "分区信息"
+          },
+          "immute_domain": {
+            "type": "string",
+            "description": "域名"
+          },
+          "cron_date": {
+            "type": "string",
+            "description": "定时任务执行日期"
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "SpiderPartitionCronDetailSerializer",
+      "builder_class": "SpiderPartitionCronFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/tendb_partition_cron.py"
+    }
+  },
+  "TENDBCLUSTER_APPEND_DEPLOY_CTL": {
+    "type": "object",
+    "title": "TENDBCLUSTER_APPEND_DEPLOY_CTL",
+    "description": "单据类型: TENDBCLUSTER_APPEND_DEPLOY_CTL",
+    "properties": {
+      "details": {
+        "type": "object",
+        "description": "单据详情",
+        "properties": {
+          "bk_cloud_id": {
+            "type": "integer",
+            "description": "云区域ID",
+            "default": 0
+          },
+          "bk_biz_id": {
+            "type": "integer",
+            "description": "业务ID"
+          },
+          "cluster_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "集群ID列表"
+          },
+          "use_stream": {
+            "type": "boolean",
+            "description": "是否使用mydumper流式备份迁移",
+            "default": false
+          },
+          "drop_before": {
+            "type": "boolean",
+            "description": "导入到tdbctl前,是否先删除",
+            "default": false
+          },
+          "threads": {
+            "type": "integer",
+            "description": "mydumper 并发",
+            "default": 0
+          },
+          "use_mydumper": {
+            "type": "boolean",
+            "description": "是否使用mydumper,myloader迁移",
+            "default": false
+          }
+        }
+      }
+    },
+    "_meta": {
+      "serializer_class": "TenDBClusterAppendDeployCTLDetailSerializer",
+      "builder_class": "TenDBClusterAppendDeployCTLFlowBuilder",
+      "source_file": "ticket/builders/tendbcluster/append_deploy_ctl.py"
+    }
+  }
+}

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/helps/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/helps/__init__.py
@@ -8,25 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-import json
-import os
-
-from django.apps import AppConfig
-
-# 全局变量，用于存储 ticket-schema.json 的内容
-TICKET_SCHEMA = {}
-
-
-class DbmAiagentConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
-    name = "backend.dbm_aiagent"
-
-    def ready(self):
-        global TICKET_SCHEMA
-        # 加载 init 目录下的 ticket-schema.json 文件
-        init_dir = os.path.join(os.path.dirname(__file__), "init")
-        schema_file = os.path.join(init_dir, "ticket-schema.json")
-        if os.path.exists(schema_file):
-            with open(schema_file, "r", encoding="utf-8") as f:
-                TICKET_SCHEMA = json.load(f)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/helps/extract_ticket_info_by_schema/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/helps/extract_ticket_info_by_schema/__init__.py
@@ -8,25 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
-import json
-import os
-
-from django.apps import AppConfig
-
-# 全局变量，用于存储 ticket-schema.json 的内容
-TICKET_SCHEMA = {}
-
-
-class DbmAiagentConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
-    name = "backend.dbm_aiagent"
-
-    def ready(self):
-        global TICKET_SCHEMA
-        # 加载 init 目录下的 ticket-schema.json 文件
-        init_dir = os.path.join(os.path.dirname(__file__), "init")
-        schema_file = os.path.join(init_dir, "ticket-schema.json")
-        if os.path.exists(schema_file):
-            with open(schema_file, "r", encoding="utf-8") as f:
-                TICKET_SCHEMA = json.load(f)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/helps/extract_ticket_info_by_schema/extracter.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/helps/extract_ticket_info_by_schema/extracter.py
@@ -1,0 +1,707 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import ast
+import json
+from typing import Any, Union
+
+from django.utils.translation import gettext_lazy as _
+
+
+class SchemaExtractionError(Exception):
+    """Schema 数据抽取异常"""
+
+    def __init__(self, message: str, path: str = "", details: dict = None):
+        self.message = message
+        self.path = path  # 发生错误的数据路径
+        self.details = details or {}
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        msg = self.message
+        if self.path:
+            msg = f"[{self.path}] {msg}"
+        if self.details:
+            msg = f"{msg} | Details: {self.details}"
+        return msg
+
+
+def _try_parse_json_string(value: str) -> Any:
+    """
+    尝试将字符串解析为 JSON 对象
+
+    Args:
+        value: 可能是 JSON 字符串的值
+
+    Returns:
+        解析后的对象，如果解析失败则返回原值
+    """
+    if not isinstance(value, str):
+        return value
+
+    # 检查是否看起来像 JSON 对象或数组
+    stripped = value.strip()
+    if not (stripped.startswith("{") or stripped.startswith("[")):
+        return value
+
+    # 方法1: 先尝试标准 JSON 解析
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # 方法2: 尝试用 ast.literal_eval 解析 Python 风格的字面量（如 True/False, 单引号等）
+    try:
+        return ast.literal_eval(stripped)
+    except (ValueError, SyntaxError):
+        pass
+
+    # 方法3: 简单替换单引号后再尝试
+    try:
+        fixed = stripped.replace("'", '"')
+        return json.loads(fixed)
+    except (json.JSONDecodeError, ValueError):
+        return value
+
+
+def _is_spec_object(obj: dict) -> bool:
+    """
+    判断一个对象是否是 spec 规格详情对象
+    spec 对象通常包含: id, cpu, mem, name, device_class, storage_spec 等字段
+
+    Args:
+        obj: 待判断的对象
+
+    Returns:
+        是否是 spec 对象
+    """
+    if not isinstance(obj, dict):
+        return False
+
+    # spec 对象的特征字段
+    spec_indicators = {"cpu", "mem", "storage_spec", "device_class", "qps"}
+    # 必须有 name 或 spec_name 字段，且至少包含 2 个特征字段
+    has_name = "name" in obj or "spec_name" in obj
+    if not has_name:
+        return False
+
+    indicator_count = sum(1 for field in spec_indicators if field in obj)
+    return indicator_count >= 2
+
+
+def _is_backupinfo_object(obj: dict) -> bool:
+    """
+    判断一个对象是否是 backupinfo 备份详情对象
+    backupinfo 对象通常包含: backup_id, backup_time, backup_host, backup_port, file_list 等字段
+
+    Args:
+        obj: 待判断的对象
+
+    Returns:
+        是否是 backupinfo 对象
+    """
+    if not isinstance(obj, dict):
+        return False
+
+    # backupinfo 对象的必要字段
+    if "backup_id" not in obj:
+        return False
+
+    # backupinfo 对象的特征字段（至少包含 2 个特征字段）
+    backupinfo_indicators = {
+        "backup_time",
+        "backup_host",
+        "backup_port",
+        "file_list",
+        "backup_type",
+        "backup_tool",
+        "cluster_id",
+    }
+    indicator_count = sum(1 for field in backupinfo_indicators if field in obj)
+    return indicator_count >= 2
+
+
+def _get_cluster_domain(cluster_id: Any, cluster_map: dict) -> str:
+    """
+    从 cluster_map 中获取指定 cluster_id 的域名
+
+    Args:
+        cluster_id: 集群ID
+        cluster_map: 集群信息映射
+
+    Returns:
+        集群域名，未找到则返回 None
+    """
+    # cluster_map 的 key 可能是字符串或整数
+    cluster_info = cluster_map.get(str(cluster_id)) or cluster_map.get(cluster_id)
+    if cluster_info and isinstance(cluster_info, dict):
+        return cluster_info.get("immute_domain")
+    return None
+
+
+def _enrich_cluster_domain(data: Any, cluster_map: dict) -> Any:
+    """
+    递归遍历提取结果，为包含 cluster_id/cluster_ids/target_cluster_id 的对象追加对应的域名字段
+
+    Args:
+        data: 提取后的结果数据
+        cluster_map: 原始数据中的 clusters 映射 {cluster_id: {immute_domain: ...}}
+
+    Returns:
+        增强后的结果数据
+    """
+    # 先尝试解析字符串化的 JSON
+    if isinstance(data, str):
+        parsed = _try_parse_json_string(data)
+        if parsed != data:  # 解析成功
+            return _enrich_cluster_domain(parsed, cluster_map)
+        return data
+
+    if isinstance(data, dict):
+        # 情况1: 检查是否包含 cluster_id（单个ID）
+        if "cluster_id" in data:
+            cluster_id = data["cluster_id"]
+            domain = _get_cluster_domain(cluster_id, cluster_map)
+            if domain:
+                data["cluster_domain"] = domain
+
+        # 情况2: 检查是否包含 cluster_ids（ID列表）
+        if "cluster_ids" in data:
+            cluster_ids = data["cluster_ids"]
+            if isinstance(cluster_ids, list):
+                # 保持与 cluster_ids 顺序对应，找不到的用 None 占位
+                domains = []
+                for cid in cluster_ids:
+                    domain = _get_cluster_domain(cid, cluster_map)
+                    domains.append(domain)  # 即使是 None 也追加，保持索引对应
+                # 只有当至少有一个有效域名时才添加 cluster_domains
+                if any(d is not None for d in domains):
+                    data["cluster_domains"] = domains
+
+        # 情况3: 检查是否包含 target_cluster_id（目标集群ID，常用于回档等场景）
+        if "target_cluster_id" in data:
+            target_cluster_id = data["target_cluster_id"]
+            domain = _get_cluster_domain(target_cluster_id, cluster_map)
+            if domain:
+                data["target_cluster_domain"] = domain
+
+        # 递归处理所有值（排除刚添加的域名字段，避免无效递归）
+        for key, value in list(data.items()):
+            if key not in ("cluster_domain", "cluster_domains", "target_cluster_domain"):
+                data[key] = _enrich_cluster_domain(value, cluster_map)
+
+    elif isinstance(data, list):
+        # 递归处理数组中的每个元素
+        for idx, item in enumerate(data):
+            data[idx] = _enrich_cluster_domain(item, cluster_map)
+
+    return data
+
+
+def _simplify_spec_objects(data: Any) -> Any:
+    """
+    递归遍历数据，将 spec 规格详情对象简化为只保留 name
+
+    场景1: nodes.hot[].spec -> 从完整对象简化为 spec.name
+    场景2: resource_spec.hot -> 保留 spec_name, count 等关键字段，删除 cpu, mem 等详情
+    场景3: 字符串化的 JSON 也会被解析和简化
+
+    Args:
+        data: 待处理的数据
+
+    Returns:
+        简化后的数据
+    """
+    # 先尝试解析字符串化的 JSON
+    if isinstance(data, str):
+        parsed = _try_parse_json_string(data)
+        if parsed != data:  # 解析成功
+            return _simplify_spec_objects(parsed)
+        return data
+
+    if isinstance(data, dict):
+        # 检查当前对象是否是完整的 spec 详情对象
+        if _is_spec_object(data):
+            # 只保留 name 或 spec_name
+            return data.get("name") or data.get("spec_name", "")
+
+        # 检查是否是 resource_spec 类型的对象（包含 spec_id, spec_name, count 等）
+        # 这类对象需要保留 spec_name, count, label_names，删除 cpu, mem, qps 等
+        if "spec_name" in data or "spec_id" in data:
+            # 需要删除的详情字段
+            fields_to_remove = {
+                "cpu",
+                "mem",
+                "qps",
+                "storage_spec",
+                "capacity",
+                "device_class",
+                "affinity",
+                "location_spec",
+            }
+            for field in fields_to_remove:
+                data.pop(field, None)
+
+        # 递归处理所有值
+        for key, value in list(data.items()):
+            data[key] = _simplify_spec_objects(value)
+
+    elif isinstance(data, list):
+        # 递归处理数组中的每个元素
+        for idx, item in enumerate(data):
+            data[idx] = _simplify_spec_objects(item)
+
+    return data
+
+
+def _simplify_specs_dict(data: Any) -> Any:
+    """
+    递归遍历数据，将 specs 字典（key 为 spec_id，value 为规格详情）简化
+
+    原始格式:
+    "specs": {
+        "385": {"id": 385, "cpu": {...}, "mem": {...}, "name": "8核_32G_100G", ...},
+        "398": {"id": 398, "cpu": {...}, "mem": {...}, "name": "32核_128G_7T_带云盘", ...}
+    }
+
+    简化为:
+    "specs": {
+        "385": "8核_32G_100G",
+        "398": "32核_128G_7T_带云盘"
+    }
+
+    Args:
+        data: 待处理的数据
+
+    Returns:
+        简化后的数据
+    """
+    # 先尝试解析字符串化的 JSON
+    if isinstance(data, str):
+        parsed = _try_parse_json_string(data)
+        if parsed != data:  # 解析成功
+            return _simplify_specs_dict(parsed)
+        return data
+
+    if isinstance(data, dict):
+        # 检查是否是 specs 字典（所有 value 都是 spec 对象）
+        if data and all(isinstance(v, dict) and _is_spec_object(v) for v in data.values()):
+            # 简化为 {spec_id: spec_name}
+            return {k: v.get("name") or v.get("spec_name", "") for k, v in data.items()}
+
+        # 递归处理所有值
+        for key, value in list(data.items()):
+            # 特殊处理：如果 key 是 "specs"，检查是否需要简化
+            if key == "specs":
+                parsed_value = _try_parse_json_string(value) if isinstance(value, str) else value
+                if isinstance(parsed_value, dict):
+                    if parsed_value and all(isinstance(v, dict) and _is_spec_object(v) for v in parsed_value.values()):
+                        data[key] = {k: v.get("name") or v.get("spec_name", "") for k, v in parsed_value.items()}
+                        continue
+            data[key] = _simplify_specs_dict(value)
+
+    elif isinstance(data, list):
+        # 递归处理数组中的每个元素
+        for idx, item in enumerate(data):
+            data[idx] = _simplify_specs_dict(item)
+
+    return data
+
+
+def _simplify_backupinfo(data: Any) -> Any:
+    """
+    递归遍历数据，将 backupinfo 备份详情对象简化为只保留 backup_id 和 backup_time
+
+    原始 backupinfo 包含大量字段如：backup_host, backup_port, file_list, binlog_info 等
+    简化后只保留 backup_id 和 backup_time 两个关键字段
+
+    Args:
+        data: 待处理的数据
+
+    Returns:
+        简化后的数据
+    """
+    # 先尝试解析字符串化的 JSON
+    if isinstance(data, str):
+        parsed = _try_parse_json_string(data)
+        if parsed != data:  # 解析成功
+            return _simplify_backupinfo(parsed)
+        return data
+
+    if isinstance(data, dict):
+        # 递归处理所有值
+        for key, value in list(data.items()):
+            # 特殊处理：如果 key 是 "backupinfo"，检查是否需要简化
+            if key == "backupinfo":
+                parsed_value = _try_parse_json_string(value) if isinstance(value, str) else value
+                if isinstance(parsed_value, dict) and _is_backupinfo_object(parsed_value):
+                    # 只保留 backup_id 和 backup_time
+                    data[key] = {
+                        "backup_id": parsed_value.get("backup_id"),
+                        "backup_time": parsed_value.get("backup_time"),
+                    }
+                    continue
+            data[key] = _simplify_backupinfo(value)
+
+    elif isinstance(data, list):
+        # 递归处理数组中的每个元素
+        for idx, item in enumerate(data):
+            data[idx] = _simplify_backupinfo(item)
+
+    return data
+
+
+def _summarize_long_lists(data: Any, max_length: int = 10) -> Any:
+    """
+    递归遍历数据，将长度大于 max_length 的列表转换为摘要形式
+
+    摘要形式：保留前2个和后1个元素，中间用省略信息替代
+    例如：[item1, item2, "...(省略 N 项)...", itemN]
+
+    Args:
+        data: 待处理的数据
+        max_length: 列表长度阈值，超过此长度的列表会被摘要
+
+    Returns:
+        处理后的数据
+    """
+    if isinstance(data, dict):
+        # 递归处理所有值
+        for key, value in list(data.items()):
+            data[key] = _summarize_long_lists(value, max_length)
+
+    elif isinstance(data, list):
+        # 先递归处理数组中的每个元素
+        for idx, item in enumerate(data):
+            data[idx] = _summarize_long_lists(item, max_length)
+
+        # 然后检查是否需要摘要
+        if len(data) > max_length:
+            # 保留前2个和后1个元素
+            first_items = data[:2]
+            last_item = data[-1]
+            omitted_count = len(data) - 3
+
+            # 构建摘要列表
+            data = first_items + [_(f"...(省略 {omitted_count} 项)...")] + [last_item]
+
+    return data
+
+
+def _handle_none_value(prop_schema: dict, current_path: str) -> Any:
+    """
+    处理值为 None 的情况
+
+    Args:
+        prop_schema: 属性的 schema 定义
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        默认值或 None
+
+    Raises:
+        SchemaExtractionError: 当必需字段值为空时抛出
+    """
+    default_value = prop_schema.get("default")
+    if default_value is not None:
+        return default_value
+    # 检查是否是必需字段
+    if prop_schema.get("required", False):
+        prop_type = prop_schema.get("type")
+        raise SchemaExtractionError(_("必需字段值为空"), path=current_path, details={"expected_type": prop_type})
+    return None
+
+
+def _extract_object_value(prop_schema: dict, value: Any, full_data: dict, current_path: str) -> Any:
+    """
+    提取 object 类型的值
+
+    Args:
+        prop_schema: 属性的 schema 定义
+        value: 属性值
+        full_data: 完整的原始数据
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        提取后的对象
+    """
+    if not isinstance(value, dict):
+        raise SchemaExtractionError(
+            _(f"类型不匹配，期望 object，实际为 {type(value).__name__}"),
+            path=current_path,
+            details={"expected_type": "object", "actual_type": type(value).__name__},
+        )
+    obj_properties = prop_schema.get("properties", {})
+    if obj_properties:
+        return _extract_object(obj_properties, value, full_data, current_path)
+    # 无 properties 定义时，根据 extractKeys 提取或返回原值
+    extract_keys = prop_schema.get("extractKeys")
+    if extract_keys:
+        return {k: v for k, v in value.items() if k in extract_keys}
+    return value
+
+
+def _extract_array_value(prop_schema: dict, value: Any, full_data: dict, current_path: str) -> list:
+    """
+    提取 array 类型的值
+
+    Args:
+        prop_schema: 属性的 schema 定义
+        value: 属性值
+        full_data: 完整的原始数据
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        提取后的数组
+    """
+    if not isinstance(value, list):
+        raise SchemaExtractionError(
+            _(f"类型不匹配，期望 array，实际为 {type(value).__name__}"),
+            path=current_path,
+            details={"expected_type": "array", "actual_type": type(value).__name__},
+        )
+    items_schema = prop_schema.get("items", {})
+    extracted_items = []
+    for idx, item in enumerate(value):
+        item_path = f"{current_path}[{idx}]"
+        try:
+            extracted_items.append(_extract_value(items_schema, item, full_data, item_path))
+        except SchemaExtractionError:
+            raise
+        except Exception as item_err:
+            raise SchemaExtractionError(_(f"数组元素提取失败: {str(item_err)}"), path=item_path)
+    return extracted_items
+
+
+def _extract_string_value(value: Any, current_path: str) -> str:
+    """
+    提取 string 类型的值
+
+    Args:
+        value: 属性值
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        字符串值
+    """
+    if isinstance(value, str):
+        return value
+    # 尝试转换为字符串
+    try:
+        return str(value)
+    except Exception:
+        raise SchemaExtractionError(
+            _("无法转换为 string 类型"), path=current_path, details={"actual_type": type(value).__name__}
+        )
+
+
+def _extract_integer_value(value: Any, current_path: str) -> int:
+    """
+    提取 integer 类型的值
+
+    Args:
+        value: 属性值
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        整数值
+    """
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise SchemaExtractionError(
+            _(f"类型不匹配，期望 integer，实际为 {type(value).__name__}"),
+            path=current_path,
+            details={"expected_type": "integer", "actual_type": type(value).__name__},
+        )
+    return value
+
+
+def _extract_number_value(value: Any, current_path: str) -> Union[int, float]:
+    """
+    提取 number 类型的值
+
+    Args:
+        value: 属性值
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        数值
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise SchemaExtractionError(
+            _(f"类型不匹配，期望 number，实际为 {type(value).__name__}"),
+            path=current_path,
+            details={"expected_type": "number", "actual_type": type(value).__name__},
+        )
+    return value
+
+
+def _extract_boolean_value(value: Any, current_path: str) -> bool:
+    """
+    提取 boolean 类型的值
+
+    Args:
+        value: 属性值
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        布尔值
+    """
+    if not isinstance(value, bool):
+        raise SchemaExtractionError(
+            _(f"类型不匹配，期望 boolean，实际为 {type(value).__name__}"),
+            path=current_path,
+            details={"expected_type": "boolean", "actual_type": type(value).__name__},
+        )
+    return value
+
+
+# 类型处理函数映射表
+_TYPE_EXTRACTORS = {
+    "object": _extract_object_value,
+    "array": _extract_array_value,
+    "string": lambda prop_schema, value, full_data, current_path: _extract_string_value(value, current_path),
+    "integer": lambda prop_schema, value, full_data, current_path: _extract_integer_value(value, current_path),
+    "number": lambda prop_schema, value, full_data, current_path: _extract_number_value(value, current_path),
+    "boolean": lambda prop_schema, value, full_data, current_path: _extract_boolean_value(value, current_path),
+}
+
+
+def _extract_value(prop_schema: dict, value: Any, full_data: dict, current_path: str) -> Any:
+    """
+    递归提取单个属性值
+
+    Args:
+        prop_schema: 属性的 schema 定义
+        value: 属性值
+        full_data: 完整的原始数据
+        current_path: 当前数据路径（用于错误提示）
+
+    Returns:
+        提取后的值
+    """
+    # 处理 None 值
+    if value is None:
+        return _handle_none_value(prop_schema, current_path)
+
+    prop_type = prop_schema.get("type")
+
+    # 使用映射表获取对应的提取函数
+    extractor = _TYPE_EXTRACTORS.get(prop_type)
+    if extractor:
+        return extractor(prop_schema, value, full_data, current_path)
+
+    # 未知类型直接返回原值
+    return value
+
+
+def _extract_object(obj_properties: dict, data: dict, full_data: dict, parent_path: str = "") -> dict:
+    """
+    提取对象类型数据
+
+    Args:
+        obj_properties: 对象的 properties schema 定义
+        data: 当前层级的数据
+        full_data: 完整的原始数据
+        parent_path: 父级路径（用于错误提示）
+
+    Returns:
+        提取后的对象
+    """
+    extracted = {}
+    for key, prop_schema in obj_properties.items():
+        current_path = f"{parent_path}.{key}" if parent_path else key
+        # 支持从其他路径取值 (通过 sourceKey)
+        source_key = prop_schema.get("sourceKey", key)
+        value = data.get(source_key)
+
+        try:
+            extracted[key] = _extract_value(prop_schema, value, full_data, current_path)
+        except SchemaExtractionError:
+            raise
+        except Exception as field_err:
+            raise SchemaExtractionError(
+                _(f"字段提取失败: {str(field_err)}"), path=current_path, details={"source_key": source_key}
+            )
+    return extracted
+
+
+def extract_by_schema(schema: dict, raw_data: Union[str, dict]) -> dict:
+    """
+    根据 JSON Schema 从原始数据中抽取数据
+
+    Args:
+        schema: JSON Schema 定义
+        raw_data: 原始数据，可以是 JSON 字符串或字典
+
+    Returns:
+        dict: 符合 Schema 结构的抽取结果
+
+    Raises:
+        SchemaExtractionError: 当数据抽取失败时抛出
+    """
+
+    # 校验 schema 参数
+    if not isinstance(schema, dict):
+        raise SchemaExtractionError(_("Schema 必须是字典类型"), path="schema", details={"actual_type": type(schema).__name__})
+
+    if "properties" not in schema:
+        raise SchemaExtractionError(_("Schema 缺少 properties 定义"), path="schema")
+
+    # 解析 raw_data
+    if isinstance(raw_data, str):
+        try:
+            parsed_data = json.loads(raw_data)
+        except json.JSONDecodeError as json_err:
+            raise SchemaExtractionError(
+                _(f"JSON 解析失败: {str(json_err)}"),
+                path="raw_data",
+                details={"error_position": json_err.pos if hasattr(json_err, "pos") else None},
+            )
+    elif isinstance(raw_data, dict):
+        parsed_data = raw_data
+    else:
+        raise SchemaExtractionError(
+            _("原始数据必须是 JSON 字符串或字典类型"), path="raw_data", details={"actual_type": type(raw_data).__name__}
+        )
+
+    try:
+        schema_properties = schema.get("properties", {})
+        extracted_result = _extract_object(schema_properties, parsed_data, parsed_data)
+
+        # 后处理1：简化 spec 规格详情对象，只保留名称（会解析字符串化的 JSON）
+        extracted_result = _simplify_spec_objects(extracted_result)
+
+        # 后处理2：简化 specs 字典（会解析字符串化的 JSON）
+        extracted_result = _simplify_specs_dict(extracted_result)
+
+        # 后处理3：简化 backupinfo 备份详情对象，只保留 backup_id 和 backup_time（会解析字符串化的 JSON）
+        extracted_result = _simplify_backupinfo(extracted_result)
+
+        # 后处理4：为包含 cluster_id 的对象追加 cluster_domain
+        # 注意：必须在所有字符串解析后处理之后执行，这样才能正确处理解析后的 cluster_id
+        clusters_map = parsed_data.get("clusters", {})
+        if clusters_map:
+            extracted_result = _enrich_cluster_domain(extracted_result, clusters_map)
+
+        # 后处理5：删除辅助字段（clusters 用于查找域名的映射，specs 是规格详情映射，machine_infos 是机器信息映射，都不是真正的需求字段）
+        for auxiliary_field in ("clusters", "specs", "machine_infos"):
+            if auxiliary_field in extracted_result:
+                del extracted_result[auxiliary_field]
+
+        # 后处理6：将长度大于10的列表转换为摘要形式
+        extracted_result = _summarize_long_lists(extracted_result)
+
+        return extracted_result
+    except SchemaExtractionError:
+        raise
+    except Exception as outer_err:
+        raise SchemaExtractionError(
+            _(f"数据抽取过程发生未知错误: {str(outer_err)}"), details={"error_type": type(outer_err).__name__}
+        )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/ticket_list.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/ticket_list.py
@@ -15,9 +15,10 @@ from typing import List
 from django.db.models import Q
 from django.utils import timezone
 
-from backend.ticket.builders import BuilderFactory
+from backend.dbm_aiagent.apps import TICKET_SCHEMA
+from backend.dbm_aiagent.mcp_tools.common.helps.extract_ticket_info_by_schema.extracter import extract_by_schema
 from backend.ticket.constants import TicketStatus, TicketType
-from backend.ticket.models import Ticket
+from backend.ticket.models import FlowSummary, Ticket
 
 logger = logging.getLogger("root")
 
@@ -49,11 +50,21 @@ def ticket_list(
         if not (username == creator or username in helpers):
             continue
 
-        # if 'clusters' in t.details:
-        #     relate_cluster_do = list(t.details['clusters'].keys())
-        # else:
-        #     relate_cluster_ids = []
+        msgs = [""]
+        if t.status == TicketStatus.SUCCEEDED:
+            current_flow = ""
+        elif t.status == TicketStatus.TERMINATED:
+            current_flow = ""
+            msgs = [t.get_terminate_reason()]
+        else:
+            current_flow = t.current_flow().flow_alias
 
+        if t.status in [TicketStatus.TERMINATED, TicketStatus.FAILED]:
+            msgs = list(
+                FlowSummary.objects.filter(flow__ticket=t, flow__status=TicketStatus.FAILED).values_list(
+                    "summary", flat=True
+                )
+            )
         relate_cluster_domains = [v["immute_domain"] for k, v in t.details.get("clusters", {}).items()]
 
         if want_cluster_domains:  # 这里要保持这样, 当输入的域名实际不对时, 就不会返回东西
@@ -67,7 +78,10 @@ def ticket_list(
                         "status": t.status,
                         "relate_clusters": "\n".join(relate_cluster_domains),
                         "created_at": t.create_at,
-                        # "bill_param": __rebuild_ticket_param(t)
+                        "ticket_param": rebuild_ticket_param(t),
+                        "current_flow": current_flow,
+                        "cost_time_seconds": t.get_cost_time(),
+                        "msgs": msgs,
                     }
                 )
         else:
@@ -80,28 +94,29 @@ def ticket_list(
                     "status": t.status,
                     "relate_clusters": "\n".join(relate_cluster_domains),
                     "created_at": t.create_at,
-                    # "bill_param": __rebuild_ticket_param(t)
+                    "ticket_param": rebuild_ticket_param(t),
+                    "current_flow": current_flow,
+                    "cost_time_seconds": t.get_cost_time(),
+                    "msgs": msgs,
                 }
             )
 
     return want_tickets
 
 
-def __rebuild_ticket_param(tk: Ticket):
-    if tk.status not in [TicketStatus.TODO, TicketStatus.APPROVE]:
-        return ""
-    # return tk.details
-    # logger.info(tk.pk)
-    #
+def rebuild_ticket_param(tk: Ticket):
     ticket_type = tk.ticket_type
-    ticket_serializer_class = BuilderFactory.get_serializer(ticket_type).__class__
-    slz = ticket_serializer_class(data=tk.details)
-    slz.context.update({"ticket_type": ticket_type})
-    slz.context.update({"bk_biz_id": tk.bk_biz_id})
-    try:
-        slz.is_valid(raise_exception=False)
-        return slz.validated_data
-    except Exception as e:
-        logger.info(f"{e}: {tk}")
+    if ticket_type in TICKET_SCHEMA:
+        ticket_schema = TICKET_SCHEMA[ticket_type]
+        details_schema = ticket_schema.get("properties", {}).get("details", {})
+        if "properties" not in details_schema:
+            return ""
 
-    return ""
+        try:
+            data = extract_by_schema(details_schema, tk.details)
+            return data
+        except Exception as e:
+            logger.error(f"extract_by_schema error: {e}")
+            raise e
+    else:
+        return ""

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_list.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_list.py
@@ -36,7 +36,10 @@ class TicketInfoSerializer(serializers.Serializer):
     status = serializers.CharField(help_text=_("单据状态"))
     relate_clusters = serializers.ListField(child=serializers.CharField(), help_text=_("关联集群"))
     created_at = serializers.TimeField(help_text=_("单据创建时间"))
-    # bill_param = serializers.JSONField(help_text=_("单据参数"))
+    ticket_param = serializers.JSONField(help_text=_("单据参数"))
+    current_flow = serializers.CharField(help_text=_("当前流程"))
+    cost_time_seconds = serializers.IntegerField(help_text=_("单据耗时（秒）"))
+    msgs = serializers.ListField(child=serializers.CharField(), help_text=_("单据消息"))
 
 
 class TicketListOutputSerializer(serializers.Serializer):

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_manipulate.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_manipulate.py
@@ -12,10 +12,10 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 
-class TicketExecuteInputSerializer(serializers.Serializer):
+class TicketManipulateInputSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
     ticket_id = serializers.IntegerField(help_text=_("单据 ID"))
 
 
-class TicketExecuteOutputSerializer(serializers.Serializer):
+class TicketManipulateOutputSerializer(serializers.Serializer):
     status = serializers.CharField(help_text=_("单据状态"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_status_tracker.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_status_tracker.py
@@ -11,20 +11,20 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
-from backend.ticket.constants import TicketStatus
+from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_list import TicketInfoSerializer
 
 
-class BillStatusTrackerInputSerializer(serializers.Serializer):
+class TicketStatusTrackerInputSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
     bill_id = serializers.IntegerField(help_text=_("单据 ID"))
 
 
-class BillStatusTrackerOutputSerializer(serializers.Serializer):
+class TicketStatusTrackerOutputSerializer(TicketInfoSerializer):
     # bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
     # bill_id = serializers.IntegerField(help_text=_("单据 ID"))
-    status = serializers.ChoiceField(choices=TicketStatus.get_choices(), help_text=_("单据状态"))
-    creator = serializers.CharField(help_text=_("建单人"))
-    created_at = serializers.TimeField(help_text=_("提单时间"))
+    # status = serializers.ChoiceField(choices=TicketStatus.get_choices(), help_text=_("单据状态"))
+    # creator = serializers.CharField(help_text=_("建单人"))
+    # created_at = serializers.TimeField(help_text=_("提单时间"))
     params = serializers.JSONField(help_text=_("单据参数"))
     current_flow = serializers.CharField(help_text=_("当前流程名称"))
     cost_time_seconds = serializers.IntegerField(help_text=_("以秒为单位的耗时"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/ticket_operation.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/ticket_operation.py
@@ -15,17 +15,13 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 
 from backend.dbm_aiagent.mcp_tools.common.impl.ticket_list import ticket_list
-from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_execute import (
-    TicketExecuteInputSerializer,
-    TicketExecuteOutputSerializer,
-)
 from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_list import (
     TicketListInputSerializer,
     TicketListOutputSerializer,
 )
-from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_status_tracker import (
-    BillStatusTrackerInputSerializer,
-    BillStatusTrackerOutputSerializer,
+from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_manipulate import (
+    TicketManipulateInputSerializer,
+    TicketManipulateOutputSerializer,
 )
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
 from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
@@ -34,7 +30,8 @@ from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.ticket.constants import TicketStatus
 from backend.ticket.handler import TicketHandler
-from backend.ticket.models import FlowSummary, Ticket
+from backend.ticket.models import Ticket
+from backend.ticket.todos import TodoActionType
 
 logger = logging.getLogger("root")
 
@@ -43,13 +40,7 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
     default_permission_class = [DBManagePermission()]
 
     @mcp_tools_api_decorator(
-        description=str(
-            _(
-                """查询单据列表
-        按 ID, 类型, 状态, 关联集群, 创建时间
-        每个单据一行返回结果"""
-            )
-        ),
+        description=str(_("""查询单据列表, 每个单据一行返回结果, 单据参数是个 json, 搞的好看点""")),
         request_slz=TicketListInputSerializer,
         response_slz=TicketListOutputSerializer,
         tags=[DBMMCPTags.READ],
@@ -67,12 +58,12 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
         username = request.user.username
 
         res = ticket_list(username, bk_biz_id, ticket_ids, cluster_domains, statuses, time_duration)
-        return Response({"bill_infos": res})
+        return Response({"ticket_infos": res})
 
     @mcp_tools_api_decorator(
         description=str(_("执行单据")),
-        request_slz=TicketExecuteInputSerializer,
-        response_slz=TicketExecuteOutputSerializer,
+        request_slz=TicketManipulateInputSerializer,
+        response_slz=TicketManipulateOutputSerializer,
         tags=[DBMMCPTags.READ],
         mcp=[DBMMcpTools.TICKET_OP],
         name_prefix="ticket_op",
@@ -87,56 +78,35 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
         if tk.status != TicketStatus.TODO:
             raise DBMMcpBadTicketStatusException(msg=f"{tk.status} 不支持当前操作")
 
-        TicketHandler.batch_process_ticket(username=username, action="approve", ticket_ids=[ticket_id], params={})
+        TicketHandler.batch_process_ticket(
+            username=username, action=TodoActionType.APPROVE, ticket_ids=[ticket_id], params={}
+        )
 
         time.sleep(5)  # 这里 sleep 是为了能返回一个正常点的状态
 
         return Response({"status": Ticket.objects.get(bk_biz_id=bk_biz_id, pk=ticket_id).status})
 
     @mcp_tools_api_decorator(
-        description=str(
-            _(
-                """查询单据的详情
-        params 是一个 json 结构, 输出的时候格式化的好看点
-        """
-            )
-        ),
-        request_slz=BillStatusTrackerInputSerializer,
-        response_slz=BillStatusTrackerOutputSerializer,
+        description=str(_("终止单据")),
+        request_slz=TicketManipulateInputSerializer,
+        response_slz=TicketManipulateOutputSerializer,
         tags=[DBMMCPTags.READ],
         mcp=[DBMMcpTools.TICKET_OP],
         name_prefix="ticket_op",
     )
-    def ticket_tracker(self, request, *args, **kwargs):
+    def ticket_terminate(self, request, *args, **kwargs):
         bk_biz_id = self.get_param("bk_biz_id")
-        bill_id = self.get_param("bill_id")
+        ticket_id = self.get_param("ticket_id")
+        username = request.user.username
 
-        tk = Ticket.objects.get(bk_biz_id=bk_biz_id, pk=bill_id)
+        tk = Ticket.objects.get(bk_biz_id=bk_biz_id, pk=ticket_id)
+        if tk.status in [TicketStatus.RUNNING, TicketStatus.TERMINATED, TicketStatus.INNER_TODO]:
+            raise DBMMcpBadTicketStatusException(msg=f"{tk.status} 不支持当前操作")
 
-        msgs = [""]
-        if tk.status == TicketStatus.SUCCEEDED:
-            current_flow = ""
-        elif tk.status == TicketStatus.TERMINATED:
-            current_flow = ""
-            msgs = [tk.get_terminate_reason()]
-        else:
-            current_flow = tk.current_flow().flow_alias
-
-        if tk.status in [TicketStatus.TERMINATED, TicketStatus.FAILED]:
-            msgs = list(
-                FlowSummary.objects.filter(flow__ticket=tk, flow__status=TicketStatus.FAILED).values_list(
-                    "summary", flat=True
-                )
-            )
-
-        return Response(
-            {
-                "status": tk.status,
-                "creator": tk.creator,
-                "created_at": tk.create_at,
-                "params": tk.details,
-                "current_flow": current_flow,
-                "cost_time_seconds": tk.get_cost_time(),
-                "msgs": msgs,
-            }
+        TicketHandler.batch_process_ticket(
+            username=username, action=TodoActionType.TERMINATE, ticket_ids=[ticket_id], params={}
         )
+
+        time.sleep(5)  # 这里 sleep 是为了能返回一个正常点的状态
+
+        return Response({"status": Ticket.objects.get(bk_biz_id=bk_biz_id, pk=ticket_id).status})


### PR DESCRIPTION
1. 自定义上报慢查询修复 MySQL 记录的日志查询开始时间错误的bug
2. 终止单据 mcp
3. 从单据 vue 文件中提取单据详情
4. 删除mysql-table-checksum 上报逻辑, 优化重试, 删除结果表结构校验逻辑