### PR TITLE
feat(backend): mcp权限框架 #16028

### DIFF
--- a/dbm-ui/backend/db_services/mongodb/resources/views.py
+++ b/dbm-ui/backend/db_services/mongodb/resources/views.py
@@ -119,7 +119,7 @@ class MongoDBViewSet(ResourceViewSet):
         operation_summary=_("获取实例的角色类型"),
         tags=[constants.RESOURCE_TAG],
     )
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET"], detail=False, serializer_class=None)
     def get_instance_role(self, request, *args, **kwargs):
         storage_role_types = MachineTypeInstanceRoleMap[MachineType.MONGODB]
         proxy_role_types = [AccessLayer.PROXY]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/auth_parser/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/auth_parser/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/auth_parser/base.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/auth_parser/base.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 from backend.dbm_aiagent.mcp_tools.typing import BizIdList, ClusterIdList
 
 
-def auth_default(request: HttpRequest) -> list:
+def auth_default(request: HttpRequest, *args, **kwargs) -> list:
     """默认鉴权"""
     return []
 
@@ -43,9 +43,14 @@ def auth_parse_clusters(request: HttpRequest, *args, **kwargs) -> ClusterIdList:
     data = request.query_params if request.method == "GET" else request.data
     if "cluster_domain" not in data and "cluster_domains" not in data:
         raise ValueError("cluster_domain is required")
+
     data = data.get("cluster_domain") or data.get("cluster_domains")
     data = data if isinstance(data, list) else [data]
     cluster_ids = list(Cluster.objects.filter(immute_domain__in=data).values_list("id", flat=True))
+
+    if not cluster_ids:
+        raise ValueError("parse error, no clusters found for the given params")
+
     return cluster_ids
 
 
@@ -79,5 +84,8 @@ def auth_parse_hosts(request: HttpRequest, *args, **kwargs) -> ClusterIdList:
         cluster_ids = list(Cluster.objects.filter(filters).values_list("id", flat=True))
     else:
         raise ValueError("ip or bk_host_id is required")
+
+    if not cluster_ids:
+        raise ValueError("parse error, no clusters found for the given params")
 
     return cluster_ids

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/auth_parser/base.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/auth_parser/base.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.db.models import Q
+from django.http import HttpRequest
+
+from backend.dbm_aiagent.mcp_tools.typing import BizIdList, ClusterIdList
+
+
+def auth_default(request: HttpRequest) -> list:
+    """默认鉴权"""
+    return []
+
+
+def auth_parse_bizs(request: HttpRequest, *args, **kwargs) -> BizIdList:
+    """
+    解析业务列表 - 获取业务列表鉴权
+    request 接收params:
+    - bk_biz_id: 业务ID
+    """
+    data = request.query_params if request.method == "GET" else request.data
+    if "bk_biz_id" not in data:
+        raise ValueError("bk_biz_id is required")
+    return [data["bk_biz_id"]]
+
+
+def auth_parse_clusters(request: HttpRequest, *args, **kwargs) -> ClusterIdList:
+    """
+    解析集群列表 - 获取集群列表鉴权
+    request 接收params:
+    - cluster_domain: 集群域名
+    - cluster_domains: 集群域名列表
+    """
+    from backend.db_meta.models import Cluster
+
+    data = request.query_params if request.method == "GET" else request.data
+    if "cluster_domain" not in data and "cluster_domains" not in data:
+        raise ValueError("cluster_domain is required")
+    data = data.get("cluster_domain") or data.get("cluster_domains")
+    data = data if isinstance(data, list) else [data]
+    cluster_ids = list(Cluster.objects.filter(immute_domain__in=data).values_list("id", flat=True))
+    return cluster_ids
+
+
+def auth_parse_hosts(request: HttpRequest, *args, **kwargs) -> ClusterIdList:
+    """
+    解析主机列表 - 获取集群列表鉴权
+    request 接收params:
+    - ip: 主机IP
+    - ips: 主机IP列表
+    - bk_host_id: 主机ID
+    - bk_host_ids: 主机ID列表
+    """
+    from backend.db_meta.models import Cluster
+
+    data = request.query_params if request.method == "GET" else request.data
+    if "ip" in data:
+        filters = Q(storageinstance__machine__ip=data["ip"]) | Q(proxyinstance__machine__ip=data["ip"])
+        cluster_ids = list(Cluster.objects.filter(filters).values_list("id", flat=True))
+    elif "ips" in data:
+        filters = Q(storageinstance__machine__ip__in=data["ips"]) | Q(proxyinstance__machine__ip__in=data["ips"])
+        cluster_ids = list(Cluster.objects.filter(filters).values_list("id", flat=True))
+    elif "bk_host_id" in data:
+        filters = Q(storageinstance__machine__bk_host_id=data["bk_host_id"]) | Q(
+            proxyinstance__machine__bk_host_id=data["bk_host_id"]
+        )
+        cluster_ids = list(Cluster.objects.filter(filters).values_list("id", flat=True))
+    elif "bk_host_ids" in data:
+        filters = Q(storageinstance__machine__bk_host_id__in=data["bk_host_ids"]) | Q(
+            proxyinstance__machine__bk_host_id__in=data["bk_host_ids"]
+        )
+        cluster_ids = list(Cluster.objects.filter(filters).values_list("id", flat=True))
+    else:
+        raise ValueError("ip or bk_host_id is required")
+
+    return cluster_ids

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/decorators.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/decorators.py
@@ -69,11 +69,13 @@ def mcp_tools_api_decorator(
     methods: list[str] = ("POST",),
     name_prefix: str = None,
     reference_view: Optional[Callable] = None,
+    permission_classes: Optional[list[Type]] = None,
+    mcp_auth_parser: Optional[Callable] = None,
     is_public: bool = False,
     allow_apply_permission: bool = False,
     resource_permission_required: bool = True,
     match_subpath: bool = False,
-    user_verified_required: bool = True,
+    user_verified_required: bool = False,
     app_verified_required: bool = True,
 ):
     """
@@ -86,13 +88,14 @@ def mcp_tools_api_decorator(
     @params tags: 标签列表
     @params mcp: MCP工具列表，表示当前API属于哪些MCP工具
     @params reference_view: 引用的视图函数，实际执行时会调用该视图的鉴权和处理逻辑
+    @params permission_classes: 使用装饰器提供的权限类进行鉴权（普通视图优先）
+    @params auth_parser: 当使用mcp专用permission_class时，使用提供的parser函数解析request参数进行鉴权
     @params is_public: 是否公开
     @params allow_apply_permission: 是否允许申请权限
     @params resource_permission_required: 是否校验资源权限
     @params match_subpath: 匹配所有子路径
-    @params user_verified_required: 是否校验用户身份
+    @params user_verified_required: 是否校验用户身份(考虑 mcp 也有后台调用，默认都已应用态接口开放)
     @params app_verified_required: 是否校验应用身份
-
     @returns 装饰器函数
     """
 
@@ -139,7 +142,26 @@ def mcp_tools_api_decorator(
             ),
         )
 
-        # 如果指定了 reference_view，包装函数以调用 reference_view 的逻辑
+        def resolve_permission_classes(view_instance, action_name: str, is_reference: bool = False) -> list:
+            if env.DEBUG_MCP:
+                return []
+
+            if is_reference or permission_classes is None:
+                try:
+                    return view_instance.get_permission_class_with_action(action_name)
+                except Exception:  # pylint: disable=broad-except
+                    raise ValueError(_("无法获取引用视图类权限类：{}").format(func.__name__))
+
+            return permission_classes
+
+        def check_permissions(view_instance, request, permission_class_list):
+            for permission_class in permission_class_list or []:
+                permission = permission_class() if isinstance(permission_class, type) else permission_class
+                setattr(permission, "mcp_auth_parser", mcp_auth_parser)
+                if not permission.has_permission(request, view_instance):
+                    raise PermissionDenied(detail=_("用户权限不足：{}").format(permission.__class__.__name__))
+
+        # 指定视图函数，包装函数以调用 reference_view 的逻辑
         if reference_view:
             # 确保视图函数名称和原引用视图函数名称一致
             if func.__name__ != reference_view.__name__:
@@ -152,37 +174,39 @@ def mcp_tools_api_decorator(
 
             @wraps(func)
             def wrapper(self, request, *args, **kwargs):
-                # 如果找到了 reference_view 所属的视图类，先进行权限校验
                 if self.action != reference_view.__name__:
-                    raise ValueError(
-                        _("视图函数action '{}' 与引用视图函数名称 '{}' 不一致").format(self.action, reference_view.__name__)
-                    )
+                    raise ValueError(_("视图函数:{}与引用视图函数{}不一致").format(self.action, reference_view.__name__))
 
-                # 创建临时视图实例用于获取权限类
+                # 创建临时视图实例用于获取引用视图权限类
+                temp_view_instance = None
                 try:
                     temp_view_instance = reference_view_class()
-                    permission_classes = temp_view_instance.get_permission_class_with_action(self.action)
                 except Exception:  # pylint: disable=broad-except
-                    # 如果无法创建实例，跳过鉴权
-                    logger.warning(_("无法获取引用视图类权限类：{}").format(reference_view.__name__))
-                    permission_classes = []
+                    logger.warning(_("无法实例化引用视图：{}").format(reference_view.__name__))
 
-                # 本地调试忽略鉴权
-                if env.DEBUG_MCP:
-                    permission_classes = []
-
-                # 检查权限
-                for permission_class in permission_classes:
-                    if not permission_class.has_permission(request, self):
-                        raise PermissionDenied(detail=_("权限不足：{}").format(permission_class.__class__.__name__))
+                # 获取引用视图权限类进行鉴权
+                resolved_permission_classes = resolve_permission_classes(
+                    temp_view_instance, self.action, is_reference=True
+                )
+                check_permissions(self, request, resolved_permission_classes)
 
                 # 调用 reference_view 的处理逻辑
                 return reference_view(self, request, *args, **kwargs)
 
-            return schema_decorator(wrapper)
+            decorated_func = schema_decorator(wrapper)
+            setattr(decorated_func, "is_mcp_tool", True)
+            return decorated_func
         else:
-            # 如果没有 reference_view，直接应用 schema_decorator
-            return schema_decorator(func)
+            # 普通视图函数
+            @wraps(func)
+            def wrapper(self, request, *args, **kwargs):
+                resolved_permission_classes = resolve_permission_classes(self, self.action)
+                check_permissions(self, request, resolved_permission_classes)
+                return func(self, request, *args, **kwargs)
+
+            decorated_func = schema_decorator(wrapper)
+            setattr(decorated_func, "is_mcp_tool", True)
+            return decorated_func
 
     return decorator
 

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/auth_parser/bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/auth_parser/bill.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from backend.db_meta.enums import ClusterType
+from backend.db_meta.models import Cluster
+
+
+def auth_parse_mysql_tdbctl_upgrade_ticket(request, *args, **kwargs):
+    data = request.query_params if request.method == "GET" else request.data
+    bk_biz_id = data.get("bk_biz_id")
+    cluster_domain = data.get("cluster_domain")
+    cluster_id = data.get("cluster_id")
+
+    clusters = None
+    if cluster_domain:
+        clusters = Cluster.objects.filter(immute_domain=cluster_domain, cluster_type=ClusterType.TenDBCluster)
+    elif cluster_id:
+        clusters = Cluster.objects.filter(id=cluster_id, cluster_type=ClusterType.TenDBCluster)
+    elif bk_biz_id:
+        clusters = Cluster.objects.filter(bk_biz_id=bk_biz_id, cluster_type=ClusterType.TenDBCluster)
+
+    if not clusters or not clusters.exists():
+        raise ValueError("No clusters found for the given params")
+
+    cluster_ids = list(clusters.values_list("id", flat=True))
+    return cluster_ids

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py
@@ -11,9 +11,11 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 
+from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import auth_parse_clusters
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
 from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
 from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpNoneBillSubmittedException, DBMMcpUsernameNotFoundException
+from backend.dbm_aiagent.mcp_tools.mysql.auth_parser.bill import auth_parse_mysql_tdbctl_upgrade_ticket
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_apply_priv import bill_apply_priv
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_db_table_backup import bill_db_table_backup
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_fullbackup import mysql_full_backup
@@ -37,6 +39,7 @@ from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_standardize_bill impo
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.tdbctl_upgrade_bill import SubmitBillTdbctlUpgradeInputSerializer
 from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
+from backend.iam_app.handlers.drf_perm.mcp import McpTicketToolPermission
 
 
 class MySQLBillMcpToolsViewSet(McpToolsViewSet):
@@ -46,6 +49,8 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         description=str(_("""创建 TenDBHA, TenDBCluster 全备单据""")),
         request_slz=SubmitBillMySQLFullBackupInputSerializer,
         response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
         mcp=[DBMMcpTools.MYSQL_BILL],
         name_prefix="mysql_bill",
@@ -69,6 +74,8 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         description=str(_("""创建 TenDBHA, TenDBCluster 库表备单据""")),
         request_slz=SubmitBillMySQLDBTableBackupInputSerializer,
         response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
         mcp=[DBMMcpTools.MYSQL_BILL],
         name_prefix="mysql_bill",
@@ -108,6 +115,8 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         ),
         request_slz=SubmitBillMySQLApplyPrivInputSerializer,
         response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
         mcp=[DBMMcpTools.MYSQL_BILL],
         name_prefix="mysql_bill",
@@ -139,6 +148,8 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         description=str(_("""创建 mysql 标准化单据""")),
         request_slz=SubmitBillMySQLStandardizeInputSerializer,
         response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
         mcp=[DBMMcpTools.MYSQL_BILL],
         name_prefix="mysql_bill",
@@ -175,6 +186,8 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         description=str(_("""创建 DB 重命名单据""")),
         request_slz=SubmitBillMySQLDBRenameInputSerializer,
         response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
         mcp=[DBMMcpTools.MYSQL_BILL],
         name_prefix="mysql_bill",
@@ -218,6 +231,8 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         ),
         request_slz=SubmitBillTdbctlUpgradeInputSerializer,
         response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_mysql_tdbctl_upgrade_ticket,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
         mcp=[DBMMcpTools.MYSQL_BILL],
         name_prefix="mysql_bill",

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_query_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_query_mcp.py
@@ -16,6 +16,7 @@ from rest_framework.response import Response
 
 from backend.db_meta.enums import ClusterType, MachineType
 from backend.db_meta.models import Cluster, Machine
+from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import auth_parse_clusters
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
 from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
 from backend.dbm_aiagent.mcp_tools.exceptions import (
@@ -61,6 +62,7 @@ from backend.dbm_aiagent.mcp_tools.mysql.serializers.show_variables import (
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.usefully_choices import MySQLProcessListInstanceGroupType
 from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
+from backend.iam_app.handlers.drf_perm.mcp import McpClusterManagePermission
 
 logger = logging.getLogger("root")
 
@@ -72,6 +74,8 @@ class MySQLQueryMcpToolsViewSet(McpToolsViewSet):
         description=str(_("获取 tendbsingle, tendbha, tendbcluster 集群的表结构")),
         request_slz=ShowCreateTableInputSerializer,
         response_slz=ShowCreateTableOutputSerializer,
+        permission_classes=[McpClusterManagePermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ],
         mcp=[DBMMcpTools.MYSQL_QUERY],
         name_prefix="mysql_query",
@@ -96,6 +100,8 @@ class MySQLQueryMcpToolsViewSet(McpToolsViewSet):
         description=str(_("查询 SQL 执行计划")),
         request_slz=ExplainSQLInputSerializer,
         response_slz=ExplainSQLOutputSerializer,
+        permission_classes=[McpClusterManagePermission],
+        mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ],
         mcp=[DBMMcpTools.MYSQL_QUERY],
         name_prefix="mysql_query",

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/typing.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/typing.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from typing import List, TypeAlias
+
+# 业务列表注解
+BizIdList: TypeAlias = List[int]
+
+# 集群列表注解
+ClusterIdList: TypeAlias = List[int]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/typing.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/typing.py
@@ -9,10 +9,13 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from typing import List, TypeAlias
+from typing import List, TypeAlias, Union
 
 # 业务列表注解
 BizIdList: TypeAlias = List[int]
 
 # 集群列表注解
 ClusterIdList: TypeAlias = List[int]
+
+# 单据鉴权注解
+TicketResourceList: TypeAlias = Union[BizIdList, ClusterIdList]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/views.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/views.py
@@ -66,12 +66,14 @@ class McpToolsViewSet(viewsets.SystemViewSet, metaclass=McpToolsViewSetMeta):
     # 这样 generate_resources_yaml 命令可以正确识别并使用 drf-spectacular 生成 schema
     schema_class = AutoSchema
 
-    # MCP 工具需要同时开启用户认证和应用认证，默认为True
-    # 这里user_verified_required 和 app_verified_required 比如和视图函数一致
-    # 如果确实无需某个认证，则类定义和 mcp_tools_api_decorator 都要改写为False
-    # TODO: 考虑 mcp 也有后台调用，暂时都已应用态接口开放
-    user_verified_required = False
-    app_verified_required = True
+    def get_permissions(self):
+        """
+        MCP 工具接口的权限校验交由装饰器处理，禁用默认的 viewset 鉴权逻辑
+        """
+        view_method = getattr(self, self.action, None)
+        if view_method and getattr(view_method, "is_mcp_tool", False):
+            return []
+        return super().get_permissions()
 
     def get_param(self, pname, default_value: Any | None = None) -> Any:
         return self.params_validate(self.get_serializer_class()).get(pname, default_value)

--- a/dbm-ui/backend/iam_app/dataclass/actions.py
+++ b/dbm-ui/backend/iam_app/dataclass/actions.py
@@ -2709,6 +2709,129 @@ class ActionEnum:
         group=_("业务"),
     )
 
+    # ---- MCP 工具权限 ---
+    # 目前集群管理可以操作集群的工具箱单据，先给到mcp工具使用
+    MYSQL_MANAGE = ActionMeta(
+        id="mysql_manage",
+        name=_("MySQL 集群管理"),
+        name_en="mysql_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.MYSQL],
+        group=_("MySQL"),
+        subgroup=_("集群管理"),
+    )
+
+    TENDBCLUSTER_MANAGE = ActionMeta(
+        id="tendbcluster_manage",
+        name=_("TenDBCluster 集群管理"),
+        name_en="tendbcluster_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.TENDBCLUSTER],
+        group=_("TenDBCluster"),
+        subgroup=_("集群管理"),
+    )
+
+    REDIS_MANAGE = ActionMeta(
+        id="redis_manage",
+        name=_("Redis 集群管理"),
+        name_en="redis_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.REDIS],
+        group=_("Redis"),
+        subgroup=_("集群管理"),
+    )
+
+    ES_MANAGE = ActionMeta(
+        id="es_manage",
+        name=_("ES 集群管理"),
+        name_en="es_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.ES],
+        group=_("ES"),
+        subgroup=_("集群管理"),
+    )
+
+    DORIS_MANAGE = ActionMeta(
+        id="doris_manage",
+        name=_("Doris 集群管理"),
+        name_en="doris_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.DORIS],
+        group=_("Doris"),
+        subgroup=_("集群管理"),
+    )
+
+    KAFKA_MANAGE = ActionMeta(
+        id="kafka_manage",
+        name=_("Kafka 集群管理"),
+        name_en="kafka_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.KAFKA],
+        group=_("Kafka"),
+        subgroup=_("集群管理"),
+    )
+
+    HDFS_MANAGE = ActionMeta(
+        id="hdfs_manage",
+        name=_("HDFS 集群管理"),
+        name_en="hdfs_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.HDFS],
+        group=_("HDFS"),
+        subgroup=_("集群管理"),
+    )
+
+    PULSAR_MANAGE = ActionMeta(
+        id="pulsar_manage",
+        name=_("Pulsar 集群管理"),
+        name_en="pulsar_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.PULSAR],
+        group=_("Pulsar"),
+        subgroup=_("集群管理"),
+    )
+
+    MONGODB_MANAGE = ActionMeta(
+        id="mongodb_manage",
+        name=_("MongoDB 集群管理"),
+        name_en="mongodb_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.MONGODB],
+        group=_("MongoDB"),
+        subgroup=_("集群管理"),
+    )
+
+    SQLSERVER_MANAGE = ActionMeta(
+        id="sqlserver_manage",
+        name=_("SQLServer 集群管理"),
+        name_en="sqlserver_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.SQLSERVER],
+        group=_("SQLServer"),
+        subgroup=_("集群管理"),
+    )
+
+    ORACLE_MANAGE = ActionMeta(
+        id="oracle_manage",
+        name=_("Oracle 集群管理"),
+        name_en="oracle_manage",
+        type="manage",
+        related_actions=[],
+        related_resource_types=[ResourceEnum.ORACLE],
+        group=_("Oracle"),
+        subgroup=_("集群管理"),
+    )
+
     @classmethod
     def get_action_by_id(cls, action_id: Union[(ActionMeta, str)]) -> ActionMeta:
         if isinstance(action_id, ActionMeta):
@@ -2716,6 +2839,10 @@ class ActionEnum:
         if action_id.lower() not in _all_actions:
             raise ActionNotExistError(_("动作ID不存在: {}").format(action_id))
         return _all_actions[action_id.lower()]
+
+    @classmethod
+    def get_action_by_ticket_type(cls, ticket_type: str) -> ActionMeta:
+        return getattr(cls, str(ticket_type).upper())
 
     @classmethod
     def cluster_type_to_action(cls, cluster_type, action_key):

--- a/dbm-ui/backend/iam_app/handlers/drf_perm/base.py
+++ b/dbm-ui/backend/iam_app/handlers/drf_perm/base.py
@@ -280,13 +280,6 @@ class DBManagePermission(ResourceActionPermission):
 
     def has_permission(self, request, view):
         return super().has_permission(request, view)
-        # try:
-        #     return super().has_permission(request, view)
-        # except PermissionDeniedError:
-        #     username = Permission(request=request).username
-        #     bk_biz_id = self.instance_biz_id_getter(request, view)
-        #     logger.error(f"api: {request.path}, bk_biz_id: {bk_biz_id}, user: {username} has no db-manage, ")
-        #     return True
 
 
 class BizOrGlobalResourceActionPermission(ResourceActionPermission):

--- a/dbm-ui/backend/iam_app/handlers/drf_perm/mcp.py
+++ b/dbm-ui/backend/iam_app/handlers/drf_perm/mcp.py
@@ -12,7 +12,9 @@ specific language governing permissions and limitations under the License.
 from typing import Callable, List
 
 from pydantic import TypeAdapter
+from rest_framework import permissions
 
+from backend.configuration.models import DBAdministrator
 from backend.db_meta.enums import ClusterType
 from backend.db_meta.models import Cluster
 from backend.dbm_aiagent.mcp_tools import typing
@@ -89,3 +91,41 @@ class McpClusterManagePermission(BaseMcpDetailPermission):
         self.resource_meta = ResourceEnum.cluster_type_to_resource_meta(cluster_types[0])
         self.actions = [ActionEnum.cluster_type_to_action(cluster_types[0], action_key="VIEW")]
         return cluster_ids
+
+
+class McpTicketToolPermission(BaseMcpDetailPermission):
+    """
+    MCP创建工具箱单据相关动作鉴权，使用方式：
+    1. 工具箱，action_key = MANAGE
+    2. 禁用/下架集群 action_key = DESTROY
+    鉴权字段：集群列表 List[int]
+    """
+
+    resource_checker = TypeAdapter(typing.TicketResourceList)
+
+    def __init__(self, action_key: str = "MANAGE"):
+        super().__init__()
+        self.action_key = action_key
+
+    def instance_ids_getter(self, request, view):
+        cluster_ids = super().instance_ids_getter(request, view)
+        # 通过了父类的checker，这里认为集群是同类且存在的
+        cluster = Cluster.objects.get(id=cluster_ids[0])
+        action = ActionEnum.cluster_type_to_action(cluster.cluster_type, action_key=self.action_key)
+        self.actions = [action]
+        self.resource_meta = action.related_resource_types[0]
+        return cluster_ids
+
+
+class McpIsDbaPermission(permissions.BasePermission):
+    """
+    是否是DBA权限来调用该MCP工具
+    """
+
+    def has_permission(self, request, view):
+        username = request.user.username
+        return DBAdministrator.is_dba(username)
+
+    def has_object_permission(self, request, view, obj):
+        username = request.user.username
+        return DBAdministrator.is_dba(username)

--- a/dbm-ui/backend/iam_app/handlers/drf_perm/mcp.py
+++ b/dbm-ui/backend/iam_app/handlers/drf_perm/mcp.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from typing import Callable, List
+
+from pydantic import TypeAdapter
+
+from backend.db_meta.enums import ClusterType
+from backend.db_meta.models import Cluster
+from backend.dbm_aiagent.mcp_tools import typing
+from backend.iam_app.dataclass import ResourceEnum, ResourceMeta
+from backend.iam_app.dataclass.actions import ActionEnum, ActionMeta
+from backend.iam_app.handlers.drf_perm.base import ResourceActionPermission
+
+
+class BaseMcpDetailPermission(ResourceActionPermission):
+    """
+    集群详情相关动作鉴权
+    """
+
+    mcp_auth_parser: Callable = None
+    resource_checker: TypeAdapter = None
+
+    def __init__(self, actions: List[ActionMeta] = None, resource_meta: ResourceMeta = None):
+        super().__init__(actions=actions, resource_meta=resource_meta, instance_ids_getter=self.instance_ids_getter)
+
+    def instance_ids_getter(self, request, view):
+        # 从mcp装饰器获得getter
+        if self.mcp_auth_parser is None:
+            raise ValueError("MCP Permission must set mcp_auth_parser attr, but not found...")
+        resources = self.mcp_auth_parser(request, view)
+
+        # resource 存在和类型检查
+        if self.resource_checker:
+            try:
+                self.resource_checker.validate_python(resources)
+            except ValueError:
+                raise ValueError("resource:{} check failed, confirm the field's type is correct".format(resources))
+
+        if self.resource_checker and not resources:
+            raise ValueError("resource check failed, confirm resource exists")
+
+        return resources
+
+
+class McpDBManagePermission(BaseMcpDetailPermission):
+    """
+    MCP工具业务管理相关动作鉴权
+    鉴权字段：业务列表 List[int]
+    """
+
+    resource_checker = TypeAdapter(typing.BizIdList)
+
+    def __init__(self, actions: List[ActionMeta] = None, resource_meta: ResourceMeta = None):
+        actions = [ActionEnum.DB_MANAGE]
+        resource_meta = ResourceEnum.BUSINESS
+        super().__init__(actions=actions, resource_meta=resource_meta)
+
+
+class McpClusterManagePermission(BaseMcpDetailPermission):
+    """
+    MCP工具集群详情相关动作鉴权
+    鉴权字段：集群列表 List[int]
+    """
+
+    resource_checker = TypeAdapter(typing.ClusterIdList)
+
+    def __init__(self, actions: List[ActionMeta] = None, resource_meta: ResourceMeta = None):
+        super().__init__(actions=actions, resource_meta=resource_meta)
+
+    def instance_ids_getter(self, request, view):
+        cluster_ids = super().instance_ids_getter(request, view)
+        cluster_types = list(Cluster.objects.filter(id__in=cluster_ids).values_list("cluster_type", flat=True))
+
+        # 集群类型对应组件必须相同
+        db_types = [ClusterType.cluster_type_to_db_type(cluster_type) for cluster_type in cluster_types]
+        if len(set(db_types)) > 1:
+            raise ValueError("Cluster types must be the same, but got {}".format(set(db_types)))
+
+        # 从获取到集群ID后，决定动作和资源类型
+        self.resource_meta = ResourceEnum.cluster_type_to_resource_meta(cluster_types[0])
+        self.actions = [ActionEnum.cluster_type_to_action(cluster_types[0], action_key="VIEW")]
+        return cluster_ids


### PR DESCRIPTION
改造要点:
- mcp_tools_api_decorator 新增 permission_classes 与 mcp_auth_parser，装饰器内统一做权限解析与校验，并可继承引用视图的权限。
- MCP 工具视图的默认权限检查被关闭，改为 仅由装饰器控制（McpToolsViewSet.get_permissions 判断 is_mcp_tool）。
- 新增 MCP 专用权限类：BaseMcpDetailPermission、McpDBManagePermission、McpClusterManagePermission，并引入 TypeAdapter 做资源类型校验。
- 新增鉴权参数解析器 auth_parser：auth_parse_bizs / auth_parse_clusters / auth_parse_hosts，用于从 request 中抽取业务/集群/主机并转资源 ID。
- 示例落地：mysql_query_mcp 两个接口改为 permission_classes=[McpClusterManagePermission] + mcp_auth_parser=auth_parse_clusters。
- 装饰器新增 resolve_permission_classes 逻辑，支持 引用视图 或 自定义权限类 两种路径。