### PR TITLE
feat(kafka): kafka mcp-tool

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/constants.py
@@ -33,6 +33,8 @@ class DBMMcpTools(StrStructuredEnum):
     REDIS_QUERY_ALARM = EnumField("redis-query-alarm", "redis-query-alarm")
     REDIS_BILL = EnumField("redis-bill", "redis-bill")
     REDIS_JOB = EnumField("redis-job", "redis-job")
+    KAFKA_QUERY_META = EnumField("kafka-query-meta", "kafka-query-meta")
+    KAFKA_BILL = EnumField("kafka-bill", "kafka-bill")
 
 
 class DBMMCPTags(StrStructuredEnum):

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/__init__.py
@@ -8,13 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.urls import include, path
-
-# common mcp tools
-urlpatterns = [
-    path("common/", include("backend.dbm_aiagent.mcp_tools.common.urls")),
-    path("mysql/", include("backend.dbm_aiagent.mcp_tools.mysql.urls")),
-    path("sqlserver/", include("backend.dbm_aiagent.mcp_tools.sqlserver.urls")),
-    path("redis/", include("backend.dbm_aiagent.mcp_tools.redis.urls")),
-    path("kafka/", include("backend.dbm_aiagent.mcp_tools.kafka.urls")),
-]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/impl/cluster_meta.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/impl/cluster_meta.py
@@ -1,0 +1,330 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from collections import defaultdict
+from typing import Dict, List
+
+from backend.db_meta.enums import ClusterType, InstanceRole, MachineType
+from backend.db_meta.models import AppCache, Cluster, ClusterEntry, StorageInstance
+
+
+def list_my_kafka_bizs(userID: str) -> List:
+    """查询用户负责的Kafka业务列表"""
+    from backend.configuration.constants import DBType
+    from backend.configuration.models import DBAdministrator
+
+    res = []
+    for app in AppCache.objects.all():
+        bk_biz_id = app.bk_biz_id
+
+        if DBAdministrator.objects.filter(bk_biz_id=bk_biz_id, users__0=userID, db_type=DBType.Kafka.value):
+            res.append({"bk_biz_id": bk_biz_id, "app_name": app.bk_biz_name, "abbr": app.db_app_abbr})
+    return res
+
+
+def list_biz_by_name(biz_name: str) -> List:
+    """根据业务英文名查询业务详情"""
+    res = []
+    for app in AppCache.objects.all():
+        if app.db_app_abbr.__contains__(biz_name.lower()):
+            res.append({"bk_biz_id": app.bk_biz_id, "app_name": app.bk_biz_name, "abbr": app.db_app_abbr})
+    return res
+
+
+def kafka_list_clusters(bk_biz_id: int) -> List:
+    """查询业务下的Kafka集群列表"""
+    clusters = Cluster.objects.filter(
+        bk_biz_id=bk_biz_id,
+        cluster_type=ClusterType.Kafka,
+    )
+
+    return [
+        {
+            "cluster_id": c.id,
+            "bk_cloud_id": c.bk_cloud_id,
+            "cluster_type": c.cluster_type,
+            "immute_domain": c.immute_domain,
+            "alias": c.alias,
+            "region": c.region,
+            "broker_count": len(c.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value)),
+            "zookeeper_count": len(c.storageinstance_set.filter(machine_type=MachineType.ZOOKEEPER.value)),
+            "kafka_version": c.major_version,
+        }
+        for c in clusters
+    ]
+
+
+def get_machine_stats(all_machine_ids) -> Dict:
+    """统计机器分布信息"""
+    from backend.db_meta.models import Machine
+
+    machines = Machine.objects.filter(bk_host_id__in=all_machine_ids).select_related("bk_city")
+
+    # 统计机器分布信息
+    machine_distribution = {
+        "total_count": len(all_machine_ids),
+        "by_sub_zone": defaultdict(int),
+        "by_os": defaultdict(int),
+        "by_device_class": defaultdict(int),
+        "spec_summary": defaultdict(int),
+    }
+
+    for machine in machines:
+        # 子Zone分布
+        if machine.bk_sub_zone:
+            machine_distribution["by_sub_zone"][machine.bk_sub_zone] += 1
+
+        # 操作系统分布
+        if machine.bk_os_name:
+            machine_distribution["by_os"][machine.bk_os_name] += 1
+
+        # 设备类型分布
+        if machine.bk_svr_device_cls_name:
+            machine_distribution["by_device_class"][machine.bk_svr_device_cls_name] += 1
+
+        # 规格统计
+        if machine.spec_id:
+            machine_distribution["spec_summary"][f"spec_{machine.spec_id}"] += 1
+
+    return machine_distribution
+
+
+def get_spec_details(spec_keys: List) -> Dict:
+    """获取规格详细信息"""
+    from backend.db_meta.models import Spec
+
+    if not spec_keys:
+        return {}
+
+    # 从 spec_keys 中提取 spec_id (spec_576 -> 576)
+    spec_ids = []
+    for key in spec_keys:
+        if key.startswith("spec_"):
+            try:
+                spec_id = int(key.replace("spec_", ""))
+                spec_ids.append(spec_id)
+            except ValueError:
+                continue
+
+    if not spec_ids:
+        return {}
+
+    # 查询 Spec 对象
+    specs = Spec.objects.filter(spec_id__in=spec_ids)
+
+    # 构建规格详情字典
+    spec_details = {}
+    for spec in specs:
+        spec_details[spec.spec_id] = {
+            "spec_id": spec.spec_id,
+            "spec_name": spec.spec_name,
+            "cpu": spec.cpu,
+            "memory": spec.mem,
+            "storage_spec": spec.storage_spec,
+            "device_class": spec.device_class,
+            "desc": spec.desc,
+        }
+
+    return spec_details
+
+
+def cluster_overview(immute_domain: str) -> Dict:
+    """查询Kafka集群详细信息，返回统计信息"""
+    from backend.db_meta.models import Spec
+
+    cluster_obj = Cluster.objects.prefetch_related("tags").get(immute_domain=immute_domain)
+
+    # 基本信息
+    stats = {
+        "bk_cloud_id": cluster_obj.bk_cloud_id,
+        "bk_biz_id": cluster_obj.bk_biz_id,
+        "cluster_id": cluster_obj.id,
+        "immute_domain": cluster_obj.immute_domain,
+        "alias": cluster_obj.alias,
+        "cluster_type": cluster_obj.cluster_type,
+        "major_version": cluster_obj.major_version,
+        "phase": cluster_obj.phase,
+        "region": cluster_obj.region,
+        "disaster_tolerance_level": cluster_obj.disaster_tolerance_level,
+        "tags": ["{}:{}".format(tag.key, tag.value) for tag in cluster_obj.tags.all()],
+        "cluster_entries": [
+            {"entry_type": ce.cluster_entry_type, "entry_addr": ce.entry}
+            for ce in ClusterEntry.objects.filter(cluster=cluster_obj)
+        ],
+    }
+
+    # 查询存储实例 (broker 和 zookeeper)
+    storage_instances = (
+        StorageInstance.objects.filter(cluster=cluster_obj)
+        .select_related("machine", "machine__bk_city")
+        .prefetch_related("bind_entry")
+    )
+
+    # 统计broker实例信息
+    broker_instances = storage_instances.filter(instance_role=InstanceRole.BROKER.value)
+    broker_stats = {
+        "by_status": defaultdict(int),
+        "by_machine_type": defaultdict(int),
+        "versions": set(),
+        "machines": set(),
+    }
+    broker_nodes = []
+
+    # 收集所有 spec_id 用于批量查询规格信息
+    broker_spec_ids = set()
+    for instance in broker_instances:
+        if instance.machine.spec_id:
+            broker_spec_ids.add(instance.machine.spec_id)
+
+    # 批量查询规格信息
+    broker_specs = {}
+    if broker_spec_ids:
+        specs = Spec.objects.filter(spec_id__in=broker_spec_ids)
+        broker_specs = {spec.spec_id: spec for spec in specs}
+
+    for instance in broker_instances:
+        broker_stats["by_status"][instance.status] += 1
+        broker_stats["by_machine_type"][instance.machine_type] += 1
+        if instance.version:
+            broker_stats["versions"].add(instance.version)
+        broker_stats["machines"].add(instance.machine.bk_host_id)
+        # 收集节点详细信息，用于缩容/替换操作
+        node_info = {
+            "ip": instance.machine.ip,
+            "bk_host_id": instance.machine.bk_host_id,
+            "bk_cloud_id": instance.machine.bk_cloud_id,
+            "port": instance.port,
+            "instance_id": instance.id,
+            "machine_type": instance.machine_type,
+            "status": instance.status,
+            "device_class": instance.machine.bk_svr_device_cls_name,
+        }
+        # 添加规格详细信息
+        if instance.machine.spec_id and instance.machine.spec_id in broker_specs:
+            spec = broker_specs[instance.machine.spec_id]
+            node_info["spec"] = {
+                "spec_id": spec.spec_id,
+                "spec_name": spec.spec_name,
+                "cpu": spec.cpu,
+                "memory": spec.mem,
+                "storage_spec": spec.storage_spec,
+            }
+        broker_nodes.append(node_info)
+
+    broker_machines = get_machine_stats(broker_stats["machines"])
+    stats["broker_instances"] = {
+        "node_count": broker_instances.count(),
+        "by_status": dict(sorted(broker_stats["by_status"].items())),
+        "versions": sorted(list(broker_stats["versions"])),
+        "machine_count": len(broker_stats["machines"]),
+        "by_os": dict(sorted(broker_machines["by_os"].items())),
+        "by_sub_zone": dict(sorted(broker_machines["by_sub_zone"].items())),
+        "by_device_class": dict(sorted(broker_machines["by_device_class"].items())),
+        "by_spec": dict(sorted(broker_machines["spec_summary"].items())),
+        "spec_details": get_spec_details(list(broker_machines["spec_summary"].keys())),
+        "nodes": broker_nodes,
+    }
+
+    # 统计zookeeper实例信息
+    zookeeper_instances = storage_instances.filter(machine_type=MachineType.ZOOKEEPER.value)
+    zookeeper_stats = {
+        "by_status": defaultdict(int),
+        "by_machine_type": defaultdict(int),
+        "versions": set(),
+        "machines": set(),
+    }
+    zookeeper_nodes = []
+
+    # 收集所有 spec_id 用于批量查询规格信息
+    zookeeper_spec_ids = set()
+    for instance in zookeeper_instances:
+        if instance.machine.spec_id:
+            zookeeper_spec_ids.add(instance.machine.spec_id)
+
+    # 批量查询规格信息
+    zookeeper_specs = {}
+    if zookeeper_spec_ids:
+        specs = Spec.objects.filter(spec_id__in=zookeeper_spec_ids)
+        zookeeper_specs = {spec.spec_id: spec for spec in specs}
+
+    for instance in zookeeper_instances:
+        zookeeper_stats["by_status"][instance.status] += 1
+        zookeeper_stats["by_machine_type"][instance.machine_type] += 1
+        if instance.version:
+            zookeeper_stats["versions"].add(instance.version)
+        zookeeper_stats["machines"].add(instance.machine.bk_host_id)
+        # 收集节点详细信息
+        node_info = {
+            "ip": instance.machine.ip,
+            "bk_host_id": instance.machine.bk_host_id,
+            "bk_cloud_id": instance.machine.bk_cloud_id,
+            "port": instance.port,
+            "instance_id": instance.id,
+            "machine_type": instance.machine_type,
+            "status": instance.status,
+            "device_class": instance.machine.bk_svr_device_cls_name,
+        }
+        # 添加规格详细信息
+        if instance.machine.spec_id and instance.machine.spec_id in zookeeper_specs:
+            spec = zookeeper_specs[instance.machine.spec_id]
+            node_info["spec"] = {
+                "spec_id": spec.spec_id,
+                "spec_name": spec.spec_name,
+                "cpu": spec.cpu,
+                "memory": spec.mem,
+                "storage_spec": spec.storage_spec,
+            }
+        zookeeper_nodes.append(node_info)
+
+    zookeeper_machines = get_machine_stats(zookeeper_stats["machines"])
+    stats["zookeeper_instances"] = {
+        "node_count": zookeeper_instances.count(),
+        "by_status": dict(sorted(zookeeper_stats["by_status"].items())),
+        "versions": sorted(list(zookeeper_stats["versions"])),
+        "machine_count": len(zookeeper_stats["machines"]),
+        "by_os": dict(sorted(zookeeper_machines["by_os"].items())),
+        "by_sub_zone": dict(sorted(zookeeper_machines["by_sub_zone"].items())),
+        "by_device_class": dict(sorted(zookeeper_machines["by_device_class"].items())),
+        "by_spec": dict(sorted(zookeeper_machines["spec_summary"].items())),
+        "spec_details": get_spec_details(list(zookeeper_machines["spec_summary"].keys())),
+        "nodes": zookeeper_nodes,
+    }
+
+    return stats
+
+
+def search_specs_by_name(spec_name: str, spec_cluster_type: str = "kafka") -> List:
+    """根据规格名称模糊查询规格信息
+
+    Args:
+        spec_name: 规格名称（支持模糊匹配，如 '16核32G'）
+        spec_cluster_type: 规格集群类型，默认为 kafka
+
+    Returns:
+        匹配的规格列表
+    """
+    from backend.db_meta.models import Spec
+
+    specs = Spec.objects.filter(spec_name__icontains=spec_name, spec_cluster_type=spec_cluster_type, enable=True)
+
+    return [
+        {
+            "spec_id": spec.spec_id,
+            "spec_name": spec.spec_name,
+            "spec_cluster_type": spec.spec_cluster_type,
+            "spec_machine_type": spec.spec_machine_type,
+            "cpu": spec.cpu,
+            "mem": spec.mem,
+            "device_class": spec.device_class,
+            "storage_spec": spec.storage_spec,
+            "desc": spec.desc,
+        }
+        for spec in specs
+    ]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/impl/kafka_bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/impl/kafka_bill.py
@@ -1,0 +1,639 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from typing import Dict
+
+from django.utils.crypto import get_random_string
+
+from backend.configuration.constants import DBPrivSecurityType
+from backend.configuration.handlers.password import DBPasswordHandler
+from backend.db_meta.enums import InstanceRole
+from backend.db_meta.models import Cluster, Spec
+from backend.ticket.builders.common.base import IpSource
+from backend.ticket.constants import TicketType
+from backend.ticket.models import Ticket
+
+
+def submit_kafka_scale_up_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    ip_source: str,
+    nodes: Dict = None,
+    resource_spec: Dict = None,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群扩容单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        ip_source: 主机来源 (resource_pool 或 manual_input)
+        nodes: 节点列表，当ip_source为manual_input时使用
+        resource_spec: 资源池规格，当ip_source为resource_pool时使用
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    ext_info = None
+
+    # 当 ip_source 为 resource_pool 时，获取第一个 broker 的 spec_id 用于资源池申请
+    if ip_source == IpSource.RESOURCE_POOL.value:
+        broker_instance = cluster_obj.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value).first()
+        if broker_instance:
+            # 如果用户传入的 resource_spec 里没有 spec_id，补充默认的 spec_id
+            if resource_spec and "broker" in resource_spec:
+                if "spec_id" not in resource_spec["broker"]:
+                    resource_spec["broker"]["spec_id"] = broker_instance.machine.spec_id
+                # 补充默认的 affinity 和 location_spec 字段，用于页面展示详细扩容信息
+                if "affinity" not in resource_spec["broker"]:
+                    resource_spec["broker"]["affinity"] = "MAX_EACH_ZONE_EQUAL"
+                if "location_spec" not in resource_spec["broker"]:
+                    resource_spec["broker"]["location_spec"] = {
+                        "city": cluster_obj.region or "default",
+                        "sub_zone_ids": cluster_obj.zone_list or [],
+                    }
+                # 补充 labels 和 label_names 字段
+                if "labels" not in resource_spec["broker"]:
+                    resource_spec["broker"]["labels"] = []
+                if "label_names" not in resource_spec["broker"]:
+                    resource_spec["broker"]["label_names"] = []
+
+                # 计算 ext_info：扩容磁盘信息和主机数
+                count = resource_spec["broker"].get("count", 1)
+                spec_id = resource_spec["broker"].get("spec_id")
+                total_hosts = cluster_obj.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value).count()
+
+                expansion_disk = 0
+                if spec_id:
+                    try:
+                        spec_obj = Spec.objects.get(spec_id=spec_id)
+                        # 计算规格的磁盘总容量（所有挂载点的min之和）
+                        expansion_disk = sum(disk_spec.get("min", 0) for disk_spec in spec_obj.storage_spec) * count
+                    except Spec.DoesNotExist:
+                        pass
+
+                ext_info = {
+                    "broker": {
+                        "total_hosts": total_hosts,
+                        "expansion_disk": expansion_disk,
+                        "total_disk": None,  # 当前集群磁盘，暂时不计算
+                    }
+                }
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_SCALE_UP,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka scale up ticket",
+        "details": {
+            "cluster_id": cluster_id,
+            "ip_source": ip_source,
+        },
+    }
+
+    # 根据主机来源添加不同的参数
+    if ip_source == IpSource.RESOURCE_POOL.value:
+        ticket_param["details"]["resource_spec"] = resource_spec
+        if ext_info:
+            ticket_param["details"]["ext_info"] = ext_info
+    elif ip_source == IpSource.MANUAL_INPUT.value:
+        ticket_param["details"]["nodes"] = nodes
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_shrink_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    nodes: Dict,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群缩容单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        nodes: 需要缩容的节点列表，格式为 {"broker": [{"ip": "xxx", "bk_host_id": xxx, "bk_cloud_id": xxx}]}
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 计算 ext_info：缩容磁盘信息
+    shrink_disk = 0
+    total_hosts = cluster_obj.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value).count()
+
+    # 计算缩容节点的磁盘容量
+    from backend.db_meta.models import Machine, Spec
+
+    shrink_host_ids = [node["bk_host_id"] for broker_nodes in nodes.values() for node in broker_nodes]
+    shrink_machines = Machine.objects.filter(bk_host_id__in=shrink_host_ids)
+    for machine in shrink_machines:
+        if machine.spec_id:
+            try:
+                spec_obj = Spec.objects.get(spec_id=machine.spec_id)
+                # 计算规格的磁盘总容量（所有挂载点的min之和）
+                shrink_disk += sum(disk_spec.get("min", 0) for disk_spec in spec_obj.storage_spec or [])
+            except Spec.DoesNotExist:
+                pass
+
+    # 计算当前集群总磁盘容量
+    total_disk = 0
+    all_broker_machines = Machine.objects.filter(
+        bk_host_id__in=cluster_obj.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value).values_list(
+            "machine__bk_host_id", flat=True
+        )
+    )
+    for machine in all_broker_machines:
+        if machine.spec_id:
+            try:
+                spec_obj = Spec.objects.get(spec_id=machine.spec_id)
+                total_disk += sum(disk_spec.get("min", 0) for disk_spec in spec_obj.storage_spec or [])
+            except Spec.DoesNotExist:
+                pass
+
+    ext_info = {
+        "broker": {
+            "total_hosts": total_hosts,
+            "shrink_disk": shrink_disk,
+            "total_disk": total_disk,
+        }
+    }
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_SHRINK,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka shrink ticket",
+        "details": {
+            "cluster_id": cluster_id,
+            "old_nodes": nodes,
+            "ext_info": ext_info,
+        },
+    }
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_replace_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    old_nodes: Dict,
+    ip_source: str,
+    new_nodes: Dict = None,
+    resource_spec: Dict = None,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群替换单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        old_nodes: 旧节点列表，格式为 {"broker": [{"ip": "xxx", "bk_host_id": xxx, "bk_cloud_id": xxx}]}
+        ip_source: 主机来源 (resource_pool 或 manual_input)
+        new_nodes: 新节点列表，当ip_source为manual_input时使用
+        resource_spec: 资源池规格，当ip_source为resource_pool时使用
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 当 ip_source 为 resource_pool 时，获取第一个 broker 的 spec_id 用于资源池申请
+    if ip_source == IpSource.RESOURCE_POOL.value:
+        # 如果 resource_spec 为 None，初始化它
+        if resource_spec is None:
+            resource_spec = {}
+
+        broker_instance = cluster_obj.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value).first()
+        if broker_instance:
+            # 确保 resource_spec 有 broker 键
+            if "broker" not in resource_spec:
+                resource_spec["broker"] = {}
+
+            # 如果用户传入的 resource_spec 里没有 spec_id，补充默认的 spec_id
+            if "spec_id" not in resource_spec["broker"]:
+                resource_spec["broker"]["spec_id"] = broker_instance.machine.spec_id
+            # 补充默认的 affinity 和 location_spec 字段
+            if "affinity" not in resource_spec["broker"]:
+                resource_spec["broker"]["affinity"] = "MAX_EACH_ZONE_EQUAL"
+            if "location_spec" not in resource_spec["broker"]:
+                resource_spec["broker"]["location_spec"] = {
+                    "city": cluster_obj.region or "default",
+                    "sub_zone_ids": cluster_obj.zone_list or [],
+                }
+            # 补充 labels 和 label_names 字段
+            if "labels" not in resource_spec["broker"]:
+                resource_spec["broker"]["labels"] = []
+            if "label_names" not in resource_spec["broker"]:
+                resource_spec["broker"]["label_names"] = []
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_REPLACE,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka replace ticket",
+        "details": {
+            "cluster_id": cluster_id,
+            "old_nodes": old_nodes,
+            "ip_source": ip_source,
+        },
+    }
+
+    # 根据主机来源添加不同的参数
+    if ip_source == IpSource.RESOURCE_POOL.value:
+        ticket_param["details"]["resource_spec"] = resource_spec
+    elif ip_source == IpSource.MANUAL_INPUT.value:
+        ticket_param["details"]["new_nodes"] = new_nodes
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_rebalance_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    topics: list,
+    throttle_rate: int,
+    target_ips: list = None,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群Topic均衡单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        topics: 需要均衡的topic列表
+        throttle_rate: 均衡速率 (bytes/s)
+        target_ips: 目标broker IP列表（可选），指定将数据均衡到这些IP所在的broker节点，不传则均衡到所有broker
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 获取所有 broker 实例
+    broker_instances = cluster_obj.storageinstance_set.filter(instance_role=InstanceRole.BROKER.value)
+
+    # 如果指定了目标IP，只选择这些IP对应的broker
+    if target_ips:
+        broker_instances = broker_instances.filter(machine__ip__in=target_ips)
+
+    # 构建 instance_list 格式: [{"bk_cloud_id": xxx, "ip": "xxx", "bk_host_id": xxx, "port": xxx}]
+    instance_list = []
+    for broker in broker_instances:
+        instance_list.append(
+            {
+                "bk_cloud_id": cluster_obj.bk_cloud_id,
+                "ip": broker.machine.ip,
+                "bk_host_id": broker.machine.bk_host_id,
+                "port": broker.port,
+            }
+        )
+
+    # 构建 instance_info (用于前端展示)
+    instance_info = []
+    for broker in broker_instances:
+        instance_info.append(
+            {
+                "ip": broker.machine.ip,
+                "bk_host_id": broker.machine.bk_host_id,
+                "bk_cloud_id": cluster_obj.bk_cloud_id,
+                "port": broker.port,
+                "instance_id": broker.id,
+            }
+        )
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_REBALANCE,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka rebalance ticket",
+        "details": {
+            "cluster_id": cluster_id,
+            "topics": topics,
+            "throttle_rate": throttle_rate,
+            "instance_list": instance_list,
+            "instance_info": instance_info,
+        },
+    }
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_reboot_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    instance_list: list,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka实例重启单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        instance_list: 需要重启的实例列表，格式为 [{"ip": "xxx", "port": xxx, "instance_id": xxx, "bk_host_id": xxx, "bk_cloud_id": xxx}]
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_REBOOT,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka reboot ticket",
+        "details": {
+            "cluster_id": cluster_id,
+            "instance_list": instance_list,
+        },
+    }
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_disable_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群禁用单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_DISABLE,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka disable ticket",
+        "details": {
+            "cluster_id": cluster_id,
+        },
+    }
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_enable_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群启用单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_ENABLE,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka enable ticket",
+        "details": {
+            "cluster_id": cluster_id,
+        },
+    }
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_destroy_bill(
+    bk_biz_id: int,
+    cluster_domain: str,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群删除单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_domain: 集群域名
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_id = cluster_obj.id
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_DESTROY,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka destroy ticket",
+        "details": {
+            "cluster_id": cluster_id,
+        },
+    }
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+def submit_kafka_apply_bill(
+    bk_biz_id: int,
+    cluster_name: str,
+    db_app_abbr: str,
+    ip_source: str,
+    timezone: str = "Asia/Shanghai",
+    city_code: str = "default",
+    region: str = "default",
+    disaster_tolerance_level: str = "MAX_EACH_ZONE_EQUAL",
+    replication_num: int = 2,
+    version: str = "2.4.0",
+    nodes: Dict = None,
+    resource_spec: Dict = None,
+    creator: str = "mcp_user",
+) -> Dict:
+    """
+    提交Kafka集群部署单据
+
+    Args:
+        bk_biz_id: 业务ID
+        cluster_name: 集群名称
+        db_app_abbr: 应用缩写
+        ip_source: 主机来源 (resource_pool 或 manual_input)
+        timezone: 时区，默认Asia/Shanghai
+        city_code: 城市代码，默认default
+        region: 区域，默认default
+        disaster_tolerance_level: 容灾级别，默认MAX_EACH_ZONE_EQUAL
+        replication_num: 副本数量，默认2
+        version: Kafka版本号，默认2.4.0
+        nodes: 节点列表，当ip_source为manual_input时使用，格式为 {"zookeeper": [...], "broker": [...]}
+        resource_spec: 资源池规格，当ip_source为resource_pool时使用
+        creator: 创建者用户名
+
+    Returns:
+        包含单据ID和单据URL的字典
+    """
+    from backend.db_services.infras.host import get_city_code_name_map
+
+    # 获取城市名称
+    city_map = get_city_code_name_map()
+    city_name = str(city_map.get(city_code, "随机"))
+
+    # 自动生成用户名和密码
+    username = get_random_string(8)
+    password = DBPasswordHandler.get_random_password(security_type=DBPrivSecurityType.KAFKA_PASSWORD)
+    domain = f"kafka.{cluster_name}.{db_app_abbr}.db"
+
+    # 构建单据参数
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "ticket_type": TicketType.KAFKA_APPLY,
+        "creator": creator,
+        "helpers": [],
+        "remark": "mcp kafka apply ticket",
+        "details": {
+            "username": username,
+            "uid": 0,  # 暂时固定为0
+            "retention_hours": 24,  # 1天
+            "replication_num": replication_num,
+            "port": 9092,
+            "password": password,
+            "partition_num": 1,
+            "no_security": 0,  # 启用认证
+            "nodes": nodes,
+            "ip_source": ip_source,
+            "db_version": version,
+            "created_by": creator,
+            "cluster_name": cluster_name,
+            "city_code": city_code,
+            "bk_cloud_id": 0,  # 默认云区域ID
+            "db_app_abbr": db_app_abbr,
+            "cluster_alias": "",
+            "retention_bytes": -1,  # 不限制
+            "disaster_tolerance_level": disaster_tolerance_level,
+            "domain": domain,
+            "timezone": timezone,
+            "region": region,
+            "city_name": city_name,  # 根据 city_code 获取
+            "sub_zone_ids": [],
+            "sub_zone_names": [],
+        },
+    }
+
+    # 根据主机来源添加不同的参数
+    if ip_source == IpSource.RESOURCE_POOL.value:
+        # 补充 resource_spec 的详细信息，用于页面展示
+        if resource_spec:
+            for role in ["broker", "zookeeper"]:
+                if role in resource_spec and "spec_id" in resource_spec[role]:
+                    spec_id = resource_spec[role]["spec_id"]
+                    try:
+                        spec_obj = Spec.objects.get(spec_id=spec_id)
+                        # 补充规格详细信息
+                        resource_spec[role]["capacity"] = spec_obj.capacity
+                        resource_spec[role]["cpu"] = spec_obj.cpu or {}
+                        resource_spec[role]["mem"] = spec_obj.mem or {}
+                        resource_spec[role]["qps"] = spec_obj.qps or {}
+                        resource_spec[role]["spec_name"] = spec_obj.spec_name
+                        resource_spec[role]["storage_spec"] = spec_obj.storage_spec or []
+                    except Spec.DoesNotExist:
+                        # 如果规格不存在，使用默认值
+                        resource_spec[role]["capacity"] = 0
+                        resource_spec[role]["cpu"] = {}
+                        resource_spec[role]["mem"] = {}
+                        resource_spec[role]["qps"] = {}
+                        resource_spec[role]["spec_name"] = ""
+                        resource_spec[role]["storage_spec"] = []
+
+                    # 补充亲和性和位置规格
+                    if "affinity" not in resource_spec[role]:
+                        resource_spec[role]["affinity"] = disaster_tolerance_level
+                    if "location_spec" not in resource_spec[role]:
+                        resource_spec[role]["location_spec"] = {"city": city_code}
+                    if "labels" not in resource_spec[role]:
+                        resource_spec[role]["labels"] = []
+                    if "label_names" not in resource_spec[role]:
+                        resource_spec[role]["label_names"] = []
+
+        ticket_param["details"]["resource_spec"] = resource_spec
+
+    # 创建单据
+    tk = Ticket.create_ticket(**ticket_param)
+
+    return {"bill_id": tk.pk, "bill_url": tk.url}

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/serializers/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/serializers/__init__.py
@@ -8,13 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.urls import include, path
-
-# common mcp tools
-urlpatterns = [
-    path("common/", include("backend.dbm_aiagent.mcp_tools.common.urls")),
-    path("mysql/", include("backend.dbm_aiagent.mcp_tools.mysql.urls")),
-    path("sqlserver/", include("backend.dbm_aiagent.mcp_tools.sqlserver.urls")),
-    path("redis/", include("backend.dbm_aiagent.mcp_tools.redis.urls")),
-    path("kafka/", include("backend.dbm_aiagent.mcp_tools.kafka.urls")),
-]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/serializers/cluster_meta.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/serializers/cluster_meta.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class KafkaBizInputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务ID"))
+
+
+class KafkaBizNameInputSerializer(serializers.Serializer):
+    biz_name = serializers.CharField(help_text=_("业务英文名"))
+
+
+class KafkaBizDetailSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务ID"))
+    app_name = serializers.CharField(help_text=_("业务中文名"))
+    abbr = serializers.CharField(help_text=_("业务英文名"))
+
+
+class KafkaClusterInputSerializer(serializers.Serializer):
+    immute_domain = serializers.CharField(help_text=_("集群域名"))
+
+
+class KafkaBrokerSerializer(serializers.Serializer):
+    address = serializers.CharField(help_text=_("Broker地址(ip:port)"))
+    status = serializers.CharField(help_text=_("Broker状态"))
+    machine_type = serializers.CharField(help_text=_("机器类型"))
+    sub_zone = serializers.CharField(help_text=_("地域-园区"))
+    cls_name = serializers.CharField(help_text=_("设备名称"))
+
+
+class KafkaZookeeperSerializer(serializers.Serializer):
+    address = serializers.CharField(help_text=_("Zookeeper地址(ip:port)"))
+    status = serializers.CharField(help_text=_("Zookeeper状态"))
+    machine_type = serializers.CharField(help_text=_("机器类型"))
+    sub_zone = serializers.CharField(help_text=_("地域-园区"))
+    cls_name = serializers.CharField(help_text=_("设备名称"))
+
+
+class KafkaClusterOutputSerializer(serializers.Serializer):
+    bk_cloud_id = serializers.IntegerField(help_text=_("云区域ID"))
+    cluster_type = serializers.CharField(help_text=_("集群类型"))
+    cluster_id = serializers.IntegerField(help_text=_("集群ID"))
+    immute_domain = serializers.CharField(help_text=_("集群域名"))
+    alias = serializers.CharField(help_text=_("集群别名"))
+    kafka_version = serializers.CharField(help_text=_("Kafka版本"))
+    region = serializers.CharField(help_text=_("地域"))
+    broker_count = serializers.IntegerField(help_text=_("Broker节点数"))
+    zookeeper_count = serializers.IntegerField(help_text=_("Zookeeper节点数"))
+
+
+class KafkaTopoOutputSerializer(serializers.Serializer):
+    cluster_id = serializers.IntegerField(help_text=_("集群ID"))
+    bk_biz_id = serializers.IntegerField(help_text=_("业务ID"))
+    cluster_type = serializers.CharField(help_text=_("集群类型"))
+    region = serializers.CharField(help_text=_("所在地域"))
+    major_version = serializers.CharField(help_text=_("Kafka版本"))
+    immute_domain = serializers.CharField(help_text=_("集群域名"))
+    alias = serializers.CharField(help_text=_("集群别名"))
+    broker_count = serializers.IntegerField(help_text=_("Broker节点数"))
+    zookeeper_count = serializers.IntegerField(help_text=_("Zookeeper节点数"))
+    brokers = serializers.ListSerializer(child=KafkaBrokerSerializer(), help_text=_("Broker节点列表"))
+    zookeepers = serializers.ListSerializer(child=KafkaZookeeperSerializer(), help_text=_("Zookeeper节点列表"))
+
+
+class SpecSearchInputSerializer(serializers.Serializer):
+    spec_name = serializers.CharField(help_text=_("规格名称，支持模糊匹配，如 '16核32G'"))
+    spec_cluster_type = serializers.CharField(
+        help_text=_("规格集群类型，默认为 kafka"),
+        required=False,
+        default="kafka",
+    )
+
+
+class SpecOutputSerializer(serializers.Serializer):
+    spec_id = serializers.IntegerField(help_text=_("规格ID"))
+    spec_name = serializers.CharField(help_text=_("规格名称"))
+    spec_cluster_type = serializers.CharField(help_text=_("规格集群类型"))
+    spec_machine_type = serializers.CharField(help_text=_("规格机器类型"))
+    cpu = serializers.DictField(help_text=_("CPU规格"))
+    mem = serializers.DictField(help_text=_("内存规格"))
+    device_class = serializers.CharField(help_text=_("设备类型"))
+    storage_spec = serializers.ListField(help_text=_("存储规格"))
+    desc = serializers.CharField(help_text=_("规格描述"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/serializers/kafka_bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/serializers/kafka_bill.py
@@ -1,0 +1,381 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+from backend.db_services.dbbase.constants import IpSource
+
+
+class SubmitBillOutputSerializer(serializers.Serializer):
+    bill_id = serializers.IntegerField(help_text=_("单据id, 理论上都会返回，如果没有返回说明有错误，需要把错误暴露出来"))
+    bill_url = serializers.CharField(help_text=_("单据地址"))
+
+
+class SubmitBillKafkaBaseInputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+    cluster_domain = serializers.CharField(help_text=_("集群域名"))
+
+
+class SubmitBillKafkaScaleUpInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    ip_source = serializers.ChoiceField(
+        choices=IpSource.get_choices(),
+        help_text=_("主机来源: resource_pool(资源池) 或 manual_input(手工输入)"),
+    )
+    nodes = serializers.JSONField(
+        help_text=_("节点列表信息，格式为 {'broker': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}]}"),
+        required=False,
+    )
+    resource_spec = serializers.JSONField(
+        help_text=_("资源池规格，格式为 {'broker': {'count': 3, 'spec_id': xxx}}，当ip_source为resource_pool时必填"),
+        required=False,
+    )
+
+    def validate(self, attrs):
+        ip_source = attrs.get("ip_source")
+        if ip_source == IpSource.RESOURCE_POOL.value:
+            if not attrs.get("resource_spec"):
+                raise serializers.ValidationError(_("当主机来源为资源池时，resource_spec字段必填"))
+        elif ip_source == IpSource.MANUAL_INPUT.value:
+            if not attrs.get("nodes"):
+                raise serializers.ValidationError(_("当主机来源为手工输入时，nodes字段必填"))
+        return attrs
+
+
+# Kafka 缩容单据相关 Serializer
+class SubmitBillKafkaShrinkInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    nodes = serializers.JSONField(
+        help_text=_("需要缩容的节点列表信息，格式为 {'broker': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}]}"),
+    )
+
+    def validate_nodes(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError(_("nodes必须是一个字典，格式为 {'broker': [...]}"))
+        for role, node_list in value.items():
+            if not isinstance(node_list, list):
+                raise serializers.ValidationError(_("nodes[{}]必须是列表").format(role))
+            for i, node in enumerate(node_list):
+                if not isinstance(node, dict):
+                    raise serializers.ValidationError(_("nodes[{}][{}]必须是字典").format(role, i))
+                required_fields = ["bk_host_id", "bk_cloud_id"]
+                missing_fields = [f for f in required_fields if f not in node]
+                if missing_fields:
+                    raise serializers.ValidationError(
+                        _(
+                            "节点{}索引{}缺少必需字段: {}，请使用cluster_overview接口获取完整节点信息。"
+                            "仅提供'ip'字段是不够的，必须包含bk_host_id和bk_cloud_id。"
+                        ).format(role, i, ", ".join(missing_fields))
+                    )
+        return value
+
+
+# Kafka 替换单据相关 Serializer
+class SubmitBillKafkaReplaceInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    old_nodes = serializers.JSONField(
+        help_text=_("旧节点列表信息，格式为 {'broker': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}]}"),
+    )
+    ip_source = serializers.ChoiceField(
+        choices=IpSource.get_choices(),
+        help_text=_("主机来源: resource_pool(资源池) 或 manual_input(手工输入)，默认为资源池"),
+        required=False,
+        default=IpSource.RESOURCE_POOL.value,
+    )
+    new_nodes = serializers.JSONField(
+        help_text=_(
+            "新节点列表信息，格式为 {'broker': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}]}，当ip_source为manual_input时必填"
+        ),
+        required=False,
+    )
+    resource_spec = serializers.JSONField(
+        help_text=_("资源池规格，格式为 {'broker': {'count': 3, 'spec_id': xxx}}，默认与被替换节点规格相同"),
+        required=False,
+    )
+
+    def _validate_node_structure(self, nodes, field_name="nodes"):
+        """验证节点结构是否包含必需字段"""
+        if not isinstance(nodes, dict):
+            raise serializers.ValidationError(_("{}必须是一个字典，格式为 {{'broker': [...]}}").format(field_name))
+        for role, node_list in nodes.items():
+            if not isinstance(node_list, list):
+                raise serializers.ValidationError(_("{}[{}]必须是列表").format(field_name, role))
+            for i, node in enumerate(node_list):
+                if not isinstance(node, dict):
+                    raise serializers.ValidationError(_("{}[{}][{}]必须是字典").format(field_name, role, i))
+                required_fields = ["bk_host_id", "bk_cloud_id"]
+                missing_fields = [f for f in required_fields if f not in node]
+                if missing_fields:
+                    raise serializers.ValidationError(
+                        _(
+                            "{}中的节点{}索引{}缺少必需字段: {}，请使用cluster_overview接口获取完整节点信息。"
+                            "仅提供'ip'字段是不够的，必须包含bk_host_id和bk_cloud_id。"
+                        ).format(field_name, role, i, ", ".join(missing_fields))
+                    )
+        return nodes
+
+    def validate_old_nodes(self, value):
+        return self._validate_node_structure(value, "old_nodes")
+
+    def validate_new_nodes(self, value):
+        return self._validate_node_structure(value, "new_nodes")
+
+    def validate(self, attrs):
+        # 如果未指定 ip_source，默认使用资源池
+        if "ip_source" not in attrs:
+            attrs["ip_source"] = IpSource.RESOURCE_POOL.value
+
+        ip_source = attrs.get("ip_source")
+        if ip_source == IpSource.RESOURCE_POOL.value:
+            # 资源池方式：resource_spec 可选，后端会自动填充与被替换节点相同的规格
+            pass
+        elif ip_source == IpSource.MANUAL_INPUT.value:
+            if not attrs.get("new_nodes"):
+                raise serializers.ValidationError(_("当主机来源为手工输入时，new_nodes字段必填"))
+        return attrs
+
+
+# Kafka 均衡单据相关 Serializer
+class SubmitBillKafkaRebalanceInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    topics = serializers.ListField(
+        help_text=_("需要均衡的topic列表，默认['*']表示所有topic"),
+        child=serializers.CharField(),
+        required=False,
+        default=["*"],
+    )
+    throttle_rate = serializers.IntegerField(
+        help_text=_("均衡速率，单位bytes/s。默认80000000(80MB/s)，建议值: 10000000-100000000(10MB/s-100MB/s)"),
+        required=False,
+        default=80000000,
+    )
+    target_ips = serializers.ListField(
+        help_text=_("目标broker IP列表（可选），指定将数据均衡到这些IP所在的broker节点，不传则均衡到所有broker"),
+        child=serializers.CharField(),
+        required=False,
+        default=None,
+    )
+
+    def validate_throttle_rate(self, value):
+        if value <= 0:
+            raise serializers.ValidationError(_("throttle_rate必须大于0"))
+        if value > 1000000000:
+            raise serializers.ValidationError(_("throttle_rate不能超过1000000000 bytes/s (1GB/s)"))
+        return value
+
+    def validate_topics(self, value):
+        if not value:
+            raise serializers.ValidationError(_("topics列表不能为空"))
+        for i, topic in enumerate(value):
+            if not isinstance(topic, str) or not topic.strip():
+                raise serializers.ValidationError(_("topics列表第{}项必须是非空字符串").format(i))
+        return value
+
+
+# Kafka 实例重启单据相关 Serializer
+class SubmitBillKafkaRebootInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    instance_list = serializers.JSONField(
+        help_text=_(
+            "需要重启的实例列表，格式为 [{'ip': 'xxx', 'port': xxx, 'instance_id': xxx, 'bk_host_id': xxx, 'bk_cloud_id': xxx}]"
+        ),
+    )
+
+    def validate_instance_list(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError(_("instance_list必须是一个列表"))
+
+        for i, instance in enumerate(value):
+            if not isinstance(instance, dict):
+                raise serializers.ValidationError(_("instance_list第{}项必须是字典").format(i))
+
+            required_fields = ["ip", "port", "bk_host_id", "bk_cloud_id"]
+            missing_fields = [f for f in required_fields if f not in instance]
+
+            if missing_fields:
+                raise serializers.ValidationError(
+                    _("instance_list第{}项缺少必需字段: {}").format(i, ", ".join(missing_fields))
+                )
+
+            # 验证 port 是整数
+            if not isinstance(instance.get("port"), int):
+                raise serializers.ValidationError(_("instance_list第{}项的port必须是整数").format(i))
+
+        return value
+
+
+# Kafka 集群启用单据相关 Serializer
+class SubmitBillKafkaEnableInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    def validate(self, attrs):
+        from backend.db_meta.enums import ClusterPhase
+        from backend.db_meta.models import Cluster
+
+        attrs = super().validate(attrs)
+
+        cluster = Cluster.objects.get(bk_biz_id=attrs["bk_biz_id"], immute_domain=attrs["cluster_domain"])
+
+        # 启用操作必须是禁用状态
+        if cluster.phase != ClusterPhase.OFFLINE.value:
+            raise serializers.ValidationError(
+                _("启用集群前，集群必须处于禁用状态。当前集群状态为：{}。" "状态转移规则：ONLINE(在线) → OFFLINE(禁用) → ONLINE(在线)").format(cluster.phase)
+            )
+
+        return attrs
+
+
+# Kafka 集群禁用单据相关 Serializer
+class SubmitBillKafkaDisableInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    def validate(self, attrs):
+        from backend.db_meta.enums import ClusterPhase
+        from backend.db_meta.models import Cluster
+
+        attrs = super().validate(attrs)
+
+        cluster = Cluster.objects.get(bk_biz_id=attrs["bk_biz_id"], immute_domain=attrs["cluster_domain"])
+
+        # 禁用操作必须是在线状态
+        if cluster.phase != ClusterPhase.ONLINE.value:
+            raise serializers.ValidationError(
+                _("禁用集群前，集群必须处于在线状态。当前集群状态为：{}。" "状态转移规则：ONLINE(在线) → OFFLINE(禁用)").format(cluster.phase)
+            )
+
+        return attrs
+
+
+# Kafka 集群删除单据相关 Serializer
+class SubmitBillKafkaDestroyInputSerializer(SubmitBillKafkaBaseInputSerializer):
+    def validate(self, attrs):
+        from backend.db_meta.enums import ClusterPhase
+        from backend.db_meta.models import Cluster
+
+        attrs = super().validate(attrs)
+
+        cluster = Cluster.objects.get(bk_biz_id=attrs["bk_biz_id"], immute_domain=attrs["cluster_domain"])
+
+        # 删除操作必须先禁用
+        if cluster.phase != ClusterPhase.OFFLINE.value:
+            raise serializers.ValidationError(
+                _("删除集群前，集群必须处于禁用状态。当前集群状态为：{}，请先执行禁用操作。" "状态转移规则：ONLINE(在线) → OFFLINE(禁用) → DESTROY(删除)").format(
+                    cluster.phase
+                )
+            )
+
+        return attrs
+
+
+# Kafka 集群部署单据相关 Serializer
+class SubmitBillKafkaApplyInputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+    cluster_name = serializers.CharField(help_text=_("集群名称"))
+    ip_source = serializers.ChoiceField(
+        choices=IpSource.get_choices(),
+        help_text=_("主机来源: resource_pool(资源池) 或 manual_input(手工输入)，默认资源池"),
+        required=False,
+        default=IpSource.RESOURCE_POOL.value,
+    )
+    nodes = serializers.JSONField(
+        help_text=(
+            _(
+                "节点列表信息，格式为 {'zookeeper': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}], "
+                "'broker': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}]}。"
+                "zookeeper必须正好3个节点，broker至少1个节点"
+            )
+        ),
+        required=False,
+    )
+    resource_spec = serializers.JSONField(
+        help_text=(
+            _(
+                "资源池规格，格式为 {'zookeeper': {'count': 3, 'spec_id': xxx}, "
+                "'broker': {'count': 3, 'spec_id': xxx}}，当ip_source为resource_pool时必填。"
+                "zookeeper固定为3个节点"
+            )
+        ),
+        required=False,
+    )
+    db_app_abbr = serializers.CharField(help_text=_("业务缩写，用于生成域名前缀"))
+    timezone = serializers.CharField(help_text=_("时区，默认 Asia/Shanghai"), required=False, default="Asia/Shanghai")
+    city_code = serializers.CharField(help_text=_("城市代码"))
+    region = serializers.CharField(help_text=_("区域，默认 default"), required=False, default="default")
+    disaster_tolerance_level = serializers.CharField(
+        help_text=_("容灾级别，默认 MAX_EACH_ZONE_EQUAL(各机房均衡)"), required=False, default="MAX_EACH_ZONE_EQUAL"
+    )
+    replication_num = serializers.IntegerField(
+        help_text=_("副本数，默认2。必须小于等于broker节点数量。" "建议值: 2 (双副本，在可靠性和性能间取得平衡)"),
+        required=False,
+        default=2,
+    )
+    version = serializers.CharField(help_text=_("Kafka版本，默认 2.4.0"), required=False, default="2.4.0")
+
+    def validate_replication_num(self, value):
+        if value < 1 or value > 10:
+            raise serializers.ValidationError(_("replication_num必须在1-10之间"))
+        return value
+
+    def validate_nodes(self, value):
+        """验证节点结构"""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError(_("nodes必须是一个字典，格式为 {'zookeeper': [...], 'broker': [...]}"))
+
+        required_roles = ["zookeeper", "broker"]
+        for role in required_roles:
+            if role not in value:
+                raise serializers.ValidationError(_("nodes必须包含{}节点列表").format(role))
+
+        for role, node_list in value.items():
+            if not isinstance(node_list, list):
+                raise serializers.ValidationError(_("nodes[{}]必须是列表").format(role))
+
+            for i, node in enumerate(node_list):
+                if not isinstance(node, dict):
+                    raise serializers.ValidationError(_("nodes[{}][{}]必须是字典").format(role, i))
+
+                required_fields = ["bk_host_id", "bk_cloud_id"]
+                missing_fields = [f for f in required_fields if f not in node]
+                if missing_fields:
+                    raise serializers.ValidationError(
+                        _(
+                            "{}中的节点{}索引{}缺少必需字段: {}，请使用cluster_overview接口获取完整节点信息。"
+                            "仅提供'ip'字段是不够的，必须包含bk_host_id和bk_cloud_id。"
+                        ).format(role, i, ", ".join(missing_fields))
+                    )
+
+        return value
+
+    def validate(self, attrs):
+        ip_source = attrs.get("ip_source")
+        if ip_source == IpSource.RESOURCE_POOL.value:
+            if not attrs.get("resource_spec"):
+                raise serializers.ValidationError(_("当主机来源为资源池时，resource_spec字段必填"))
+            # 验证zookeeper固定为3个节点
+            spec = attrs["resource_spec"]
+            if "zookeeper" not in spec or spec["zookeeper"].get("count") != 3:
+                raise serializers.ValidationError(_("资源池规格中zookeeper必须固定为3个节点"))
+        elif ip_source == IpSource.MANUAL_INPUT.value:
+            if not attrs.get("nodes"):
+                raise serializers.ValidationError(_("当主机来源为手工输入时，nodes字段必填"))
+            # 验证zookeeper必须正好3个节点
+            nodes = attrs["nodes"]
+            zk_count = len(nodes.get("zookeeper", []))
+            if zk_count != 3:
+                raise serializers.ValidationError(_("zookeeper节点必须正好3个节点，当前为{}个").format(zk_count))
+            # 验证broker至少1个节点
+            broker_count = len(nodes.get("broker", []))
+            if broker_count < 1:
+                raise serializers.ValidationError(_("broker节点至少需要1个节点"))
+
+        # 验证副本数不能超过broker节点数量
+        broker_count = 0
+        if ip_source == IpSource.RESOURCE_POOL.value:
+            broker_count = attrs["resource_spec"]["broker"]["count"]
+        else:
+            broker_count = len(attrs["nodes"].get("broker", []))
+
+        replication_num = attrs.get("replication_num", 2)
+        if replication_num > broker_count:
+            raise serializers.ValidationError(_("副本数({})不能超过broker节点数量({})").format(replication_num, broker_count))
+
+        return attrs

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/urls.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/urls.py
@@ -8,13 +8,16 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.urls import include, path
+from rest_framework.routers import DefaultRouter
 
-# common mcp tools
-urlpatterns = [
-    path("common/", include("backend.dbm_aiagent.mcp_tools.common.urls")),
-    path("mysql/", include("backend.dbm_aiagent.mcp_tools.mysql.urls")),
-    path("sqlserver/", include("backend.dbm_aiagent.mcp_tools.sqlserver.urls")),
-    path("redis/", include("backend.dbm_aiagent.mcp_tools.redis.urls")),
-    path("kafka/", include("backend.dbm_aiagent.mcp_tools.kafka.urls")),
-]
+from backend.dbm_aiagent.mcp_tools.kafka.views.kafka_bill_mcp import KafkaBillMcpToolsViewSet
+from backend.dbm_aiagent.mcp_tools.kafka.views.query_meta import KafkaQueryMetaMcpToolsViewSet
+
+routers = DefaultRouter(trailing_slash=True)
+
+# 与 元数据相关的 query
+routers.register(r"", KafkaQueryMetaMcpToolsViewSet, basename="mcp-kafka-query-meta")
+# 与 dbm 交互 创建单据类的 操作
+routers.register(r"", KafkaBillMcpToolsViewSet, basename="mcp-kafka-bill")
+
+urlpatterns = routers.urls

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/views/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/views/__init__.py
@@ -8,13 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.urls import include, path
-
-# common mcp tools
-urlpatterns = [
-    path("common/", include("backend.dbm_aiagent.mcp_tools.common.urls")),
-    path("mysql/", include("backend.dbm_aiagent.mcp_tools.mysql.urls")),
-    path("sqlserver/", include("backend.dbm_aiagent.mcp_tools.sqlserver.urls")),
-    path("redis/", include("backend.dbm_aiagent.mcp_tools.redis.urls")),
-    path("kafka/", include("backend.dbm_aiagent.mcp_tools.kafka.urls")),
-]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/views/kafka_bill_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/views/kafka_bill_mcp.py
@@ -1,0 +1,387 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import logging.config
+
+from django.utils.translation import gettext_lazy as _
+from rest_framework.response import Response
+
+from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
+from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
+from backend.dbm_aiagent.mcp_tools.kafka.impl.kafka_bill import (
+    submit_kafka_apply_bill,
+    submit_kafka_destroy_bill,
+    submit_kafka_disable_bill,
+    submit_kafka_enable_bill,
+    submit_kafka_rebalance_bill,
+    submit_kafka_reboot_bill,
+    submit_kafka_replace_bill,
+    submit_kafka_scale_up_bill,
+    submit_kafka_shrink_bill,
+)
+from backend.dbm_aiagent.mcp_tools.kafka.serializers.kafka_bill import (
+    SubmitBillKafkaApplyInputSerializer,
+    SubmitBillKafkaDestroyInputSerializer,
+    SubmitBillKafkaDisableInputSerializer,
+    SubmitBillKafkaEnableInputSerializer,
+    SubmitBillKafkaRebalanceInputSerializer,
+    SubmitBillKafkaRebootInputSerializer,
+    SubmitBillKafkaReplaceInputSerializer,
+    SubmitBillKafkaScaleUpInputSerializer,
+    SubmitBillKafkaShrinkInputSerializer,
+    SubmitBillOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
+from backend.iam_app.handlers.drf_perm.base import RejectPermission
+
+logger = logging.getLogger("flow")
+
+"""
+Kafka 单据相关的 mcp
+- broker扩容
+- broker缩容
+- broker替换
+- topic均衡
+"""
+
+
+class KafkaBillMcpToolsViewSet(McpToolsViewSet):
+    default_permission_class = [RejectPermission()]
+
+    @mcp_tools_api_decorator(
+        description=str(_("Kafka集群扩容单据(支持资源池和手工输入两种方式)")),
+        request_slz=SubmitBillKafkaScaleUpInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_scale_up(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+        ip_source = validated_params["ip_source"]
+        nodes = validated_params.get("nodes")
+        resource_spec = validated_params.get("resource_spec")
+
+        result = submit_kafka_scale_up_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            ip_source=ip_source,
+            nodes=nodes,
+            resource_spec=resource_spec,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka集群缩容单据。"
+                "注意事项："
+                "1. nodes参数需要包含待缩容节点的(ip, bk_host_id, bk_cloud_id)"
+                "2. 当用户只提供IP地址时，必须先调用cluster_overview接口获取完整的节点信息(bk_host_id, bk_cloud_id)"
+            )
+        ),
+        request_slz=SubmitBillKafkaShrinkInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_shrink(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+        nodes = validated_params["nodes"]
+
+        result = submit_kafka_shrink_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            nodes=nodes,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka集群替换单据。支持资源池和手工输入两种方式。"
+                "参数说明："
+                "1. bk_biz_id：必填，业务ID"
+                "2. cluster_domain：必填，集群域名"
+                "3. old_nodes：必填，待替换节点信息 {'broker': [{'ip': 'xxx', 'bk_host_id': xxx, 'bk_cloud_id': xxx}]}"
+                "4. ip_source：必填，主机来源(resource_pool资源池 或 manual_input手工_input)，默认resource_pool"
+                "5. new_nodes：手工输入时必填，新节点信息"
+                "6. resource_spec：资源池方式时可选，指定新节点规格 {'broker': {'spec_id': xxx}}"
+                ""
+                "重要规则："
+                "- 当用户指定规格名称（如'IT5_16核_64G_3.5TB'）时："
+                "  1. 必须先调用search_specs_by_name接口查询该规格名称对应的spec_id"
+                "  2. 然后传入resource_spec={'broker': {'spec_id': 查询到的spec_id}}，否则系统将使用原节点规格"
+                "- 当用户不指定规格时：使用原节点规格，无需提供resource_spec"
+                "- 当用户指定手动输入(ip_source=manual_input)时：必须提供new_nodes"
+                "- old_nodes必须包含bk_host_id和bk_cloud_id，仅IP不够时调用cluster_overview获取完整信息"
+            )
+        ),
+        request_slz=SubmitBillKafkaReplaceInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_replace(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+        old_nodes = validated_params["old_nodes"]
+        ip_source = validated_params["ip_source"]
+        new_nodes = validated_params.get("new_nodes")
+        resource_spec = validated_params.get("resource_spec")
+
+        result = submit_kafka_replace_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            old_nodes=old_nodes,
+            ip_source=ip_source,
+            new_nodes=new_nodes,
+            resource_spec=resource_spec,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka集群Topic均衡单据。"
+                "用途：对指定topic进行数据分区重均衡，平衡各个broker之间的数据负载。"
+                "参数说明："
+                "1. bk_biz_id：必填，业务ID"
+                "2. cluster_domain：必填，集群域名"
+                "3. topics：可选，需要均衡的topic列表，不传则均衡所有topic"
+                "4. throttle_rate：可选，均衡速率(字节/秒)。系统默认为80MB/s。"
+                "5. target_ips：可选，目标broker IP列表。指定将数据均衡到这些IP所在的broker节点，不传则均衡到所有broker。"
+                ""
+                "重要规则："
+                "- 当用户需要将数据均衡到指定的broker时（如'均衡到IP为x.x.x.x的broker'），"
+                "  1. 必须先调用cluster_overview接口获取集群中所有broker节点的IP信息"
+                "  2. 然后传入target_ips=['x.x.x.x', ...]，只对指定IP的broker进行均衡"
+                "- 当用户没有指定目标broker时，省略target_ips参数，系统会均衡到所有broker"
+                ""
+                "重要：当用户当前请求中没有提及速率相关词汇（如'速率xx MB/s'、'每秒xx字节'、'throttle_rate'等）时，"
+                "必须省略throttle_rate参数，不要从历史对话或上下文中获取任何速率值。"
+                "只有用户在当前请求中明确指定了速率时，才需要传递此参数"
+            )
+        ),
+        request_slz=SubmitBillKafkaRebalanceInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_rebalance(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+        topics = validated_params["topics"]
+        throttle_rate = validated_params["throttle_rate"]
+        target_ips = validated_params.get("target_ips")
+
+        result = submit_kafka_rebalance_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            topics=topics,
+            throttle_rate=throttle_rate,
+            target_ips=target_ips,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka实例重启单据。"
+                "用途：重启指定的Kafka broker实例。"
+                "参数说明："
+                "1. bk_biz_id：必填，业务ID"
+                "2. cluster_domain：必填，集群域名"
+                "3. instance_list：必填，需要重启的实例列表。每个实例需要包含ip、port、bk_host_id、bk_cloud_id。"
+                ""
+                "注意事项："
+                "当用户只提供IP地址时，必须先调用cluster_overview接口获取完整的实例信息(bk_host_id, bk_cloud_id, port)"
+            )
+        ),
+        request_slz=SubmitBillKafkaRebootInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_reboot(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+        instance_list = validated_params["instance_list"]
+
+        result = submit_kafka_reboot_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            instance_list=instance_list,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka集群启用单据。"
+                "用途：将禁用的Kafka集群重新上线。"
+                "参数说明："
+                "1. bk_biz_id：必填，业务ID"
+                "2. cluster_domain：必填，集群域名"
+                ""
+                "前置条件：集群必须处于禁用状态才能启用。如果集群是在线状态，无需操作。"
+            )
+        ),
+        request_slz=SubmitBillKafkaEnableInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_enable(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+
+        result = submit_kafka_enable_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _("Kafka集群禁用单据。" "用途：将Kafka集群下线禁用，数据保留，可恢复。" "参数说明：" "1. bk_biz_id：必填，业务ID" "2. cluster_domain：必填，集群域名")
+        ),
+        request_slz=SubmitBillKafkaDisableInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_disable(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+
+        result = submit_kafka_disable_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka集群删除单据。"
+                "用途：永久删除Kafka集群及其数据，不可恢复。"
+                "参数说明："
+                "1. bk_biz_id：必填，业务ID"
+                "2. cluster_domain：必填，集群域名"
+                ""
+                "前置条件：集群必须处于禁用状态才能删除。如果集群是在线状态，请先调用禁用接口。"
+                " important: 此操作将永久删除集群数据，不可恢复，请谨慎操作！"
+            )
+        ),
+        request_slz=SubmitBillKafkaDestroyInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_destroy(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_domain = validated_params["cluster_domain"]
+
+        result = submit_kafka_destroy_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            creator=request.user.username,
+        )
+        return Response(result)
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                "Kafka集群部署单据。支持资源池和手工输入两种方式。"
+                "用途：部署一个新的Kafka集群，包含zookeeper和broker组件。"
+                "参数说明："
+                "1. bk_biz_id：必填，业务ID"
+                "2. cluster_name：必填，集群名称"
+                "3. ip_source：主机来源(资源池resource_pool或手工输入manual_input)，默认资源池"
+                "4. nodes：手工输入时必填，格式{'zookeeper': [...], 'broker': [...]}。zookeeper必须正好3个节点"
+                "5. resource_spec：资源池时必填，格式{'zookeeper': {'count': 3, 'spec_id': xxx}, 'broker': {...}}"
+                "6. db_app_abbr：必填，业务缩写，用于生成域名(kafka.{cluster_name}.{db_app_abbr}.db)"
+                "7. city_code：必填，城市名称。用户说'随机'或不指定城市时，使用'default'；其他情况使用实际城市名称"
+                "8. timezone：可选，时区，默认Asia/Shanghai"
+                "9. region：可选，区域，默认default"
+                "10. disaster_tolerance_level：可选，容灾级别，默认MAX_EACH_ZONE_EQUAL(各机房均衡)"
+                "11. replication_num：可选，副本数，默认2，必须小于等于broker节点数量"
+                "12. version：可选，Kafka版本，默认2.4.0"
+                ""
+                "注意事项："
+                "1. zookeeper节点固定为3个，不可更改"
+                "2. broker节点至少需要1个"
+                "3. 副本数不能超过broker节点数量"
+                "4. 系统自动生成用户名和密码，返回在结果中"
+                "5. 当用户只提供IP地址时，必须先调用cluster_overview接口获取完整的节点信息(bk_host_id, bk_cloud_id)"
+            )
+        ),
+        request_slz=SubmitBillKafkaApplyInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.KAFKA_BILL],
+        name_prefix="kafka_bill",
+    )
+    def submit_bill_apply(self, request, *args, **kwargs):
+        validated_params = self.params_validate(self.get_serializer_class())
+        bk_biz_id = validated_params["bk_biz_id"]
+        cluster_name = validated_params["cluster_name"]
+        ip_source = validated_params.get("ip_source", "resource_pool")
+        nodes = validated_params.get("nodes")
+        resource_spec = validated_params.get("resource_spec")
+        db_app_abbr = validated_params["db_app_abbr"]
+        timezone = validated_params.get("timezone", "Asia/Shanghai")
+        city_code = validated_params["city_code"]
+        region = validated_params.get("region", "default")
+        disaster_tolerance_level = validated_params.get("disaster_tolerance_level", "MAX_EACH_ZONE_EQUAL")
+        replication_num = validated_params.get("replication_num", 2)
+        version = validated_params.get("version", "2.4.0")
+
+        result = submit_kafka_apply_bill(
+            bk_biz_id=bk_biz_id,
+            cluster_name=cluster_name,
+            ip_source=ip_source,
+            nodes=nodes,
+            resource_spec=resource_spec,
+            db_app_abbr=db_app_abbr,
+            timezone=timezone,
+            city_code=city_code,
+            region=region,
+            disaster_tolerance_level=disaster_tolerance_level,
+            replication_num=replication_num,
+            version=version,
+            creator=request.user.username,
+        )
+        return Response(result)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/views/query_meta.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/views/query_meta.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import logging.config
+
+from django.utils.translation import gettext_lazy as _
+from rest_framework.response import Response
+
+from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
+from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
+from backend.dbm_aiagent.mcp_tools.kafka.impl.cluster_meta import (
+    cluster_overview,
+    kafka_list_clusters,
+    list_biz_by_name,
+    list_my_kafka_bizs,
+    search_specs_by_name,
+)
+from backend.dbm_aiagent.mcp_tools.kafka.serializers.cluster_meta import (
+    KafkaBizDetailSerializer,
+    KafkaBizInputSerializer,
+    KafkaBizNameInputSerializer,
+    KafkaClusterInputSerializer,
+    KafkaClusterOutputSerializer,
+    KafkaTopoOutputSerializer,
+    SpecOutputSerializer,
+    SpecSearchInputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
+from backend.iam_app.handlers.drf_perm.base import RejectPermission
+
+logger = logging.getLogger("flow")
+
+"""
+Kafka meta 相关的 query
+"""
+
+
+class KafkaQueryMetaMcpToolsViewSet(McpToolsViewSet):
+    default_permission_class = [RejectPermission()]
+
+    @mcp_tools_api_decorator(
+        description=str(_("查询我负责的Kafka业务列表")),
+        request_slz=KafkaBizInputSerializer,
+        response_slz=KafkaBizDetailSerializer(many=True),
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.KAFKA_QUERY_META],
+        name_prefix="kafka_query_meta",
+    )
+    def list_my_bizs(self, request, *args, **kwargs):
+        return Response(list_my_kafka_bizs(userID=request.user.username))
+
+    @mcp_tools_api_decorator(
+        description=str(_("根据业务英文名查询业务详情")),
+        request_slz=KafkaBizNameInputSerializer,
+        response_slz=KafkaBizDetailSerializer(many=True),
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.KAFKA_QUERY_META],
+        name_prefix="kafka_query_meta",
+    )
+    def list_bizs_by_name(self, request, *args, **kwargs):
+        biz_name = self.get_param("biz_name")
+        return Response(list_biz_by_name(biz_name=biz_name))
+
+    @mcp_tools_api_decorator(
+        description=str(_("查询业务下的Kafka集群列表")),
+        request_slz=KafkaBizInputSerializer,
+        response_slz=KafkaClusterOutputSerializer(many=True),
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.KAFKA_QUERY_META],
+        name_prefix="kafka_query_meta",
+    )
+    def list_kafka_clusters(self, request, *args, **kwargs):
+        bk_biz_id = self.get_param("bk_biz_id")
+        return Response(kafka_list_clusters(bk_biz_id=bk_biz_id))
+
+    @mcp_tools_api_decorator(
+        description=str(_("查询 Kafka 集群信息")),
+        request_slz=KafkaClusterInputSerializer,
+        response_slz=KafkaTopoOutputSerializer,
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.KAFKA_QUERY_META],
+        name_prefix="kafka_query_meta",
+    )
+    def cluster_overview(self, request, *args, **kwargs):
+        immute_domain = self.get_param("immute_domain")
+        return Response(cluster_overview(immute_domain=immute_domain))
+
+    @mcp_tools_api_decorator(
+        description=str(_("根据规格名称模糊查询规格信息，支持如 '16核32G' 等规格名称搜索")),
+        request_slz=SpecSearchInputSerializer,
+        response_slz=SpecOutputSerializer(many=True),
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.KAFKA_QUERY_META],
+        name_prefix="kafka_query_meta",
+    )
+    def search_specs_by_name(self, request, *args, **kwargs):
+        spec_name = self.get_param("spec_name")
+        spec_cluster_type = self.get_param("spec_cluster_type", "kafka")
+        return Response(search_specs_by_name(spec_name=spec_name, spec_cluster_type=spec_cluster_type))

--- a/dbm-ui/config/default.py
+++ b/dbm-ui/config/default.py
@@ -914,6 +914,32 @@ BK_APIGW_STAGE_MCP_SERVERS = [
         # 自动发现并填充该 MCP 服务器对应的工具
         "tools": [],
     },
+    {
+        "name": "kafka-query-meta",
+        "description": """Kafka cluster meta information query services""",
+        # 主动授权 app_code
+        "target_app_codes": [APP_CODE],
+        "labels": ["kafka-query-meta"],
+        # 是否启用：1-启用，0-停止
+        "status": 1,
+        # 是否公开
+        "is_public": False,
+        # 自动发现并填充该 MCP 服务器对应的工具
+        "tools": [],
+    },
+    {
+        "name": "kafka-bill",
+        "description": """Kafka bill creation services""",
+        # 主动授权 app_code
+        "target_app_codes": [APP_CODE],
+        "labels": ["kafka-bill"],
+        # 是否启用：1-启用，0-停止
+        "status": 1,
+        # 是否公开
+        "is_public": False,
+        # 自动发现并填充该 MCP 服务器对应的工具
+        "tools": [],
+    },
 ]
 
 # 智能体配置


### PR DESCRIPTION
● Kafka MCP 工具总结

  一、查询类接口 (KAFKA_QUERY_META)

  1. list_my_bizs - 查询用户负责的Kafka业务列表
  2. list_biz_by_name - 根据业务英文名查询业务详情
  3. list_clusters - 查询业务下的Kafka集群列表
  4. cluster_overview - 查询Kafka集群详细信息（返回统计信息、节点列表、规格详情等）
  5. search_specs_by_name - 根据规格名称模糊查询规格信息

  二、单据类接口 (KAFKA_BILL)
  ┌───────────────────────┬────────────┬───────────────────────────────────────────────┐
  │         接口          │    功能    │                     说明                      │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_apply     │ 部署新集群 │ 支持资源池和手工输入，包含 zookeeper + broker │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_scale_up  │ broker扩容 │ 支持资源池和手工输入                          │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_shrink    │ broker缩容 │ 需要完整的节点信息(bk_host_id, bk_cloud_id)   │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_replace   │ broker替换 │ 支持资源池和手工输入，可指定新节点规格        │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_rebalance │ topic均衡  │ 可指定速率、目标IP等参数                      │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_reboot    │ 实例重启   │ 重启指定的broker实例                          │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_enable    │ 集群启用   │ 将禁用的集群重新上线                          │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_disable   │ 集群禁用   │ 下线集群，数据保留可恢复                      │
  ├───────────────────────┼────────────┼───────────────────────────────────────────────┤
  │ submit_bill_destroy   │ 集群删除   │ 永久删除集群和数据                            │
  └───────────────────────┴────────────┴───────────────────────────────────────────────┘
  三、注意事项

  1. 节点信息完整性：缩容/替换/重启等操作需要完整的节点信息，仅IP不够时需先调用 cluster_overview 获取 bk_host_id 和 bk_cloud_id
  2. 城市字段：city_code 为必填字段，用户说"随机"或不指定时使用 "default"
  3. 规格名称：指定规格名称时需先调用 search_specs_by_name 获取 spec_id
  4. 速率参数：只有用户当前请求中明确指定速率时才传递 throttle_rate

  四、文件结构

  dbm-ui/backend/dbm_aiagent/mcp_tools/kafka/
  ├── __init__.py
  ├── urls.py
  ├── impl/
  │   ├── cluster_meta.py    # 查询类实现
  │   └── kafka_bill.py      # 单据类实现
  ├── serializers/
  │   ├── cluster_meta.py    # 查询类序列化器
  │   └── kafka_bill.py      # 单据类序列化器
  └── views/
      ├── query_meta.py      # 查询类视图
      └── kafka_bill_mcp.py  # 单据类视图