### PR TITLE
feat(mysql): split-mysql-ticket-mcp-to-generator-and-commiter #16210

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/agent_prompts/ai-db-workbench.md
+++ b/dbm-ui/backend/dbm_aiagent/agent_prompts/ai-db-workbench.md
@@ -20,3 +20,7 @@
 * 使用 list_bizs_base_info 做 bk_biz_id 和 app_abbr 的转换
 * 集群同步状态查询先获取集群拓扑结构, 再获取 slave 和 repeater 实例的同步状态汇总
 * 连接数评估应先获取 processlist 摘要, 再对比运行时变量 max_connections
+* 单据参数生成后, 必须先返回给用户获得确认
+* generate 工具生成的单据参数, 不允许任何形式的修改
+* ticket_url 渲染成一个<a href=ticket_url>ticket_url</a> 形式的超链接
+

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/ticket_list.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/ticket_list.py
@@ -72,6 +72,7 @@ def ticket_list(
                 want_tickets.append(
                     {
                         "ticket_id": t.pk,
+                        "ticket_url": t.url,
                         "ticket_type": TicketType.get_choice_label(t.ticket_type),
                         "creator": creator,
                         "helpers": helpers[:2],
@@ -88,6 +89,7 @@ def ticket_list(
             want_tickets.append(
                 {
                     "ticket_id": t.pk,
+                    "ticket_url": t.url,
                     "ticket_type": TicketType.get_choice_label(t.ticket_type),
                     "creator": creator,
                     "helpers": helpers[:2],

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_commit.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_commit.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class SingleTicketCommitInputSerializer(serializers.Serializer):
+    #     # bk_biz_id = serializers.IntegerField(help_text=_("业务ID"))
+    #     # ticket_type = serializers.ChoiceField(choices=TicketType.get_choices(), help_text=_("工单类型"))
+    ticket_param = serializers.JSONField(help_text=_("单据参数"))
+
+
+class TicketCommitInputSerializer(serializers.Serializer):
+    # bk_biz_id = serializers.IntegerField(help_text=_("业务ID"))
+    ticket_params = serializers.ListSerializer(child=SingleTicketCommitInputSerializer(), help_text=_("单据参数"))
+
+
+class SingleTicketInfoSerializer(serializers.Serializer):
+    ticket_id = serializers.IntegerField(help_text=_("单据 ID"))
+    ticket_url = serializers.URLField(help_text=_("单据链接"))
+
+
+class TicketCommitOutputSerializer(serializers.Serializer):
+    tickets = serializers.ListSerializer(child=SingleTicketInfoSerializer(), help_text=_("单据列表"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_list.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/ticket_list.py
@@ -30,6 +30,7 @@ class TicketListInputSerializer(serializers.Serializer):
 
 class TicketInfoSerializer(serializers.Serializer):
     ticket_id = serializers.IntegerField(help_text=_("单据 ID"))
+    ticket_url = serializers.URLField(help_text=_("单据链接"))
     ticket_type = serializers.ChoiceField(choices=TicketType.get_labels(), help_text=_("单据类型"))
     creator = serializers.CharField(help_text=_("提单人"))
     helpers = serializers.ListField(child=serializers.CharField(), help_text=_("前 2 个协助人"))
@@ -44,3 +45,4 @@ class TicketInfoSerializer(serializers.Serializer):
 
 class TicketListOutputSerializer(serializers.Serializer):
     ticket_infos = serializers.ListField(child=TicketInfoSerializer(), help_text=_("单据信息"))
+    username = serializers.CharField(help_text=_("用户名"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/ticket_operation.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/ticket_operation.py
@@ -15,6 +15,10 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 
 from backend.dbm_aiagent.mcp_tools.common.impl.ticket_list import ticket_list
+from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_commit import (
+    TicketCommitInputSerializer,
+    TicketCommitOutputSerializer,
+)
 from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_list import (
     TicketListInputSerializer,
     TicketListOutputSerializer,
@@ -25,7 +29,7 @@ from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_manipulate import (
 )
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
 from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
-from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpBadTicketStatusException
+from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpBadTicketStatusException, DBMMcpUsernameNotFoundException
 from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.ticket.constants import TicketStatus
@@ -40,7 +44,14 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
     default_permission_class = [DBManagePermission()]
 
     @mcp_tools_api_decorator(
-        description=str(_("""查询单据列表, 每个单据一行返回结果, 单据参数是个 json, 搞的好看点""")),
+        description=str(
+            _(
+                """查询单据
+        * 在显眼的地方明确告知只能查询和 username 相关的单据
+        * 返回的单据超过 1 个时, 隐藏单据参数并展示成表格
+        * 返回的单据为 1 个时, 展示单据参数"""
+            )
+        ),
         request_slz=TicketListInputSerializer,
         response_slz=TicketListOutputSerializer,
         tags=[DBMMCPTags.READ],
@@ -58,7 +69,7 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
         username = request.user.username
 
         res = ticket_list(username, bk_biz_id, ticket_ids, cluster_domains, statuses, time_duration)
-        return Response({"ticket_infos": res})
+        return Response({"ticket_infos": res, "username": username})
 
     @mcp_tools_api_decorator(
         description=str(_("执行单据")),
@@ -110,3 +121,30 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
         time.sleep(5)  # 这里 sleep 是为了能返回一个正常点的状态
 
         return Response({"status": Ticket.objects.get(bk_biz_id=bk_biz_id, pk=ticket_id).status})
+
+    @mcp_tools_api_decorator(
+        description=str(_("提交单据")),
+        request_slz=TicketCommitInputSerializer,
+        response_slz=TicketCommitOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.TICKET_OP],
+        name_prefix="ticket_op",
+    )
+    def ticket_commit(self, request, *args, **kwargs):
+        ticket_params = self.get_param("ticket_params")
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        res = []
+        for ticket_param in ticket_params:
+            tk = Ticket.create_ticket(**ticket_param["ticket_param"])
+            res.append(
+                {
+                    "ticket_id": tk.id,
+                    "ticket_url": tk.url,
+                }
+            )
+
+        return Response({"tickets": res})

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/constants.py
@@ -18,7 +18,7 @@ class DBMMcpTools(StrStructuredEnum):
     DBMETA_QUERY = EnumField("dbmeta-query", "dbmeta-query")
     DBMETA_UPDATE = EnumField("dbmeta-update", "dbmeta-update")
     MYSQL_QUERY = EnumField("mysql-query", "mysql-query")
-    MYSQL_BILL = EnumField("mysql-bill", "mysql-bill")
+    MYSQL_TICKET = EnumField("mysql-ticket", "mysql-ticket")
     MYSQL_SLOWLOG = EnumField("mysql-slowlog", "mysql-slowlog")
     MYSQL_METRICS = EnumField("mysql-metrics", "mysql-metrics")
     SQLSERVER_QUERY = EnumField("sqlserver-query", "sqlserver-query")

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/exceptions.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/exceptions.py
@@ -76,3 +76,9 @@ class DBMMcpBadTicketStatusException(DBMMcpBaseException):
     ERROR_CODE = "010"
     MESSAGE = _("单据类型不支持当前操作")
     MESSAGE_TPL = _("{msg}")
+
+
+class DBMMcpMultiBkBizIdFoundException(DBMMcpBaseException):
+    ERROR_CODE = "011"
+    MESSAGE = _("多个业务ID")
+    MESSAGE_TPL = _("{msg}")

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_apply_priv.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_apply_priv.py
@@ -16,7 +16,6 @@ from backend.components import DBPrivManagerApi
 from backend.db_meta.enums import ClusterType
 from backend.db_meta.models import Cluster
 from backend.db_services.dbpermission.db_account.handlers import AccountHandler
-from backend.dbm_aiagent.mcp_tools.decorators import bill_response_wrapper
 from backend.dbm_aiagent.mcp_tools.exceptions import (
     DBMMcpMySQLApplyPrivAccountNotFoundException,
     DBMMcpMySQLApplyPrivDBRuleNotFoundException,
@@ -24,20 +23,18 @@ from backend.dbm_aiagent.mcp_tools.exceptions import (
 )
 from backend.ticket.builders.mysql.mysql_authorize_rules import MySQLAuthorizeRulesSerializer
 from backend.ticket.constants import TicketType
-from backend.ticket.models import Ticket
 
 
-@bill_response_wrapper
-def bill_apply_priv(
+# @bill_response_wrapper
+def ticket_param_apply_priv(
     request,
     username: str,
     apply_access_dbs: List[str],
     apply_username: str,
     apply_source_ips: List[str],
-    cluster_domain: str,
-    bk_biz_id: int,
-) -> Ticket:
-    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    cluster_obj: Cluster,
+):
+    # cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
     cluster_type = cluster_obj.cluster_type
 
     if cluster_type == ClusterType.TenDBCluster:
@@ -51,18 +48,18 @@ def bill_apply_priv(
         "access_dbs": apply_access_dbs,
         "user": apply_username,
         "source_ips": apply_source_ips,
-        "target_instances": [cluster_domain],
+        "target_instances": [cluster_obj.immute_domain],
         "cluster_type": cluster_type,
     }
 
     account_type = ClusterType.cluster_type_to_db_type(cluster_type)
 
-    priv_res = DBPrivManagerApi.get_account(params={"cluster_type": account_type, "bk_biz_id": bk_biz_id})
+    priv_res = DBPrivManagerApi.get_account(params={"cluster_type": account_type, "bk_biz_id": cluster_obj.bk_biz_id})
     user_info_map = {user["user"]: user for user in priv_res["results"]}
     if apply_username not in user_info_map:
         raise DBMMcpMySQLApplyPrivAccountNotFoundException(msg=_("需要在 DBM 授权管理中创建 {} 账号".format(apply_username)))
 
-    user_db_map = AccountHandler.aggregate_user_db_rules(bk_biz_id, account_type)
+    user_db_map = AccountHandler.aggregate_user_db_rules(cluster_obj.bk_biz_id, account_type)
 
     not_found_dbs = [a_db for a_db in apply_access_dbs if a_db not in user_db_map[apply_username]]
 
@@ -72,7 +69,7 @@ def bill_apply_priv(
         )
 
     slz = MySQLAuthorizeRulesSerializer(
-        data={"authorize_plugin_infos": [{**auth_data, "bk_biz_id": bk_biz_id}], "need_itsm": True}
+        data={"authorize_plugin_infos": [{**auth_data, "bk_biz_id": cluster_obj.bk_biz_id}], "need_itsm": True}
     )
     slz.context["request"] = request
     slz.is_valid(raise_exception=True)
@@ -82,8 +79,8 @@ def bill_apply_priv(
         "remark": ticket_type,
         "creator": username,
         "helpers": [],
-        "bk_biz_id": bk_biz_id,
+        "bk_biz_id": cluster_obj.bk_biz_id,
         "details": slz.validated_data,
     }
 
-    return Ticket.create_ticket(**ticket_param)
+    return {"ticket_params": [{"ticket_param": ticket_param}]}  # Ticket.create_ticket(**ticket_param)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_db_table_backup.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_db_table_backup.py
@@ -12,19 +12,14 @@ from typing import List
 
 from backend.db_meta.enums import ClusterType
 from backend.db_meta.models import Cluster
-from backend.dbm_aiagent.mcp_tools.decorators import bill_response_wrapper
 from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpNotSupportClusterTypeException
 from backend.ticket.builders.mysql.mysql_db_table_backup import MySQLDBTableBackupDetailSerializer
 from backend.ticket.builders.tendbcluster.db_table_backup import TenDBClusterDBTableBackUpDetailSerializer
 from backend.ticket.constants import TicketType
-from backend.ticket.models import Ticket
 
 
-@bill_response_wrapper
-def bill_db_table_backup(
-    username: str, bk_biz_id: int, cluster_domain: str, include_dbs: List[str], ignore_dbs: List[str]
-) -> Ticket:
-    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+# @bill_response_wrapper
+def ticket_param_db_table_backup(username: str, cluster_obj: Cluster, include_dbs: List[str], ignore_dbs: List[str]):
     cluster_type = cluster_obj.cluster_type
 
     if cluster_type == ClusterType.TenDBCluster:
@@ -39,7 +34,7 @@ def bill_db_table_backup(
         "remark": ticket_type,
         "creator": username,
         "helpers": [],
-        "bk_biz_id": bk_biz_id,
+        "bk_biz_id": cluster_obj.bk_biz_id,
         "details": {
             "infos": [
                 {
@@ -59,8 +54,8 @@ def bill_db_table_backup(
         slz = TenDBClusterDBTableBackUpDetailSerializer(data=ticket_param["details"])
 
     slz.context["ticket_type"] = ticket_type
-    slz.context["bk_biz_id"] = bk_biz_id
+    slz.context["bk_biz_id"] = cluster_obj.bk_biz_id
 
     slz.is_valid(raise_exception=True)
 
-    return Ticket.create_ticket(**ticket_param)
+    return {"ticket_params": [{"ticket_param": ticket_param}]}  # Ticket.create_ticket(**ticket_param)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_fullbackup.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_fullbackup.py
@@ -10,18 +10,16 @@ specific language governing permissions and limitations under the License.
 """
 from backend.db_meta.enums import ClusterType, InstanceInnerRole
 from backend.db_meta.models import Cluster
-from backend.dbm_aiagent.mcp_tools.decorators import bill_response_wrapper
 from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpNotSupportClusterTypeException
 from backend.flow.consts import MySQLBackupFileTagEnum
 from backend.ticket.builders.mysql.mysql_full_backup import MySQLFullBackupDetailSerializer
 from backend.ticket.builders.tendbcluster.full_backup import TenDBClusterFullBackUpDetailSerializer
 from backend.ticket.constants import TicketType
-from backend.ticket.models import Ticket
 
 
-@bill_response_wrapper
-def mysql_full_backup(bk_biz_id: int, username: str, backup_type: str, cluster_domain: str) -> Ticket:
-    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+# @bill_response_wrapper
+def ticket_param_mysql_full_backup(username: str, backup_type: str, cluster_obj: Cluster):
+    # cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
     cluster_type = cluster_obj.cluster_type
 
     if cluster_type == ClusterType.TenDBCluster:
@@ -36,7 +34,7 @@ def mysql_full_backup(bk_biz_id: int, username: str, backup_type: str, cluster_d
         "remark": ticket_type,
         "creator": username,
         "helpers": [],
-        "bk_biz_id": bk_biz_id,
+        "bk_biz_id": cluster_obj.bk_biz_id,
         "details": {
             "backup_type": backup_type,  # MySQLBackupTypeEnum.PHYSICAL,
             "file_tag": MySQLBackupFileTagEnum.DBFILE1M,
@@ -54,9 +52,9 @@ def mysql_full_backup(bk_biz_id: int, username: str, backup_type: str, cluster_d
     else:
         slz = TenDBClusterFullBackUpDetailSerializer(data=ticket_param["details"])
 
-    slz.context["bk_biz_id"] = bk_biz_id
+    slz.context["bk_biz_id"] = cluster_obj.bk_biz_id
     slz.context["ticket_type"] = ticket_type
 
     slz.is_valid(raise_exception=True)
 
-    return Ticket.create_ticket(**ticket_param)
+    return {"ticket_params": [{"ticket_param": ticket_param}]}  # Ticket.create_ticket(**ticket_param)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_mysql_standardize.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_mysql_standardize.py
@@ -9,37 +9,37 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import copy
-from typing import List
+from typing import TYPE_CHECKING
+
+from django.db.models import QuerySet
 
 from backend.db_meta.enums import ClusterType
-from backend.db_meta.models import Cluster
-from backend.dbm_aiagent.mcp_tools.decorators import bill_response_wrapper
-from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpClusterNotFoundException
 from backend.ticket.constants import TicketType
-from backend.ticket.models import Ticket
+
+if TYPE_CHECKING:
+    from backend.db_meta.models import Cluster
 
 
-@bill_response_wrapper
-def bill_mysql_standardize(
+# @bill_response_wrapper
+def ticket_param_mysql_standardize(
     username: str,
     bk_biz_id: int,
-    cluster_domains: List[str],
+    cluster_objs: "QuerySet[Cluster]",
+    # cluster_domains: List[str],
     with_instance_standardize: bool,
     with_cc_standardize: bool,
     with_deploy_binary: bool,
     with_push_config: bool,
-) -> List[Ticket]:
-    mysql_clusters = Cluster.objects.filter(
+):
+    mysql_clusters = cluster_objs.filter(
         bk_biz_id=bk_biz_id,
         cluster_type__in=[ClusterType.TenDBSingle, ClusterType.TenDBHA],
-        immute_domain__in=cluster_domains,
+        # immute_domain__in=cluster_domains,
     )
-    tendbcluster_clusters = Cluster.objects.filter(
-        bk_biz_id=bk_biz_id, cluster_type=ClusterType.TenDBCluster, immute_domain__in=cluster_domains
-    )
+    tendbcluster_clusters = cluster_objs.filter(bk_biz_id=bk_biz_id, cluster_type=ClusterType.TenDBCluster)
 
-    if not mysql_clusters.exists() and not tendbcluster_clusters.exists():
-        raise DBMMcpClusterNotFoundException(msg=f"{cluster_domains}")
+    # if not mysql_clusters.exists() and not tendbcluster_clusters.exists():
+    #     raise DBMMcpClusterNotFoundException(msg=f"{cluster_domains}")
 
     ticket_param_common = {
         "creator": username,
@@ -62,15 +62,15 @@ def bill_mysql_standardize(
         ticket_param["ticket_type"] = TicketType.MYSQL_CLUSTER_STANDARDIZE
         ticket_param["remark"] = TicketType.MYSQL_CLUSTER_STANDARDIZE
         ticket_param["details"]["cluster_ids"] = list(mysql_clusters.values_list("pk", flat=True).distinct())
-        tk = Ticket.create_ticket(**ticket_param)
-        res.append(tk)
+        # tk = Ticket.create_ticket(**ticket_param)
+        res.append({"ticket_param": ticket_param})
 
     if tendbcluster_clusters.exists():
         ticket_param = copy.deepcopy(ticket_param_common)
         ticket_param["ticket_type"] = TicketType.TENDBCLUSTER_CLUSTER_STANDARDIZE
         ticket_param["remark"] = TicketType.TENDBCLUSTER_CLUSTER_STANDARDIZE
         ticket_param["details"]["cluster_ids"] = list(tendbcluster_clusters.values_list("pk", flat=True).distinct())
-        tk = Ticket.create_ticket(**ticket_param)
-        res.append(tk)
+        # tk = Ticket.create_ticket(**ticket_param)
+        res.append({"ticket_param": ticket_param})
 
-    return res
+    return {"ticket_params": res}

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_rename_db.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_rename_db.py
@@ -10,19 +10,15 @@ specific language governing permissions and limitations under the License.
 """
 from backend.db_meta.enums import ClusterType
 from backend.db_meta.models import Cluster
-from backend.dbm_aiagent.mcp_tools.decorators import bill_response_wrapper
 from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpNotSupportClusterTypeException
 from backend.ticket.builders.mysql.mysql_rename_database import MySQLRenameDatabaseSerializer
 from backend.ticket.builders.tendbcluster.tendb_rename import TendbRenameSerializer
 from backend.ticket.constants import TicketType
-from backend.ticket.models import Ticket
 
 
-@bill_response_wrapper
-def bill_rename_db(
-    bk_biz_id: int, username: str, cluster_domain: str, source_dbname: str, target_dbname: str
-) -> Ticket:
-    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+# @bill_response_wrapper
+def ticket_param_rename_db(cluster_obj: Cluster, username: str, source_dbname: str, target_dbname: str):
+    # cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
     if cluster_obj.cluster_type in [ClusterType.TenDBSingle, ClusterType.TenDBHA]:
         ticket_type = TicketType.MYSQL_RENAME_DATABASE
     elif cluster_obj.cluster_type == ClusterType.TenDBCluster:
@@ -35,7 +31,7 @@ def bill_rename_db(
         "remark": ticket_type,
         "creator": username,
         "helpers": [],
-        "bk_biz_id": bk_biz_id,
+        "bk_biz_id": cluster_obj.bk_biz_id,
         "details": {
             "force": True,
             "infos": [{"cluster_id": cluster_obj.pk, "from_database": source_dbname, "to_database": target_dbname}],
@@ -48,8 +44,8 @@ def bill_rename_db(
         slz = TendbRenameSerializer(data=ticket_param["details"])
 
     slz.context["ticket_type"] = ticket_type
-    slz.context["bk_biz_id"] = bk_biz_id
+    slz.context["bk_biz_id"] = cluster_obj.bk_biz_id
 
     slz.is_valid(raise_exception=True)
 
-    return Ticket.create_ticket(**ticket_param)
+    return {"ticket_params": [{"ticket_param": ticket_param}]}  # Ticket.create_ticket(**ticket_param)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_tdbctl_upgrade.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/ticket_param_tdbctl_upgrade.py
@@ -15,19 +15,17 @@ from backend.db_meta.models import Cluster
 from backend.db_package.models import Package
 from backend.db_services.mysql.toolbox.serializers import TdbctlUpgradeSerializer
 from backend.db_services.mysql.toolbox.tdbctl_upgrade_handler import TdbctlUpgradeHandler
-from backend.dbm_aiagent.mcp_tools.decorators import bill_response_wrapper
 from backend.ticket.constants import TicketType
-from backend.ticket.models import Ticket
 
 
-@bill_response_wrapper
-def bill_tdbctl_upgrade(
+# @bill_response_wrapper
+def ticket_param_tdbctl_upgrade(
     bk_biz_id: int,
     username: str,
     cluster_domain: str = None,
     cluster_id: int = None,
     version: str = None,
-) -> Ticket:
+):
     """
     创建 TenDBCluster 中控（tdbctl）升级单据
 
@@ -136,4 +134,4 @@ def bill_tdbctl_upgrade(
         "details": details,
     }
 
-    return Ticket.create_ticket(**ticket_param)
+    return {"ticket_params": [{"ticket_param": ticket_param}]}  # Ticket.create_ticket(**ticket_param)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_apply_priv.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_apply_priv.py
@@ -8,21 +8,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
-from backend.flow.consts import MySQLBackupTypeEnum
 
-
-class SubmitBillMySQLFullBackupInputSerializer(serializers.Serializer):
-    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+class GenerateMySQLApplyPrivParamInputSerializer(serializers.Serializer):
+    # bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
     cluster_domain = serializers.CharField(help_text=_("集群域名"))
-    backup_type = serializers.ChoiceField(choices=MySQLBackupTypeEnum.get_choices(), help_text=_("备份类型"))
-    # cluster_type = serializers.ChoiceField(
-    #     choices=[
-    #         (ClusterType.TenDBHA.value, ClusterType.TenDBHA.name),
-    #         # (ClusterType.TenDBSingle.value, ClusterType.TenDBSingle.name),
-    #         (ClusterType.TenDBCluster.value, ClusterType.TenDBCluster.name)
-    #     ],
-    #     help_text=_("集群类型, 只能是 tendbha, tendbcluster"),
-    # )
+    account_name = serializers.CharField(help_text=_("权限模版中的用户名"))
+    dbnames = serializers.ListField(child=serializers.CharField(), help_text=_("权限模版中用户名下的 db 名"))
+    apply_source_ips = serializers.ListField(child=serializers.CharField(), help_text=_("新权限访问来源 IP 列表, 允许带有 % 通配符"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_db_rename.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_db_rename.py
@@ -14,8 +14,8 @@ from rest_framework import serializers
 from backend.flow.consts import STAGE_DB_HEADER
 
 
-class SubmitBillMySQLDBRenameInputSerializer(serializers.Serializer):
-    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+class GenerateMySQLDBRenameParamInputSerializer(serializers.Serializer):
+    # bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
     cluster_domain = serializers.CharField(help_text=_("集群域名"))
     source_dbname = serializers.RegexField(regex=r"^{}.*$".format(STAGE_DB_HEADER), help_text=_("源 DB 名"))
     target_dbname = serializers.CharField(help_text=_("新 DB 名"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_db_table_backup.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_db_table_backup.py
@@ -13,9 +13,10 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 
-class SubmitBillMySQLApplyPrivInputSerializer(serializers.Serializer):
-    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+class GenerateMySQLDBTableBackupParamInputSerializer(serializers.Serializer):
+    # bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
     cluster_domain = serializers.CharField(help_text=_("集群域名"))
-    account_name = serializers.CharField(help_text=_("权限模版中的用户名"))
-    dbnames = serializers.ListField(child=serializers.CharField(), help_text=_("权限模版中用户名下的 db 名"))
-    apply_source_ips = serializers.ListField(child=serializers.CharField(), help_text=_("新权限访问来源 IP 列表, 允许带有 % 通配符"))
+    include_dbs = serializers.ListField(child=serializers.CharField(), help_text=_("需要备份的库名列表, 都允许带有 %, ?, * 这样的通配"))
+    ignore_dbs = serializers.ListField(
+        child=serializers.CharField(), help_text=_("需要排除的库名列表, 都允许带有 %, ?, * 这样的通配"), required=False
+    )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_full_backup.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_full_backup.py
@@ -8,15 +8,21 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
+from backend.flow.consts import MySQLBackupTypeEnum
 
-class SubmitBillMySQLDBTableBackupInputSerializer(serializers.Serializer):
-    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+
+class GenerateMySQLFullBackupParamInputSerializer(serializers.Serializer):
+    # bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
     cluster_domain = serializers.CharField(help_text=_("集群域名"))
-    include_dbs = serializers.ListField(child=serializers.CharField(), help_text=_("需要备份的库名列表, 都允许带有 %, ?, * 这样的通配"))
-    ignore_dbs = serializers.ListField(
-        child=serializers.CharField(), help_text=_("需要排除的库名列表, 都允许带有 %, ?, * 这样的通配"), required=False
-    )
+    backup_type = serializers.ChoiceField(choices=MySQLBackupTypeEnum.get_choices(), help_text=_("备份类型"))
+    # cluster_type = serializers.ChoiceField(
+    #     choices=[
+    #         (ClusterType.TenDBHA.value, ClusterType.TenDBHA.name),
+    #         # (ClusterType.TenDBSingle.value, ClusterType.TenDBSingle.name),
+    #         (ClusterType.TenDBCluster.value, ClusterType.TenDBCluster.name)
+    #     ],
+    #     help_text=_("集群类型, 只能是 tendbha, tendbcluster"),
+    # )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_standardize.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_mysql_standardize.py
@@ -12,9 +12,9 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 
-class SubmitBillMySQLStandardizeInputSerializer(serializers.Serializer):
+class GenerateMySQLStandardizeParamInputSerializer(serializers.Serializer):
     # bk_cloud_id = serializers.Serializer(help_text=_("云区域 ID"))
-    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    # bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
     cluster_domains = serializers.ListField(child=serializers.CharField(), help_text=_("集群域名列表"))
     with_instance_standardize = serializers.BooleanField(
         help_text=_("是否实例标准化, 重建 DBM 系统库表和权限. 高危慎用"), default=False, required=False

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_tdbctl_upgrade.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/ticket_param_tdbctl_upgrade.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 
-class SubmitBillTdbctlUpgradeInputSerializer(serializers.Serializer):
+class GenerateTdbctlUpgradeParamInputSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(help_text=_("业务ID"))
     cluster_domain = serializers.CharField(
         help_text=_("集群域名（可选，与 cluster_id 二选一）"),

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/urls.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/urls.py
@@ -11,17 +11,17 @@ specific language governing permissions and limitations under the License.
 from rest_framework.routers import DefaultRouter
 
 from backend.dbm_aiagent.mcp_tools.mysql.views import (
-    MySQLBillMcpToolsViewSet,
     MySQLMetricsMcpToolsViewSet,
     MySQLQueryMcpToolsViewSet,
     MySQLSlowlogMcpToolsViewSet,
+    MySQLTicketMcpToolsViewSet,
     SqlSyntaxCheckMcpViewSet,
 )
 
 routers = DefaultRouter(trailing_slash=True)
 
 routers.register(r"", MySQLQueryMcpToolsViewSet, basename="mcp-mysql-query")
-routers.register(r"", MySQLBillMcpToolsViewSet, basename="mcp-mysql-bill")
+routers.register(r"", MySQLTicketMcpToolsViewSet, basename="mcp-mysql-ticket")
 routers.register(r"", MySQLSlowlogMcpToolsViewSet, basename="mcp-mysql-slowlog")
 routers.register(r"", SqlSyntaxCheckMcpViewSet, basename="mcp-sql-syntax-check")
 routers.register(r"", MySQLMetricsMcpToolsViewSet, basename="mcp-mysql-metrics")

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/__init__.py
@@ -8,8 +8,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .mysql_bill_mcp import MySQLBillMcpToolsViewSet
 from .mysql_metrics_mcp import MySQLMetricsMcpToolsViewSet
 from .mysql_query_mcp import MySQLQueryMcpToolsViewSet
 from .mysql_slowlog_mcp import MySQLSlowlogMcpToolsViewSet
+from .mysql_ticket_mcp import MySQLTicketMcpToolsViewSet
 from .sql_syntax_check_mcp import SqlSyntaxCheckMcpViewSet

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_ticket_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_ticket_mcp.py
@@ -11,77 +11,88 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 
+from backend.db_meta.enums import ClusterType
+from backend.db_meta.models import Cluster
 from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import auth_parse_clusters
+from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_commit import TicketCommitInputSerializer
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
 from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
-from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpNoneBillSubmittedException, DBMMcpUsernameNotFoundException
+from backend.dbm_aiagent.mcp_tools.exceptions import (
+    DBMMcpClusterNotFoundException,
+    DBMMcpMultiBkBizIdFoundException,
+    DBMMcpNoneBillSubmittedException,
+    DBMMcpUsernameNotFoundException,
+)
 from backend.dbm_aiagent.mcp_tools.mysql.auth_parser.bill import auth_parse_mysql_tdbctl_upgrade_ticket
-from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_apply_priv import bill_apply_priv
-from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_db_table_backup import bill_db_table_backup
-from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_fullbackup import mysql_full_backup
-from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_mysql_standardize import bill_mysql_standardize
-from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_rename_db import bill_rename_db
-from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_tdbctl_upgrade import bill_tdbctl_upgrade
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.bill_output import SubmitBillOutputSerializer
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_apply_priv_bill import (
-    SubmitBillMySQLApplyPrivInputSerializer,
+from backend.dbm_aiagent.mcp_tools.mysql.impl.ticket_param_apply_priv import ticket_param_apply_priv
+from backend.dbm_aiagent.mcp_tools.mysql.impl.ticket_param_db_table_backup import ticket_param_db_table_backup
+from backend.dbm_aiagent.mcp_tools.mysql.impl.ticket_param_fullbackup import ticket_param_mysql_full_backup
+from backend.dbm_aiagent.mcp_tools.mysql.impl.ticket_param_mysql_standardize import ticket_param_mysql_standardize
+from backend.dbm_aiagent.mcp_tools.mysql.impl.ticket_param_rename_db import ticket_param_rename_db
+from backend.dbm_aiagent.mcp_tools.mysql.impl.ticket_param_tdbctl_upgrade import ticket_param_tdbctl_upgrade
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.ticket_param_mysql_apply_priv import (
+    GenerateMySQLApplyPrivParamInputSerializer,
 )
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_db_rename_bill import SubmitBillMySQLDBRenameInputSerializer
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_db_table_backup import (
-    SubmitBillMySQLDBTableBackupInputSerializer,
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.ticket_param_mysql_db_rename import (
+    GenerateMySQLDBRenameParamInputSerializer,
 )
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_full_backup_bill import (
-    SubmitBillMySQLFullBackupInputSerializer,
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.ticket_param_mysql_db_table_backup import (
+    GenerateMySQLDBTableBackupParamInputSerializer,
 )
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_standardize_bill import (
-    SubmitBillMySQLStandardizeInputSerializer,
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.ticket_param_mysql_full_backup import (
+    GenerateMySQLFullBackupParamInputSerializer,
 )
-from backend.dbm_aiagent.mcp_tools.mysql.serializers.tdbctl_upgrade_bill import SubmitBillTdbctlUpgradeInputSerializer
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.ticket_param_mysql_standardize import (
+    GenerateMySQLStandardizeParamInputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.ticket_param_tdbctl_upgrade import (
+    GenerateTdbctlUpgradeParamInputSerializer,
+)
 from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.mcp import McpTicketToolPermission
 
 
-class MySQLBillMcpToolsViewSet(McpToolsViewSet):
+class MySQLTicketMcpToolsViewSet(McpToolsViewSet):
     default_permission_class = [DBManagePermission()]
 
     @mcp_tools_api_decorator(
-        description=str(_("""创建 TenDBHA, TenDBCluster 全备单据""")),
-        request_slz=SubmitBillMySQLFullBackupInputSerializer,
-        response_slz=SubmitBillOutputSerializer,
+        description=str(_("""生成 TenDBHA, TenDBCluster 全备单据参数""")),
+        request_slz=GenerateMySQLFullBackupParamInputSerializer,
+        response_slz=TicketCommitInputSerializer,
         permission_classes=[McpTicketToolPermission],
         mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
-        mcp=[DBMMcpTools.MYSQL_BILL],
-        name_prefix="mysql_bill",
+        mcp=[DBMMcpTools.MYSQL_TICKET],
+        name_prefix="mysql_ticket",
     )
-    def submit_bill_mysql_full_backup(self, request, *args, **kwargs):
-        bk_biz_id = self.get_param("bk_biz_id")
+    def generate_mysql_full_backup_param(self, request, *args, **kwargs):
+        # bk_biz_id = self.get_param("bk_biz_id")
         backup_type = self.get_param("backup_type")
         cluster_domain = self.get_param("cluster_domain")
+
+        cluster_obj = Cluster.objects.get(immute_domain=cluster_domain)
 
         username = request.user.username
         if not username:
             raise DBMMcpUsernameNotFoundException()
 
         return Response(
-            mysql_full_backup(
-                username=username, bk_biz_id=bk_biz_id, backup_type=backup_type, cluster_domain=cluster_domain
-            )
+            ticket_param_mysql_full_backup(username=username, cluster_obj=cluster_obj, backup_type=backup_type)
         )
 
     @mcp_tools_api_decorator(
-        description=str(_("""创建 TenDBHA, TenDBCluster 库表备单据""")),
-        request_slz=SubmitBillMySQLDBTableBackupInputSerializer,
-        response_slz=SubmitBillOutputSerializer,
+        description=str(_("""生成 TenDBHA, TenDBCluster 库表备单据参数""")),
+        request_slz=GenerateMySQLDBTableBackupParamInputSerializer,
+        response_slz=TicketCommitInputSerializer,
         permission_classes=[McpTicketToolPermission],
         mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
-        mcp=[DBMMcpTools.MYSQL_BILL],
-        name_prefix="mysql_bill",
+        mcp=[DBMMcpTools.MYSQL_TICKET],
+        name_prefix="mysql_ticket",
     )
-    def submit_bill_mysql_db_table_backup(self, request, *args, **kwargs):
-        bk_biz_id = self.get_param("bk_biz_id")
+    def generate_mysql_db_table_backup_param(self, request, *args, **kwargs):
+        # bk_biz_id = self.get_param("bk_biz_id")
         cluster_domain = self.get_param("cluster_domain")
         include_dbs = self.get_param("include_dbs")
         ignore_dbs = self.get_param("ignore_dbs")
@@ -90,14 +101,15 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         if not username:
             raise DBMMcpUsernameNotFoundException()
 
+        cluster_obj = Cluster.objects.get(immute_domain=cluster_domain)
+
         if not ignore_dbs:
             ignore_dbs = []
 
         return Response(
-            bill_db_table_backup(
+            ticket_param_db_table_backup(
                 username=username,
-                bk_biz_id=bk_biz_id,
-                cluster_domain=cluster_domain,
+                cluster_obj=cluster_obj,
                 include_dbs=include_dbs,
                 ignore_dbs=ignore_dbs,
             )
@@ -106,23 +118,23 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=str(
             _(
-                """创建 mysql 权限申请单据
+                """生成 mysql 权限申请单据参数
         * 按照权限模版的定义在集群上开通权限
         * account_name 和 dbname 需要在模版预录入
         * 如果缺少参数参考权限模版
         """
             )
         ),
-        request_slz=SubmitBillMySQLApplyPrivInputSerializer,
-        response_slz=SubmitBillOutputSerializer,
+        request_slz=GenerateMySQLApplyPrivParamInputSerializer,
+        response_slz=TicketCommitInputSerializer,
         permission_classes=[McpTicketToolPermission],
         mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
-        mcp=[DBMMcpTools.MYSQL_BILL],
-        name_prefix="mysql_bill",
+        mcp=[DBMMcpTools.MYSQL_TICKET],
+        name_prefix="mysql_ticket",
     )
-    def submit_bill_mysql_apply_priv(self, request, *args, **kwargs):
-        bk_biz_id = self.get_param("bk_biz_id")
+    def generate_mysql_apply_priv_param(self, request, *args, **kwargs):
+        # bk_biz_id = self.get_param("bk_biz_id")
         cluster_domain = self.get_param("cluster_domain")
         account_name = self.get_param("account_name")
         dbnames = self.get_param("dbnames")
@@ -132,31 +144,52 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         if not username:
             raise DBMMcpUsernameNotFoundException()
 
+        cluster_obj = Cluster.objects.get(immute_domain=cluster_domain)
+
         return Response(
-            bill_apply_priv(
+            ticket_param_apply_priv(
                 request=request,
                 username=username,
-                bk_biz_id=bk_biz_id,
+                # bk_biz_id=bk_biz_id,
                 apply_username=account_name,
                 apply_access_dbs=dbnames,
                 apply_source_ips=apply_source_ips,
-                cluster_domain=cluster_domain,
+                cluster_obj=cluster_obj,
+                # cluster_domain=cluster_domain,
             )
         )
 
     @mcp_tools_api_decorator(
-        description=str(_("""创建 mysql 标准化单据""")),
-        request_slz=SubmitBillMySQLStandardizeInputSerializer,
-        response_slz=SubmitBillOutputSerializer,
+        description=str(_("""生成 mysql 标准化单据参数""")),
+        request_slz=GenerateMySQLStandardizeParamInputSerializer,
+        response_slz=TicketCommitInputSerializer,
         permission_classes=[McpTicketToolPermission],
         mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
-        mcp=[DBMMcpTools.MYSQL_BILL],
-        name_prefix="mysql_bill",
+        mcp=[DBMMcpTools.MYSQL_TICKET],
+        name_prefix="mysql_ticket",
     )
-    def submit_bill_mysql_standardize(self, request, *args, **kwargs):
-        bk_biz_id = self.get_param("bk_biz_id")
+    def generate_mysql_standardize_param(self, request, *args, **kwargs):
+        # bk_biz_id = self.get_param("bk_biz_id")
         cluster_domains = self.get_param("cluster_domains")
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        cluster_objs = Cluster.objects.filter(
+            immute_domain__in=cluster_domains,
+            cluster_type__in=[ClusterType.TenDBSingle, ClusterType.TenDBHA, ClusterType.TenDBCluster],
+        )
+        if len(cluster_objs) != len(cluster_domains):
+            found_domains = set(cluster_objs.values_list("immute_domain", flat=True))
+            missing_domains = set(cluster_domains) - found_domains
+            raise DBMMcpClusterNotFoundException(msg=_("集群不存在: {}").format(", ".join(missing_domains)))
+
+        bk_biz_ids = set(cluster_objs.values_list("bk_biz_id", flat=True))
+        if len(bk_biz_ids) > 1:
+            raise DBMMcpMultiBkBizIdFoundException(msg=_("集群属于多个业务: {}").format(", ".join(map(str, bk_biz_ids))))
+        bk_biz_id = bk_biz_ids.pop()
 
         with_instance_standardize = self.get_param("with_instance_standardize", False)
         with_cc_standardize = self.get_param("with_cc_standardize", False)
@@ -166,15 +199,12 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         if not (with_instance_standardize or with_cc_standardize or with_deploy_binary or with_push_config):
             raise DBMMcpNoneBillSubmittedException(msg=_("所有选项为否, 无需提交单据"))
 
-        username = request.user.username
-        if not username:
-            raise DBMMcpUsernameNotFoundException()
-
         return Response(
-            bill_mysql_standardize(
+            ticket_param_mysql_standardize(
                 username=username,
                 bk_biz_id=bk_biz_id,
-                cluster_domains=cluster_domains,
+                cluster_objs=cluster_objs,
+                # cluster_domains=cluster_domains,
                 with_instance_standardize=with_instance_standardize,
                 with_cc_standardize=with_cc_standardize,
                 with_deploy_binary=with_deploy_binary,
@@ -183,17 +213,17 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         )
 
     @mcp_tools_api_decorator(
-        description=str(_("""创建 DB 重命名单据""")),
-        request_slz=SubmitBillMySQLDBRenameInputSerializer,
-        response_slz=SubmitBillOutputSerializer,
+        description=str(_("""生成 DB 重命名单据参数""")),
+        request_slz=GenerateMySQLDBRenameParamInputSerializer,
+        response_slz=TicketCommitInputSerializer,
         permission_classes=[McpTicketToolPermission],
         mcp_auth_parser=auth_parse_clusters,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
-        mcp=[DBMMcpTools.MYSQL_BILL],
-        name_prefix="mysql_bill",
+        mcp=[DBMMcpTools.MYSQL_TICKET],
+        name_prefix="mysql_ticket",
     )
-    def submit_bill_mysql_db_rename(self, request, *args, **kwargs):
-        bk_biz_id = self.get_param("bk_biz_id")
+    def generate_mysql_db_rename_param(self, request, *args, **kwargs):
+        # bk_biz_id = self.get_param("bk_biz_id")
         cluster_domain = self.get_param("cluster_domain")
         source_dbname = self.get_param("source_dbname")
         target_dbname = self.get_param("target_dbname")
@@ -202,11 +232,14 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         if not username:
             raise DBMMcpUsernameNotFoundException()
 
+        cluster_obj = Cluster.objects.get(immute_domain=cluster_domain)
+
         return Response(
-            bill_rename_db(
-                bk_biz_id=bk_biz_id,
+            ticket_param_rename_db(
+                # bk_biz_id=bk_biz_id,
+                cluster_obj=cluster_obj,
                 username=username,
-                cluster_domain=cluster_domain,
+                # cluster_domain=cluster_domain,
                 source_dbname=source_dbname,
                 target_dbname=target_dbname,
             )
@@ -215,7 +248,7 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=str(
             _(
-                """创建 TenDBCluster 中控（tdbctl）升级单据
+                """生成 TenDBCluster 中控（tdbctl）升级单据参数
 
 参数说明：
 - bk_biz_id: 业务ID（必填）
@@ -229,15 +262,15 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         """
             )
         ),
-        request_slz=SubmitBillTdbctlUpgradeInputSerializer,
-        response_slz=SubmitBillOutputSerializer,
+        request_slz=GenerateTdbctlUpgradeParamInputSerializer,
+        response_slz=TicketCommitInputSerializer,
         permission_classes=[McpTicketToolPermission],
         mcp_auth_parser=auth_parse_mysql_tdbctl_upgrade_ticket,
         tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
-        mcp=[DBMMcpTools.MYSQL_BILL],
-        name_prefix="mysql_bill",
+        mcp=[DBMMcpTools.MYSQL_TICKET],
+        name_prefix="mysql_ticket",
     )
-    def submit_bill_tdbctl_upgrade(self, request, *args, **kwargs):
+    def generate_tdbctl_upgrade_param(self, request, *args, **kwargs):
         bk_biz_id = self.get_param("bk_biz_id")
         cluster_domain = self.get_param("cluster_domain", None)
         cluster_id = self.get_param("cluster_id", None)
@@ -248,7 +281,7 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
             raise DBMMcpUsernameNotFoundException()
 
         return Response(
-            bill_tdbctl_upgrade(
+            ticket_param_tdbctl_upgrade(
                 bk_biz_id=bk_biz_id,
                 username=username,
                 cluster_domain=cluster_domain,

--- a/dbm-ui/config/default.py
+++ b/dbm-ui/config/default.py
@@ -683,11 +683,11 @@ BK_APIGW_STAGE_MCP_SERVERS = [
         "tools": [],
     },
     {
-        "name": "mysql-bill",
-        "description": """create mysql bill""",
+        "name": "mysql-ticket",
+        "description": """generate mysql ticket param""",
         # 主动授权 app_code
         "target_app_codes": [APP_CODE],
-        "labels": ["mysql-bill"],
+        "labels": ["mysql-ticket"],
         # 是否启用：1-启用，0-停止
         "status": 1,
         # 是否公开


### PR DESCRIPTION
1. mysql-bill mcp 更名为 mysql-ticket
2. common-ticket-op 增加 ticket-commit 方法
3. 所有 mysql 提单工具修改为只生成单据参数
4. 提示词要求单据参数获得确认后再调用 ticket-commit 提单
