### PR TITLE
fix(mysql): optimize-mysql-monitor-update-config #16369

### DIFF
--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/update_monitor_config/init.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/itemscollect/update_monitor_config/init.go
@@ -5,7 +5,6 @@ import (
 	"dbm-services/common/reverseapi/define/mysql"
 	acst "dbm-services/mysql/db-tools/dbactuator/pkg/core/cst"
 	"dbm-services/mysql/db-tools/mysql-monitor/pkg/config"
-	"dbm-services/mysql/db-tools/mysql-monitor/pkg/utils"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -144,6 +143,9 @@ func (c *Checker) updateConfigFile(sii *mysql.StorageInstanceInfo) (err error) {
 		slog.Error(name, slog.String("err", err.Error()))
 		return err
 	}
+	defer func() {
+		_ = cf.Close()
+	}()
 
 	_, err = cf.WriteString(string(b) + "\n")
 	if err != nil {
@@ -152,13 +154,13 @@ func (c *Checker) updateConfigFile(sii *mysql.StorageInstanceInfo) (err error) {
 	}
 	slog.Info(name, slog.String("config", string(b)))
 
-	configFileDir, configFileName := filepath.Split(configFilePath)
-	err = utils.Reschedule(configFileDir, configFileName, "monitor")
-
-	if err != nil {
-		slog.Error(name, slog.String("err", err.Error()))
-		return err
-	}
+	//configFileDir, configFileName := filepath.Split(configFilePath)
+	//err = utils.Reschedule(configFileDir, configFileName, "monitor")
+	//
+	//if err != nil {
+	//	slog.Error(name, slog.String("err", err.Error()))
+	//	return err
+	//}
 
 	return nil
 }

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/mainloop/main_loop.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/mainloop/main_loop.go
@@ -115,6 +115,22 @@ func itemsRun(iNames []string, cc *monitoriteminterface.ConnectionCollect) error
 		itemLogger = itemLogger.With("current item", iName)
 		slog.SetDefault(itemLogger)
 
+		idx := slices.IndexFunc(
+			config.ItemsConfig, func(item *config.MonitorItem) bool {
+				return item.Name == iName
+			},
+		)
+		if idx < 0 {
+			err := fmt.Errorf("item %s not found in items config", iName)
+			slog.Error("run monitor item", slog.String("error", err.Error()))
+			return err
+		}
+		itemConfig := config.ItemsConfig[idx]
+		if !itemConfig.IsMatchRole() {
+			slog.Info("run monitor item role not match, skipped")
+			continue
+		}
+
 		if constructor, ok := itemscollect.RegisteredItemConstructor()[iName]; ok {
 			msg, err := constructor(cc).Run()
 			if err != nil {

--- a/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/do_reschedule.go
+++ b/dbm-services/mysql/db-tools/mysql-monitor/pkg/utils/do_reschedule.go
@@ -49,7 +49,8 @@ func Reschedule(configFileDir, configFileName, staff string) error {
 			continue
 		}
 
-		if ele.IsEnable() && ele.IsMatchMachineType() && ele.IsMatchRole() {
+		// 改成角色无差别的注册
+		if ele.IsEnable() && ele.IsMatchMachineType() { //&& ele.IsMatchRole() {
 			var key string
 
 			if ele.Schedule == nil {

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/db_table_backup.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/db_table_backup.py
@@ -165,12 +165,13 @@ class TenDBClusterDBTableBackupFlow(object):
             ),
         )
 
-        return on_ctl_sub_pipe.build_sub_process(sub_name=_("spider/ctl备份库表结构"))
+        return on_ctl_sub_pipe.build_sub_process(sub_name=_("{} spider/ctl备份库表结构".format(ctl_primary_ip)))
 
     def backup_on_remote(self, backup_id: uuid.UUID, job: dict, cluster_obj: Cluster) -> List[SubProcess]:
         # 在 所有 is_stand_by slave 上备份数据
         # slave 上的备份同机器串行
         on_slave_pipes = []
+        # 这是按 ip 聚合的 dtls
         stand_by_slaves = defaultdict(list)
         for tp in StorageInstanceTuple.objects.filter(
             ejector__cluster=cluster_obj,
@@ -188,21 +189,45 @@ class TenDBClusterDBTableBackupFlow(object):
             )
 
         for ip, dtls in stand_by_slaves.items():
+            on_this_ip_flow = SubBuilder(
+                root_id=self.root_id,
+                data={
+                    **job,
+                    "uid": self.data["uid"],
+                    "created_by": self.data["created_by"],
+                    "bk_biz_id": self.data["bk_biz_id"],
+                    "ticket_type": self.data["ticket_type"],
+                    "backup_id": backup_id,
+                },
+            )
+
+            on_this_ip_flow.add_act(
+                act_name=_("下发actuator介质"),
+                act_component_code=TransFileComponent.code,
+                kwargs=asdict(
+                    DownloadMediaKwargs(
+                        bk_cloud_id=cluster_obj.bk_cloud_id,
+                        exec_ip=ip,
+                        file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
+                    )
+                ),
+            )
+
             for dtl in dtls:
-                on_slave_job = copy.deepcopy(job)
-                on_slave_job["db_patterns"] = [
+                on_this_slave_instance_job = copy.deepcopy(job)
+                on_this_slave_instance_job["db_patterns"] = [
                     ele if ele.endswith("%") or ele == "*" else "{}_{}".format(ele, dtl["shard_id"])
-                    for ele in on_slave_job["db_patterns"]
+                    for ele in on_this_slave_instance_job["db_patterns"]
                 ]
-                on_slave_job["ignore_dbs"] = [
+                on_this_slave_instance_job["ignore_dbs"] = [
                     ele if ele.endswith("%") or ele == "*" else "{}_{}".format(ele, dtl["shard_id"])
-                    for ele in on_slave_job["ignore_dbs"]
+                    for ele in on_this_slave_instance_job["ignore_dbs"]
                 ]
 
-                on_slave_pipe = SubBuilder(
+                on_this_slave_instance_pipe = SubBuilder(
                     root_id=self.root_id,
                     data={
-                        **on_slave_job,
+                        **on_this_slave_instance_job,
                         "uid": self.data["uid"],
                         "created_by": self.data["created_by"],
                         "bk_biz_id": self.data["bk_biz_id"],
@@ -218,25 +243,13 @@ class TenDBClusterDBTableBackupFlow(object):
                     },
                 )
 
-                on_slave_pipe.add_act(
+                on_this_slave_instance_pipe.add_act(
                     act_name=_("构造remote mydumper正则"),
                     act_component_code=DatabaseTableFilterRegexBuilderComponent.code,
                     kwargs={},
                 )
 
-                on_slave_pipe.add_act(
-                    act_name=_("下发actuator介质"),
-                    act_component_code=TransFileComponent.code,
-                    kwargs=asdict(
-                        DownloadMediaKwargs(
-                            bk_cloud_id=cluster_obj.bk_cloud_id,
-                            exec_ip=ip,
-                            file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
-                        )
-                    ),
-                )
-
-                on_slave_pipe.add_act(
+                on_this_slave_instance_pipe.add_act(
                     act_name=_("remote 执行库表备份"),
                     act_component_code=ExecuteDBActuatorScriptComponent.code,
                     kwargs=asdict(
@@ -250,7 +263,13 @@ class TenDBClusterDBTableBackupFlow(object):
                     ),
                 )
 
-                on_slave_pipes.append(on_slave_pipe.build_sub_process(sub_name=_("remote 备份库表")))
+                on_this_ip_flow.add_sub_pipeline(
+                    on_this_slave_instance_pipe.build_sub_process(
+                        sub_name=_("{}:{} remote 备份库表".format(ip, dtl["port"]))
+                    )
+                )
+
+            on_slave_pipes.append(on_this_ip_flow.build_sub_process(sub_name=_("{} remote 备份库表".format(ip))))
         return on_slave_pipes
 
     def backup_on_spider_mnt(self, backup_id: uuid.UUID, job: dict, cluster_obj: Cluster) -> SubProcess:
@@ -346,7 +365,7 @@ class TenDBClusterDBTableBackupFlow(object):
                     )
                 )
             job_flow.add_act(
-                act_name=_("关联备份id"),
+                act_name=_("关联备份id: {}".format(backup_id)),
                 act_component_code=MySQLLinkBackupIdBillIdComponent.code,
                 kwargs={},
             )

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/full_backup.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/full_backup.py
@@ -107,7 +107,7 @@ class TenDBClusterFullBackupFlow(object):
                 raise MySQLBackupLocalException(msg=_("不支持的备份位置 {}".format(backup_local)))
 
             cluster_pipe.add_act(
-                act_name=_("关联备份id"),
+                act_name=_("关联备份id: {}".format(backup_id)),
                 act_component_code=MySQLLinkBackupIdBillIdComponent.code,
                 kwargs={},
             )
@@ -180,15 +180,41 @@ class TenDBClusterFullBackupFlow(object):
             ),
         )
 
-        return on_ctl_sub_pipe.build_sub_process(sub_name=_("spider/ctl备份库表结构"))
+        return on_ctl_sub_pipe.build_sub_process(sub_name=_("{} spider/ctl备份库表结构".format(ctl_primary_ip)))
 
     def __backup_on_remote(
         self, backup_id: uuid.UUID, bk_cloud_id: int, machine_instance_dict: Dict
     ) -> List[SubProcess]:
         on_remote_pipes = []
         for ip, dtls in machine_instance_dict.items():
+            on_this_ip_flow = SubBuilder(
+                root_id=self.root_id,
+                data={
+                    "uid": self.data["uid"],
+                    "created_by": self.data["created_by"],
+                    "bk_biz_id": self.data["bk_biz_id"],
+                    "ticket_type": self.data["ticket_type"],
+                    "backup_id": backup_id,
+                    "file_tag": self.data["file_tag"],
+                    "backup_type": self.data["backup_type"],
+                    "ip": ip,
+                    "backup_gsd": ["all"],
+                },
+            )
+            on_this_ip_flow.add_act(
+                act_name=_("下发actuator介质"),
+                act_component_code=TransFileComponent.code,
+                kwargs=asdict(
+                    DownloadMediaKwargs(
+                        bk_cloud_id=bk_cloud_id,
+                        exec_ip=ip,
+                        file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
+                    )
+                ),
+            )
+
             for dtl in dtls:
-                on_remote_pipe = SubBuilder(
+                on_this_remote_instance_pipe = SubBuilder(
                     root_id=self.root_id,
                     data={
                         "uid": self.data["uid"],
@@ -205,19 +231,8 @@ class TenDBClusterFullBackupFlow(object):
                         "shard_id": dtl["shard_id"],
                     },
                 )
-                on_remote_pipe.add_act(
-                    act_name=_("下发actuator介质"),
-                    act_component_code=TransFileComponent.code,
-                    kwargs=asdict(
-                        DownloadMediaKwargs(
-                            bk_cloud_id=bk_cloud_id,
-                            exec_ip=ip,
-                            file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
-                        )
-                    ),
-                )
 
-                on_remote_pipe.add_act(
+                on_this_remote_instance_pipe.add_act(
                     act_name=_("remote 执行全库备份"),
                     act_component_code=ExecuteDBActuatorScriptComponent.code,
                     kwargs=asdict(
@@ -231,7 +246,13 @@ class TenDBClusterFullBackupFlow(object):
                     ),
                 )
 
-                on_remote_pipes.append(on_remote_pipe.build_sub_process(sub_name=_("remote 全库备份")))
+                on_this_ip_flow.add_sub_pipeline(
+                    on_this_remote_instance_pipe.build_sub_process(
+                        sub_name=_("{}:{} remote 全库备份".format(ip, dtl["port"]))
+                    )
+                )
+
+            on_remote_pipes.append(on_this_ip_flow.build_sub_process(sub_name=_("{} remote 全库备份".format(ip))))
         return on_remote_pipes
 
     def backup_on_remote_master(self, backup_id: uuid.UUID, cluster_obj: Cluster) -> List[SubProcess]:


### PR DESCRIPTION
1. mysql-monitor 现在会注册全量的监控项, 执行期间才根据角色决定是否执行. 减少后续维护时的reschedule
2. tendbcluster 库表备份, 全量备份修改为同机器实例串行
<img width="1072" height="99" alt="image" src="https://github.com/user-attachments/assets/38dc02fe-5ed0-4c56-8de0-77f2533b63b4" />
<img width="1152" height="621" alt="image" src="https://github.com/user-attachments/assets/d9197862-3732-4a5b-92b7-885ec940a72a" />
