### PR TITLE
fix(kafka): kafka java执行路径软链接路径不对

### DIFF
--- a/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/install_kafka.go
+++ b/dbm-services/bigdata/db-tools/dbactuator/pkg/components/kafka/install_kafka.go
@@ -206,7 +206,7 @@ export SASL_ENABLED=true
 	}
 
 	// 创建 java 软链接到 /usr/bin/java，解决 crontab 拉起 supervisord 时找不到 java 的问题
-	extraCmd = "[ ! -e /usr/bin/java ] && ln -sf $JAVA_HOME/bin/java /usr/bin/java || true"
+	extraCmd = ". /etc/profile; [ ! -e /usr/bin/java ] && ln -sf $JAVA_HOME/bin/java /usr/bin/java || true"
 	if _, err := osutil.ExecShellCommand(false, extraCmd); err != nil {
 		logger.Error("创建java软链接失败: %s", err.Error())
 		return err

--- a/dbm-ui/backend/flow/engine/bamboo/scene/kafka/kafka_scale_up_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/kafka/kafka_scale_up_flow.py
@@ -242,7 +242,7 @@ class KafkaScaleUpFlow(object):
         ]
         details = {
             "cluster_id": self.data["cluster_id"],
-            "throttle_rate": 50000000,
+            "throttle_rate": 100000000,
             "topics": ["*"],
             "instance_list": instance_list,
         }

--- a/dbm-ui/backend/flow/utils/kafka/kafka_act_playload.py
+++ b/dbm-ui/backend/flow/utils/kafka/kafka_act_playload.py
@@ -214,7 +214,7 @@ class KafkaActPayload(object):
                     "zookeeper_ip": zookeeper_ip,
                     "exclude_brokers": host,
                     "new_brokers": new_host,
-                    "throttle_rate": self.ticket_data.get("throttle_rate", 20000000),
+                    "throttle_rate": self.ticket_data.get("throttle_rate", 100000000),
                     "topics": self.ticket_data.get("topics", ["*"]),
                 },
             },
@@ -246,7 +246,7 @@ class KafkaActPayload(object):
                 "general": {},
                 "extend": {
                     "brokers": host,
-                    "throttle_rate": self.ticket_data.get("throttle_rate", 20000000),
+                    "throttle_rate": self.ticket_data.get("throttle_rate", 100000000),
                     "topics": self.ticket_data.get("topics", ["*"]),
                 },
             },

--- a/dbm-ui/backend/flow/utils/kafka/script_template.py
+++ b/dbm-ui/backend/flow/utils/kafka/script_template.py
@@ -10,7 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 # fast_execute_script接口固定参数
 fast_execute_script_common_kwargs = {
-    "timeout": 86400,
+    "timeout": 259200,
     "account_alias": "root",
     "is_param_sensitive": 0,
 }


### PR DESCRIPTION
1. 修复kafka java执行路径软链接路径不对
2. 调整均衡，缩容，替换，数据搬迁默认速率为100MB/s
3. 调整单据超时时间到3天