### PR TITLE
fix(backend): 安装节点管理插件原子任务卡死，增加轮询超时机制

### DIFF
--- a/dbm-ui/backend/flow/plugins/components/collections/common/install_nodeman_plugin.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/install_nodeman_plugin.py
@@ -26,7 +26,8 @@ class InstallNodemanPluginService(BaseService):
     HTTP_STATUS_OK = 200  # HTTP请求成功的状态码
 
     __need_schedule__ = True
-    interval = StaticIntervalGenerator(5)
+    interval = StaticIntervalGenerator(10)
+    MAX_POLL_COUNT = 50  # 最多轮询次数，超过后任务失败
 
     def _execute(self, data, parent_data):
         kwargs = data.get_one_of_inputs("kwargs")
@@ -68,12 +69,25 @@ class InstallNodemanPluginService(BaseService):
             {"job_type": "MAIN_INSTALL_PLUGIN", "plugin_params": {"name": plugin_name}, "bk_host_id": bk_host_ids}
         )
         data.outputs.job_id = job["job_id"]
+        data.outputs.poll_count = 0  # 每次execute重置轮询计数器
         self.log_info(_("安装插件任务: {}/#/task-list/detail/{}").format(env.BK_NODEMAN_URL, data.outputs.job_id))
 
     def _schedule(self, data, parent_data, callback_data=None):
         job_id = data.get_one_of_outputs("job_id")
         max_retries = 3  # 最大重试次数
         retry_count = data.get_one_of_outputs("retry_count", 0)
+
+        # 轮询次数超限检查
+        poll_count = data.get_one_of_outputs("poll_count", 0)
+        poll_count += 1
+        data.outputs.poll_count = poll_count
+        if poll_count > self.MAX_POLL_COUNT:
+            self.log_error(
+                _("安装节点管理插件任务超时: 轮询次数已达上限 {} 次（间隔 {}s），job_id={}").format(
+                    self.MAX_POLL_COUNT, self.interval.interval, job_id
+                )
+            )
+            return False
         # 调用 API 并设置 raw=True, raise_exception=False，遇到特定错误码时重试
         raw_response = BKNodeManApi.job_details._send(params={"job_id": job_id}, headers={})
         # 检查网络状态

--- a/dbm-ui/backend/tests/flow/components/collections/mysql/test_install_nodeman_plugin.py
+++ b/dbm-ui/backend/tests/flow/components/collections/mysql/test_install_nodeman_plugin.py
@@ -64,6 +64,7 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
     def _set_excepted_outputs(cls) -> None:
         cls.excepted_outputs = {
             "job_id": JOB_ID,
+            "poll_count": 0,  # _execute 重置轮询计数器
         }
 
     def to_mock_class_list(self) -> List:
@@ -114,12 +115,12 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
         1. 当HTTP状态码为504时的重试逻辑
         2. 验证retry_count被正确设置
         """
-        # 由于实际组件在执行时设置了retry_count，我们的测试期望也应该包含它
+        # _execute 设置 poll_count=0，_schedule 第一次执行后 poll_count=1，retry_count=1
         return [
             ScheduleAssertion(
                 success=True,
                 schedule_finished=False,
-                outputs={"job_id": JOB_ID, "retry_count": 1},  # 期望job_id和retry_count
+                outputs={"job_id": JOB_ID, "poll_count": 1, "retry_count": 1},
                 callback_data=None,
             )
         ]
@@ -135,8 +136,8 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
         return [
             ScheduleAssertion(
                 success=False,  # 重试达到最大次数应该返回失败
-                schedule_finished=False,  # 根据实际行为修改为False
-                outputs={"job_id": JOB_ID},  # 确保包含job_id
+                schedule_finished=False,
+                outputs={"job_id": JOB_ID, "poll_count": 0},  # execute后poll_count=0，mock _schedule不修改它
                 callback_data=None,
             )
         ]
@@ -148,8 +149,8 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
         第一个用例: 测试常规重试场景（重试次数未超过最大值）
         第二个用例: 测试重试次数达到最大值的场景
         """
-        # 第一个用例设置特定的断言，确保只期望job_id而不是retry_count
-        first_case_execute_assertion = ExecuteAssertion(success=True, outputs={"job_id": JOB_ID})
+        # 第一个用例设置特定的断言，确保期望job_id和poll_count
+        first_case_execute_assertion = ExecuteAssertion(success=True, outputs={"job_id": JOB_ID, "poll_count": 0})
         case1 = ComponentTestCase(
             name=f"{self.component_cls().__name__}组件基本重试测试",
             inputs={"global_data": self.global_data, "trans_data": self.trans_data, "kwargs": self.kwargs},
@@ -201,10 +202,10 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
             )
         )
 
-        # 期望输出中，重试失败的断言
+        # 期望输出中，重试失败的断言（execute 阶段会设置 poll_count=0）
         failed_outputs = {
-            "job_id": JOB_ID
-            # 不检查retry_count的值，因为在失败情况下我们只关心返回值为False
+            "job_id": JOB_ID,
+            "poll_count": 0,  # _execute 重置轮询计数器
         }
 
         case2 = ComponentTestCase(


### PR DESCRIPTION
close #16505

## 问题描述
安装节点管理插件的原子任务在 `_schedule` 轮询时无超时机制，当节点管理侧任务异常挂起时会导致流程永久卡死。

## 修复内容
- 轮询间隔从 5s 调整为 **10s**
- 新增 `MAX_POLL_COUNT = 50` 轮询次数上限，超出后任务失败并记录日志（最大超时 ~500s）
- `_execute` 每次执行时重置 `poll_count = 0`，避免重试时计数累积

## 测试
- [ ] 单元测试通过
- [ ] 功能验证完成
