### PR TITLE
refactor(dbha-v2): reporter single-instance and code quality. issue: #16481

### DIFF
--- a/dbm-services/common/dbha-v2/etc/probe.yaml
+++ b/dbm-services/common/dbha-v2/etc/probe.yaml
@@ -4,10 +4,10 @@ version: v2.0.0
 pidFile: ./pids/probe.pid
 
 reporter:
-  - name: gse
-    endpoint: ""
-    dataID: 0
-    connTimeout: 5s
+  name: gse
+  endpoint: ""
+  dataID: 0
+  connTimeout: 5s
 
 harvester:
   mysql:

--- a/dbm-services/common/dbha-v2/etc/probe_harvester.yaml
+++ b/dbm-services/common/dbha-v2/etc/probe_harvester.yaml
@@ -1,5 +1,0 @@
-dbType: mysql
-endpoint: ""
-interval: 20s
-user: root
-password: 123456

--- a/dbm-services/common/dbha-v2/internal/probe/config/config.go
+++ b/dbm-services/common/dbha-v2/internal/probe/config/config.go
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+// Package config provides probe configuration loading and structures.
 package config
 
 import (
@@ -95,13 +96,13 @@ type LogConfig struct {
 
 // Configuration receiver's configuration
 type Configuration struct {
-	Name      string           `yaml:"name"      mapstructure:"name"`
-	Version   string           `yaml:"version"   mapstructure:"version"`
-	ServiceID string           `yaml:"serviceID" mapstructure:"serviceID"`
-	PidFile   string           `yaml:"pidFile"   mapstructure:"pidFile"`
-	Reporters []ReporterConfig `yaml:"reporter"  mapstructure:"reporter"`
-	Harvester HarvesterConfig  `yaml:"harvester" mapstructure:"harvester"`
-	Log       LogConfig        `yaml:"log"       mapstructure:"log"`
+	Name      string          `yaml:"name"      mapstructure:"name"`
+	Version   string          `yaml:"version"   mapstructure:"version"`
+	ServiceID string          `yaml:"serviceID" mapstructure:"serviceID"`
+	PidFile   string          `yaml:"pidFile"   mapstructure:"pidFile"`
+	Reporter  *ReporterConfig `yaml:"reporter"  mapstructure:"reporter"`
+	Harvester HarvesterConfig `yaml:"harvester" mapstructure:"harvester"`
+	Log       LogConfig       `yaml:"log"       mapstructure:"log"`
 }
 
 // Load loads probe configuration from file

--- a/dbm-services/common/dbha-v2/internal/probe/probe.go
+++ b/dbm-services/common/dbha-v2/internal/probe/probe.go
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+// Package probe implements the probe main framework for harvesting and reporting DB instance data.
 package probe
 
 import (
@@ -42,7 +43,7 @@ type Probe struct {
 	clientID  string
 	machineID string
 	serviceID string
-	reporters []reporter.Reporter
+	reporter  reporter.Reporter
 	plugins   []plugin.Plugin
 	quit      chan struct{}
 	wg        sync.WaitGroup
@@ -77,6 +78,10 @@ func (p *Probe) runPlugin(ctx context.Context, plug plugin.Plugin) {
 				return
 			}
 
+			baseInfo := p.reporter.GetBaseInfo()
+
+			data.AgentID = baseInfo.AgentID
+			data.BkCloudID = baseInfo.BkCloudID
 			data.DbTypeName = data.Value.GetDbType()
 
 			dataEncoded, err := json.Marshal(data)
@@ -87,14 +92,10 @@ func (p *Probe) runPlugin(ctx context.Context, plug plugin.Plugin) {
 
 			logger.Debug("harvester reported data: %s", string(dataEncoded))
 
-			for _, r := range p.reporters {
-				err := r.Post(ctx, dataEncoded)
-				if err == nil {
-					// NOTE: Just one reporter sending the data is sufficient.
-					break
+			if p.reporter != nil {
+				if err := p.reporter.Post(ctx, dataEncoded); err != nil {
+					logger.Warn("post data to receiver failed, plugin(%s), reporter(%s), %v", name, p.reporter.Name(), err)
 				}
-
-				logger.Warn("post data to receiver failed, plugin(%s), reporter(%s), %v", name, r.Name(), err)
 			}
 		}
 	}
@@ -136,8 +137,11 @@ func (p *Probe) createReporter() {
 	// Once the reporter is created successfully, the network abnormalities of the reporter itself
 	// need to be maintained by the reporter itself.
 
-	cfgs := config.Cfg.Reporters
+	if config.Cfg.Reporter == nil {
+		return
+	}
 
+	cfg := *config.Cfg.Reporter
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
@@ -148,34 +152,22 @@ func (p *Probe) createReporter() {
 				return
 
 			default:
-
-				var failedCfgs []config.ReporterConfig
-
-				for _, cfg := range cfgs {
-					r, err := reporter.NewReporter(cfg)
-					if err != nil {
-						logger.Warn("create new reporter failed, reporter(%s), %v", cfg.Name, err)
-						failedCfgs = append(failedCfgs, cfg)
-						continue
-					}
-
-					p.reporters = append(p.reporters, r)
+				r, err := reporter.NewReporter(cfg)
+				if err != nil {
+					logger.Warn("create new reporter failed, reporter(%s), %v", cfg.Name, err)
+					time.Sleep(100 * time.Millisecond)
+					continue
 				}
 
-				if len(failedCfgs) == 0 {
-					logger.Info("created all reporter successfully, reporter count(%d)", len(p.reporters))
-					return
-				}
-
-				cfgs = failedCfgs
-				failedCfgs = make([]config.ReporterConfig, 0)
-
-				time.Sleep(100 * time.Millisecond)
+				p.reporter = r
+				logger.Info("created reporter successfully, reporter(%s)", cfg.Name)
+				return
 			}
 		}
 	}()
 }
 
+// Run starts the probe: loads plugins, creates the reporter, and runs the event loop until quit.
 func (p *Probe) Run(ctx context.Context) error {
 	p.quit = make(chan struct{})
 
@@ -198,6 +190,7 @@ func (p *Probe) Run(ctx context.Context) error {
 	}
 }
 
+// Close signals the probe to stop and waits for goroutines to exit.
 func (p *Probe) Close() {
 	if p.quit != nil {
 		close(p.quit) // Notify all goroutines exited.

--- a/dbm-services/common/dbha-v2/internal/probe/reporter/gse.go
+++ b/dbm-services/common/dbha-v2/internal/probe/reporter/gse.go
@@ -63,12 +63,11 @@ func NewGSEClient(cfg config.ReporterConfig, logger types.Logger) (Reporter, err
 
 		return nil, gerrors.Newf(gerrors.BkGseFailure, "do not connect with GSE agent, %v", err)
 	}
-	g := &gse{
+
+	return &gse{
 		cfg:      cfg,
 		agentCli: cli,
-	}
-
-	return g, nil
+	}, nil
 }
 
 // Name return reporter's name
@@ -86,6 +85,19 @@ func (g *gse) Post(ctx context.Context, content []byte) error {
 	}
 
 	return nil
+}
+
+func (g *gse) GetBaseInfo() BaseInfo {
+	agentInfo, err := g.agentCli.GetAgentInfo()
+	if err != nil {
+		logger.Errorf("failed to get agent info, errmsg: %s", err)
+		return BaseInfo{}
+	}
+
+	return BaseInfo{
+		AgentID:   agentInfo.AgentID,
+		BkCloudID: agentInfo.CloudID,
+	}
 }
 
 func (g *gse) Close() {

--- a/dbm-services/common/dbha-v2/internal/probe/reporter/reporter.go
+++ b/dbm-services/common/dbha-v2/internal/probe/reporter/reporter.go
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+// Package reporter provides reporter implementations for sending harvest data to backends (e.g. GSE).
 package reporter
 
 import (
@@ -33,9 +34,17 @@ import (
 	"dbm-services/common/dbha-v2/pkg/logger"
 )
 
+// BaseInfo holds agent identity info used by reporters.
+type BaseInfo struct {
+	AgentID   string
+	BkCloudID int
+}
+
+// Reporter sends harvested data to a backend and provides base info.
 type Reporter interface {
 	Name() string
 	Post(ctx context.Context, content []byte) error
+	GetBaseInfo() BaseInfo
 	Close()
 }
 


### PR DESCRIPTION


- config: use Reporter *ReporterConfig instead of Reporters []ReporterConfig
- probe: single reporter instance; createReporter retries one config, runPlugin posts to p.reporter
- etc/probe.yaml: reporter as single object (no list)
- Add package and exported symbol comments for golint (probe, reporter, config)