### PR TITLE
fix(backend): 安装节点管理插件原子任务卡死修复及安全漏洞修复

### DIFF
--- a/dbm-ui/backend/dbm_init/medium/handlers.py
+++ b/dbm-ui/backend/dbm_init/medium/handlers.py
@@ -13,9 +13,11 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import subprocess
 import zipfile
 from datetime import datetime
+from pathlib import Path
 
 import yaml
 from bkstorages.backends.bkrepo import TIMEOUT_THRESHOLD, BKGenericRepoClient, BKRepoStorage, urljoin
@@ -258,13 +260,10 @@ class MediumHandler:
                     # 如果介质和安装模式不匹配，忽略
                     if medium_info.get("installation", False) != installation:
                         continue
-                    # 将编译好的介质复制到指定目录
-                    target_medium_path = f"{bkrepo_tmp_dir}/{db_type}/{medium_type}/{medium_info['version']}"
-                    result = subprocess.run(
-                        [f"mkdir -p {target_medium_path} && cp {medium_info['buildPath']} {target_medium_path}"],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        shell=True,
-                    )
-                    if result.returncode:
-                        print("Error: move medium fail! message: %s", result.stderr)
+                    # 将编译好的介质复制到指定目录（使用 pathlib+shutil 替代 shell 命令，避免命令注入风险）
+                    target_path = Path(bkrepo_tmp_dir) / db_type / medium_type / medium_info["version"]
+                    target_path.mkdir(parents=True, exist_ok=True)
+                    try:
+                        shutil.copy2(medium_info["buildPath"], target_path)
+                    except OSError as e:
+                        print("Error: move medium fail! message: %s", str(e))


### PR DESCRIPTION
close #16505
close #16508
close #16509

## 问题描述

1. 安装节点管理插件的原子任务在 `_schedule` 轮询时无超时机制，当节点管理侧任务异常挂起时会导致流程永久卡死。
2. 修复上述功能后，单元测试断言未同步新增的 `poll_count` 字段，导致 CI 失败。
3. `build_medium` 函数使用 `subprocess.run(shell=True)` 拼接路径，存在命令注入安全漏洞。

## 修复内容

- 轮询间隔从 5s 调整为 10s
- 新增 `MAX_POLL_COUNT = 50` 轮询次数上限，超出后任务失败并记录日志（最大超时 ~500s）
- `_execute` 每次执行时重置 `poll_count = 0`，避免重试时计数累积
- 修复单元测试中断言缺少 `poll_count` 字段导致 CI 失败
- 用 `pathlib.Path` + `shutil.copy2` 替换 `subprocess.run(shell=True)`，消除命令注入风险

## 测试

- [x] 单元测试通过
- [x] 功能验证完成
