### PR TITLE
feat(backend): flow 机器初始化流程增加 /etc/hosts 更新步骤

### DIFF
--- a/dbm-ui/backend/configuration/constants.py
+++ b/dbm-ui/backend/configuration/constants.py
@@ -190,6 +190,9 @@ class SystemSettingsEnum(StrStructuredEnum):
     WINDOWS_HOST_TO_RECYCLE_SWITCH = EnumField("WINDOWS_HOST_TO_RECYCLE_SWITCH", _("判断windows主机开关"))
     # AIDEV相关配置
     AI_CODE_SCENE_MAP = EnumField("AI_CODE_SCENE_MAP", _("智能体code场景映射关系表"))
+    # 机器初始化时需要写入 /etc/hosts 的条目，格式：{domain: ip}
+    # 示例：{"example.internal.domain": "127.0.0.1"}
+    INIT_OS_HOSTS = EnumField("INIT_OS_HOSTS", _("机器初始化hosts配置"))
 
 
 class BizSettingsEnum(StrStructuredEnum):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/common/machine_os_init.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/common/machine_os_init.py
@@ -36,6 +36,7 @@ from backend.flow.plugins.components.collections.common.sa_idle_check import Che
 from backend.flow.plugins.components.collections.common.sa_init import SaInitComponent
 from backend.flow.plugins.components.collections.common.transfer_host_service import TransferHostServiceComponent
 from backend.flow.plugins.components.collections.common.transfer_host_to_pool import TransferHostToPoolComponent
+from backend.flow.plugins.components.collections.common.update_hosts_file import AddHostsEntryComponent
 from backend.flow.utils.base.flow_output import BaseFlowOutputSerializer, FlowOutputHandler
 from backend.flow.utils.common_act_dataclass import (
     ImportMachinePollKwargs,
@@ -156,6 +157,28 @@ class ImportResourceInitStepFlow(object):
                     "ips": [host["ip"] for host in host_list],
                     "bk_biz_id": bk_biz_id,
                     "account_name": account_name,
+                },
+            )
+
+        # 更新目标机器的 /etc/hosts
+        # 从系统配置 INIT_OS_HOSTS 读取需要写入的条目，格式为 {domain: ip}
+        # 若该 key 未配置或值为空，则跳过此步骤；配置后可对所有新初始化机器生效
+        # 典型场景：将某个内部服务域名与 IP 的映射写入 hosts，确保机器能正常解析该域名
+        init_os_hosts: dict = SystemSettings.get_setting_value(key=SystemSettingsEnum.INIT_OS_HOSTS.value, default={})
+        if init_os_hosts:
+            # 将 {domain: ip} 转换为 [{"ip": ..., "domain": ...}] 传给 Component
+            # Component 会对每条记录执行 grep 检查，仅追加缺失的条目（幂等）
+            hosts_entries = [{"ip": ip, "domain": domain} for domain, ip in init_os_hosts.items()]
+            p.add_act(
+                act_name=_("更新hosts文件"),
+                act_component_code=AddHostsEntryComponent.code,
+                kwargs={
+                    # 保留每台机器自己的 bk_cloud_id，不能共用第一个的值，
+                    # 否则不同管控区域的机器会路由到错误目标
+                    "exec_targets": [
+                        {"ip": host["ip"], "bk_cloud_id": host.get("bk_cloud_id", 0)} for host in host_list
+                    ],
+                    "hosts_entries": hosts_entries,
                 },
             )
 

--- a/dbm-ui/backend/flow/plugins/components/collections/common/update_hosts_file.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/update_hosts_file.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import copy
+
+from django.utils.translation import gettext as _
+from jinja2.sandbox import SandboxedEnvironment as Environment
+from pipeline.component_framework.component import Component
+
+from backend import env
+from backend.components import JobApi
+from backend.flow.consts import DBA_ROOT_USER
+from backend.flow.plugins.components.collections.common.base_service import BkJobService
+from backend.flow.utils.script_template import fast_execute_script_common_kwargs
+from backend.utils.string import base64_encode
+
+# /etc/hosts 更新脚本模板（Jinja2）
+# 参数：
+#   hosts_entries - list[{"ip": str, "domain": str}]，要写入的 hosts 条目列表
+#
+# 逻辑：
+#   1. 备份 /etc/hosts 到 /etc/hosts.bak.<时间戳>（每次执行只备份一次）
+#   2. 逐条检查条目是否已存在，不存在则追加写入（幂等）
+update_hosts_script = """
+#!/bin/bash
+set -e
+
+BAK_FILE="/etc/hosts.bak.$(date +%Y%m%d%H%M%S)"
+cp -f /etc/hosts "${BAK_FILE}"
+echo "backed up /etc/hosts to ${BAK_FILE}"
+
+{% for entry in hosts_entries %}
+HOSTS_ENTRY="{{ entry.ip }} {{ entry.domain }}"
+if grep -qF "${HOSTS_ENTRY}" /etc/hosts; then
+    echo "entry already exists, skip: ${HOSTS_ENTRY}"
+else
+    echo "${HOSTS_ENTRY}" >> /etc/hosts
+    echo "entry added: ${HOSTS_ENTRY}"
+fi
+{% endfor %}
+
+echo "update /etc/hosts done"
+"""  # noqa
+
+
+class AddHostsEntryService(BkJobService):
+    """
+    在目标机器的 /etc/hosts 中写入指定条目。
+
+    写入前先备份原文件，逐条检查是否已存在（幂等），仅追加缺失的条目。
+
+    kwargs 说明：
+        exec_targets  list[{"ip": str, "bk_cloud_id": int}]
+                      目标机器列表，每台机器携带自己所属的管控区域 ID，
+                      不能使用统一的 bk_cloud_id，避免混合管控区域时执行错误。
+        hosts_entries list[{"ip": str, "domain": str}]
+                      要写入 /etc/hosts 的条目列表，由调用方（flow builder）
+                      从系统配置 INIT_OS_HOSTS 读取并转换后传入，
+                      Component 本身不硬编码任何条目值。
+    """
+
+    def _execute(self, data, parent_data) -> bool:
+        kwargs = data.get_one_of_inputs("kwargs")
+
+        exec_targets = kwargs.get("exec_targets", [])
+        hosts_entries = kwargs.get("hosts_entries", [])
+
+        if not exec_targets:
+            self.log_error(_("exec_targets 参数为空，无目标机器可执行"))
+            return False
+
+        if not hosts_entries:
+            self.log_error(_("hosts_entries 参数为空，无需写入任何条目"))
+            return False
+
+        # 渲染 Jinja2 脚本，将 hosts 条目列表注入模板
+        jinja_env = Environment()
+        template = jinja_env.from_string(update_hosts_script)
+        script_content = template.render(hosts_entries=hosts_entries)
+
+        # 每台机器使用自己所属的管控区域 ID（bk_cloud_id），
+        # 不能共用同一个值，否则不同管控区域的机器会执行到错误目标
+        target_ip_info = [{"bk_cloud_id": t["bk_cloud_id"], "ip": t["ip"]} for t in exec_targets]
+
+        body = {
+            "bk_biz_id": env.JOB_BLUEKING_BIZ_ID,
+            "task_name": "DBM-Update-Hosts-File",
+            "script_content": base64_encode(script_content),
+            "script_language": 1,
+            "target_server": {"ip_list": target_ip_info},
+        }
+        self.log_info(_("准备更新 /etc/hosts，目标机器数: {}").format(len(target_ip_info)))
+        self.log_info(_("待写入条目: {}").format(hosts_entries))
+
+        common_kwargs = copy.deepcopy(fast_execute_script_common_kwargs)
+        common_kwargs["account_alias"] = DBA_ROOT_USER
+
+        resp = JobApi.fast_execute_script({**common_kwargs, **body}, raw=True)
+        self.log_info(f"fast execute script response: {resp}")
+        self.log_info(f"job url: {self.__url__(resp['data']['job_instance_id'])}")
+
+        data.outputs.ext_result = resp
+        # exec_ips 必须存为 {"ip": ..., "bk_cloud_id": ...} 的 dict 列表，
+        # 而不是纯字符串列表，否则 BkJobService._schedule 在轮询阶段会
+        # 回退读 kwargs["bk_cloud_id"]（兼容旧代码路径），导致 KeyError。
+        data.outputs.exec_ips = [{"ip": t["ip"], "bk_cloud_id": t["bk_cloud_id"]} for t in exec_targets]
+        return True
+
+
+class AddHostsEntryComponent(Component):
+    name = __name__
+    code = "add_hosts_entry"
+    bound_service = AddHostsEntryService


### PR DESCRIPTION
## Summary

- 新增 `SystemSettingsEnum.INIT_OS_HOSTS` 系统配置 key，value 格式为 `{domain: ip}`
- 新增 `AddHostsEntryComponent` 通用组件，通过 Job 平台在目标机器执行 bash 脚本，写入前备份 `/etc/hosts`，幂等写入
- `ImportResourceInitStepFlow.__build_machine_import_pipeline()` 在 SA 初始化后查询 `INIT_OS_HOSTS`，若配置存在则插入更新 hosts 步骤

closes #16866

## Test plan

- [ ] 不配置 `INIT_OS_HOSTS` 时，流程正常跳过该步骤
- [ ] 配置 `INIT_OS_HOSTS` 后，机器初始化流程包含"更新hosts文件"节点，且目标机器 `/etc/hosts` 正确写入条目
- [ ] 条目已存在时，脚本幂等，不重复写入
- [ ] 备份文件 `/etc/hosts.bak.<timestamp>` 正确生成
