### PR TITLE
fix(other): fix(spiderctl): TenDB Cluster 后端切换释放 Master Spider 锁时增加成功日志 #16941

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/spiderctl/backend_switch.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/spiderctl/backend_switch.go
@@ -791,6 +791,8 @@ func (r *SpiderClusterBackendSwitchComp) cutOverNormal(tdbctlNotFlushed *bool, f
 	defer func() {
 		if uerr := r.UnlockMasterSpiders(); uerr != nil {
 			logger.Error("unlock failed: %v", uerr)
+		} else {
+			logger.Info("unlock master spiders successfully")
 		}
 	}()
 	logger.Info("Spider节点锁定成功，开始检查复制状态")
@@ -1164,6 +1166,7 @@ func (c *CutOverCtx) UnlockMasterSpiders() (err error) {
 				return ierr
 			}
 			// 归还连接到连接池
+			logger.Info("unlock lock tables at %s successfully", addr)
 			lockConn.Close()
 			return nil
 		})

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/spiderctl/backend_switch.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/spiderctl/backend_switch.go
@@ -1171,7 +1171,7 @@ func (c *CutOverCtx) UnlockMasterSpiders() (err error) {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("addr:%s,err:%w", addr, err)
+			return fmt.Errorf("unlock lock tables at %s failed,err:%w", addr, err)
 		}
 	}
 	return


### PR DESCRIPTION
close #16941

## 变更说明

在 `cutOverNormal` 切换流程中，`UnlockMasterSpiders()` 成功释放锁后增加 `Info` 日志，以及 `UnlockMasterSpiders()` 函数内部对每个节点解锁成功时增加节点级日志，便于排查切换过程中的锁释放状态。