### PR TITLE
feat(mysql): clone-mysql-grant-in-actuator #16837

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/mysqlcmd.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/mysqlcmd.go
@@ -16,6 +16,7 @@ import (
 
 	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
 	v2 "dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util/templates"
 )
 
@@ -78,6 +79,13 @@ func NewMysqlCommand() *cobra.Command {
 				v2.NewReloadPeripheralToolsConfigCommand(),
 				v2.NewInitCommonConfigCommand(),
 				NewMysqlPartitionExec(),
+				clone_grants_from_file.NewCloneGrantsDumpPrivCommand(),
+				clone_grants_from_file.NewCloneGrantsParsePrivFileCommand(),
+				clone_grants_from_file.NewCloneGrantsPrecheckCreateCommand(),
+				clone_grants_from_file.NewCloneGrantsImportCreateCommand(),
+				clone_grants_from_file.NewCloneGrantsImportGrantCommand(),
+				clone_grants_from_file.NewCloneGrantsVerifyCreateCommand(),
+				clone_grants_from_file.NewCloneGrantsVerifyGrantCommand(),
 			},
 		},
 		{

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_dump_priv.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_dump_priv.go
@@ -1,0 +1,87 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsDumpPrivAct struct {
+	*subcmd.BaseOptions
+	Service mysql.DumpPrivComponent
+}
+
+const CloneGrantsDumpPrivCmd = `clone-grants-dump-priv`
+
+func NewCloneGrantsDumpPrivCommand() *cobra.Command {
+	act := &CloneGrantsDumpPrivAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsDumpPrivCmd,
+		Short: "dump priv component",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsDumpPrivCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsDumpPrivAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsDumpPrivAct) Init() error {
+	if err := c.Deserialize(&c.Service.Params); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Params)
+	return nil
+}
+
+func (c *CloneGrantsDumpPrivAct) Run() (err error) {
+	defer util.LoggerErrorStack(logger.Error, err)
+	steps := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "生成备份配置",
+			Func:    c.Service.GenerateBackupConfig,
+		},
+		{
+			FunName: "终止残留备份进程",
+			Func:    c.Service.KillLegacyBackup,
+		},
+		{
+			FunName: "执行备份",
+			Func:    c.Service.DoBackup,
+		},
+		{
+			FunName: "复制权限文件",
+			Func:    c.Service.RenamePrivFile,
+		},
+	}
+
+	if err = steps.Run(); err != nil {
+		return err
+	}
+
+	logger.Info("权限导出完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_import_create.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_import_create.go
@@ -1,0 +1,78 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsImportCreateAct struct {
+	*subcmd.BaseOptions
+	Service mysql.ImportPrivFileComponent
+}
+
+const CloneGrantsImportCreateCmd = `clone-grants-import-create`
+
+func NewCloneGrantsImportCreateCommand() *cobra.Command {
+	act := &CloneGrantsImportCreateAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsImportCreateCmd,
+		Short: "import create user file to target db",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsImportCreateCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsImportCreateAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsImportCreateAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsImportCreateAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		//{
+		//	FunName: "处理权限文件",
+		//	Func:    c.Service.ParseFile,
+		//},
+		{
+			FunName: "导入账号文件",
+			Func:    c.Service.ImportCreateUserFile,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("导入账号文件完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_import_grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_import_grant.go
@@ -1,0 +1,78 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsImportGrantAct struct {
+	*subcmd.BaseOptions
+	Service mysql.ImportPrivFileComponent
+}
+
+const CloneGrantsImportGrantCmd = `clone-grants-import-grant`
+
+func NewCloneGrantsImportGrantCommand() *cobra.Command {
+	act := &CloneGrantsImportGrantAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsImportGrantCmd,
+		Short: "import grant privilege file to target db",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsImportGrantCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsImportGrantAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsImportGrantAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsImportGrantAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		//{
+		//	FunName: "处理权限文件",
+		//	Func:    c.Service.ParseFile,
+		//},
+		{
+			FunName: "导入权限文件",
+			Func:    c.Service.ImportGrantPrivFile,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("导入权限文件完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_parse_file.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_parse_file.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsParsePrivFileAct struct {
+	*subcmd.BaseOptions
+	Service mysql.ImportPrivFileComponent
+}
+
+const CloneGrantsParsePrivFileCmd = `clone-grants-parse-file`
+
+func NewCloneGrantsParsePrivFileCommand() *cobra.Command {
+	act := &CloneGrantsParsePrivFileAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsParsePrivFileCmd,
+		Short: "parse privilege file into create user and grant files",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsParsePrivFileCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsParsePrivFileAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsParsePrivFileAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsParsePrivFileAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "处理权限文件",
+			Func:    c.Service.ParseFile,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("处理权限文件完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_precheck_create.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_precheck_create.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsPrecheckCreateAct struct {
+	*subcmd.BaseOptions
+	Service mysql.ImportPrivFileComponent
+}
+
+const CloneGrantsPrecheckCreateCmd = `clone-grants-precheck-create`
+
+func NewCloneGrantsPrecheckCreateCommand() *cobra.Command {
+	act := &CloneGrantsPrecheckCreateAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsPrecheckCreateCmd,
+		Short: "pre-check create user statements against target db",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsPrecheckCreateCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsPrecheckCreateAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsPrecheckCreateAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsPrecheckCreateAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "预检查账号",
+			Func:    c.Service.PreCheckCreateUser,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("预检查账号完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_verify_create.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_verify_create.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsVerifyCreateAct struct {
+	*subcmd.BaseOptions
+	Service mysql.ImportPrivFileComponent
+}
+
+const CloneGrantsVerifyCreateCmd = `clone-grants-verify-create`
+
+func NewCloneGrantsVerifyCreateCommand() *cobra.Command {
+	act := &CloneGrantsVerifyCreateAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsVerifyCreateCmd,
+		Short: "verify create user accounts on target db after import",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsVerifyCreateCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsVerifyCreateAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsVerifyCreateAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsVerifyCreateAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "验证账号",
+			Func:    c.Service.VerifyCreateUser,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("验证账号完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_verify_grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/v2/clone_grants_from_file/clone_grants_verify_grant.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsVerifyGrantAct struct {
+	*subcmd.BaseOptions
+	Service mysql.ImportPrivFileComponent
+}
+
+const CloneGrantsVerifyGrantCmd = `clone-grants-verify-grant`
+
+func NewCloneGrantsVerifyGrantCommand() *cobra.Command {
+	act := &CloneGrantsVerifyGrantAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsVerifyGrantCmd,
+		Short: "verify grant privileges on target db after import",
+		Example: fmt.Sprintf(
+			`dbactuator mysql %s %s %s`,
+			CloneGrantsVerifyGrantCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsVerifyGrantAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsVerifyGrantAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsVerifyGrantAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "验证权限",
+			Func:    c.Service.VerifyGrantPriv,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("验证权限完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_dump_priv.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_dump_priv.go
@@ -1,0 +1,87 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsDumpPrivAct struct {
+	*subcmd.BaseOptions
+	Service spider.DumpPrivComponent
+}
+
+const CloneGrantsDumpPrivCmd = `clone-grants-dump-priv`
+
+func NewCloneGrantsDumpPrivCommand() *cobra.Command {
+	act := &CloneGrantsDumpPrivAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsDumpPrivCmd,
+		Short: "dump priv component",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsDumpPrivCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsDumpPrivAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsDumpPrivAct) Init() error {
+	if err := c.Deserialize(&c.Service.Params); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Params)
+	return nil
+}
+
+func (c *CloneGrantsDumpPrivAct) Run() (err error) {
+	defer util.LoggerErrorStack(logger.Error, err)
+	steps := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "生成备份配置",
+			Func:    c.Service.GenerateBackupConfig,
+		},
+		{
+			FunName: "终止残留备份进程",
+			Func:    c.Service.KillLegacyBackup,
+		},
+		{
+			FunName: "执行备份",
+			Func:    c.Service.DoBackup,
+		},
+		{
+			FunName: "复制权限文件",
+			Func:    c.Service.RenamePrivFile,
+		},
+	}
+
+	if err = steps.Run(); err != nil {
+		return err
+	}
+
+	logger.Info("权限导出完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_import_create.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_import_create.go
@@ -1,0 +1,78 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsImportCreateAct struct {
+	*subcmd.BaseOptions
+	Service spider.ImportPrivFileComponent
+}
+
+const CloneGrantsImportCreateCmd = `clone-grants-import-create`
+
+func NewCloneGrantsImportCreateCommand() *cobra.Command {
+	act := &CloneGrantsImportCreateAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsImportCreateCmd,
+		Short: "import create user file to target db",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsImportCreateCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsImportCreateAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsImportCreateAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsImportCreateAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		//{
+		//	FunName: "处理权限文件",
+		//	Func:    c.Service.ParseFile,
+		//},
+		{
+			FunName: "导入账号文件",
+			Func:    c.Service.ImportCreateUserFile,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("导入账号文件完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_import_grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_import_grant.go
@@ -1,0 +1,78 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsImportGrantAct struct {
+	*subcmd.BaseOptions
+	Service spider.ImportPrivFileComponent
+}
+
+const CloneGrantsImportGrantCmd = `clone-grants-import-grant`
+
+func NewCloneGrantsImportGrantCommand() *cobra.Command {
+	act := &CloneGrantsImportGrantAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsImportGrantCmd,
+		Short: "import grant privilege file to target db",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsImportGrantCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsImportGrantAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsImportGrantAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsImportGrantAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		//{
+		//	FunName: "处理权限文件",
+		//	Func:    c.Service.ParseFile,
+		//},
+		{
+			FunName: "导入权限文件",
+			Func:    c.Service.ImportGrantPrivFile,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("导入权限文件完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_parse_file.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_parse_file.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsParsePrivFileAct struct {
+	*subcmd.BaseOptions
+	Service spider.ImportPrivFileComponent
+}
+
+const CloneGrantsParsePrivFileCmd = `clone-grants-parse-file`
+
+func NewCloneGrantsParsePrivFileCommand() *cobra.Command {
+	act := &CloneGrantsParsePrivFileAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsParsePrivFileCmd,
+		Short: "parse privilege file into create user and grant files",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsParsePrivFileCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsParsePrivFileAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsParsePrivFileAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsParsePrivFileAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "处理权限文件",
+			Func:    c.Service.ParseFile,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("处理权限文件完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_precheck_create.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_precheck_create.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsPrecheckCreateAct struct {
+	*subcmd.BaseOptions
+	Service spider.ImportPrivFileComponent
+}
+
+const CloneGrantsPrecheckCreateCmd = `clone-grants-precheck-create`
+
+func NewCloneGrantsPrecheckCreateCommand() *cobra.Command {
+	act := &CloneGrantsPrecheckCreateAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsPrecheckCreateCmd,
+		Short: "pre-check create user statements against target db",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsPrecheckCreateCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsPrecheckCreateAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsPrecheckCreateAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsPrecheckCreateAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "预检查账号",
+			Func:    c.Service.PreCheckCreateUser,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("预检查账号完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_verify_create.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_verify_create.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsVerifyCreateAct struct {
+	*subcmd.BaseOptions
+	Service spider.ImportPrivFileComponent
+}
+
+const CloneGrantsVerifyCreateCmd = `clone-grants-verify-create`
+
+func NewCloneGrantsVerifyCreateCommand() *cobra.Command {
+	act := &CloneGrantsVerifyCreateAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsVerifyCreateCmd,
+		Short: "verify create user accounts on target db after import",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsVerifyCreateCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsVerifyCreateAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsVerifyCreateAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsVerifyCreateAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "验证账号",
+			Func:    c.Service.VerifyCreateUser,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("验证账号完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_verify_grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file/clone_grants_verify_grant.go
@@ -1,0 +1,74 @@
+package clone_grants_from_file
+
+import (
+	"dbm-services/bigdata/db-tools/dbactuator/pkg/util"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type CloneGrantsVerifyGrantAct struct {
+	*subcmd.BaseOptions
+	Service spider.ImportPrivFileComponent
+}
+
+const CloneGrantsVerifyGrantCmd = `clone-grants-verify-grant`
+
+func NewCloneGrantsVerifyGrantCommand() *cobra.Command {
+	act := &CloneGrantsVerifyGrantAct{
+		BaseOptions: subcmd.GBaseOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   CloneGrantsVerifyGrantCmd,
+		Short: "verify grant privileges on target db after import",
+		Example: fmt.Sprintf(
+			`dbactuator spider %s %s %s`,
+			CloneGrantsVerifyGrantCmd,
+			subcmd.CmdBaseExampleStr,
+			subcmd.ToPrettyJson(act.Service.Example()),
+		),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(act.Validate())
+			util.CheckErr(act.Init())
+			util.CheckErr(act.Run())
+		},
+	}
+	return cmd
+}
+
+func (c *CloneGrantsVerifyGrantAct) Validate() error {
+	return c.BaseOptions.Validate()
+}
+
+func (c *CloneGrantsVerifyGrantAct) Init() error {
+	if err := c.Deserialize(&c.Service.Param); err != nil {
+		logger.Error("DeserializerAndValidate err %s", err.Error())
+		return err
+	}
+	c.Service.GeneralParam = subcmd.GeneralRuntimeParam
+	logger.Info("extend params: %s", c.Service.Param)
+	return nil
+}
+
+func (c *CloneGrantsVerifyGrantAct) Run() error {
+	s := subcmd.Steps{
+		{
+			FunName: "初始化",
+			Func:    c.Service.Init,
+		},
+		{
+			FunName: "验证权限",
+			Func:    c.Service.VerifyGrantPriv,
+		},
+	}
+	if err := s.Run(); err != nil {
+		logger.Error("Run err %s", err.Error())
+		return err
+	}
+
+	logger.Info("验证权限完成")
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/cmd.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/cmd.go
@@ -6,6 +6,7 @@ package spidercmd
 
 import (
 	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd"
+	"dbm-services/mysql/db-tools/dbactuator/internal/subcmd/spidercmd/clone_grants_from_file"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util/templates"
 
 	"github.com/spf13/cobra"
@@ -26,6 +27,13 @@ func NewSpiderCommand() *cobra.Command {
 				NewUnInstallSpiderCommand(),
 				NewRestratSpiderCommand(),
 				NewUpgradeSpiderCommand(),
+				clone_grants_from_file.NewCloneGrantsDumpPrivCommand(),
+				clone_grants_from_file.NewCloneGrantsParsePrivFileCommand(),
+				clone_grants_from_file.NewCloneGrantsPrecheckCreateCommand(),
+				clone_grants_from_file.NewCloneGrantsImportCreateCommand(),
+				clone_grants_from_file.NewCloneGrantsVerifyCreateCommand(),
+				clone_grants_from_file.NewCloneGrantsImportGrantCommand(),
+				clone_grants_from_file.NewCloneGrantsVerifyGrantCommand(),
 			},
 		},
 	}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/checker.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/checker.go
@@ -1,0 +1,130 @@
+package checker
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type userRow struct {
+	AuthString     string `db:"auth_string"`
+	MaxQuestions   int    `db:"max_questions"`
+	MaxUpdates     int    `db:"max_updates"`
+	MaxConnections int    `db:"max_connections"`
+	MaxUserConns   int    `db:"max_user_connections"`
+}
+
+// CheckAccountOnTarget 检查 create_user 文件中的一条语句对应的账号在目标 DB 上的状态。
+//
+// 支持的语句格式：
+//   - CREATE USER [IF NOT EXISTS] 'user'@'host' IDENTIFIED WITH 'plugin' AS 'hash' ...  (5.7/8.0)
+//   - CREATE USER [IF NOT EXISTS] 'user'@'host' IDENTIFIED BY PASSWORD 'hash' ...       (5.5/5.6)
+//   - CREATE USER [IF NOT EXISTS] 'user'@'host'                                         (无密码用户)
+//   - GRANT USAGE ON *.* TO 'user'@'host' IDENTIFIED BY PASSWORD 'hash' ...             (5.5/5.6)
+//   - GRANT USAGE ON *.* TO 'user'@'host'                                               (无密码用户)
+//
+// 返回值：
+//   - exists: 账号是否存在
+//   - passwordMatch: 密码 hash 是否一致（账号不存在时为 false）
+//   - resourceMatch: 资源限制是否一致（账号不存在时为 false）
+//   - err: 解析或查询错误
+func CheckAccountOnTarget(
+	ctx context.Context, conn *sqlx.Conn, stmt string, dstVer int64,
+) (exists, passwordMatch, resourceMatch bool, err error) {
+	user, host, hash, rest, parseErr := parseCreateStmt(stmt)
+	if parseErr != nil {
+		logger.Error("parseCreateStmt: %v", parseErr)
+		return false, false, false, parseErr
+	}
+
+	stmtLimits := pkg.ParseResourceLimits(rest)
+
+	row, queryErr := queryUserRow(ctx, conn, user, host, dstVer)
+	if queryErr != nil {
+		logger.Error("queryUserRow %s@%s: %v", user, host, queryErr)
+		return false, false, false, queryErr
+	}
+	if row == nil {
+		return false, false, false, nil
+	}
+
+	pwMatch := row.AuthString == hash
+	rlMatch := row.MaxQuestions == stmtLimits.MaxQuestions &&
+		row.MaxUpdates == stmtLimits.MaxUpdates &&
+		row.MaxConnections == stmtLimits.MaxConnections &&
+		row.MaxUserConns == stmtLimits.MaxUserConns
+
+	return true, pwMatch, rlMatch, nil
+}
+
+// parseCreateStmt 从 CREATE USER 或 GRANT USAGE 语句中提取 user、host、hash 和 rest。
+func parseCreateStmt(stmt string) (user, host, hash, rest string, err error) {
+	stmt = strings.TrimSuffix(strings.TrimSpace(stmt), ";")
+
+	if matches := pkg.ReCreateUser.FindStringSubmatch(stmt); matches != nil {
+		user, host, _, hash, rest, _ = pkg.ExtractCreateUserFields(matches)
+		return
+	}
+
+	if matches := pkg.ReCreateUserLegacy.FindStringSubmatch(stmt); matches != nil {
+		user, host, hash, rest, _ = pkg.ExtractCreateUserLegacyFields(matches)
+		return
+	}
+
+	if matches := pkg.ReCreateUserPlain.FindStringSubmatch(stmt); matches != nil {
+		user, host, rest, _ = pkg.ExtractCreateUserPlainFields(matches)
+		hash = ""
+		return
+	}
+
+	if matches := pkg.ReGrantWithAuth.FindStringSubmatch(stmt); matches != nil {
+		_, _, user, host, hash, rest, _ = pkg.ExtractGrantWithAuthFields(matches)
+		return
+	}
+
+	if matches := pkg.ReGrantPlain.FindStringSubmatch(stmt); matches != nil {
+		privs, _, u, h, r, _ := pkg.ExtractGrantPlainFields(matches)
+		if strings.EqualFold(strings.TrimSpace(privs), "USAGE") {
+			user, host, hash, rest = u, h, "", r
+			return
+		}
+	}
+
+	err = fmt.Errorf("statement does not match CREATE USER or GRANT USAGE: %s", stmt)
+	logger.Error("%v", err)
+	return
+}
+
+// queryUserRow 查询 mysql.user 表获取账号信息。
+// 如果账号不存在返回 (nil, nil)。
+func queryUserRow(ctx context.Context, conn *sqlx.Conn, user, host string, dstVer int64) (*userRow, error) {
+	var authCol string
+	if dstVer >= 5007000 {
+		authCol = "authentication_string"
+	} else {
+		authCol = "Password"
+	}
+
+	query := fmt.Sprintf(
+		"SELECT %s AS auth_string, max_questions, max_updates, max_connections, max_user_connections "+
+			"FROM mysql.user WHERE User = ? AND Host = ?",
+		authCol,
+	)
+
+	var row userRow
+	if err := conn.QueryRowxContext(ctx, query, user, host).StructScan(&row); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		logger.Error("query mysql.user for %s@%s: %v", user, host, err)
+		return nil, fmt.Errorf("query mysql.user for %s@%s: %w", user, host, err)
+	}
+	return &row, nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/precheck.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/precheck.go
@@ -1,0 +1,158 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// PreCheckCreateUserFile 逐行读取 create_user 文件，执行所有检查后统一报错：
+//   - 文件自身正确性（重复账号、不支持的认证插件）
+//   - 每个账号在目标 DB 上的密码和资源限制是否一致
+func PreCheckCreateUserFile(conn *sqlx.Conn, filePath string, dstVer int64) error {
+	var allErrors []error
+
+	if err := checkCreateUserFileValidity(filePath); err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	if err := checkAccountsOnTarget(conn, filePath, dstVer); err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	if len(allErrors) > 0 {
+		for _, e := range allErrors {
+			logger.Error("pre-check: %v", e)
+		}
+		return fmt.Errorf("pre-check failed with %d error(s): %v", len(allErrors), allErrors)
+	}
+
+	return nil
+}
+
+// checkCreateUserFileValidity 扫描 create_user 文件，检查：
+//   - 同一 user@host 是否出现多次（重复条目）
+//   - 是否存在 caching_sha2_password 认证插件（不支持跨版本迁移）
+func checkCreateUserFileValidity(filePath string) error {
+	scanner, closeFile, err := pkg.OpenFileWithScanner(filePath)
+	if err != nil {
+		logger.Error("open create user file %s: %v", filePath, err)
+		return fmt.Errorf("open create user file: %w", err)
+	}
+	defer closeFile()
+
+	ls := pkg.NewLineScanner(scanner, filePath, 0)
+	defer ls.Stop()
+	seen := make(map[string]int) // user@host → 首次出现的行号
+	var problems []string
+
+	for ls.Next() {
+		stmt := ls.Stmt()
+
+		user, host, _, _, parseErr := parseCreateStmt(stmt)
+		if parseErr != nil {
+			logger.Error("parse line %d: %v", ls.LineNo(), parseErr)
+			return fmt.Errorf("parse line %d: %w", ls.LineNo(), parseErr)
+		}
+
+		key := user + "@" + host
+		if firstLine, exists := seen[key]; exists {
+			problems = append(problems, fmt.Sprintf(
+				"line %d: duplicate CREATE USER for %s (first seen at line %d)",
+				ls.LineNo(), key, firstLine,
+			))
+		} else {
+			seen[key] = ls.LineNo()
+		}
+
+		if plugin := extractAuthPlugin(stmt); strings.EqualFold(plugin, "caching_sha2_password") {
+			problems = append(problems, fmt.Sprintf(
+				"line %d: unsupported auth plugin caching_sha2_password for %s",
+				ls.LineNo(), key,
+			))
+		}
+	}
+
+	if err := ls.Err(); err != nil {
+		logger.Error("reading create user file: %v", err)
+		return fmt.Errorf("reading create user file: %w", err)
+	}
+
+	if len(problems) > 0 {
+		for _, p := range problems {
+			logger.Error("file check: %s", p)
+		}
+		return fmt.Errorf("pre-check failed: %d problems found in create_user file", len(problems))
+	}
+
+	logger.Info("file validity check passed, unique users=%d", len(seen))
+	return nil
+}
+
+// extractAuthPlugin 从 CREATE USER 语句中提取认证插件名。
+// 仅匹配 IDENTIFIED WITH 'plugin' 格式（5.7/8.0），其他格式返回空字符串。
+func extractAuthPlugin(stmt string) string {
+	matches := pkg.ReCreateUser.FindStringSubmatch(strings.TrimSuffix(strings.TrimSpace(stmt), ";"))
+	if matches == nil {
+		return ""
+	}
+	_, _, plugin, _, _, _ := pkg.ExtractCreateUserFields(matches)
+	return plugin
+}
+
+// checkAccountsOnTarget 逐行检查 create_user 文件中每个账号在目标 DB 上的密码和资源限制是否一致。
+// 账号不存在的跳过，有不一致的收集后统一报错。
+func checkAccountsOnTarget(conn *sqlx.Conn, filePath string, dstVer int64) error {
+	scanner, closeFile, err := pkg.OpenFileWithScanner(filePath)
+	if err != nil {
+		logger.Error("open create user file %s: %v", filePath, err)
+		return fmt.Errorf("open create user file: %w", err)
+	}
+	defer closeFile()
+
+	ls := pkg.NewLineScanner(scanner, filePath, 0)
+	defer ls.Stop()
+	ctx := context.Background()
+	var mismatches []string
+
+	for ls.Next() {
+		line := ls.Stmt()
+
+		exists, pwMatch, rlMatch, checkErr := CheckAccountOnTarget(ctx, conn, line, dstVer)
+		if checkErr != nil {
+			logger.Error("pre-check line %d: %v", ls.LineNo(), checkErr)
+			return fmt.Errorf("pre-check line %d: %w", ls.LineNo(), checkErr)
+		}
+
+		if !exists {
+			continue
+		}
+
+		if !pwMatch || !rlMatch {
+			detail := fmt.Sprintf(
+				"line %d: passwordMatch=%t resourceMatch=%t stmt=%s", ls.LineNo(), pwMatch, rlMatch, line,
+			)
+			mismatches = append(mismatches, detail)
+		}
+	}
+
+	if err := ls.Err(); err != nil {
+		logger.Error("reading create user file: %v", err)
+		return fmt.Errorf("reading create user file: %w", err)
+	}
+
+	if len(mismatches) > 0 {
+		for _, m := range mismatches {
+			logger.Error("pre-check mismatch: %s", m)
+		}
+		return fmt.Errorf("pre-check failed: %d accounts have mismatched password or resource limits", len(mismatches))
+	}
+
+	logger.Info("pre-check passed, total lines=%d", ls.LineNo())
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_grant.go
@@ -1,0 +1,337 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// scopeGrants 表示某个 scope 上的权限集合和 GRANT OPTION 状态。
+type scopeGrants struct {
+	privs       map[string]struct{}
+	grantOption bool
+}
+
+// VerifyGrantPrivFile 逐行读取 grant_priv 文件，验证每条 GRANT 语句对应的权限已在目标 DB 生效。
+// 使用子集检查：文件中的权限必须是目标实际权限的子集。
+// 当 dstVer >= 8.0 且源权限为 ALL PRIVILEGES ON *.* 时，通过 mysql.user 系统表验证所有静态权限。
+func VerifyGrantPrivFile(conn *sqlx.Conn, filePath string, dstVer int64) error {
+	expected, err := buildExpectedGrants(filePath)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	var mismatches []string
+
+	for userHost, scopeMap := range expected {
+		parts := strings.SplitN(userHost, "@", 2)
+		user, host := parts[0], parts[1]
+
+		actual, queryErr := queryShowGrants(ctx, conn, user, host)
+		if queryErr != nil {
+			logger.Error("SHOW GRANTS FOR %s: %v", userHost, queryErr)
+			mismatches = append(mismatches, fmt.Sprintf("%s: SHOW GRANTS failed: %v", userHost, queryErr))
+			continue
+		}
+
+		for scope, exp := range scopeMap {
+			if _, isAll := exp.privs["ALL PRIVILEGES"]; isAll && scope == "*.*" && dstVer >= 8000000 {
+				if missing, verifyErr := verifyAllStaticPrivs(ctx, conn, user, host); verifyErr != nil {
+					mismatches = append(mismatches, fmt.Sprintf("%s: verify ALL static privs failed: %v", userHost, verifyErr))
+				} else if len(missing) > 0 {
+					mismatches = append(mismatches, fmt.Sprintf("%s: scope *.* static privs not 'Y': %v", userHost, missing))
+				}
+
+				if exp.grantOption {
+					if grantPriv, verifyErr := queryGrantPriv(ctx, conn, user, host); verifyErr != nil {
+						mismatches = append(mismatches, fmt.Sprintf("%s: query Grant_priv failed: %v", userHost, verifyErr))
+					} else if grantPriv != "Y" {
+						mismatches = append(mismatches, fmt.Sprintf("%s: scope *.* missing GRANT OPTION", userHost))
+					}
+				}
+				continue
+			}
+
+			act, ok := actual[scope]
+			if !ok {
+				mismatches = append(
+					mismatches, fmt.Sprintf(
+						"%s: scope %s not found in SHOW GRANTS, expected privs=%s",
+						userHost, scope, formatPrivSet(exp.privs),
+					),
+				)
+				continue
+			}
+
+			missing := checkPrivSubset(exp.privs, act.privs)
+			if len(missing) > 0 {
+				mismatches = append(
+					mismatches, fmt.Sprintf(
+						"%s: scope %s missing privs=%v", userHost, scope, missing,
+					),
+				)
+			}
+
+			if exp.grantOption && !act.grantOption {
+				mismatches = append(
+					mismatches, fmt.Sprintf(
+						"%s: scope %s missing GRANT OPTION", userHost, scope,
+					),
+				)
+			}
+		}
+	}
+
+	if len(mismatches) > 0 {
+		for _, m := range mismatches {
+			logger.Error("verify grant mismatch: %s", m)
+		}
+		return fmt.Errorf("verify grant failed: %d mismatches", len(mismatches))
+	}
+
+	logger.Info("verify grant passed")
+	return nil
+}
+
+// buildExpectedGrants 解析 grant_priv 文件，构建 map[user@host]map[scope]*scopeGrants。
+func buildExpectedGrants(filePath string) (map[string]map[string]*scopeGrants, error) {
+	scanner, closeFile, err := pkg.OpenFileWithScanner(filePath)
+	if err != nil {
+		logger.Error("open grant file %s: %v", filePath, err)
+		return nil, fmt.Errorf("open grant file: %w", err)
+	}
+	defer closeFile()
+
+	ls := pkg.NewLineScanner(scanner, filePath, 0)
+	defer ls.Stop()
+	result := make(map[string]map[string]*scopeGrants)
+
+	for ls.Next() {
+		line := ls.Stmt()
+
+		matches := pkg.ReGrantPlain.FindStringSubmatch(line)
+		if matches == nil {
+			logger.Error("verify grant: unrecognized statement at line %d: %s", ls.LineNo(), line)
+			return nil, fmt.Errorf("unrecognized statement at line %d: %s", ls.LineNo(), line)
+		}
+
+		privs, scope, user, host, rest, _ := pkg.ExtractGrantPlainFields(matches)
+		normScope := normalizeScope(scope)
+
+		if strings.EqualFold(strings.TrimSpace(privs), "USAGE") && normScope == "*.*" {
+			continue
+		}
+
+		userHost := user + "@" + host
+		if result[userHost] == nil {
+			result[userHost] = make(map[string]*scopeGrants)
+		}
+
+		sg := result[userHost][normScope]
+		if sg == nil {
+			sg = &scopeGrants{privs: make(map[string]struct{})}
+			result[userHost][normScope] = sg
+		}
+
+		for _, p := range parsePrivSet(privs) {
+			sg.privs[p] = struct{}{}
+		}
+		if hasGrantOption(rest) {
+			sg.grantOption = true
+		}
+	}
+
+	if err := ls.Err(); err != nil {
+		logger.Error("reading grant file: %v", err)
+		return nil, fmt.Errorf("reading grant file: %w", err)
+	}
+
+	return result, nil
+}
+
+// queryShowGrants 执行 SHOW GRANTS FOR 'user'@'host' 并解析为 map[scope]*scopeGrants。
+func queryShowGrants(ctx context.Context, conn *sqlx.Conn, user, host string) (map[string]*scopeGrants, error) {
+	query := fmt.Sprintf("SHOW GRANTS FOR '%s'@'%s'", user, host)
+	rows, err := conn.QueryxContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]*scopeGrants)
+
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			return nil, fmt.Errorf("scan SHOW GRANTS row: %w", err)
+		}
+
+		line = strings.TrimSuffix(strings.TrimSpace(line), ";")
+		matches := pkg.ReGrantPlain.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		privs, scope, _, _, rest, _ := pkg.ExtractGrantPlainFields(matches)
+		normScope := normalizeScope(scope)
+
+		sg := result[normScope]
+		if sg == nil {
+			sg = &scopeGrants{privs: make(map[string]struct{})}
+			result[normScope] = sg
+		}
+
+		for _, p := range parsePrivSet(privs) {
+			sg.privs[p] = struct{}{}
+		}
+		if hasGrantOption(rest) {
+			sg.grantOption = true
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating SHOW GRANTS rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// verifyAllStaticPrivs 通过 mysql.user 系统表验证用户是否拥有所有静态权限。
+// 动态获取所有 _priv 列，排除 Grant_priv，检查是否全部为 'Y'。
+// 返回值为 'N' 的列名列表。
+func verifyAllStaticPrivs(ctx context.Context, conn *sqlx.Conn, user, host string) ([]string, error) {
+	cols, err := queryPrivColumns(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	selectCols := strings.Join(cols, ", ")
+	query := fmt.Sprintf("SELECT %s FROM mysql.user WHERE User = ? AND Host = ?", selectCols)
+
+	row := conn.QueryRowxContext(ctx, query, user, host)
+	result := make(map[string]interface{})
+	if err := row.MapScan(result); err != nil {
+		return nil, fmt.Errorf("query mysql.user for %s@%s: %w", user, host, err)
+	}
+
+	var notGranted []string
+	for _, col := range cols {
+		val, ok := result[col]
+		if !ok {
+			notGranted = append(notGranted, col)
+			continue
+		}
+
+		var s string
+		switch v := val.(type) {
+		case []byte:
+			s = string(v)
+		case string:
+			s = v
+		default:
+			s = fmt.Sprintf("%v", v)
+		}
+
+		if s != "Y" {
+			notGranted = append(notGranted, col)
+		}
+	}
+
+	sort.Strings(notGranted)
+	return notGranted, nil
+}
+
+// queryPrivColumns 从 INFORMATION_SCHEMA 获取 mysql.user 表中所有 _priv 结尾的列，排除 Grant_priv。
+func queryPrivColumns(ctx context.Context, conn *sqlx.Conn) ([]string, error) {
+	query := "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
+		"WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user' AND COLUMN_NAME LIKE '%\\_priv' " +
+		"AND COLUMN_NAME != 'Grant_priv' ORDER BY ORDINAL_POSITION"
+
+	var cols []string
+	if err := sqlx.SelectContext(ctx, conn, &cols, query); err != nil {
+		return nil, fmt.Errorf("query INFORMATION_SCHEMA.COLUMNS for _priv columns: %w", err)
+	}
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("no _priv columns found in mysql.user")
+	}
+	return cols, nil
+}
+
+// queryGrantPriv 查询 mysql.user 中指定用户的 Grant_priv 值。
+func queryGrantPriv(ctx context.Context, conn *sqlx.Conn, user, host string) (string, error) {
+	var val string
+	query := "SELECT Grant_priv FROM mysql.user WHERE User = ? AND Host = ?"
+	if err := conn.QueryRowxContext(ctx, query, user, host).Scan(&val); err != nil {
+		return "", fmt.Errorf("query Grant_priv for %s@%s: %w", user, host, err)
+	}
+	return val, nil
+}
+
+// checkPrivSubset 检查 expected 是否是 actual 的子集。
+// ALL PRIVILEGES 特判：
+//   - actual 含 ALL PRIVILEGES -> 任何 expected 都算匹配
+//   - expected 含 ALL PRIVILEGES -> actual 必须也含 ALL PRIVILEGES
+//
+// 返回缺失的权限列表。
+func checkPrivSubset(expected, actual map[string]struct{}) []string {
+	if _, ok := actual["ALL PRIVILEGES"]; ok {
+		return nil
+	}
+
+	if _, ok := expected["ALL PRIVILEGES"]; ok {
+		if _, ok2 := actual["ALL PRIVILEGES"]; !ok2 {
+			return []string{"ALL PRIVILEGES"}
+		}
+		return nil
+	}
+
+	var missing []string
+	for p := range expected {
+		if _, ok := actual[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+// parsePrivSet 将 "SELECT, INSERT, UPDATE" 解析为 {"SELECT", "INSERT", "UPDATE"}。
+func parsePrivSet(privs string) []string {
+	parts := strings.Split(privs, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, strings.ToUpper(p))
+		}
+	}
+	return result
+}
+
+// normalizeScope 去掉 scope 中的反引号。
+// "`db`.*" -> "db.*"，"`db`.`table`" -> "db.table"
+func normalizeScope(scope string) string {
+	return strings.ReplaceAll(scope, "`", "")
+}
+
+// hasGrantOption 判断 rest 中是否含 GRANT OPTION。
+func hasGrantOption(rest string) bool {
+	return strings.Contains(strings.ToUpper(rest), "GRANT OPTION")
+}
+
+// formatPrivSet 将权限集合格式化为排序后的字符串，用于日志。
+func formatPrivSet(privs map[string]struct{}) string {
+	list := make([]string, 0, len(privs))
+	for p := range privs {
+		list = append(list, p)
+	}
+	sort.Strings(list)
+	return strings.Join(list, ",")
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_user.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_user.go
@@ -1,0 +1,62 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// VerifyCreateUserFile 逐行读取 create_user 文件，验证每个账号在目标 DB 上存在且密码和资源限制一致。
+// 与 PreCheckCreateUserFile 的区别：账号不存在也算 mismatch（导入后必须都在）。
+func VerifyCreateUserFile(conn *sqlx.Conn, filePath string, dstVer int64) error {
+	scanner, closeFile, err := pkg.OpenFileWithScanner(filePath)
+	if err != nil {
+		logger.Error("open create user file %s: %v", filePath, err)
+		return fmt.Errorf("open create user file: %w", err)
+	}
+	defer closeFile()
+
+	ls := pkg.NewLineScanner(scanner, filePath, 0)
+	defer ls.Stop()
+	ctx := context.Background()
+	var mismatches []string
+
+	for ls.Next() {
+		line := ls.Stmt()
+
+		exists, pwMatch, rlMatch, checkErr := CheckAccountOnTarget(ctx, conn, line, dstVer)
+		if checkErr != nil {
+			logger.Error("verify line %d: %v", ls.LineNo(), checkErr)
+			mismatches = append(mismatches, fmt.Sprintf("line %d: check error: %v", ls.LineNo(), checkErr))
+			continue
+		}
+
+		if !exists {
+			mismatches = append(mismatches, fmt.Sprintf("line %d: account not found stmt=%s", ls.LineNo(), line))
+			continue
+		}
+
+		if !pwMatch || !rlMatch {
+			mismatches = append(mismatches, fmt.Sprintf("line %d: passwordMatch=%t resourceMatch=%t stmt=%s", ls.LineNo(), pwMatch, rlMatch, line))
+		}
+	}
+
+	if err := ls.Err(); err != nil {
+		logger.Error("reading create user file: %v", err)
+		return fmt.Errorf("reading create user file: %w", err)
+	}
+
+	if len(mismatches) > 0 {
+		for _, m := range mismatches {
+			logger.Error("verify mismatch: %s", m)
+		}
+		return fmt.Errorf("verify failed: %d accounts missing or mismatched", len(mismatches))
+	}
+
+	logger.Info("verify create user passed, total lines=%d", ls.LineNo())
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer/executor.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer/executor.go
@@ -1,0 +1,111 @@
+package importer
+
+import (
+	"context"
+	"fmt"
+
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// validateProgress 校验进度文件的合法性
+// 返回值：
+//   - lastDoneLine: 上次成功执行的最后行号（0 表示从头开始）
+//   - totalLines: SQL 文件总行数
+//   - done: 如果为 true，表示所有行已在上次执行中完成，无需再执行
+//   - err: 校验过程中的错误
+func validateProgress(filePath string) (lastDoneLine int, totalLines int, done bool, err error) {
+	lastDoneLine, err = readProgress(filePath)
+	if err != nil {
+		logger.Error("读取进度信息失败: %v", err)
+		return 0, 0, false, fmt.Errorf("读取进度信息失败: %w", err)
+	}
+	logger.Info("读取进度信息成功 lastDoneLine=%d file=%s", lastDoneLine, filePath)
+
+	totalLines, err = countLines(filePath)
+	if err != nil {
+		logger.Error("统计文件行数失败: %v", err)
+		return 0, 0, false, fmt.Errorf("统计文件行数失败: %w", err)
+	}
+	logger.Info("统计文件行数成功 file=%s totalLines=%d", filePath, totalLines)
+
+	if lastDoneLine == 0 {
+		return 0, totalLines, false, nil
+	}
+
+	if lastDoneLine > totalLines {
+		logger.Error(
+			"进度文件记录的行号 %d 超出 SQL 文件实际行数 %d，进度文件与 SQL 文件不匹配",
+			lastDoneLine, totalLines,
+		)
+		return 0, 0, false, fmt.Errorf(
+			"进度文件记录的行号 %d 超出 SQL 文件实际行数 %d，进度文件与 SQL 文件不匹配",
+			lastDoneLine, totalLines,
+		)
+	}
+
+	if lastDoneLine == totalLines {
+		logger.Info("所有行已在上次执行中完成，清理进度文件 file=%s", filePath)
+		if err := removeProgress(filePath); err != nil {
+			logger.Error("清理进度文件失败: %v", err)
+			return 0, 0, false, fmt.Errorf("清理进度文件失败: %w", err)
+		}
+		logger.Info("清理进度文件成功 file=%s", filePath)
+		return 0, totalLines, true, nil
+	}
+
+	logger.Info(
+		"检测到进度文件，从断点恢复执行 file=%s lastDoneLine=%d totalLines=%d", filePath, lastDoneLine, totalLines,
+	)
+
+	return lastDoneLine, totalLines, false, nil
+}
+
+// executeSQL 逐行读取 SQL 文件并执行，跳过前 skipLines 行
+// 每成功执行一行就持久化进度，遇到错误立即返回
+// 返回值：
+//   - executed: 本次执行成功的行数
+//   - lastLine: 文件的最后行号
+//   - err: 执行过程中的错误
+func executeSQL(conn *sqlx.Conn, filePath string, skipLines int, totalLines int) (
+	executed int, lastLine int, err error,
+) {
+	scanner, closeFile, openErr := pkg.OpenFileWithScanner(filePath)
+	if openErr != nil {
+		logger.Error("打开文件 %s 失败: %v", filePath, openErr)
+		return 0, 0, fmt.Errorf("打开文件 %s 失败: %w", filePath, openErr)
+	}
+	defer closeFile()
+
+	ls := pkg.NewLineScanner(scanner, filePath, totalLines)
+	defer ls.Stop()
+
+	for ls.Next() {
+		if ls.LineNo() <= skipLines {
+			continue
+		}
+
+		line := ls.Stmt()
+
+		if _, execErr := conn.ExecContext(context.Background(), line); execErr != nil {
+			logger.Error("执行第 %d 行失败: %v", ls.LineNo(), execErr)
+			return executed, ls.LineNo(), fmt.Errorf("执行第 %d 行失败: %w\n语句: %s", ls.LineNo(), execErr, line)
+		}
+
+		if writeErr := writeProgress(filePath, ls.LineNo()); writeErr != nil {
+			logger.Error("持久化进度失败（已成功执行到第 %d 行）: %v", ls.LineNo(), writeErr)
+			return executed, ls.LineNo(), fmt.Errorf("持久化进度失败（已成功执行到第 %d 行）: %w", ls.LineNo(), writeErr)
+		}
+
+		executed++
+	}
+
+	if scanErr := ls.Err(); scanErr != nil {
+		logger.Error("读取文件 %s 失败: %v", filePath, scanErr)
+		return executed, ls.LineNo(), fmt.Errorf("读取文件 %s 失败: %w", filePath, scanErr)
+	}
+
+	return executed, ls.LineNo(), nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer/importer.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer/importer.go
@@ -1,0 +1,49 @@
+package importer
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"fmt"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+// ImportFile 是 ImportFile 的核心实现，接受已建立的数据库连接
+// 编排整体流程：校验进度 → 执行 SQL → 清理进度文件
+func ImportFile(conn *sqlx.Conn, filePath string) error {
+	// 校验进度，获取应跳过的行数和总行数
+	lastDoneLine, totalLines, done, err := validateProgress(filePath)
+	if err != nil {
+		logger.Error("校验进度失败: %v", err)
+		return err
+	}
+	logger.Info("校验进度成功 file=%s lastDoneLine=%d totalLines=%d", filePath, lastDoneLine, totalLines)
+	if done {
+		logger.Info("文件已导入完成，跳过 file=%s", filePath)
+		return nil
+	}
+
+	// 输出工作摘要
+	remaining := totalLines - lastDoneLine
+	if lastDoneLine == 0 {
+		logger.Info("开始导入 %s 共 %d 行", filePath, totalLines)
+	} else {
+		logger.Info("从断点恢复导入 %s 已完成 %d 行，剩余 %d 行", filePath, lastDoneLine, remaining)
+
+	}
+
+	// 逐行执行 SQL
+	executed, lastLine, err := executeSQL(conn, filePath, lastDoneLine, totalLines)
+	if err != nil {
+		logger.Error("执行 SQL 失败: %v", err)
+		return err
+	}
+
+	if err := removeProgress(filePath); err != nil {
+		logger.Error("清理进度文件失败: %v", err)
+		return fmt.Errorf("清理进度文件失败: %v", err)
+	}
+
+	logger.Info("导入完成 %s 共 %d 行, last line %d", filePath, executed, lastLine)
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer/progress.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer/progress.go
@@ -1,0 +1,131 @@
+package importer
+
+import (
+	"bufio"
+	"dbm-services/common/go-pubpkg/logger"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// progressFilePath 返回 SQL 文件对应的进度文件路径
+// 规则：SQL 文件路径 + ".progress" 后缀
+func progressFilePath(sqlFilePath string) string {
+	return sqlFilePath + ".progress"
+}
+
+// readProgress 读取进度文件，返回已成功执行的最后行号
+// 如果进度文件不存在，返回 0（表示从头开始）
+// 如果进度文件内容无法解析，返回明确的错误
+func readProgress(sqlFilePath string) (int, error) {
+	pf := progressFilePath(sqlFilePath)
+
+	data, err := os.ReadFile(pf)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		logger.Error("读取进度文件 %s 失败: %v", pf, err)
+		return 0, fmt.Errorf("读取进度文件 %s 失败: %w", pf, err)
+	}
+	logger.Info("读取进度文件成功 pf=%s size=%d", pf, len(data))
+
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		logger.Error("进度文件 %s 内容为空", pf)
+		return 0, fmt.Errorf("进度文件 %s 内容为空", pf)
+	}
+
+	lineNo, err := strconv.Atoi(content)
+	if err != nil {
+		logger.Error("进度文件 %s 内容无法解析为行号: %q: %v", pf, content, err)
+		return 0, fmt.Errorf("进度文件 %s 内容无法解析为行号: %q: %w", pf, content, err)
+	}
+	logger.Info("解析进度文件行号成功 pf=%s lineNo=%d", pf, lineNo)
+
+	if lineNo < 0 {
+		logger.Error("进度文件 %s 中的行号无效: %d", pf, lineNo)
+		return 0, fmt.Errorf("进度文件 %s 中的行号无效: %d", pf, lineNo)
+	}
+
+	return lineNo, nil
+}
+
+// writeProgress 原子写入进度文件
+// 先写入临时文件，再通过 os.Rename 原子替换，避免写入中途崩溃导致进度文件损坏
+func writeProgress(sqlFilePath string, lineNo int) error {
+	pf := progressFilePath(sqlFilePath)
+	dir := filepath.Dir(pf)
+
+	tmpFile, err := os.CreateTemp(dir, ".progress-tmp-*")
+	if err != nil {
+		logger.Error("创建临时进度文件失败: %v", err)
+		return fmt.Errorf("创建临时进度文件失败: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	_, writeErr := fmt.Fprintf(tmpFile, "%d\n", lineNo)
+	closeErr := tmpFile.Close()
+
+	if writeErr != nil {
+		_ = os.Remove(tmpPath)
+		logger.Error("写入临时进度文件失败: %v", writeErr)
+		return fmt.Errorf("写入临时进度文件失败: %w", writeErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		logger.Error("关闭临时进度文件失败: %v", closeErr)
+		return fmt.Errorf("关闭临时进度文件失败: %w", closeErr)
+	}
+
+	if err := os.Rename(tmpPath, pf); err != nil {
+		_ = os.Remove(tmpPath)
+		logger.Error("原子替换进度文件失败: %v", err)
+		return fmt.Errorf("原子替换进度文件失败: %w", err)
+	}
+
+	return nil
+}
+
+// removeProgress 删除进度文件
+// 如果文件不存在，不返回错误
+func removeProgress(sqlFilePath string) error {
+	pf := progressFilePath(sqlFilePath)
+	err := os.Remove(pf)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		logger.Error("删除进度文件 %s 失败: %v", pf, err)
+		return fmt.Errorf("删除进度文件 %s 失败: %w", pf, err)
+	}
+	return nil
+}
+
+// countLines 统计文件的总行数
+// 用于在恢复执行前校验进度文件中的行号是否超出 SQL 文件实际行数
+func countLines(filePath string) (int, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		logger.Error("打开文件 %s 失败: %v", filePath, err)
+		return 0, fmt.Errorf("打开文件 %s 失败: %w", filePath, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	count := 0
+	for scanner.Scan() {
+		count++
+	}
+
+	if err := scanner.Err(); err != nil {
+		logger.Error("读取文件 %s 失败: %v", filePath, err)
+		return 0, fmt.Errorf("读取文件 %s 失败: %w", filePath, err)
+	}
+
+	return count, nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/init.go
@@ -1,0 +1,24 @@
+package internal
+
+// StaticSystemUsers 定义不需要迁移的系统账号列表。
+// 来源于权限服务 (blueking-dbm) clone_instance_priv 定义：
+//   - mysql.session, mysql.sys, mysql.infoschema, mysql: internal/mysql/init.go
+//   - mariadb.sys, PUBLIC: clone_mysql_priv.go 中 spider 4 额外排除
+var StaticSystemUsers = []string{
+	"mysql.session",
+	"mysql.sys",
+	"mysql.infoschema",
+	"mysql",
+	"mariadb.sys",
+	"PUBLIC",
+	"MONITOR",
+	"gcs_admin",
+	"gcs_dba",
+	"repl",
+	"GM",
+	"sync",
+	"ADMIN",
+	"dba_bak_all_sel",
+	"partition_yw",
+	"yw",
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/init.go
@@ -1,0 +1,20 @@
+package mysql
+
+import (
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+)
+
+// expandSuperPrivilege 当目标版本 >= 80 且 GRANT 语句包含 SUPER 时，
+// 额外写入一条包含所有 MySQL 8.0 SUPER 拆分动态权限的 GRANT 语句。
+// 原有的 SUPER 权限保留不动。
+func expandSuperPrivilege(stmt string, dstVer int64, w *pkg.Writers) error {
+	if dstVer < 8000000 {
+		return nil
+	}
+	return pkg.ExpandSuperPrivileges(stmt, pkg.MySQLSuperDynamicPrivileges, "MySQL 8.0+", w)
+}
+
+// rewritePrivsNoop MySQL 不需要权限改名，原样返回。
+func rewritePrivsNoop(stmt string, _ int64) string {
+	return stmt
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/legacy.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/legacy.go
@@ -1,0 +1,166 @@
+package mysql
+
+import (
+	"bufio"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+	"strings"
+)
+
+// ParseLegacyFile 解析 legacy 版本（MySQL 5.5/5.6 或 Spider 1）的备份文件。
+//
+// 采用单次扫描 + 累积策略：
+//  1. 扫描阶段：逐行读取，每行提取 user@host 信息并累积密码和资源限制到 map 中，
+//     同时将清洗后的 GRANT 语句立即写入 grant 文件。
+//  2. 输出阶段：扫描完成后，根据 map 中累积的信息一次性生成所有 CREATE USER 语句。
+//
+// 差异点（系统用户判断、CREATE USER 生成、SUPER 展开）通过 cfg 注入。
+func ParseLegacyFile(
+	scanner *bufio.Scanner, path string, totalLines int, dstVer int64,
+	replacer *pkg.HostReplacer, cfg *pkg.ParseConfig, w *pkg.Writers,
+) error {
+	ls := pkg.NewLineScanner(scanner, path, totalLines)
+	defer ls.Stop()
+
+	userMap := make(map[string]*pkg.UserEntry)
+	var userOrder []string
+	systemUserCount := 0
+
+	for ls.Next() {
+		line := replacer.Replace(ls.Stmt())
+
+		if matches := pkg.ReGrantWithAuth.FindStringSubmatch(line); matches != nil {
+			privs, scope, user, host, hash, rest, style := pkg.ExtractGrantWithAuthFields(matches)
+			key := user + "@" + host
+
+			if cfg.IsSystemUser(user, host) {
+				if err := w.WriteSystemUser(fmt.Sprintf("%s;\n", line)); err != nil {
+					logger.Error("WriteSystemUser: %v", err)
+					return err
+				}
+				systemUserCount++
+				logger.Info("skipping system/job user %s", key)
+				continue
+			}
+
+			entry := getOrCreateEntry(userMap, &userOrder, key, user, host, style)
+			if entry.Hash == "" {
+				entry.Hash = hash
+			}
+			entry.Resources = entry.Resources.Merge(pkg.ParseResourceLimits(rest))
+
+			if err := writeCleanGrant(privs, scope, user, host, rest, dstVer, cfg, w); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if matches := pkg.ReGrantPlain.FindStringSubmatch(line); matches != nil {
+			privs, scope, user, host, rest, style := pkg.ExtractGrantPlainFields(matches)
+			key := user + "@" + host
+
+			if cfg.IsSystemUser(user, host) {
+				if err := w.WriteSystemUser(fmt.Sprintf("%s;\n", line)); err != nil {
+					logger.Error("WriteSystemUser: %v", err)
+					return err
+				}
+				systemUserCount++
+				logger.Info("skipping system/job user %s", key)
+				continue
+			}
+
+			entry := getOrCreateEntry(userMap, &userOrder, key, user, host, style)
+			entry.Resources = entry.Resources.Merge(pkg.ParseResourceLimits(rest))
+
+			if err := writeCleanGrant(privs, scope, user, host, rest, dstVer, cfg, w); err != nil {
+				return err
+			}
+			continue
+		}
+	}
+
+	if err := ls.Err(); err != nil {
+		logger.Error("reading backup file: %v", err)
+		return fmt.Errorf("reading backup file: %w", err)
+	}
+
+	for _, key := range userOrder {
+		entry := userMap[key]
+		createSQL := cfg.BuildCreateFromEntry(entry, dstVer)
+		if err := w.WriteCreate(createSQL); err != nil {
+			logger.Error("WriteCreate for %s: %v", key, err)
+			return err
+		}
+	}
+
+	logger.Info("users=%d systemUserStatements=%d", len(userOrder), systemUserCount)
+	return nil
+}
+
+// getOrCreateEntry 从 map 中获取或创建 UserEntry。
+// 首次创建时记录顺序到 order 切片，保证输出顺序稳定。
+func getOrCreateEntry(
+	m map[string]*pkg.UserEntry, order *[]string, key, user, host string, style pkg.QuoteStyle,
+) *pkg.UserEntry {
+	if e, ok := m[key]; ok {
+		return e
+	}
+	e := &pkg.UserEntry{User: user, Host: host, Style: style}
+	m[key] = e
+	*order = append(*order, key)
+	return e
+}
+
+// BuildCreateFromEntryMySQL 根据累积的 UserEntry 信息生成 MySQL 的 CREATE USER 语句。
+//
+// 目标版本 < 5.7 时输出 GRANT USAGE 载体格式（兼容 5.5/5.6），
+// 目标版本 >= 5.7 时输出 CREATE USER 格式（使用 /*!50706 IF NOT EXISTS */ hint）。
+func BuildCreateFromEntryMySQL(e *pkg.UserEntry, dstVer int64) string {
+	withClause := e.Resources.FormatWithClause()
+
+	if dstVer < 5007000 {
+		if e.Hash != "" {
+			return fmt.Sprintf("GRANT USAGE ON *.* TO '%s'@'%s' IDENTIFIED BY PASSWORD '%s'%s;\n",
+				e.User, e.Host, e.Hash, withClause)
+		}
+		return fmt.Sprintf("GRANT USAGE ON *.* TO '%s'@'%s'%s;\n",
+			e.User, e.Host, withClause)
+	}
+
+	if e.Hash != "" {
+		return fmt.Sprintf(
+			"CREATE USER /*!50706 IF NOT EXISTS */ '%s'@'%s' IDENTIFIED WITH 'mysql_native_password' AS '%s'%s;\n",
+			e.User, e.Host, e.Hash, withClause)
+	}
+	return fmt.Sprintf("CREATE USER /*!50706 IF NOT EXISTS */ '%s'@'%s'%s;\n",
+		e.User, e.Host, withClause)
+}
+
+// writeCleanGrant 写入清洗后的 GRANT 语句。
+//
+// 清洗规则：
+//   - 剥离 IDENTIFIED BY PASSWORD（由调用方通过正则分离，rest 中已不含）
+//   - 剥离资源限制（已累积到 CREATE USER）
+//   - 保留 GRANT OPTION
+func writeCleanGrant(privs, scope, user, host, rest string, dstVer int64, cfg *pkg.ParseConfig, w *pkg.Writers) error {
+	grantOption := extractGrantOption(rest)
+
+	var withClause string
+	if grantOption {
+		withClause = " WITH GRANT OPTION"
+	}
+
+	grantSQL := fmt.Sprintf("GRANT %s ON %s TO '%s'@'%s'%s;\n", privs, scope, user, host, withClause)
+	grantSQL = cfg.RewritePrivs(grantSQL, dstVer)
+	if err := w.WriteGrant(grantSQL); err != nil {
+		logger.Error("WriteGrant: %v", err)
+		return err
+	}
+	return cfg.ExpandSuper(grantSQL, dstVer, w)
+}
+
+// extractGrantOption 检查 rest 字符串中是否包含 GRANT OPTION。
+func extractGrantOption(rest string) bool {
+	return strings.Contains(strings.ToUpper(rest), "GRANT OPTION")
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/modern.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/modern.go
@@ -1,0 +1,141 @@
+package mysql
+
+import (
+	"bufio"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+	"strings"
+)
+
+// ParseModernFile 解析 modern 版本（MySQL 5.7/8.0 或 Spider 3/4）的备份文件。
+//
+// 该版本的特征：CREATE USER 语句携带认证信息，GRANT 语句为纯授权不含密码。
+// 差异点（系统用户判断、IF NOT EXISTS 语法、SUPER 展开、未识别语句处理）通过 cfg 注入。
+func ParseModernFile(
+	scanner *bufio.Scanner, path string, totalLines int, dstVer int64,
+	replacer *pkg.HostReplacer, cfg *pkg.ParseConfig, w *pkg.Writers,
+) error {
+	userCount := 0
+	systemUserCount := 0
+	lastUser := ""
+
+	ls := pkg.NewLineScanner(scanner, path, totalLines)
+	defer ls.Stop()
+
+	for ls.Next() {
+		stmt := replacer.Replace(ls.Stmt())
+
+		if matches := pkg.ReCreateUser.FindStringSubmatch(stmt); matches != nil {
+			if err := handleModernCreateUser(stmt, matches, cfg, &lastUser, &userCount, &systemUserCount, w); err != nil {
+				logger.Error("handleModernCreateUser: %v", err)
+				return err
+			}
+			continue
+		}
+
+		if matches := pkg.ReGrantPlain.FindStringSubmatch(stmt); matches != nil {
+			if err := handleModernGrant(stmt, matches, dstVer, cfg, &systemUserCount, w); err != nil {
+				logger.Error("handleModernGrant: %v", err)
+				return err
+			}
+			continue
+		}
+
+		if strings.EqualFold(strings.TrimSuffix(stmt, ";"), "FLUSH PRIVILEGES") {
+			logger.Info("skipping FLUSH PRIVILEGES at line %d", ls.LineNo())
+			continue
+		}
+
+		if cfg.StrictUnrecognized {
+			err := fmt.Errorf("unrecognized statement at line %d: %s", ls.LineNo(), stmt)
+			logger.Error("%v", err)
+			return err
+		}
+		logger.Warn("unrecognized statement, skipping line=%d stmt=%s", ls.LineNo(), stmt)
+	}
+
+	if err := ls.Err(); err != nil {
+		logger.Error("reading backup file: %v", err)
+		return fmt.Errorf("reading backup file: %w", err)
+	}
+
+	logger.Info("users=%d systemUserStatements=%d", userCount, systemUserCount)
+	return nil
+}
+
+// handleModernCreateUser 处理 modern 格式的 CREATE USER 语句。
+// 系统用户写入独立文件，普通用户通过 cfg.AddIfNotExists 加工后写入 create 文件。
+func handleModernCreateUser(
+	stmt string, matches []string, cfg *pkg.ParseConfig,
+	lastUser *string, userCount *int, systemUserCount *int, w *pkg.Writers,
+) error {
+	user, host, _ := pkg.ExtractUserHost(matches, 1)
+	key := user + "@" + host
+
+	if cfg.IsSystemUser(user, host) {
+		if err := w.WriteSystemUser(fmt.Sprintf("%s;\n", stmt)); err != nil {
+			logger.Error("WriteSystemUser: %v", err)
+			return err
+		}
+		*systemUserCount++
+		logger.Info("skipping system/job user %s", key)
+		return nil
+	}
+
+	if key != *lastUser {
+		*userCount++
+		*lastUser = key
+	}
+
+	outStmt := cfg.AddIfNotExists(stmt)
+	if err := w.WriteCreate(fmt.Sprintf("%s;\n", outStmt)); err != nil {
+		logger.Error("WriteCreate: %v", err)
+		return err
+	}
+	return nil
+}
+
+// handleModernGrant 处理 modern 格式的纯 GRANT 语句。
+// 系统用户写入独立文件，普通用户写入 grant 文件并通过 cfg.ExpandSuper 展开 SUPER 权限。
+func handleModernGrant(
+	stmt string, matches []string, dstVer int64, cfg *pkg.ParseConfig,
+	systemUserCount *int, w *pkg.Writers,
+) error {
+	_, _, user, host, _, _ := pkg.ExtractGrantPlainFields(matches)
+
+	if cfg.IsSystemUser(user, host) {
+		if err := w.WriteSystemUser(fmt.Sprintf("%s;\n", stmt)); err != nil {
+			logger.Error("WriteSystemUser: %v", err)
+			return err
+		}
+		*systemUserCount++
+		logger.Info("skipping system/job user grant user=%s", user+"@"+host)
+		return nil
+	}
+
+	stmt = cfg.RewritePrivs(stmt, dstVer)
+	if err := w.WriteGrant(fmt.Sprintf("%s;\n", stmt)); err != nil {
+		logger.Error("WriteGrant: %v", err)
+		return err
+	}
+	return cfg.ExpandSuper(stmt, dstVer, w)
+}
+
+// AddIfNotExistsHint 给 CREATE USER 语句加上 /*!50706 IF NOT EXISTS */ hint（MySQL 专用）。
+func AddIfNotExistsHint(stmt string) string {
+	upper := strings.ToUpper(stmt)
+	if strings.Contains(upper, "IF NOT EXISTS") {
+		return stmt
+	}
+	return pkg.ReCreateUserPrefix.ReplaceAllString(stmt, "CREATE USER /*!50706 IF NOT EXISTS */ ")
+}
+
+// AddIfNotExistsDirect 给 CREATE USER 语句加上直接的 IF NOT EXISTS（Spider 专用）。
+func AddIfNotExistsDirect(stmt string) string {
+	upper := strings.ToUpper(stmt)
+	if strings.Contains(upper, "IF NOT EXISTS") {
+		return stmt
+	}
+	return pkg.ReCreateUserPrefix.ReplaceAllString(stmt, "CREATE USER IF NOT EXISTS ")
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/parser.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql/parser.go
@@ -1,0 +1,74 @@
+package mysql
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+)
+
+// ParseFile 读取 SQL 备份文件，根据源版本分发到对应的解析函数。
+// <= 56 使用 ParseLegacyFile，>= 57 使用 ParseModernFile。
+// 输出文件与源文件同目录，文件名基于源文件名添加后缀。
+// 返回生成的输出文件路径信息。
+func ParseFile(
+	path string, srcVer, dstVer int64, sourceIP, targetIP string, dynamicSystemUsers []string,
+) (pkg.OutputFiles, error) {
+	systemUsers := pkg.BuildSystemUserMap(internal.StaticSystemUsers, dynamicSystemUsers)
+
+	totalLines, err := pkg.CountFileLines(path)
+	if err != nil {
+		logger.Error("统计源文件行数失败: %v", err)
+		return pkg.OutputFiles{}, fmt.Errorf("统计源文件行数失败: %w", err)
+	}
+	logger.Info("file=%s totalLines=%d srcVer=%d dstVer=%d", path, totalLines, srcVer, dstVer)
+
+	w, out, closeFiles, err := pkg.CreateOutputFiles(path)
+	if err != nil {
+		logger.Error("CreateOutputFiles: %v", err)
+		return pkg.OutputFiles{}, err
+	}
+	defer closeFiles()
+
+	scanner, closeFile, err := pkg.OpenFileWithScanner(path)
+	if err != nil {
+		logger.Error("OpenFileWithScanner: %v", err)
+		return pkg.OutputFiles{}, err
+	}
+	defer closeFile()
+
+	replacer := pkg.NewHostReplacer(sourceIP, targetIP)
+
+	cfg := &pkg.ParseConfig{
+		IsSystemUser: func(user, host string) bool {
+			return pkg.IsSystemOrJobUser(user, host, sourceIP, systemUsers)
+		},
+		AddIfNotExists:       AddIfNotExistsHint,
+		BuildCreateFromEntry: BuildCreateFromEntryMySQL,
+		ExpandSuper:          expandSuperPrivilege,
+		RewritePrivs:         rewritePrivsNoop,
+		StrictUnrecognized:   true,
+	}
+
+	if srcVer < 5007000 {
+		err = ParseLegacyFile(scanner, path, totalLines, dstVer, replacer, cfg, w)
+	} else {
+		err = ParseModernFile(scanner, path, totalLines, dstVer, replacer, cfg, w)
+	}
+	if err != nil {
+		logger.Error("parse backup file: %v", err)
+		return pkg.OutputFiles{}, err
+	}
+
+	if err := w.Flush(); err != nil {
+		logger.Error("flush output: %v", err)
+		return pkg.OutputFiles{}, fmt.Errorf("flush output: %w", err)
+	}
+
+	err = pkg.LogOutputSummary(out)
+	if err != nil {
+		return pkg.OutputFiles{}, err
+	}
+
+	return out, nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/common.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/common.go
@@ -1,0 +1,200 @@
+package pkg
+
+import (
+	"bufio"
+	"dbm-services/common/go-pubpkg/logger"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// BuildSystemUserMap 合并静态和动态系统用户列表，返回用于快速查找的 map。
+// staticUsers 是预定义的系统用户列表，dynamicUsers 是运行时传入的额外系统用户。
+func BuildSystemUserMap(staticUsers, dynamicUsers []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(staticUsers)+len(dynamicUsers))
+	for _, u := range staticUsers {
+		m[u] = struct{}{}
+	}
+	for _, u := range dynamicUsers {
+		m[u] = struct{}{}
+	}
+	return m
+}
+
+// HostReplacer 封装 IP 替换逻辑。
+// 当 sourceIP 和 targetIP 不同且均非空时，替换语句中的 host 部分。
+type HostReplacer struct {
+	needReplace bool
+	oldHostSQ   string // 单引号格式: 'sourceIP'
+	newHostSQ   string // 单引号格式: 'targetIP'
+	oldHostBQ   string // 反引号格式: `sourceIP`
+	newHostBQ   string // 反引号格式: `targetIP`
+}
+
+// NewHostReplacer 创建 HostReplacer。
+// 如果 sourceIP 和 targetIP 相同或任一为空，则 Replace 方法不做任何替换。
+func NewHostReplacer(sourceIP, targetIP string) *HostReplacer {
+	r := &HostReplacer{}
+	if sourceIP != "" && targetIP != "" && sourceIP != targetIP {
+		r.needReplace = true
+		r.oldHostSQ = "@'" + sourceIP + "'"
+		r.newHostSQ = "@'" + targetIP + "'"
+		r.oldHostBQ = "@`" + sourceIP + "`"
+		r.newHostBQ = "@`" + targetIP + "`"
+	}
+	return r
+}
+
+// Replace 对语句执行 host 替换，同时处理单引号和反引号两种格式。
+// 如果不需要替换，原样返回。
+func (r *HostReplacer) Replace(stmt string) string {
+	if !r.needReplace {
+		return stmt
+	}
+	stmt = strings.ReplaceAll(stmt, r.oldHostSQ, r.newHostSQ)
+	stmt = strings.ReplaceAll(stmt, r.oldHostBQ, r.newHostBQ)
+	return stmt
+}
+
+// LineScanner 封装逐行扫描 SQL 备份文件的通用逻辑：
+// 进度日志、去除行尾分号、跳过空行。
+//
+// 进度日志通过独立的 ticker goroutine 按固定时间间隔输出，
+// 避免快速处理大量行时造成日志风暴。调用方必须在使用完毕后调用 Stop()。
+type LineScanner struct {
+	scanner    *bufio.Scanner
+	path       string
+	totalLines int
+	lineNo     int64
+	stmt       string
+	stopCh     chan struct{}
+}
+
+// ProgressLogDuration 进度日志的输出时间间隔。
+const ProgressLogDuration = 5 * time.Second
+
+// NewLineScanner 创建 LineScanner 并启动后台进度日志 goroutine。
+// 调用方必须在扫描结束后调用 Stop() 停止后台 goroutine。
+func NewLineScanner(scanner *bufio.Scanner, path string, totalLines int) *LineScanner {
+	ls := &LineScanner{
+		scanner:    scanner,
+		path:       path,
+		totalLines: totalLines,
+		stopCh:     make(chan struct{}),
+	}
+	go ls.progressLogger()
+	return ls
+}
+
+func (ls *LineScanner) progressLogger() {
+	ticker := time.NewTicker(ProgressLogDuration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			current := atomic.LoadInt64(&ls.lineNo)
+			logger.Info("scanning file=%s currentLine=%d totalLines=%d", ls.path, current, ls.totalLines)
+		case <-ls.stopCh:
+			return
+		}
+	}
+}
+
+// Stop 停止后台进度日志 goroutine。必须在扫描结束后调用。
+func (ls *LineScanner) Stop() {
+	close(ls.stopCh)
+}
+
+// Next 读取下一个非空语句。
+// 返回 false 表示没有更多行。调用方通过 Stmt() 获取当前语句，LineNo() 获取行号。
+func (ls *LineScanner) Next() bool {
+	for ls.scanner.Scan() {
+		atomic.AddInt64(&ls.lineNo, 1)
+		line := ls.scanner.Text()
+
+		stmt := strings.TrimSuffix(strings.TrimSpace(line), ";")
+		if stmt == "" {
+			continue
+		}
+
+		ls.stmt = stmt
+		return true
+	}
+	return false
+}
+
+// Stmt 返回当前行去除首尾空白和尾部分号后的语句。
+func (ls *LineScanner) Stmt() string {
+	return ls.stmt
+}
+
+// LineNo 返回当前行号。
+func (ls *LineScanner) LineNo() int {
+	return int(atomic.LoadInt64(&ls.lineNo))
+}
+
+// Err 返回扫描过程中的错误。
+func (ls *LineScanner) Err() error {
+	return ls.scanner.Err()
+}
+
+// IsGrantUsageOnAll 判断语句是否是 GRANT USAGE ON *.* 格式。
+//
+// 在 MySQL 5.5/5.6 中，GRANT USAGE ON *.* 是"创建用户"的载体，本身不授予任何实际权限。
+// SHOW GRANTS 输出中，全局级别的用户信息（认证、资源限制）都附着在这条语句上。
+//
+// 示例匹配：
+//
+//	GRANT USAGE ON *.* TO 'app'@'%'
+//	GRANT USAGE ON *.* TO 'app'@'%' IDENTIFIED BY PASSWORD '*xxx' WITH MAX_QUERIES_PER_HOUR 90
+//
+// 示例不匹配：
+//
+//	GRANT SELECT ON *.* TO 'app'@'%'
+//	GRANT USAGE ON `db`.* TO 'app'@'%'
+func IsGrantUsageOnAll(stmt string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(stmt))
+	return strings.HasPrefix(upper, "GRANT USAGE ON *.*")
+}
+
+// IsSystemOrJobUser 判断用户是否为系统用户或 Job 账号，这类用户在权限迁移时应跳过。
+//
+// 系统用户通过 systemUsers map 查找（由 BuildSystemUserMap 生成）。
+// Job 账号使用 "J_" 前缀命名，且 host 为 localhost 或源 IP，
+// 例如 'J_backup'@'localhost'
+func IsSystemOrJobUser(user, host, sourceIP string, systemUsers map[string]struct{}) bool {
+	if _, ok := systemUsers[user]; ok {
+		return true
+	}
+	return strings.HasPrefix(user, "J_") && (host == "localhost" || host == sourceIP)
+}
+
+// OpenFileWithScanner 打开文件并创建带大缓冲区的 Scanner。
+// 返回 Scanner、关闭函数和可能的错误。调用方必须在使用完毕后调用 closeFunc。
+func OpenFileWithScanner(path string) (*bufio.Scanner, func(), error) {
+	f, err := os.Open(path)
+	if err != nil {
+		logger.Error("open backup file: %v", err)
+		return nil, nil, fmt.Errorf("open backup file: %w", err)
+	}
+	logger.Info("opened backup file for scanning file=%s", path)
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	closeFunc := func() {
+		_ = f.Close()
+	}
+
+	return scanner, closeFunc, nil
+}
+
+// ReplacePrivName 在 GRANT 语句中将旧权限名替换为新权限名（大小写不敏感）。
+func ReplacePrivName(stmt, oldPriv, newPriv string) string {
+	re := regexp.MustCompile(`(?i)` + regexp.QuoteMeta(oldPriv))
+	return re.ReplaceAllLiteralString(stmt, newPriv)
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/parse_config.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/parse_config.go
@@ -1,0 +1,35 @@
+package pkg
+
+// UserEntry 保存从源文件中为某个 user@host 累积的创建信息。
+type UserEntry struct {
+	User, Host string
+	Hash       string
+	Resources  ResourceLimits
+	Style      QuoteStyle
+}
+
+// ParseConfig 将 MySQL 和 Spider 的解析差异参数化。
+type ParseConfig struct {
+	// IsSystemUser 判断是否为系统用户，命中则写入 system_user 文件并跳过。
+	IsSystemUser func(user, host string) bool
+
+	// AddIfNotExists 给 CREATE USER 语句加上 IF NOT EXISTS。
+	// MySQL 使用 /*!50706 IF NOT EXISTS */ hint 语法，Spider 使用直接语法。
+	AddIfNotExists func(stmt string) string
+
+	// BuildCreateFromEntry 根据累积的 UserEntry 生成 CREATE USER 语句（legacy 模式专用）。
+	BuildCreateFromEntry func(e *UserEntry, dstVer int64) string
+
+	// ExpandSuper 展开 GRANT 语句中的 SUPER 权限为细粒度权限。
+	// MySQL 8.0 使用动态权限，Spider4 使用 MariaDB 权限。
+	ExpandSuper func(stmt string, dstVer int64, w *Writers) error
+
+	// RewritePrivs 在写入 grant 文件前对权限名做替换。
+	// Spider 4 (MariaDB 10.5+) 将 REPLICATION CLIENT 改名为 BINLOG MONITOR 等。
+	// MySQL 实现为 no-op。
+	RewritePrivs func(stmt string, dstVer int64) string
+
+	// StrictUnrecognized 遇到无法识别的语句时是否返回错误。
+	// true = 返回 error（MySQL 行为），false = warn 并跳过（Spider 行为）。
+	StrictUnrecognized bool
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/regex.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/regex.go
@@ -1,0 +1,180 @@
+package pkg
+
+import "regexp"
+
+// QuoteStyle 表示 SQL 语句中用户名/主机名的引号风格。
+type QuoteStyle int
+
+const (
+	// QuoteSingle 单引号风格：'user'@'host'（MySQL 5.5/5.6/5.7）
+	QuoteSingle QuoteStyle = iota
+	// QuoteBacktick 反引号风格：`user`@`host`（MySQL 8.0 / Spider4）
+	QuoteBacktick
+)
+
+// QuoteUser 根据引号风格格式化 'user'@'host' 或 `user`@`host`。
+func QuoteUser(user, host string, style QuoteStyle) string {
+	if style == QuoteBacktick {
+		return "`" + user + "`@`" + host + "`"
+	}
+	return "'" + user + "'@'" + host + "'"
+}
+
+// userHostPattern 是匹配 'user'@'host' 或 `user`@`host` 的正则片段。
+// 产生 2 个捕获组：(user, host)，其中单引号和反引号各占一对。
+// 总共 4 个捕获组：(sq_user, sq_host, bq_user, bq_host)
+const userHostPattern = `(?:'([^']+)'@'([^']+)'|` + "`([^`]+)`@`([^`]+)`)"
+
+// identifiedWithPattern 匹配 IDENTIFIED WITH 'plugin' [AS 'hash']
+// plugin 和 hash 始终使用单引号（即使 user@host 用反引号）
+const identifiedWithPattern = `\s+IDENTIFIED\s+WITH\s+'([^']+)'(?:\s+AS\s+'([^']*)')?`
+
+// identifiedByPasswordPattern 匹配 IDENTIFIED BY PASSWORD '*hash'
+// hash 始终使用单引号
+const identifiedByPasswordPattern = `\s+IDENTIFIED\s+BY\s+PASSWORD\s+'([^']+)'`
+
+var (
+	// ReCreateUser 匹配 5.7/8.0 的 CREATE USER 语句。
+	// 示例: CREATE USER 'app'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*2470C...' REQUIRE NONE ...
+	// 示例: CREATE USER IF NOT EXISTS `app`@`%` IDENTIFIED WITH 'mysql_native_password' AS '*2470C...'
+	// 捕获组: (sq_user, sq_host, bq_user, bq_host, plugin, hash, rest)
+	ReCreateUser *regexp.Regexp
+
+	// ReGrantWithAuth 匹配 5.5/5.6 带 IDENTIFIED BY PASSWORD 的 GRANT 语句。
+	// 示例: GRANT SELECT ON `db`.* TO 'app'@'%' IDENTIFIED BY PASSWORD '*2470C...'
+	// 捕获组: (privs, scope, sq_user, sq_host, bq_user, bq_host, hash, rest)
+	ReGrantWithAuth *regexp.Regexp
+
+	// ReGrantPlain 匹配不含认证信息的纯 GRANT 语句。
+	// 示例: GRANT SELECT ON `db`.* TO 'app'@'%'
+	// 示例: GRANT SELECT ON `db`.* TO `app`@`%` WITH GRANT OPTION
+	// 捕获组: (privs, scope, sq_user, sq_host, bq_user, bq_host, rest)
+	ReGrantPlain *regexp.Regexp
+
+	// ReUserHost 从 GRANT 语句中提取 user@host 部分。
+	// 捕获组: (sq_user, sq_host, bq_user, bq_host)
+	ReUserHost *regexp.Regexp
+
+	// ReCreateUserLegacy 匹配 5.5/5.6/Spider3 的 CREATE USER 语句（IDENTIFIED BY PASSWORD 格式）。
+	// 示例: CREATE USER IF NOT EXISTS 'app'@'%' IDENTIFIED BY PASSWORD '*2470C...'
+	// 捕获组: (sq_user, sq_host, bq_user, bq_host, hash, rest)
+	ReCreateUserLegacy *regexp.Regexp
+
+	// ReCreateUserPlain 匹配不含 IDENTIFIED 子句的 CREATE USER 语句（无密码用户）。
+	// 示例: CREATE USER 'app'@'%'
+	// 示例: CREATE USER /*!50706 IF NOT EXISTS */ 'app'@'%'
+	// 捕获组: (sq_user, sq_host, bq_user, bq_host, rest)
+	ReCreateUserPlain *regexp.Regexp
+
+	// ReCreateUserPrefix 匹配 CREATE USER 语句开头，用于插入 IF NOT EXISTS。
+	// 兼容已有 IF NOT EXISTS 和 /*!50706 IF NOT EXISTS */ 的情况。
+	ReCreateUserPrefix *regexp.Regexp
+)
+
+func init() {
+	// CREATE USER [IF NOT EXISTS] 'user'@'host' IDENTIFIED WITH 'plugin' [AS 'hash'] [rest...]
+	// 兼容 /*!50706 IF NOT EXISTS */ 和原生 IF NOT EXISTS
+	// 注意：AS 'hash' 部分是可选的，空密码用户没有该子句
+	ReCreateUser = regexp.MustCompile(
+		`(?i)^\s*CREATE\s+USER\s+(?:(?:/\*!?\d*\s*)?IF\s+NOT\s+EXISTS\s*(?:\*/)?\s*)?` +
+			userHostPattern + identifiedWithPattern + `(.*)$`,
+	)
+
+	// GRANT ... ON ... TO 'user'@'host' IDENTIFIED BY PASSWORD '*hash' [rest...]
+	ReGrantWithAuth = regexp.MustCompile(
+		`(?i)^\s*GRANT\s+(.+?)\s+ON\s+(\S+)\s+TO\s+` +
+			userHostPattern + identifiedByPasswordPattern + `(.*)$`,
+	)
+
+	// GRANT ... ON ... TO 'user'@'host' [rest...]
+	ReGrantPlain = regexp.MustCompile(
+		`(?i)^\s*GRANT\s+(.+?)\s+ON\s+(\S+)\s+TO\s+` + userHostPattern + `(.*)$`,
+	)
+
+	// TO 'user'@'host' 或 TO `user`@`host` — 从任意 GRANT 行中提取 user 和 host
+	ReUserHost = regexp.MustCompile(`TO\s+` + userHostPattern)
+
+	// CREATE USER [IF NOT EXISTS] 'user'@'host' IDENTIFIED BY PASSWORD '*hash'
+	// 匹配 5.5/5.6/Spider3 的 legacy 格式 CREATE USER
+	ReCreateUserLegacy = regexp.MustCompile(
+		`(?i)^\s*CREATE\s+USER\s+(?:(?:/\*!?\d*\s*)?IF\s+NOT\s+EXISTS\s*(?:\*/)?\s*)?` +
+			userHostPattern + identifiedByPasswordPattern + `(.*)$`,
+	)
+
+	// CREATE USER [IF NOT EXISTS] 'user'@'host' [rest...]
+	// 无 IDENTIFIED 子句，匹配无密码用户
+	ReCreateUserPlain = regexp.MustCompile(
+		`(?i)^\s*CREATE\s+USER\s+(?:(?:/\*!?\d*\s*)?IF\s+NOT\s+EXISTS\s*(?:\*/)?\s*)?` +
+			userHostPattern + `(.*)$`,
+	)
+
+	// CREATE USER [/*!50706 IF NOT EXISTS */] 'user'@'host' ...
+	// 匹配 CREATE USER 开头部分，用于在没有 IF NOT EXISTS 时插入
+	ReCreateUserPrefix = regexp.MustCompile(
+		`(?i)^\s*CREATE\s+USER\s+`,
+	)
+}
+
+// ExtractUserHost 从 userHostPattern 的 4 个捕获组中提取 user、host 和引号风格。
+// offset 是 userHostPattern 在整个正则中的第一个捕获组的索引（从 1 开始）。
+// 例如 ReGrantPlain 中 userHostPattern 从第 3 个捕获组开始，offset=3。
+func ExtractUserHost(matches []string, offset int) (user, host string, style QuoteStyle) {
+	if matches[offset] != "" {
+		return matches[offset], matches[offset+1], QuoteSingle
+	}
+	return matches[offset+2], matches[offset+3], QuoteBacktick
+}
+
+// ExtractCreateUserFields 从 ReCreateUser 的匹配结果中提取所有字段。
+// 返回: user, host, plugin, hash, rest, quoteStyle
+func ExtractCreateUserFields(matches []string) (user, host, plugin, hash, rest string, style QuoteStyle) {
+	user, host, style = ExtractUserHost(matches, 1)
+	plugin = matches[5]
+	hash = matches[6]
+	rest = matches[7]
+	return
+}
+
+// ExtractGrantWithAuthFields 从 ReGrantWithAuth 的匹配结果中提取所有字段。
+// 返回: privs, scope, user, host, hash, rest, quoteStyle
+func ExtractGrantWithAuthFields(matches []string) (privs, scope, user, host, hash, rest string, style QuoteStyle) {
+	privs = matches[1]
+	scope = matches[2]
+	user, host, style = ExtractUserHost(matches, 3)
+	hash = matches[7]
+	rest = matches[8]
+	return
+}
+
+// ExtractGrantPlainFields 从 ReGrantPlain 的匹配结果中提取所有字段。
+// 返回: privs, scope, user, host, rest, quoteStyle
+func ExtractGrantPlainFields(matches []string) (privs, scope, user, host, rest string, style QuoteStyle) {
+	privs = matches[1]
+	scope = matches[2]
+	user, host, style = ExtractUserHost(matches, 3)
+	rest = matches[7]
+	return
+}
+
+// ExtractUserHostFields 从 ReUserHost 的匹配结果中提取 user 和 host。
+// 返回: user, host, quoteStyle
+func ExtractUserHostFields(matches []string) (user, host string, style QuoteStyle) {
+	return ExtractUserHost(matches, 1)
+}
+
+// ExtractCreateUserLegacyFields 从 ReCreateUserLegacy 的匹配结果中提取所有字段。
+// 返回: user, host, hash, rest, quoteStyle
+func ExtractCreateUserLegacyFields(matches []string) (user, host, hash, rest string, style QuoteStyle) {
+	user, host, style = ExtractUserHost(matches, 1)
+	hash = matches[5]
+	rest = matches[6]
+	return
+}
+
+// ExtractCreateUserPlainFields 从 ReCreateUserPlain 的匹配结果中提取所有字段。
+// 返回: user, host, rest, quoteStyle
+func ExtractCreateUserPlainFields(matches []string) (user, host, rest string, style QuoteStyle) {
+	user, host, style = ExtractUserHost(matches, 1)
+	rest = matches[5]
+	return
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/resource_limits.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/resource_limits.go
@@ -1,0 +1,99 @@
+package pkg
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ResourceKeywords 是 MySQL 语句中可能出现的资源限制关键字。
+// 顺序与 ResourceRegexps 一一对应，也与 ResourceLimits 结构体字段对应。
+var ResourceKeywords = []string{
+	"MAX_QUERIES_PER_HOUR",
+	"MAX_UPDATES_PER_HOUR",
+	"MAX_CONNECTIONS_PER_HOUR",
+	"MAX_USER_CONNECTIONS",
+}
+
+// ResourceRegexps 是 ResourceKeywords 对应的预编译正则，用于从 WITH 子句中提取资源限制值。
+var ResourceRegexps []*regexp.Regexp
+
+func init() {
+	ResourceRegexps = make([]*regexp.Regexp, len(ResourceKeywords))
+	for i, kw := range ResourceKeywords {
+		ResourceRegexps[i] = regexp.MustCompile(`(?i)` + kw + `\s+(\d+)`)
+	}
+}
+
+// ResourceLimits 表示 MySQL 账号的 4 种资源限制。
+type ResourceLimits struct {
+	MaxQuestions   int
+	MaxUpdates     int
+	MaxConnections int
+	MaxUserConns   int
+}
+
+// Merge 将 other 中的非零值合并到当前 ResourceLimits 中。
+// 用于从多条 GRANT 语句中累积同一用户的资源限制。
+func (rl ResourceLimits) Merge(other ResourceLimits) ResourceLimits {
+	if other.MaxQuestions > 0 {
+		rl.MaxQuestions = other.MaxQuestions
+	}
+	if other.MaxUpdates > 0 {
+		rl.MaxUpdates = other.MaxUpdates
+	}
+	if other.MaxConnections > 0 {
+		rl.MaxConnections = other.MaxConnections
+	}
+	if other.MaxUserConns > 0 {
+		rl.MaxUserConns = other.MaxUserConns
+	}
+	return rl
+}
+
+// FormatWithClause 将资源限制格式化为 SQL 的 WITH 子句。
+// 如果所有限制均为 0，返回空字符串。
+func (rl ResourceLimits) FormatWithClause() string {
+	var parts []string
+	if rl.MaxQuestions > 0 {
+		parts = append(parts, fmt.Sprintf("MAX_QUERIES_PER_HOUR %d", rl.MaxQuestions))
+	}
+	if rl.MaxUpdates > 0 {
+		parts = append(parts, fmt.Sprintf("MAX_UPDATES_PER_HOUR %d", rl.MaxUpdates))
+	}
+	if rl.MaxConnections > 0 {
+		parts = append(parts, fmt.Sprintf("MAX_CONNECTIONS_PER_HOUR %d", rl.MaxConnections))
+	}
+	if rl.MaxUserConns > 0 {
+		parts = append(parts, fmt.Sprintf("MAX_USER_CONNECTIONS %d", rl.MaxUserConns))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " WITH " + strings.Join(parts, " ")
+}
+
+// ParseResourceLimits 从 SQL 语句的尾部（rest）中提取资源限制值。
+// 未出现的关键字对应值为 0（MySQL 默认）。
+func ParseResourceLimits(rest string) ResourceLimits {
+	var rl ResourceLimits
+	for i, re := range ResourceRegexps {
+		m := re.FindStringSubmatch(rest)
+		if m == nil {
+			continue
+		}
+		val, _ := strconv.Atoi(m[1])
+		switch i {
+		case 0:
+			rl.MaxQuestions = val
+		case 1:
+			rl.MaxUpdates = val
+		case 2:
+			rl.MaxConnections = val
+		case 3:
+			rl.MaxUserConns = val
+		}
+	}
+	return rl
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/super.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/super.go
@@ -1,0 +1,72 @@
+package pkg
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"fmt"
+	"strings"
+)
+
+// MySQLSuperDynamicPrivileges 是 MySQL 8.0.0 中随动态权限框架（WL#8131）一起引入的基础动态权限，
+// 用于替代 SUPER 权限。仅包含 8.0.0 即存在的 8 个权限，确保所有 8.0.x GA 版本都支持。
+var MySQLSuperDynamicPrivileges = []string{
+	"BINLOG_ADMIN",
+	"CONNECTION_ADMIN",
+	"ENCRYPTION_KEY_ADMIN",
+	"GROUP_REPLICATION_ADMIN",
+	"REPLICATION_SLAVE_ADMIN",
+	"ROLE_ADMIN",
+	"SET_USER_ID",
+	"SYSTEM_VARIABLES_ADMIN",
+}
+
+// MariaDBSuperPrivileges 是 MariaDB 10.5.2 (MDEV-21743) 中从 SUPER 权限拆分出的 7 个细粒度权限。
+var MariaDBSuperPrivileges = []string{
+	"BINLOG ADMIN",
+	"BINLOG REPLAY",
+	"CONNECTION ADMIN",
+	"FEDERATED ADMIN",
+	"READ_ONLY ADMIN",
+	"REPLICATION MASTER ADMIN",
+	"REPLICATION SLAVE ADMIN",
+}
+
+// GRANTHasSuper 检测 GRANT 语句的权限列表中是否包含 SUPER 权限。
+// privs 是正则捕获的权限部分，如 "SELECT, SUPER, INSERT" 或 "ALL PRIVILEGES"。
+func GRANTHasSuper(privs string) bool {
+	upper := strings.ToUpper(privs)
+	// ALL PRIVILEGES 包含 SUPER
+	if strings.Contains(upper, "ALL PRIVILEGES") {
+		return true
+	}
+	for _, p := range strings.Split(upper, ",") {
+		if strings.TrimSpace(p) == "SUPER" {
+			return true
+		}
+	}
+	return false
+}
+
+// ExpandSuperPrivileges 从 GRANT 语句中提取权限列表和 user@host，
+// 如果包含 SUPER，则额外写入一条包含指定细粒度权限的 GRANT 语句。
+// privileges 是要展开的权限列表（MySQL 或 MariaDB 的），logTag 用于日志标识。
+// 输出的引号风格与输入保持一致。
+func ExpandSuperPrivileges(stmt string, privileges []string, logTag string, w *Writers) error {
+	matches := ReGrantPlain.FindStringSubmatch(strings.TrimSpace(stmt))
+	if matches == nil {
+		return nil
+	}
+	privs, _, user, host, _, style := ExtractGrantPlainFields(matches)
+	if !GRANTHasSuper(privs) {
+		return nil
+	}
+	dynamicGrant := fmt.Sprintf(
+		"GRANT %s ON *.* TO %s;\n",
+		strings.Join(privileges, ", "), QuoteUser(user, host, style),
+	)
+	logger.Info("expanding SUPER to fine-grained privileges target=%s user=%s", logTag, user+"@"+host)
+	if err := w.WriteGrant(dynamicGrant); err != nil {
+		logger.Error("write dynamic grant err: %v", err)
+		return err
+	}
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/writers.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg/writers.go
@@ -1,0 +1,204 @@
+package pkg
+
+import (
+	"bufio"
+	"dbm-services/common/go-pubpkg/logger"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// OutputFiles 记录 ParseFile 生成的输出文件路径。
+type OutputFiles struct {
+	CreateUser string // CREATE USER 语句文件
+	GrantPriv  string // GRANT 语句文件
+	Combined   string // 合并的完整 SQL 文件
+	SystemUser string // 系统用户语句文件
+}
+
+// Writers 封装解析过程中需要的输出 writer。
+type Writers struct {
+	CreateWriter        *bufio.Writer
+	GrantWriter         *bufio.Writer
+	TranslatedSqlWriter *bufio.Writer
+	SystemUserWriter    *bufio.Writer
+}
+
+// WriteCreate 将 SQL 语句写入 CreateWriter 和 TranslatedSqlWriter。
+func (w *Writers) WriteCreate(sql string) error {
+	if _, err := w.CreateWriter.WriteString(sql); err != nil {
+		return fmt.Errorf("write create sql: %w", err)
+	}
+	if _, err := w.TranslatedSqlWriter.WriteString(sql); err != nil {
+		return fmt.Errorf("write translated sql: %w", err)
+	}
+	return nil
+}
+
+// WriteGrant 将 SQL 语句写入 GrantWriter 和 TranslatedSqlWriter。
+func (w *Writers) WriteGrant(sql string) error {
+	if _, err := w.GrantWriter.WriteString(sql); err != nil {
+		return fmt.Errorf("write grant sql: %w", err)
+	}
+	if _, err := w.TranslatedSqlWriter.WriteString(sql); err != nil {
+		return fmt.Errorf("write translated sql: %w", err)
+	}
+	return nil
+}
+
+// WriteSystemUser 将系统用户相关的 SQL 语句写入 SystemUserWriter。
+func (w *Writers) WriteSystemUser(sql string) error {
+	if _, err := w.SystemUserWriter.WriteString(sql); err != nil {
+		return fmt.Errorf("write system user sql: %w", err)
+	}
+	return nil
+}
+
+// Flush 刷新所有 writer 的缓冲区。
+func (w *Writers) Flush() error {
+	if err := w.CreateWriter.Flush(); err != nil {
+		return fmt.Errorf("flush create writer: %w", err)
+	}
+	if err := w.GrantWriter.Flush(); err != nil {
+		return fmt.Errorf("flush grant writer: %w", err)
+	}
+	if err := w.TranslatedSqlWriter.Flush(); err != nil {
+		return fmt.Errorf("flush translated sql writer: %w", err)
+	}
+	if err := w.SystemUserWriter.Flush(); err != nil {
+		return fmt.Errorf("flush system user writer: %w", err)
+	}
+	return nil
+}
+
+// NewWriters 创建一组 Writers，写入指定的 io.Writer。
+func NewWriters(createW, grantW, translatedW, systemUserW io.Writer) *Writers {
+	return &Writers{
+		CreateWriter:        bufio.NewWriter(createW),
+		GrantWriter:         bufio.NewWriter(grantW),
+		TranslatedSqlWriter: bufio.NewWriter(translatedW),
+		SystemUserWriter:    bufio.NewWriter(systemUserW),
+	}
+}
+
+// outputSuffix 根据源文件路径生成带后缀的输出文件路径。
+// 始终返回绝对路径，避免下游依赖工作目录。
+// 例如 /data/backup.sql + "create_user" → /data/backup.create_user.sql
+func outputSuffix(srcPath, suffix string) string {
+	absPath, _ := filepath.Abs(srcPath)
+	dir := filepath.Dir(absPath)
+	ext := filepath.Ext(absPath)
+	base := strings.TrimSuffix(filepath.Base(absPath), ext)
+	return filepath.Join(dir, base+"."+suffix+ext)
+}
+
+// OutputFilePaths 根据源文件路径计算所有输出文件的绝对路径，不创建文件。
+func OutputFilePaths(srcPath string) OutputFiles {
+	return OutputFiles{
+		CreateUser: outputSuffix(srcPath, "create_user"),
+		GrantPriv:  outputSuffix(srcPath, "grant_priv"),
+		Combined:   outputSuffix(srcPath, "combined"),
+		SystemUser: outputSuffix(srcPath, "system_user"),
+	}
+}
+
+// CreateOutputFiles 根据源文件路径创建输出文件，返回 Writers、OutputFiles 和关闭函数。
+// 调用方必须在使用完毕后先调用 Writers.Flush()，再调用 closeFunc 关闭文件。
+func CreateOutputFiles(srcPath string) (w *Writers, out OutputFiles, closeFunc func(), err error) {
+	out.CreateUser = outputSuffix(srcPath, "create_user")
+	out.GrantPriv = outputSuffix(srcPath, "grant_priv")
+	out.Combined = outputSuffix(srcPath, "combined")
+	out.SystemUser = outputSuffix(srcPath, "system_user")
+
+	var files []*os.File
+
+	closeAll := func() {
+		for _, f := range files {
+			_ = f.Close()
+		}
+	}
+
+	createFp, e := os.Create(out.CreateUser)
+	if e != nil {
+		err = fmt.Errorf("create output file %s: %w", out.CreateUser, e)
+		return
+	}
+	files = append(files, createFp)
+
+	grantFp, e := os.Create(out.GrantPriv)
+	if e != nil {
+		closeAll()
+		err = fmt.Errorf("create output file %s: %w", out.GrantPriv, e)
+		return
+	}
+	files = append(files, grantFp)
+
+	combinedFp, e := os.Create(out.Combined)
+	if e != nil {
+		closeAll()
+		err = fmt.Errorf("create output file %s: %w", out.Combined, e)
+		return
+	}
+	files = append(files, combinedFp)
+
+	systemUserFp, e := os.Create(out.SystemUser)
+	if e != nil {
+		closeAll()
+		err = fmt.Errorf("create output file %s: %w", out.SystemUser, e)
+		return
+	}
+	files = append(files, systemUserFp)
+
+	w = NewWriters(createFp, grantFp, combinedFp, systemUserFp)
+	closeFunc = closeAll
+	return
+}
+
+// CountFileLines 统计文件的行数。
+func CountFileLines(filePath string) (int, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return 0, fmt.Errorf("打开文件 %s 失败: %w", filePath, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	count := 0
+	for scanner.Scan() {
+		count++
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("读取文件 %s 失败: %w", filePath, err)
+	}
+
+	return count, nil
+}
+
+// LogOutputSummary 统计并输出所有结果文件的行数摘要。
+func LogOutputSummary(out OutputFiles) error {
+	for _, item := range []struct {
+		name string
+		path string
+	}{
+		{"create_user", out.CreateUser},
+		{"grant_priv", out.GrantPriv},
+		{"combined", out.Combined},
+		{"system_user", out.SystemUser},
+	} {
+		lines, err := CountFileLines(item.path)
+		if err != nil {
+			logger.Error("统计输出文件行数失败 file=%s error=%v", item.path, err)
+			return err
+		}
+		logger.Info("type=%s file=%s lines=%d", item.name, item.path, lines)
+	}
+
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/create_user.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/create_user.go
@@ -1,0 +1,37 @@
+package spider
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+)
+
+// processCreateUser 处理 CREATE USER 语句：Spider 节点原样输出，不加 IF NOT EXISTS。
+// 返回 true 表示该语句已被处理。
+func processCreateUser(stmt string, lastUser *string, userCount *int, w *pkg.Writers) (bool, error) {
+	// 先尝试 modern 格式 (IDENTIFIED WITH 'plugin')，再尝试 legacy 格式 (IDENTIFIED BY PASSWORD)
+	var user, host string
+	if matches := pkg.ReCreateUser.FindStringSubmatch(stmt); matches != nil {
+		user, host, _, _, _, _ = pkg.ExtractCreateUserFields(matches)
+	} else if matches := pkg.ReCreateUserLegacy.FindStringSubmatch(stmt); matches != nil {
+		user, host, _, _, _ = pkg.ExtractCreateUserLegacyFields(matches)
+	} else if matches := pkg.ReCreateUserPlain.FindStringSubmatch(stmt); matches != nil {
+		user, host, _, _ = pkg.ExtractCreateUserPlainFields(matches)
+	} else {
+		return false, nil
+	}
+
+	key := user + "@" + host
+
+	if key != *lastUser {
+		*userCount++
+		*lastUser = key
+	}
+
+	if err := w.WriteCreate(fmt.Sprintf("%s;\n", stmt)); err != nil {
+		logger.Error("process create user write create: %v", err)
+		return true, err
+	}
+	logger.Info("parsed spider CREATE USER user=%s", key)
+	return true, nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/grant.go
@@ -1,0 +1,125 @@
+package spider
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+	"strings"
+)
+
+// buildPlainGrantUsage 生成无密码的 GRANT USAGE ON *.* 语句，保持原始引号风格。
+func buildPlainGrantUsage(user, host string, style pkg.QuoteStyle) string {
+	return fmt.Sprintf("GRANT USAGE ON *.* TO %s", pkg.QuoteUser(user, host, style))
+}
+
+// trackSpider1User 在 Spider1 场景下将语句写入 create_user 文件，并更新用户计数。
+// 仅当 srcVer <= spider1MaxVersion 时调用。
+func trackSpider1User(stmt, key string, lastUser *string, userCount *int, w *pkg.Writers) error {
+	if err := w.WriteCreate(fmt.Sprintf("%s;\n", stmt)); err != nil {
+		logger.Error("track spider1 user write create: %v", err)
+		return err
+	}
+	if key != *lastUser {
+		*userCount++
+		*lastUser = key
+	}
+	return nil
+}
+
+// processGrant 处理 GRANT 语句，分发到带认证和不带认证两个子处理函数。
+// 返回 true 表示该语句已被处理。
+func processGrant(
+	stmt string, srcVer, dstVer int64, lastUser *string, userCount *int, w *pkg.Writers,
+) (bool, error) {
+	// 先尝试匹配带认证信息的 GRANT（ReGrantWithAuth 必须在 ReGrantPlain 之前）
+	if matches := pkg.ReGrantWithAuth.FindStringSubmatch(stmt); matches != nil {
+		return true, processGrantWithAuth(stmt, matches, srcVer, dstVer, lastUser, userCount, w)
+	}
+
+	if matches := pkg.ReGrantPlain.FindStringSubmatch(stmt); matches != nil {
+		return true, processGrantPlain(stmt, matches, srcVer, dstVer, lastUser, userCount, w)
+	}
+
+	return false, nil
+}
+
+// processGrantWithAuth 处理带 IDENTIFIED BY PASSWORD 的 GRANT 语句。
+//   - GRANT USAGE ON *.*：Spider1 写入 create_user + 所有版本写入无密码 grant usage
+//   - 其他 GRANT：Spider1 拆出 create_user + 原样写入 grant_priv + 展开 SUPER
+func processGrantWithAuth(
+	stmt string, matches []string, srcVer, dstVer int64,
+	lastUser *string, userCount *int, w *pkg.Writers,
+) error {
+	_, _, user, host, hash, rest, style := pkg.ExtractGrantWithAuthFields(matches)
+	key := user + "@" + host
+
+	if pkg.IsGrantUsageOnAll(stmt) {
+		if srcVer < 2000000 {
+			if err := trackSpider1User(stmt, key, lastUser, userCount, w); err != nil {
+				logger.Error("process grant with auth track spider1 user: %v", err)
+				return err
+			}
+			logger.Info("spider1 GRANT USAGE ON *.* → create_user user=%s", key)
+		}
+		plainUsage := buildPlainGrantUsage(user, host, style)
+		if err := w.WriteGrant(fmt.Sprintf("%s;\n", plainUsage)); err != nil {
+			logger.Error("process grant with auth write plain usage: %v", err)
+			return err
+		}
+		return nil
+	}
+
+	// 非 USAGE 的带密码 GRANT
+	if srcVer < 2000000 {
+		createStmt := fmt.Sprintf(
+			"GRANT USAGE ON *.* TO %s IDENTIFIED BY PASSWORD '%s'",
+			pkg.QuoteUser(user, host, style), hash,
+		)
+		if trimRest := strings.TrimSpace(rest); trimRest != "" {
+			createStmt += " " + trimRest
+		}
+		if err := trackSpider1User(createStmt, key, lastUser, userCount, w); err != nil {
+			logger.Error("process grant with auth track spider1 user (non-usage): %v", err)
+			return err
+		}
+	}
+
+	if err := w.WriteGrant(fmt.Sprintf("%s;\n", stmt)); err != nil {
+		logger.Error("process grant with auth write grant: %v", err)
+		return err
+	}
+	return expandSuperForSpider4(stmt, dstVer, w)
+}
+
+// processGrantPlain 处理不含认证信息的纯 GRANT 语句。
+//   - GRANT USAGE ON *.*：Spider1 写入 create_user + 所有版本写入无密码 grant usage
+//   - 其他 GRANT：原样写入 grant_priv + 展开 SUPER
+func processGrantPlain(
+	stmt string, matches []string, srcVer, dstVer int64,
+	lastUser *string, userCount *int, w *pkg.Writers,
+) error {
+	_, _, user, host, _, style := pkg.ExtractGrantPlainFields(matches)
+	key := user + "@" + host
+
+	if pkg.IsGrantUsageOnAll(stmt) {
+		if srcVer < 2000000 {
+			if err := trackSpider1User(stmt, key, lastUser, userCount, w); err != nil {
+				logger.Error("process grant plain track spider1 user: %v", err)
+				return err
+			}
+			logger.Info("spider1 plain GRANT USAGE ON *.* → create_user user=%s", key)
+		}
+		plainUsage := buildPlainGrantUsage(user, host, style)
+		if err := w.WriteGrant(fmt.Sprintf("%s;\n", plainUsage)); err != nil {
+			logger.Error("process grant plain write plain usage: %v", err)
+			return err
+		}
+		return nil
+	}
+
+	if err := w.WriteGrant(fmt.Sprintf("%s;\n", stmt)); err != nil {
+		logger.Error("process grant plain write grant: %v", err)
+		return err
+	}
+	return expandSuperForSpider4(stmt, dstVer, w)
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/init.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/init.go
@@ -1,0 +1,33 @@
+package spider
+
+import "dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+
+// expandSuperForSpider4 当目标版本是 Spider4（MariaDB）且 GRANT 语句包含 SUPER 时，
+// 额外写入一条包含 MariaDB SUPER 拆分权限的 GRANT 语句。
+// 原有的 SUPER 权限保留不动。
+func expandSuperForSpider4(stmt string, dstVer int64, w *pkg.Writers) error {
+	if dstVer < 4000000 {
+		return nil
+	}
+	return pkg.ExpandSuperPrivileges(stmt, pkg.MariaDBSuperPrivileges, "MariaDB/Spider4", w)
+}
+
+// mariaDBPrivAliases MariaDB 10.5.2 (MDEV-21743) 重命名的权限。
+// SHOW GRANTS 返回新名，但 GRANT 旧名仍可执行。
+// 在写入 grant 文件时统一为新名，避免 verify 阶段字符串不匹配。
+var mariaDBPrivAliases = map[string]string{
+	"REPLICATION CLIENT": "BINLOG MONITOR",
+	"REPLICATION SLAVE":  "REPLICATION REPLICA",
+}
+
+// rewritePrivsForSpider 当目标版本是 Spider 4 (MariaDB 10.5+) 时，
+// 将 GRANT 语句中的旧权限名替换为新名。
+func rewritePrivsForSpider(stmt string, dstVer int64) string {
+	if dstVer < 4000000 {
+		return stmt
+	}
+	for old, new_ := range mariaDBPrivAliases {
+		stmt = pkg.ReplacePrivName(stmt, old, new_)
+	}
+	return stmt
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/parser.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider/parser.go
@@ -1,0 +1,105 @@
+package spider
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+)
+
+// ParseFile 解析 Spider 节点的 SQL 备份文件，复用 MySQL 的 legacy/modern 解析逻辑。
+//
+// Spider 1 = legacy（只有 GRANT 语句），Spider 3/4 = modern（有 CREATE USER + GRANT）。
+// 与 MySQL 的差异通过 ParseConfig 注入：
+//   - IF NOT EXISTS 使用直接语法（非 hint）
+//   - SUPER 展开使用 MariaDB 权限（仅 Spider 4）
+//   - 系统用户只按用户名判断（不检查 host/sourceIP）
+//   - 未识别语句 warn 跳过（不报错）
+func ParseFile(
+	path string, srcVer, dstVer int64, sourceIP, targetIP string, dynamicSystemUsers []string,
+) (pkg.OutputFiles, error) {
+	systemUsers := pkg.BuildSystemUserMap(internal.StaticSystemUsers, dynamicSystemUsers)
+
+	totalLines, err := pkg.CountFileLines(path)
+	if err != nil {
+		logger.Error("count source file lines: %v", err)
+		return pkg.OutputFiles{}, fmt.Errorf("统计源文件行数失败: %w", err)
+	}
+	logger.Info("开始解析 Spider 备份文件 file=%s totalLines=%d srcVer=%d dstVer=%d", path, totalLines, srcVer, dstVer)
+
+	w, out, closeFiles, err := pkg.CreateOutputFiles(path)
+	if err != nil {
+		logger.Error("create output files: %v", err)
+		return pkg.OutputFiles{}, err
+	}
+	defer closeFiles()
+
+	scanner, closeFile, err := pkg.OpenFileWithScanner(path)
+	if err != nil {
+		logger.Error("open file with scanner: %v", err)
+		return pkg.OutputFiles{}, err
+	}
+	defer closeFile()
+
+	replacer := pkg.NewHostReplacer(sourceIP, targetIP)
+
+	cfg := &pkg.ParseConfig{
+		IsSystemUser: func(user, host string) bool {
+			_, ok := systemUsers[user]
+			return ok
+		},
+		AddIfNotExists:       mysql.AddIfNotExistsDirect,
+		BuildCreateFromEntry: buildCreateFromEntrySpider,
+		ExpandSuper:          expandSuperForSpider4,
+		RewritePrivs:         rewritePrivsForSpider,
+		StrictUnrecognized:   false,
+	}
+
+	if srcVer < 2000000 {
+		err = mysql.ParseLegacyFile(scanner, path, totalLines, dstVer, replacer, cfg, w)
+	} else {
+		err = mysql.ParseModernFile(scanner, path, totalLines, dstVer, replacer, cfg, w)
+	}
+	if err != nil {
+		logger.Error("parse spider backup file: %v", err)
+		return pkg.OutputFiles{}, err
+	}
+
+	if err := w.Flush(); err != nil {
+		logger.Error("flush output: %v", err)
+		return pkg.OutputFiles{}, fmt.Errorf("flush output: %w", err)
+	}
+
+	logger.Info("Spider 解析完成")
+	err = pkg.LogOutputSummary(out)
+	if err != nil {
+		return pkg.OutputFiles{}, err
+	}
+
+	return out, nil
+}
+
+// buildCreateFromEntrySpider 根据累积的 UserEntry 信息生成 Spider 的 CREATE USER 语句。
+//
+// Spider 1 目标：GRANT USAGE 载体格式（兼容 Spider 1）。
+// Spider 3/4 目标：CREATE USER IF NOT EXISTS（直接语法，无 hint）。
+func buildCreateFromEntrySpider(e *pkg.UserEntry, dstVer int64) string {
+	withClause := e.Resources.FormatWithClause()
+
+	if dstVer < 2000000 {
+		if e.Hash != "" {
+			return fmt.Sprintf("GRANT USAGE ON *.* TO '%s'@'%s' IDENTIFIED BY PASSWORD '%s'%s;\n",
+				e.User, e.Host, e.Hash, withClause)
+		}
+		return fmt.Sprintf("GRANT USAGE ON *.* TO '%s'@'%s'%s;\n",
+			e.User, e.Host, withClause)
+	}
+
+	if e.Hash != "" {
+		return fmt.Sprintf("CREATE USER IF NOT EXISTS '%s'@'%s' IDENTIFIED BY PASSWORD '%s'%s;\n",
+			e.User, e.Host, e.Hash, withClause)
+	}
+	return fmt.Sprintf("CREATE USER IF NOT EXISTS '%s'@'%s'%s;\n",
+		e.User, e.Host, withClause)
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql/dump_priv.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql/dump_priv.go
@@ -1,0 +1,99 @@
+package mysql
+
+import (
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/backupdemand"
+	"dbm-services/mysql/db-tools/mysql-dbbackup/pkg/src/dbareport"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+type DumpPrivComponent struct {
+	GeneralParam *components.GeneralParam `json:"general"`
+	backupdemand.Component
+	Params *DumpPrivParam `json:"extend"`
+}
+
+type DumpPrivParam struct {
+	backupdemand.Param
+	SourcePrivFilePath string `json:"source_priv_file_path"`
+}
+
+func (c *DumpPrivComponent) Init() error {
+	logger.Info("params: %v", c.Params)
+	c.Component.Params = &c.Params.Param
+	c.Component.GeneralParam = c.GeneralParam
+	return c.Component.Init()
+}
+
+func (c *DumpPrivComponent) RenamePrivFile() error {
+	report, _, err := c.GenerateReport()
+	if err != nil {
+		logger.Error("generating report failed: %s", err.Error())
+		return err
+	}
+
+	b, err := json.Marshal(*report)
+	if err != nil {
+		logger.Error("report json marshal failed: %s", err.Error())
+		return err
+	}
+	logger.Info("report content: %s", string(b))
+
+	idx := slices.IndexFunc(
+		report.Result.FileList, func(ele *dbareport.TarFileItem) bool {
+			return ele.FileType == "priv"
+		},
+	)
+	if idx < 0 {
+		err := fmt.Errorf("priv file not found")
+		logger.Error(err.Error())
+		return err
+	}
+
+	privFileItem := report.Result.FileList[idx]
+	//if privFileItem.ContainFiles == nil {
+	//	err := fmt.Errorf("priv file does not contain any files")
+	//	logger.Error(err.Error())
+	//	return err
+	//}
+	//if len(privFileItem.ContainFiles) > 1 {
+	//	err := fmt.Errorf("priv file contains more than one file: %v", privFileItem.ContainFiles)
+	//	logger.Error(err.Error())
+	//	return err
+	//}
+
+	privFilePath := filepath.Join(report.Result.OriginalBackupDir, privFileItem.FileName)
+
+	// 把权限备份文件复制一份
+	src, err := os.Open(privFilePath)
+	if err != nil {
+		logger.Error("open priv file %s err: %v", privFilePath, err)
+		return err
+	}
+	defer func() {
+		_ = src.Close()
+	}()
+
+	dst, err := os.Create(c.Params.SourcePrivFilePath)
+	if err != nil {
+		logger.Error("create copy file %s err: %v", c.Params.SourcePrivFilePath, err)
+		return err
+	}
+	defer func() {
+		_ = dst.Close()
+	}()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		logger.Error("copy file from %s to %s err: %v", privFilePath, c.Params.SourcePrivFilePath, err)
+		return err
+	}
+
+	logger.Info("copied priv file from %s to %s", privFilePath, c.Params.SourcePrivFilePath)
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql/import_priv_file.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql/import_priv_file.go
@@ -1,0 +1,271 @@
+package mysql
+
+import (
+	"context"
+	"dbm-services/common/go-pubpkg/cmutil"
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/importer"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/mysql"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/pkg"
+	"fmt"
+	"io"
+	"os"
+
+	_ "github.com/go-sql-driver/mysql" // mysql 驱动
+
+	"github.com/jmoiron/sqlx"
+)
+
+type ImportPrivFileParam struct {
+	SystemUsers        []string `json:"system_users"`
+	SourceIP           string   `json:"source_ip"`
+	SourcePort         int      `json:"source_port"`
+	SourceRawVersion   string   `json:"source_raw_version"`
+	SourcePrivFilePath string   `json:"source_priv_file_path"`
+	TargetIP           string   `json:"target_ip"`
+	TargetPort         int      `json:"target_port"`
+	IsSpider           bool     `json:"is_spider"`
+	//SpiderSkipUser     string   `json:"spider_skip_user"`
+}
+
+type importPrivFileCtx struct {
+	targetDB             *sqlx.DB
+	targetConn           *sqlx.Conn
+	srcVer               int64
+	dstVer               int64
+	sourcePrivFileCpPath string
+}
+type ImportPrivFileComponent struct {
+	GeneralParam *components.GeneralParam `json:"general"`
+	Param        *ImportPrivFileParam     `json:"extend"`
+	importPrivFileCtx
+}
+
+func (c *ImportPrivFileComponent) Init() error {
+	db, err := sqlx.Connect(
+		"mysql",
+		fmt.Sprintf(
+			"%s:%s@tcp(%s:%d)/",
+			c.GeneralParam.RuntimeAccountParam.AdminUser,
+			c.GeneralParam.RuntimeAccountParam.AdminPwd,
+			c.Param.TargetIP,
+			c.Param.TargetPort,
+		),
+	)
+	if err != nil {
+		logger.Error("connect target mysql %s:%d err: %v", c.Param.TargetIP, c.Param.TargetPort, err)
+		return err
+	}
+	logger.Info("connect target mysql %s:%d success", c.Param.TargetIP, c.Param.TargetPort)
+
+	c.targetDB = db
+
+	if err := c.initConn(); err != nil {
+		logger.Error("get conn from target mysql %s:%d err: %v", c.Param.TargetIP, c.Param.TargetPort, err)
+		return err
+	}
+
+	if err := c.parseVersion(); err != nil {
+		logger.Error("parse version err: %v", err)
+		return err
+	}
+
+	if err := c.copySourcePrivFile(); err != nil {
+		logger.Error("copy source priv file err: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (c *ImportPrivFileComponent) initConn() error {
+	conn, err := c.targetDB.Connx(context.Background())
+	if err != nil {
+		logger.Error("get connect from target mysql err: %v", err)
+		return err
+	}
+	logger.Info("get connect from target mysql success")
+
+	_, err = conn.ExecContext(context.Background(), `SET SESSION sql_log_bin = 0`)
+	if err != nil {
+		logger.Error("set sql_log_bin = 0 err: %v", err)
+		_ = conn.Close()
+		return err
+	}
+	logger.Info("set sql_log_bin = 0 success")
+	c.targetConn = conn
+	return nil
+}
+
+func (c *ImportPrivFileComponent) parseVersion() error {
+	// 在 target 执行 select @@Version
+	var rawVersion string
+	if err := c.targetDB.Get(&rawVersion, "SELECT @@VERSION"); err != nil {
+		logger.Error("get target raw version err: %v", err)
+		return err
+	}
+	logger.Info("target raw version: %s", rawVersion)
+
+	// 解析版本号
+	if c.Param.IsSpider {
+		c.dstVer = int64(cmutil.SpiderVersionParse(rawVersion))
+		c.srcVer = int64(cmutil.SpiderVersionParse(c.Param.SourceRawVersion))
+	} else {
+		c.dstVer = int64(cmutil.MySQLVersionParse(rawVersion))
+		c.srcVer = int64(cmutil.MySQLVersionParse(c.Param.SourceRawVersion))
+	}
+
+	logger.Info("source version: %d, target version: %d", c.srcVer, c.dstVer)
+	return nil
+}
+
+// 把 sourcePrivFilePath 复制到当前路径下
+func (c *ImportPrivFileComponent) copySourcePrivFile() error {
+	sourceFile := c.Param.SourcePrivFilePath
+	sourceFileCp := fmt.Sprintf(
+		`./%s_%d_%s_%d.priv`,
+		c.Param.SourceIP, c.Param.SourcePort, c.Param.TargetIP, c.Param.TargetPort,
+	)
+
+	// 打开源文件
+	src, err := os.Open(sourceFile)
+	if err != nil {
+		logger.Error("open source file %s err: %v", sourceFile, err)
+		return err
+	}
+	defer func() {
+		_ = src.Close()
+	}()
+
+	// 创建目标文件
+	dst, err := os.Create(sourceFileCp)
+	if err != nil {
+		logger.Error("create destination file %s err: %v", sourceFileCp, err)
+		return err
+	}
+	defer func() {
+		_ = dst.Close()
+	}()
+
+	// 复制文件内容
+	if _, err := io.Copy(dst, src); err != nil {
+		logger.Error("copy file from %s to %s err: %v", sourceFile, sourceFileCp, err)
+		return err
+	}
+
+	logger.Info("copied file from %s to %s", sourceFile, sourceFileCp)
+
+	c.sourcePrivFileCpPath = sourceFileCp
+	return nil
+}
+
+func (c *ImportPrivFileComponent) ParseFile() (err error) {
+	if c.Param.IsSpider {
+		err := fmt.Errorf("ParseFile called with wrong IsSpider flag, mysql expects IsSpider=false, spider expects IsSpider=true")
+		logger.Error(err.Error())
+		return err
+	}
+
+	_, err = mysql.ParseFile(
+		c.sourcePrivFileCpPath,
+		c.srcVer,
+		c.dstVer,
+		c.Param.SourceIP,
+		c.Param.TargetIP,
+		c.Param.SystemUsers,
+	)
+
+	if err != nil {
+		logger.Error("parse grants file err: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (c *ImportPrivFileComponent) flushPrivileges() {
+	if _, err := c.targetConn.ExecContext(context.Background(), "FLUSH PRIVILEGES"); err != nil {
+		logger.Error("flush privileges err: %v", err)
+	} else {
+		logger.Info("flush privileges success")
+	}
+}
+
+func (c *ImportPrivFileComponent) PreCheckCreateUser() error {
+	outFiles := pkg.OutputFilePaths(c.sourcePrivFileCpPath)
+	if err := checker.PreCheckCreateUserFile(c.targetConn, outFiles.CreateUser, c.dstVer); err != nil {
+		logger.Error("pre-check create user file %s err: %v", outFiles.CreateUser, err)
+		return err
+	}
+
+	logger.Info("pre-check create user file success")
+	return nil
+}
+
+func (c *ImportPrivFileComponent) ImportCreateUserFile() error {
+	defer c.flushPrivileges()
+
+	outFiles := pkg.OutputFilePaths(c.sourcePrivFileCpPath)
+	if err := importer.ImportFile(c.targetConn, outFiles.CreateUser); err != nil {
+		logger.Error("import file %s err: %v", outFiles.CreateUser, err)
+		return err
+	}
+
+	logger.Info("import create user file success")
+	return nil
+}
+
+func (c *ImportPrivFileComponent) ImportGrantPrivFile() error {
+	defer c.flushPrivileges()
+
+	outFiles := pkg.OutputFilePaths(c.sourcePrivFileCpPath)
+	if err := importer.ImportFile(c.targetConn, outFiles.GrantPriv); err != nil {
+		logger.Error("import file %s err: %v", outFiles.GrantPriv, err)
+		return err
+	}
+
+	logger.Info("import grant priv file success")
+	return nil
+}
+
+func (c *ImportPrivFileComponent) VerifyCreateUser() error {
+	outFiles := pkg.OutputFilePaths(c.sourcePrivFileCpPath)
+	if err := checker.VerifyCreateUserFile(c.targetConn, outFiles.CreateUser, c.dstVer); err != nil {
+		logger.Error("verify create user file %s err: %v", outFiles.CreateUser, err)
+		return err
+	}
+
+	logger.Info("verify create user file success")
+	return nil
+}
+
+func (c *ImportPrivFileComponent) VerifyGrantPriv() error {
+	outFiles := pkg.OutputFilePaths(c.sourcePrivFileCpPath)
+	if err := checker.VerifyGrantPrivFile(c.targetConn, outFiles.GrantPriv, c.dstVer); err != nil {
+		logger.Error("verify grant priv file %s err: %v", outFiles.GrantPriv, err)
+		return err
+	}
+
+	logger.Info("verify grant priv file success")
+	return nil
+}
+
+func (c *ImportPrivFileComponent) SrcVer() int64                { return c.srcVer }
+func (c *ImportPrivFileComponent) DstVer() int64                { return c.dstVer }
+func (c *ImportPrivFileComponent) SourcePrivFileCpPath() string { return c.sourcePrivFileCpPath }
+
+func (c *ImportPrivFileComponent) Example() interface{} {
+	return ImportPrivFileComponent{
+		Param: &ImportPrivFileParam{
+			SystemUsers:        []string{"fake_admin"},
+			SourceIP:           "1.1.1.1",
+			SourcePort:         1234,
+			SourceRawVersion:   "5.5.24-tmysql-1.6-log",
+			SourcePrivFilePath: "/path/to/file",
+			TargetIP:           "2.2.2.2",
+			TargetPort:         2345,
+			IsSpider:           false,
+		},
+	}
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider/dump_priv.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider/dump_priv.go
@@ -1,0 +1,7 @@
+package spider
+
+import "dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+
+type DumpPrivComponent struct {
+	mysql.DumpPrivComponent
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider/import_priv_file.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/spider/import_priv_file.go
@@ -1,0 +1,40 @@
+package spider
+
+import (
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/spider"
+	"fmt"
+
+	"dbm-services/common/go-pubpkg/logger"
+	"dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/mysql"
+)
+
+type ImportPrivFileComponent struct {
+	mysql.ImportPrivFileComponent
+}
+
+func (c *ImportPrivFileComponent) ParseFile() error {
+	if !c.Param.IsSpider {
+		err := fmt.Errorf("ParseFile called with wrong IsSpider flag, mysql expects IsSpider=false, spider expects IsSpider=true")
+		logger.Error(err.Error())
+		return err
+	}
+
+	//systemUsers := c.Param.SystemUsers
+	//if c.Param.SpiderSkipUser != "" {
+	//	systemUsers = append(systemUsers, c.Param.SpiderSkipUser)
+	//}
+
+	_, err := spider.ParseFile(
+		c.ImportPrivFileComponent.SourcePrivFileCpPath(),
+		c.ImportPrivFileComponent.SrcVer(),
+		c.DstVer(),
+		c.Param.SourceIP,
+		c.Param.TargetIP,
+		c.Param.SystemUsers,
+	)
+	if err != nil {
+		logger.Error("parse spider grants file err: %v", err)
+		return err
+	}
+	return nil
+}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/backupdemand/backup_demand.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/backupdemand/backup_demand.go
@@ -292,7 +292,7 @@ func (c *Component) DoBackup() error {
 	return nil
 }
 
-func (c *Component) generateReport() (report *Report, indexFile string, err error) {
+func (c *Component) GenerateReport() (report *Report, indexFile string, err error) {
 	report = &Report{}
 
 	indexFileSearch := filepath.Join(c.backupDir, "*.index")
@@ -326,7 +326,7 @@ func (c *Component) generateReport() (report *Report, indexFile string, err erro
 }
 
 func (c *Component) OutPut() error {
-	report, _, err := c.generateReport()
+	report, _, err := c.GenerateReport()
 	if err != nil {
 		return err
 	}
@@ -357,7 +357,7 @@ func (c *Component) Example() interface{} {
 // OutPutForTBinlogDumper 增加为tbinlogdumper做库表备份的日志输出，保存流程上下文
 func (c *Component) OutPutForTBinlogDumper() error {
 	ret := make(map[string]interface{})
-	report, indexFile, err := c.generateReport()
+	report, indexFile, err := c.GenerateReport()
 	if err != nil {
 		return err
 	}

--- a/dbm-ui/backend/flow/consts.py
+++ b/dbm-ui/backend/flow/consts.py
@@ -521,6 +521,14 @@ class DBActuatorActionEnum(StrStructuredEnum):
     DeployPeripheralToolsBinary = EnumField("prepare-peripheraltools-binary", _("prepare-peripheraltools-binary"))
     InitCommonConfig = EnumField("init-common-config", _("初始化公共配置"))
     MysqlPartitionV2 = EnumField("partition-execute-v2", _("mysql分区执行V2"))
+    # clone 权限 v2
+    CloneGrantsDumpPriv = EnumField("clone-grants-dump-priv", _("导出权限"))
+    CloneGrantsParseFile = EnumField("clone-grants-parse-file", _("处理权限文件"))
+    CloneGrantsPrecheckCreate = EnumField("clone-grants-precheck-create", _("账号预检查"))
+    CloneGrantsImportCreate = EnumField("clone-grants-import-create", _("恢复账号"))
+    CloneGrantsImportGrant = EnumField("clone-grants-import-grant", _("恢复权限"))
+    CloneGrantsVerifyCreate = EnumField("clone-grants-verify-create", _("验证账号"))
+    CloneGrantsVerifyGrant = EnumField("clone-grants-verify-grant", _("验证权限"))
 
 
 class RedisActuatorActionEnum(StrStructuredEnum):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/__init__.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from .subflow import clone_grants_from_file_subflow

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/payload/payload.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/payload/payload.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from backend.db_meta.enums import MachineType
+from backend.db_meta.models import Machine, ProxyInstance, StorageInstance
+from backend.flow.consts import TDBCTL_USER, DBActuatorActionEnum, DBActuatorTypeEnum
+from backend.flow.utils.mysql.act_payload.base.payload_base import PayloadBase
+from backend.flow.utils.mysql.act_payload.mixed.account_mixed.mysql_account_mixed import MySQLAccountMixed
+
+
+class CloneGrantsFromFilePayload(PayloadBase, MySQLAccountMixed):
+    def dump_priv_on_source(self, **kwargs):
+        """从文件中克隆授权"""
+        ip = kwargs["ip"]
+        port = self.cluster["port"]
+
+        m = Machine.objects.get(ip=ip, bk_cloud_id=self.bk_cloud_id)
+        if m.machine_type == MachineType.SPIDER:
+            role = ProxyInstance.objects.get(machine=m, port=port).instance_role
+            db_type = DBActuatorTypeEnum.Spider.value
+        else:
+            role = StorageInstance.objects.get(machine=m, port=port).instance_role
+            db_type = DBActuatorTypeEnum.MySQL.value
+
+        return {
+            "db_type": db_type,
+            "action": DBActuatorActionEnum.CloneGrantsDumpPriv.value,
+            "payload": {
+                "general": {
+                    "runtime_account": {
+                        **self.mysql_admin_account(self.ticket_data),
+                        **self.mysql_static_account(),
+                    }
+                },
+                "extend": {
+                    "host": ip,
+                    "port": int(port),
+                    "role": role,
+                    "backup_type": "logical",
+                    "backup_gsd": ["grant"],
+                    "backup_id": self.cluster["backup_id"],
+                    "bill_id": str(self.ticket_data["uid"]),
+                    "custom_backup_dir": "",
+                    "shard_id": 0,
+                    "backup_file_tag": "",
+                    "db_patterns": ["*"],
+                    "ignore_dbs": [],
+                    "table_patterns": ["*"],
+                    "ignore_tables": [],
+                    "source_priv_file_path": self.cluster["source_priv_file_path"],
+                },
+            },
+        }
+
+    def on_dest(self, **kwargs):
+        ip = kwargs["ip"]  # self.cluster["ip"]
+        m = Machine.objects.get(ip=ip, bk_cloud_id=self.bk_cloud_id)
+        if m.machine_type == MachineType.SPIDER:
+            db_type = DBActuatorTypeEnum.Spider.value
+        else:
+            db_type = DBActuatorTypeEnum.MySQL.value
+
+        static_accounts = self.mysql_static_account()
+        system_users = list(
+            {v for k, v in static_accounts.items() if k.endswith("_user")}
+            | {
+                self.mysql_drs_account(self.bk_cloud_id)["user"],
+                self.mysql_dbha_account(self.bk_cloud_id)["user"],
+                self.mysql_webconsole_account(self.bk_cloud_id)["user"],
+                self.mysql_admin_account(self.ticket_data)["admin_user"],
+            }
+        )
+
+        system_users.append(TDBCTL_USER)  # TenDBCluster 集群内部的账号不需要克隆
+
+        return {
+            "db_type": db_type,
+            "action": self.cluster["action"],
+            "payload": {
+                "general": {
+                    "runtime_account": {
+                        **self.mysql_admin_account(self.ticket_data),
+                        **self.mysql_static_account(),
+                    }
+                },
+                "extend": {
+                    "system_users": system_users,
+                    "source_ip": self.cluster["source_ip"],
+                    "source_port": int(self.cluster["source_port"]),
+                    "source_raw_version": self.cluster["source_raw_version"],
+                    "source_priv_file_path": self.cluster["source_priv_file_path"],
+                    "target_ip": kwargs["ip"],
+                    "target_port": int(self.cluster["dest_port"]),
+                    "is_spider": self.cluster["is_spider"],
+                },
+            },
+        }

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/subflow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/subflow.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import copy
+import logging
+import os
+import uuid
+from dataclasses import asdict
+from typing import Dict
+
+from django.utils.translation import gettext as _
+
+from backend.components import DRSApi
+from backend.configuration.constants import DBType
+from backend.db_meta.enums import MachineType
+from backend.db_meta.models import Machine
+from backend.flow.consts import DBA_ROOT_USER, LONG_JOB_TIMEOUT, DBActuatorActionEnum
+from backend.flow.engine.bamboo.scene.common.builder import SubBuilder, SubProcess
+from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file.payload.payload import CloneGrantsFromFilePayload
+from backend.flow.plugins.components.collections.mysql.clone_grants_from_file.version_check import (
+    CloneGrantsVersionCheckComponent,
+)
+from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
+from backend.flow.plugins.components.collections.mysql.trans_flies import TransFileComponent
+from backend.flow.plugins.components.collections.mysql.trans_flies import TransFileComponent as MySQLTransFileComponent
+from backend.flow.utils.mysql.mysql_act_dataclass import DownloadMediaKwargs, ExecActuatorKwargs, P2PFileKwargs
+
+logger = logging.getLogger("flow")
+
+
+def clone_grants_from_file_subflow(
+    root_id: str,
+    data: Dict,
+    bk_cloud_id: int,
+    bk_biz_id: int,
+    source_address: str,
+    dest_addresses: list[str],
+    run_as_system_user: str = DBA_ROOT_USER,
+) -> SubProcess:
+    source_ip, source_port = source_address.split(":")
+    dest_ips = list({addr.split(":")[0] for addr in dest_addresses})
+    all_ips = list({source_ip, *dest_ips})
+
+    backup_id = uuid.uuid1().__str__()
+    source_priv_file_name = f"source_priv_{backup_id}_{source_ip}_{source_port}.priv"
+    source_priv_file_path = os.path.join("/data/dbbak", source_priv_file_name)
+
+    is_spider = Machine.objects.get(ip=source_ip, bk_cloud_id=bk_cloud_id).machine_type == MachineType.SPIDER.value
+
+    try:
+        res = DRSApi.rpc(
+            {
+                "addresses": [source_address],
+                "cmds": ["select @@version as version"],
+                "force": False,
+                "bk_cloud_id": bk_cloud_id,
+            }
+        )
+        if res[0]["error_msg"]:
+            logger.error(f"check source version failed: {res[0]['error_msg']}")
+            raise Exception(f"{res[0]['error_msg']}")
+        if res[0]["cmd_results"][0]["error_msg"]:
+            logger.error(f"check source version failed: {res[0]['cmd_results'][0]['error_msg']}")
+            raise Exception(f"{res[0]['cmd_results'][0]['error_msg']}")
+
+        source_raw_version = res[0]["cmd_results"][0]["table_data"][0]["version"]
+        logger.info(f"source raw version: {source_raw_version}")
+    except Exception as e:  # noqa
+        raise Exception(f"check source version failed: {e}") from e
+
+    pipe = SubBuilder(root_id=root_id, data=data)
+
+    pipe.add_act(
+        act_name=_("版本号检查"),
+        act_component_code=CloneGrantsVersionCheckComponent.code,
+        kwargs={
+            "source_raw_version": source_raw_version,
+            "dest_addresses": dest_addresses,
+            "bk_cloud_id": bk_cloud_id,
+            "is_spider": is_spider,
+        },
+    )
+
+    pipe.add_act(
+        act_name=_("下发 dbactuator"),
+        act_component_code=TransFileComponent.code,
+        kwargs=asdict(
+            DownloadMediaKwargs(
+                bk_cloud_id=bk_cloud_id,
+                exec_ip=all_ips,
+                file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
+                run_as_system_user=run_as_system_user,
+            )
+        ),
+    )
+
+    pipe.add_act(
+        act_name=_("在 {} 备份权限".format(source_address)),
+        act_component_code=ExecuteDBActuatorScriptComponent.code,
+        kwargs=asdict(
+            ExecActuatorKwargs(
+                job_timeout=LONG_JOB_TIMEOUT,
+                bk_cloud_id=bk_cloud_id,
+                run_as_system_user=run_as_system_user,
+                exec_ip=source_ip,
+                payload_class=CloneGrantsFromFilePayload.payload_class_path(),
+                get_mysql_payload_func=CloneGrantsFromFilePayload.dump_priv_on_source.__name__,
+                cluster={
+                    "port": source_port,
+                    "ip": source_ip,
+                    "backup_id": backup_id,
+                    "source_priv_file_path": source_priv_file_path,
+                },
+            )
+        ),
+    )
+
+    pipe.add_act(
+        act_name=_("分发备份文件到 {}".format(dest_ips)),
+        act_component_code=MySQLTransFileComponent.code,
+        kwargs=asdict(
+            P2PFileKwargs(
+                bk_cloud_id=bk_cloud_id,
+                file_list=[source_priv_file_path],
+                file_target_path="/data/dbbak",
+                source_ip_list=[source_ip],
+                exec_ip=dest_ips,
+                run_as_system_user=run_as_system_user,
+            )
+        ),
+    )
+
+    on_dest_subflows = []
+
+    for dest_address in dest_addresses:
+        dest_ip, dest_port = dest_address.split(":")
+        on_dest_subflow = SubBuilder(root_id=root_id, data=copy.deepcopy(data))
+        for action in [
+            DBActuatorActionEnum.CloneGrantsParseFile,
+            DBActuatorActionEnum.CloneGrantsPrecheckCreate,
+            DBActuatorActionEnum.CloneGrantsImportCreate,
+            DBActuatorActionEnum.CloneGrantsVerifyCreate,
+            DBActuatorActionEnum.CloneGrantsImportGrant,
+            DBActuatorActionEnum.CloneGrantsVerifyGrant,
+        ]:
+            on_dest_subflow.add_act(
+                act_name=str(DBActuatorActionEnum.get_choice_label(action)),
+                act_component_code=ExecuteDBActuatorScriptComponent.code,
+                kwargs=asdict(
+                    ExecActuatorKwargs(
+                        job_timeout=LONG_JOB_TIMEOUT,
+                        bk_cloud_id=bk_cloud_id,
+                        run_as_system_user=run_as_system_user,
+                        exec_ip=dest_ip,
+                        payload_class=CloneGrantsFromFilePayload.payload_class_path(),
+                        get_mysql_payload_func=CloneGrantsFromFilePayload.on_dest.__name__,
+                        cluster={
+                            "source_ip": source_ip,
+                            "source_port": source_port,
+                            "dest_port": dest_port,
+                            "source_priv_file_path": source_priv_file_path,
+                            "source_raw_version": source_raw_version,
+                            "action": action.value,
+                            "is_spider": is_spider,
+                        },
+                    )
+                ),
+            )
+
+        on_dest_subflows.append(on_dest_subflow.build_sub_process(sub_name=_("在 {} 恢复权限".format(dest_address))))
+
+    pipe.add_parallel_sub_pipeline(on_dest_subflows)
+    return pipe.build_sub_process(sub_name=_("克隆 {} 的权限到 {}".format(source_address, dest_addresses)))

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/slave_recover_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/slave_recover_switch.py
@@ -7,6 +7,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import copy
 import logging.config
 from dataclasses import asdict
 
@@ -18,8 +19,8 @@ from backend.db_meta.enums import InstanceStatus
 from backend.db_meta.models import Cluster
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.cluster_entrys import get_tendb_ha_entry
-from backend.flow.plugins.components.collections.mysql.clone_user import CloneUserComponent
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.mysql_check_slave_delay import MySQLCheckSlaveDelayComponent
 from backend.flow.plugins.components.collections.mysql.mysql_check_slave_delay_probe import (
@@ -32,7 +33,6 @@ from backend.flow.utils.mysql.mysql_act_dataclass import (
     CreateDnsKwargs,
     DownloadMediaKwargs,
     ExecuteRdsKwargs,
-    InstanceUserCloneKwargs,
     IpDnsRecordRecycleKwargs,
     RecycleDnsRecordKwargs,
 )
@@ -164,11 +164,17 @@ def slave_migrate_switch_sub_flow(
     logging.info(clone_data)
 
     if len(clone_data) > 0:
-        sub_pipeline.add_act(
-            act_name=_("克隆权限"),
-            act_component_code=CloneUserComponent.code,
-            kwargs=asdict(InstanceUserCloneKwargs(clone_data=clone_data)),
-        )
+        for ele in clone_data:
+            sub_pipeline.add_sub_pipeline(
+                sub_flow=clone_grants_from_file_subflow(
+                    root_id=root_id,
+                    data=copy.deepcopy(ticket_data),
+                    bk_cloud_id=cluster.bk_cloud_id,
+                    bk_biz_id=cluster.bk_biz_id,
+                    source_address=ele["source"],
+                    dest_addresses=[new_slave],
+                )
+            )
 
     domain_map = get_tendb_ha_entry(cluster.id)
     domain_add_list = []

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
@@ -25,6 +25,7 @@ from backend.db_package.models import Package
 from backend.flow.consts import MediumEnum
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file.subflow import clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.cluster_entrys import get_tendb_ha_entry
 from backend.flow.engine.bamboo.scene.mysql.common.common_sub_flow import install_mysql_in_cluster_sub_flow
 from backend.flow.engine.bamboo.scene.mysql.common.get_master_config import get_instance_config
@@ -45,7 +46,6 @@ from backend.flow.plugins.components.collections.common.disable_alarm_shield imp
 from backend.flow.plugins.components.collections.common.download_backup_client import DownloadBackupClientComponent
 from backend.flow.plugins.components.collections.common.pause import PauseComponent
 from backend.flow.plugins.components.collections.mysql.clear_machine import MySQLClearMachineComponent
-from backend.flow.plugins.components.collections.mysql.clone_user import CloneUserComponent
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.plugins.components.collections.mysql.mysql_check_binlog_dump import MySQLCheckBinlogDumpComponent
@@ -69,7 +69,6 @@ from backend.flow.utils.mysql.mysql_act_dataclass import (
     DownloadMediaKwargs,
     ExecActuatorKwargs,
     ExecuteRdsKwargs,
-    InstanceUserCloneKwargs,
     IpDnsRecordRecycleKwargs,
     RecycleDnsRecordKwargs,
 )
@@ -738,19 +737,17 @@ class MySQLRestoreSlaveRemoteFlow(object):
                         )
                     ),
                 )
-            # is_stand_by可以克隆主库权限
+            #  克隆权限
             if master.is_stand_by:
-                clone_data = [
-                    {
-                        "source": old_master,
-                        "target": new_slave,
-                        "bk_cloud_id": cluster_model.bk_cloud_id,
-                    }
-                ]
-                tendb_migrate_pipeline.add_act(
-                    act_name=_("克隆权限"),
-                    act_component_code=CloneUserComponent.code,
-                    kwargs=asdict(InstanceUserCloneKwargs(clone_data=clone_data)),
+                tendb_migrate_pipeline.add_sub_pipeline(
+                    sub_flow=clone_grants_from_file_subflow(
+                        root_id=self.root_id,
+                        data=copy.deepcopy(self.data),
+                        bk_cloud_id=cluster_model.bk_cloud_id,
+                        bk_biz_id=cluster_model.bk_biz_id,
+                        source_address=old_master,
+                        dest_addresses=[new_slave],
+                    )
                 )
 
             domain_map = get_tendb_ha_entry(cluster_model.id)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/__init__.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/subflow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/subflow.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import copy
+from typing import Dict
+
+from backend.flow.consts import DBA_ROOT_USER
+from backend.flow.engine.bamboo.scene.common.builder import SubProcess
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import (
+    clone_grants_from_file_subflow as m_clone_subflow,
+)
+
+
+def clone_grants_from_file_subflow(
+    root_id: str,
+    data: Dict,
+    bk_cloud_id: int,
+    bk_biz_id: int,
+    source_address: str,
+    dest_addresses: list[str],
+    run_as_system_user: str = DBA_ROOT_USER,
+) -> SubProcess:
+    return m_clone_subflow(
+        root_id=root_id,
+        data=copy.deepcopy(data),
+        bk_cloud_id=bk_cloud_id,
+        bk_biz_id=bk_biz_id,
+        source_address=source_address,
+        dest_addresses=dest_addresses,
+        run_as_system_user=run_as_system_user,
+    )

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/clone_grants_from_file/version_check.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/clone_grants_from_file/version_check.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import re
+
+from pipeline.component_framework.component import Component
+
+from backend.components import DRSApi
+from backend.flow.plugins.components.collections.common.base_service import BaseService
+
+
+class CloneGrantsVersionCheckService(BaseService):
+    def _execute(self, data, parent_data):
+        kwargs = data.get_one_of_inputs("kwargs")
+
+        source_raw_version = kwargs["source_raw_version"]
+        dest_addresses = kwargs["dest_addresses"]
+        bk_cloud_id = kwargs["bk_cloud_id"]
+        is_spider = kwargs["is_spider"]
+
+        if is_spider:
+            source_main_version = self._get_spider_main_version(source_raw_version)
+        else:
+            source_main_version = self._get_mysql_main_version(source_raw_version)
+
+        res = DRSApi.rpc(
+            {
+                "addresses": dest_addresses,
+                "cmds": ["select @@version as version"],
+                "force": False,
+                "bk_cloud_id": bk_cloud_id,
+            }
+        )
+
+        bad_dest_versions = []
+        for ele in res:
+            if ele["error_msg"]:
+                self.log_error(f"check source version failed: {ele['error_msg']}")
+                return False
+
+            if ele["cmd_results"][0]["error_msg"]:
+                self.log_error(f"check source version failed: {ele['cmd_results'][0]['error_msg']}")
+                return False
+
+            addr = ele["address"]
+            raw_version = ele["cmd_results"][0]["table_data"][0]["version"]
+            if is_spider:
+                main_version = self._get_spider_main_version(raw_version)
+            else:
+                main_version = self._get_mysql_main_version(raw_version)
+
+            if main_version < source_main_version:
+                bad_dest_versions.append({"address": addr, "raw_version": raw_version, "main_version": main_version})
+
+        if bad_dest_versions:
+            self.log_error(f"source versions higher than dest({source_main_version}): {bad_dest_versions}")
+            return False
+
+        return True
+
+    @staticmethod
+    def _get_spider_main_version(raw_version: str) -> int:
+        """Extract tspider major version from raw version string like '5.5.24-tspider-1.13-log' -> 1"""
+        m = re.search(r"-tspider-(\d+)\.\d+", raw_version)
+        if not m:
+            raise ValueError(f"cannot parse tspider version from '{raw_version}'")
+        return int(m.group(1))
+
+    @staticmethod
+    def _get_mysql_main_version(raw_version: str) -> int:
+        """Extract mysql major+minor as int from raw version string like '5.7.20-tmysql-3.3-log' -> 57"""
+        m = re.match(r"(\d+)\.(\d+)", raw_version)
+        if not m:
+            raise ValueError(f"cannot parse mysql version from '{raw_version}'")
+        return int(m.group(1)) * 10 + int(m.group(2))
+
+
+class CloneGrantsVersionCheckComponent(Component):
+    name = __name__
+    code = "clone_grants_version_check"
+    bound_service = CloneGrantsVersionCheckService


### PR DESCRIPTION
1. 从权限备份克隆 mysql/spider 权限
<img width="497" height="494" alt="image" src="https://github.com/user-attachments/assets/9b3cccca-4396-4a30-9a54-298f193810e6" />


2. 克隆后增加账号和权限验证
3. 替换了原地重建, 新机重建 mysql slave 单据的克隆权限流程
<img width="1214" height="170" alt="image" src="https://github.com/user-attachments/assets/ebc1615c-4db2-4314-ae31-193db000d710" />

4. 完成了 mysql 5.5, 5.6, 5.7, 8.0 测试
5. 完成了 spider 1, 3, 4 测试