### PR TITLE
feat(redis): Harden Redis rollback drill flow against dropped polling schedules #16979

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/task.py
@@ -8,11 +8,23 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import logging
+from datetime import timedelta
+
 from celery.schedules import crontab
+from django.utils import timezone as django_timezone
+from django.utils.translation import gettext as _
 
 from backend.db_periodic_task.local_tasks.register import register_periodic_task
+from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
+from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.flow.consts import StateType
+from backend.flow.models import FlowTree
+from backend.flow.signal.redis_rollback_exercise_handler import wakeup_redis_rollback_runner_by_child
 
 from .base import RedisRollbackExercise
+
+logger = logging.getLogger("root")
 
 
 @register_periodic_task(run_every=crontab(day_of_week="0", hour="12", minute="0"))
@@ -29,3 +41,47 @@ def redis_rollback_exercise():
     Generate Redis rollback exercise tasks
     """
     RedisRollbackExercise().start()
+
+
+@register_periodic_task(run_every=crontab(minute="0"))
+def repair_stuck_redis_rollback_exercise():
+    """
+    Best-effort safety net for stuck rollback exercise reports.
+    """
+    exercise_cfg = RedisRollbackExercise().config
+    polling_timeout = exercise_cfg.polling_timeout
+    overdue_cutoff = django_timezone.now() - timedelta(seconds=polling_timeout)
+    long_overdue_cutoff = django_timezone.now() - timedelta(seconds=polling_timeout * 3)
+
+    reports = Report.objects.filter(
+        task_stage__in=[TaskStage.ROLLBACK_STARTED, TaskStage.ROLLBACK_SUCCEEDED], update_at__lt=overdue_cutoff
+    )
+
+    recovered = 0
+    for report in reports:
+        child_root_id = report.delete_flow_obj_id or report.rollback_flow_obj_id
+        if not child_root_id:
+            continue
+
+        try:
+            child_flow_tree = FlowTree.objects.get(root_id=child_root_id)
+        except FlowTree.DoesNotExist:
+            if report.update_at < long_overdue_cutoff:
+                logger.warning(
+                    _("Redis rollback report {} has no child FlowTree and exceeds 3*timeout").format(report.id)
+                )
+            continue
+
+        if child_flow_tree.status in [StateType.FINISHED, StateType.FAILED, StateType.REVOKED]:
+            recovered += wakeup_redis_rollback_runner_by_child(
+                child_root_id=child_root_id, child_state=child_flow_tree.status, trigger="periodic_safety_net"
+            )
+        elif report.update_at < long_overdue_cutoff:
+            logger.warning(
+                _("Redis rollback report {} still in stage {} with child flow {} state {} (>3*timeout)").format(
+                    report.id, report.task_stage, child_root_id, child_flow_tree.status
+                )
+            )
+
+    if recovered:
+        logger.info(_("Recovered {} stuck redis rollback runner(s)").format(recovered))

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -13,6 +13,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+from django.core.cache import cache
 from django.utils.translation import gettext as _
 from pipeline.component_framework.component import Component
 from pipeline.core.flow.activity import StaticIntervalGenerator
@@ -25,6 +26,7 @@ from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
 from backend.flow.consts import StateType
+from backend.flow.engine.bamboo.engine import BambooEngine
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure import RedisDataStructureFlow
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete import RedisDataStructureTaskDeleteFlow
 from backend.flow.models import FlowTree
@@ -166,6 +168,9 @@ class RedisExerciseReportUpdateComponent(Component):
     bound_service = RedisExerciseReportUpdateService
 
 
+CHILD2RUNNER_CACHE_PREFIX = "redis_rollback_drill:child2runner_node"
+
+
 FLOW_REGISTRY = {
     "redis_data_structure": (RedisDataStructureFlow, "redis_data_structure_flow"),
     "redis_data_structure_task_delete": (RedisDataStructureTaskDeleteFlow, "redis_rollback_task_delete_flow"),
@@ -202,6 +207,33 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
     def _set_result(self, data, code: int):
         output_var = data.get_one_of_outputs("output_var") or "rollback_code"
         setattr(data.outputs, output_var, code)
+
+    def _finish_by_child_state(self, data, child_root_id: str, child_state) -> bool:
+        if child_state == StateType.FINISHED:
+            self.log_info(_("Child pipeline {} finished successfully").format(child_root_id))
+            self._set_result(data, 0)
+            self.finish_schedule()
+            return True
+
+        if child_state in (StateType.FAILED, StateType.REVOKED):
+            self.log_error(_("Child pipeline {} ended with status {}").format(child_root_id, child_state))
+            self._set_result(data, 1)
+            self.finish_schedule()
+            return True
+
+        return False
+
+    def _terminate_child_pipeline(self, child_root_id: str):
+        try:
+            revoke_result = BambooEngine(root_id=child_root_id).revoke_pipeline()
+            if not revoke_result.result:
+                self.log_warning(
+                    _("Failed to revoke child pipeline {}: {}").format(child_root_id, revoke_result.message)
+                )
+            else:
+                self.log_info(_("Revoked child pipeline {}").format(child_root_id))
+        except Exception:
+            logger.warning(_("Exception while revoking child pipeline {}").format(child_root_id), exc_info=True)
 
     def _execute_inner_captured(self, data, parent_data) -> bool:
         kwargs = data.get_one_of_inputs("kwargs")
@@ -244,6 +276,15 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
 
         self.log_info(_("Child pipeline {} ({}) submitted").format(child_root_id, flow_identifier))
         data.outputs.child_root_id = child_root_id
+
+        runner_node_id = self.runtime_attrs.get("id")
+        parent_root_id = self.runtime_attrs.get("root_pipeline_id")
+        if runner_node_id and parent_root_id:
+            cache.set(
+                f"{CHILD2RUNNER_CACHE_PREFIX}:{child_root_id}",
+                {"runner_node_id": runner_node_id, "parent_root_id": parent_root_id},
+                polling_timeout,
+            )
         data.outputs.start_time = datetime.now().isoformat()
         data.outputs.polling_timeout = polling_timeout
         return True
@@ -253,6 +294,23 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
         if not child_root_id:
             self.finish_schedule()
             return True
+
+        if callback_data:
+            callback_child_root_id = callback_data.get("child_root_id")
+            callback_child_state = callback_data.get("child_state")
+
+            if not callback_child_root_id:
+                self.log_warning("Received callback_data without child_root_id, ignoring fast-path")
+            elif callback_child_root_id != child_root_id:
+                self.log_warning(
+                    _("Callback child root id mismatch: expected {}, got {}").format(
+                        child_root_id, callback_child_root_id
+                    )
+                )
+            else:
+                # Callback comes from child terminal signal and can fast-path finish.
+                if self._finish_by_child_state(data, child_root_id, callback_child_state):
+                    return True
 
         raw_start_time = data.get_one_of_outputs("start_time")
         if not raw_start_time:
@@ -264,8 +322,10 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
         polling_timeout = data.get_one_of_outputs("polling_timeout") or 3600
 
         elapsed = (datetime.now() - start_time).total_seconds()
+
         if elapsed > polling_timeout:
             self.log_error(_("Child pipeline {} timed out after {:.0f}s").format(child_root_id, elapsed))
+            self._terminate_child_pipeline(child_root_id)
             self._set_result(data, 1)
             self.finish_schedule()
             return True
@@ -275,18 +335,7 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
         except FlowTree.DoesNotExist:
             return True
 
-        if flow_tree.status == StateType.FINISHED:
-            self.log_info(_("Child pipeline {} finished successfully").format(child_root_id))
-            self._set_result(data, 0)
-            self.finish_schedule()
-            return True
-        elif flow_tree.status in (StateType.FAILED, StateType.REVOKED):
-            self.log_error(_("Child pipeline {} ended with status {}").format(child_root_id, flow_tree.status))
-            self._set_result(data, 1)
-            self.finish_schedule()
-            return True
-
-        return True
+        return self._finish_by_child_state(data, child_root_id, flow_tree.status)
 
 
 class RedisExerciseFlowRunnerComponent(Component):

--- a/dbm-ui/backend/flow/signal/README_redis_rollback_exercise.md
+++ b/dbm-ui/backend/flow/signal/README_redis_rollback_exercise.md
@@ -1,0 +1,67 @@
+# Redis回档演练信号处理说明
+
+## 概述
+
+`redis_rollback_exercise_handler.py` 用于处理 Redis 回档演练相关子单据的状态回调，目标是让主流程中的 `FlowRunner` 在子流程终态后尽快被唤醒，避免因轮询任务丢失或调度锁异常导致主流程长期卡住。
+
+该机制专门服务于 `REDIS_ROLLBACK_EXERCISE` 场景，不额外注册独立的 `post_set_state` 处理器，而是复用通用回调分发链路。
+
+## 关键能力
+
+### 1) 子单据类型注册
+
+通过 `@create_ticket_handler(...)` 注册以下子单据类型：
+
+- `TicketType.REDIS_DATA_STRUCTURE`
+- `TicketType.REDIS_DATA_STRUCTURE_TASK_DELETE`
+
+当对应子流程状态变更时，通用信号处理器会路由到这里执行。
+
+### 2) Drill 场景保护（is_drill guard）
+
+处理器仅在父单据类型为 `TicketType.REDIS_ROLLBACK_EXERCISE` 时执行唤醒逻辑：
+
+- 非演练单据直接忽略
+- 仅终态触发（`FINISHED` / `FAILED` / `REVOKED`）
+
+这保证了回调逻辑不会影响普通 Redis 流程。
+
+### 3) 主流程 Runner 唤醒
+
+`wakeup_redis_rollback_runner_by_child(...)` 的核心步骤：
+
+1. 通过 `RedisRollbackExerciseReport` 中的 `rollback_flow_obj_id/delete_flow_obj_id` 反查子流程关联报告
+2. 使用 `report.ticket_id` 反查父流程 `root_id`（不改表结构）
+3. 在父流程运行中节点里定位与该 `child_root_id` 对应的 runner 节点
+4. 清理 `Schedule.scheduling=True` 且未完成的陈旧锁
+5. 调用 `BambooEngine.callback(...)` 触发 runner 立即进入下一轮 `_schedule`
+
+## 为什么需要清理 Schedule 锁
+
+在滚动升级或 worker 异常中断场景下，schedule 任务可能在持锁阶段退出，导致 `scheduling=True` 长时间残留。  
+此时即使子流程已结束，主流程轮询也可能无法继续推进。
+
+在回调前显式执行锁修复，可以提升恢复成功率，并且该操作是幂等、可重复调用的。
+
+## 周期兜底任务
+
+`db_periodic_task/local_tasks/redis_backup_rollback/task.py` 中的 `repair_stuck_redis_rollback_exercise` 提供二级保障：
+
+- 扫描超过 `polling_timeout` 且仍在中间阶段的报告
+- 若子流程已终态，复用同一个 `wakeup_redis_rollback_runner_by_child(...)` 进行修复
+- 若超过 `3 * polling_timeout` 仍异常，输出告警日志用于可观测性
+
+## 触发链路（简版）
+
+1. 子流程状态进入终态  
+2. `post_set_state` 通用处理器按 `ticket_type` 分发到 redis 回调处理函数  
+3. 命中 drill 场景保护后执行 wakeup  
+4. runner 收到 callback 并尝试快速完成主流程调度
+
+## 相关文件
+
+- `redis_rollback_exercise_handler.py`：Redis 回调与唤醒实现
+- `callback_map.py`：`create_ticket_handler` 注册机制
+- `handlers.py`：通用 `post_set_state` 分发入口
+- `test_redis_rollback_exercise_handler.py`：信号处理单测
+- `db_periodic_task/local_tasks/redis_backup_rollback/task.py`：周期修复任务

--- a/dbm-ui/backend/flow/signal/__init__.py
+++ b/dbm-ui/backend/flow/signal/__init__.py
@@ -11,4 +11,5 @@ specific language governing permissions and limitations under the License.
 
 # 导入信号处理器以确保注册
 from . import mysql_rollback_exercise_handler  # noqa
+from . import redis_rollback_exercise_handler  # noqa
 from . import tdbctl_upgrade_handler  # noqa

--- a/dbm-ui/backend/flow/signal/redis_rollback_exercise_handler.py
+++ b/dbm-ui/backend/flow/signal/redis_rollback_exercise_handler.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import logging
+
+from django.core.cache import cache
+from django.db.models import Q
+from django.utils.translation import gettext as _
+from pipeline.eri.models import Schedule
+
+from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.flow.consts import StateType
+from backend.flow.engine.bamboo.engine import BambooEngine
+from backend.flow.models import FlowNode, FlowTree
+from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import CHILD2RUNNER_CACHE_PREFIX
+from backend.flow.signal.callback_map import create_ticket_handler
+from backend.ticket.constants import TicketType
+from backend.ticket.models import Ticket
+
+logger = logging.getLogger("flow")
+
+TERMINAL_STATES = {StateType.FINISHED, StateType.FAILED, StateType.REVOKED}
+
+
+def _resolve_parent_root_id(ticket_id: int):
+    parent_tree = (
+        FlowTree.objects.filter(uid=ticket_id, ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE)
+        .order_by("-created_at")
+        .first()
+    )
+    if not parent_tree:
+        return None
+    return parent_tree.root_id
+
+
+def _resolve_runner_node_id(parent_root_id: str, child_root_id: str):
+    candidate_node_ids = list(
+        FlowNode.objects.filter(
+            root_id=parent_root_id, status__in=[StateType.RUNNING, StateType.CREATED, StateType.READY]
+        )
+        .order_by("-updated_at")
+        .values_list("node_id", flat=True)[:20]
+    )
+    if not candidate_node_ids:
+        return None
+
+    engine = BambooEngine(root_id=parent_root_id)
+    for node_id in candidate_node_ids:
+        try:
+            node_outputs = engine.get_node_output_data(node_id).data or {}
+            if node_outputs.get("child_root_id") == child_root_id:
+                return node_id
+        except Exception as e:
+            logger.warning(
+                _("Resolve runner node output failed. parent_root_id={}, node_id={}, err={}").format(
+                    parent_root_id, node_id, e
+                )
+            )
+
+    return None
+
+
+def wakeup_redis_rollback_runner_by_child(child_root_id: str, child_state: str, trigger: str) -> int:
+    """
+    Wake up parent FlowRunner nodes bound to a child pipeline.
+
+    This is best-effort and safe to call repeatedly.
+    """
+    logger.info(
+        f"Wakeup redis rollback runner by child. "
+        f"child_root_id={child_root_id}, child_state={child_state}, trigger={trigger}"
+    )
+
+    cached_key = f"{CHILD2RUNNER_CACHE_PREFIX}:{child_root_id}"
+    cached = cache.get(cached_key)
+    if cached:
+        parent_root_id = cached["parent_root_id"]
+        runner_node_id = cached["runner_node_id"]
+    else:
+        # Fallback path, normally should not get here, there's no index covering the obj_id fields.
+        report = Report.objects.filter(
+            Q(rollback_flow_obj_id=child_root_id) | Q(delete_flow_obj_id=child_root_id)
+        ).first()
+        if not report or not report.ticket_id:
+            logger.warning(_("No matching report for child_root_id={}").format(child_root_id))
+            return 0
+
+        parent_root_id = _resolve_parent_root_id(ticket_id=report.ticket_id)
+        if not parent_root_id:
+            logger.warning(
+                _("Resolve parent root id failed for report {} ticket_id={}").format(report.id, report.ticket_id)
+            )
+            return 0
+
+        runner_node_id = _resolve_runner_node_id(parent_root_id=parent_root_id, child_root_id=child_root_id)
+        if not runner_node_id:
+            logger.warning(
+                _("Resolve runner node id failed. parent_root_id={}, child_root_id={}").format(
+                    parent_root_id, child_root_id
+                )
+            )
+            return 0
+
+    logger.info(
+        f"Resolved runner mapping. parent_root_id={parent_root_id}, "
+        f"runner_node_id={runner_node_id}, cached={'yes' if cached else 'no'}"
+    )
+
+    try:
+        Schedule.objects.filter(node_id=runner_node_id, scheduling=True, finished=False).update(scheduling=False)
+
+        callback_result = BambooEngine(root_id=parent_root_id).callback(
+            node_id=runner_node_id,
+            desc={"child_root_id": child_root_id, "child_state": child_state, "trigger": trigger},
+        )
+        if callback_result.result:
+            cache.delete(cached_key)
+            return 1
+        logger.warning(
+            _("Redis rollback runner callback failed. parent_root_id={}, runner_node_id={}, child_root_id={}").format(
+                parent_root_id, runner_node_id, child_root_id
+            )
+        )
+    except Exception as e:
+        logger.warning(
+            _(
+                "Redis rollback runner callback exception. parent_root_id={}, runner_node_id={}, child_root_id={}, err={}"
+            ).format(parent_root_id, runner_node_id, child_root_id, e)
+        )
+
+    return 0
+
+
+def _handle_redis_sub_ticket_callback(root_id: str, status: str, ticket_id: int):
+    if status not in TERMINAL_STATES:
+        return
+
+    if not ticket_id:
+        return
+
+    ticket = Ticket.objects.filter(id=ticket_id).only("ticket_type").first()
+    if not ticket:
+        logger.info(_("Redis rollback drill sub-ticket callback ticket not found, ticket_id={}").format(ticket_id))
+        return
+
+    if ticket.ticket_type != TicketType.REDIS_ROLLBACK_EXERCISE:
+        # Guard non-drill tickets: only rollback exercise should trigger wakeup.
+        return
+
+    wakeup_redis_rollback_runner_by_child(child_root_id=root_id, child_state=status, trigger="post_set_state")
+
+
+@create_ticket_handler(TicketType.REDIS_DATA_STRUCTURE)
+def redis_data_structure_callback_handler(root_id: str, node_id: str, status: StateType, ticket_id: int, **kwargs):
+    _handle_redis_sub_ticket_callback(root_id=root_id, status=status, ticket_id=ticket_id)
+
+
+@create_ticket_handler(TicketType.REDIS_DATA_STRUCTURE_TASK_DELETE)
+def redis_data_structure_task_delete_callback_handler(
+    root_id: str, node_id: str, status: StateType, ticket_id: int, **kwargs
+):
+    _handle_redis_sub_ticket_callback(root_id=root_id, status=status, ticket_id=ticket_id)

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/__init__.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/__init__.py
@@ -8,6 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .task import init_redis_rollback_candidates, redis_rollback_exercise, repair_stuck_redis_rollback_exercise
-
-__all__ = ["init_redis_rollback_candidates", "redis_rollback_exercise", "repair_stuck_redis_rollback_exercise"]

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise_repair.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise_repair.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
+from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.flow.consts import StateType
+from backend.flow.models import FlowTree
+from backend.ticket.constants import TicketType
+
+pytestmark = pytest.mark.django_db
+
+_PATCH_EXERCISE_CFG = patch(
+    "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.RedisRollbackExercise",
+    return_value=SimpleNamespace(config=SimpleNamespace(polling_timeout=10)),
+)
+
+
+def _make_report(
+    stage: str,
+    rollback_child_root_id: str = "",
+    delete_child_root_id: str = "",
+    hours_ago: int = 2,
+) -> Report:
+    report = Report.objects.create(
+        cluster_id=1,
+        cluster_domain="d",
+        cluster_type="Redis",
+        instance_ip="127.0.0.1",
+        instance_port=6379,
+        redis_version="7.0",
+        ticket_id=1,
+        rollback_flow_obj_id=rollback_child_root_id,
+        delete_flow_obj_id=delete_child_root_id,
+        task_stage=stage,
+    )
+    Report.objects.filter(id=report.id).update(update_at=timezone.now() - timedelta(hours=hours_ago))
+    report.refresh_from_db()
+    return report
+
+
+def _make_flow_tree(root_id: str, status: str):
+    return FlowTree.objects.create(
+        uid=1,
+        bk_biz_id=1,
+        ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE,
+        root_id=root_id,
+        tree={},
+        status=status,
+        created_by="tester",
+    )
+
+
+def _import_repair():
+    from backend.db_periodic_task.local_tasks.redis_backup_rollback.task import repair_stuck_redis_rollback_exercise
+
+    return repair_stuck_redis_rollback_exercise
+
+
+# ==================== Terminal child states trigger wakeup ====================
+
+
+def test_periodic_repair_wakes_up_finished_child():
+    report = _make_report(TaskStage.ROLLBACK_STARTED, rollback_child_root_id="child_root_id")
+    flow_tree = _make_flow_tree("child_root_id", StateType.FINISHED)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child",
+        return_value=1,
+    ) as mock_wakeup:
+        _import_repair()()
+
+    mock_wakeup.assert_called_once_with(
+        child_root_id="child_root_id", child_state=StateType.FINISHED, trigger="periodic_safety_net"
+    )
+    report.delete()
+    flow_tree.delete()
+
+
+@pytest.mark.parametrize("terminal_state", [StateType.FAILED, StateType.REVOKED])
+def test_periodic_repair_wakes_up_failed_or_revoked_child(terminal_state):
+    """FAILED and REVOKED children should also be woken up, not just FINISHED."""
+    report = _make_report(TaskStage.ROLLBACK_STARTED, rollback_child_root_id="child_root_id")
+    flow_tree = _make_flow_tree("child_root_id", terminal_state)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child",
+        return_value=1,
+    ) as mock_wakeup:
+        _import_repair()()
+
+    mock_wakeup.assert_called_once_with(
+        child_root_id="child_root_id", child_state=terminal_state, trigger="periodic_safety_net"
+    )
+    report.delete()
+    flow_tree.delete()
+
+
+# ==================== ROLLBACK_SUCCEEDED stage is also picked up ====================
+
+
+def test_periodic_repair_handles_rollback_succeeded_stage():
+    """Reports in ROLLBACK_SUCCEEDED (waiting for cleanup child) should also be repaired."""
+    report = _make_report(TaskStage.ROLLBACK_SUCCEEDED, rollback_child_root_id="child_root_id")
+    flow_tree = _make_flow_tree("child_root_id", StateType.FINISHED)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child",
+        return_value=1,
+    ) as mock_wakeup:
+        _import_repair()()
+
+    mock_wakeup.assert_called_once()
+    report.delete()
+    flow_tree.delete()
+
+
+# ==================== delete_flow_obj_id preferred over rollback_flow_obj_id ====================
+
+
+def test_periodic_repair_prefers_delete_flow_obj_id():
+    """When delete_flow_obj_id is set, it should be used (takes priority via `or`)."""
+    report = _make_report(
+        TaskStage.ROLLBACK_SUCCEEDED,
+        rollback_child_root_id="rollback_root",
+        delete_child_root_id="delete_root",
+    )
+    flow_tree = _make_flow_tree("delete_root", StateType.FINISHED)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child",
+        return_value=1,
+    ) as mock_wakeup:
+        _import_repair()()
+
+    mock_wakeup.assert_called_once_with(
+        child_root_id="delete_root", child_state=StateType.FINISHED, trigger="periodic_safety_net"
+    )
+    report.delete()
+    flow_tree.delete()
+
+
+# ==================== Warning / skip paths ====================
+
+
+def test_periodic_repair_warns_when_running_over_3_timeout():
+    report = _make_report(TaskStage.ROLLBACK_STARTED, rollback_child_root_id="running_child_root_id")
+    flow_tree = _make_flow_tree("running_child_root_id", StateType.RUNNING)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.logger.warning"
+    ) as mock_warning:
+        _import_repair()()
+
+    assert mock_warning.called
+    report.delete()
+    flow_tree.delete()
+
+
+def test_periodic_repair_skips_report_without_child_root_id():
+    report = _make_report(TaskStage.ROLLBACK_STARTED)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child"
+    ) as mock_wakeup:
+        _import_repair()()
+
+    mock_wakeup.assert_not_called()
+    report.delete()
+
+
+def test_periodic_repair_flowtree_not_found_under_3_timeout_silently_continues():
+    """When FlowTree doesn't exist and report is not yet 3*timeout overdue, silently continue."""
+    report = _make_report(TaskStage.ROLLBACK_STARTED, rollback_child_root_id="missing_flow_child")
+
+    with patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.RedisRollbackExercise",
+        return_value=SimpleNamespace(config=SimpleNamespace(polling_timeout=3600)),
+    ), patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child"
+    ) as mock_wakeup, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.logger.warning"
+    ) as mock_warning:
+        _import_repair()()
+
+    mock_wakeup.assert_not_called()
+    mock_warning.assert_not_called()
+    report.delete()
+
+
+def test_periodic_repair_flowtree_not_found_over_3_timeout_warns():
+    """When FlowTree doesn't exist and report exceeds 3*timeout, should emit warning."""
+    report = _make_report(
+        TaskStage.ROLLBACK_STARTED,
+        rollback_child_root_id="missing_flow_child_old",
+        hours_ago=24,
+    )
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child"
+    ) as mock_wakeup, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.logger.warning"
+    ) as mock_warning:
+        _import_repair()()
+
+    mock_wakeup.assert_not_called()
+    assert mock_warning.called
+    report.delete()
+
+
+# ==================== No overdue reports ====================
+
+
+def test_periodic_repair_no_overdue_reports_is_noop():
+    """When no reports match the overdue criteria, function should complete cleanly."""
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child"
+    ) as mock_wakeup:
+        _import_repair()()
+
+    mock_wakeup.assert_not_called()
+
+
+# ==================== Multiple reports ====================
+
+
+def test_periodic_repair_multiple_reports_accumulates_recovery():
+    """When multiple reports have terminal children, recovered count should accumulate."""
+    reports = []
+    flow_trees = []
+    for i in range(3):
+        r = _make_report(TaskStage.ROLLBACK_STARTED, rollback_child_root_id=f"child_{i}")
+        ft = _make_flow_tree(f"child_{i}", StateType.FINISHED)
+        reports.append(r)
+        flow_trees.append(ft)
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child",
+        return_value=1,
+    ) as mock_wakeup, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.logger.info"
+    ) as mock_info:
+        _import_repair()()
+
+    assert mock_wakeup.call_count == 3
+    mock_info.assert_called()
+    for r in reports:
+        r.delete()
+    for ft in flow_trees:
+        ft.delete()
+
+
+# ==================== Running child under 3*timeout is silently skipped ====================
+
+
+def test_periodic_repair_running_child_under_3_timeout_no_warning():
+    """A running child that hasn't exceeded 3*timeout should be silently skipped."""
+    report = _make_report(
+        TaskStage.ROLLBACK_STARTED,
+        rollback_child_root_id="running_child",
+    )
+    flow_tree = _make_flow_tree("running_child", StateType.RUNNING)
+
+    with patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.RedisRollbackExercise",
+        return_value=SimpleNamespace(config=SimpleNamespace(polling_timeout=3600)),
+    ), patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.wakeup_redis_rollback_runner_by_child"
+    ) as mock_wakeup, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.logger.warning"
+    ) as mock_warning:
+        _import_repair()()
+
+    mock_wakeup.assert_not_called()
+    mock_warning.assert_not_called()
+    report.delete()
+    flow_tree.delete()

--- a/dbm-ui/backend/tests/flow/components/collections/redis/__init__.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/__init__.py
@@ -8,6 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .task import init_redis_rollback_candidates, redis_rollback_exercise, repair_stuck_redis_rollback_exercise
-
-__all__ = ["init_redis_rollback_candidates", "redis_rollback_exercise", "repair_stuck_redis_rollback_exercise"]

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bamboo_engine.api import EngineAPIResult
+
+from backend.flow.consts import StateType
+from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
+    CHILD2RUNNER_CACHE_PREFIX,
+    RedisExerciseFlowRunnerService,
+)
+
+
+class FakeData:
+    def __init__(self, outputs=None):
+        self.outputs = SimpleNamespace(**(outputs or {}))
+
+    def get_one_of_outputs(self, key):
+        return getattr(self.outputs, key, None)
+
+
+def _build_schedule_data(start_delta_seconds=10, polling_timeout=3600, child_root_id="child_root_id"):
+    return FakeData(
+        outputs={
+            "child_root_id": child_root_id,
+            "start_time": (datetime.now() - timedelta(seconds=start_delta_seconds)).isoformat(),
+            "polling_timeout": polling_timeout,
+            "output_var": "rollback_code",
+        }
+    )
+
+
+def _build_execute_kwargs(**overrides):
+    defaults = {
+        "flow_identifier": "redis_data_structure",
+        "flow_data": {"infos": []},
+        "report_id": 1,
+        "flow_id_field": "rollback_flow_obj_id",
+        "polling_timeout": 3600,
+        "output_var": "rollback_code",
+        "polling_interval": 10,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+# ==================== Schedule: callback fast-path ====================
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get",
+    return_value=SimpleNamespace(status=StateType.FINISHED),
+)
+def test_callback_data_terminal_finishes_early_skipping_flowtree_poll(_mock_flowtree_get):
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    service._schedule_inner_captured(
+        data,
+        parent_data=None,
+        callback_data={"child_root_id": "child_root_id", "child_state": StateType.FINISHED},
+    )
+
+    assert data.outputs.rollback_code == 0
+    service.finish_schedule.assert_called_once()
+    _mock_flowtree_get.assert_not_called()
+
+
+@pytest.mark.parametrize("child_state", [StateType.FAILED, StateType.REVOKED])
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get")
+def test_callback_failed_or_revoked_sets_code_1(mock_flowtree_get, child_state):
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    service._schedule_inner_captured(
+        data,
+        parent_data=None,
+        callback_data={"child_root_id": "child_root_id", "child_state": child_state},
+    )
+
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+    mock_flowtree_get.assert_not_called()
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get")
+def test_callback_without_child_root_id_falls_through_to_poll(mock_flowtree_get):
+    """callback_data missing child_root_id should warn and fall through to FlowTree polling."""
+    mock_flowtree_get.return_value = SimpleNamespace(status=StateType.FINISHED)
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    service._schedule_inner_captured(data, parent_data=None, callback_data={"child_state": StateType.FINISHED})
+
+    assert data.outputs.rollback_code == 0
+    mock_flowtree_get.assert_called_once_with(root_id="child_root_id")
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get")
+def test_callback_mismatched_child_root_id_falls_through_to_poll(mock_flowtree_get):
+    """callback_data with wrong child_root_id should warn and fall through to FlowTree polling."""
+    mock_flowtree_get.return_value = SimpleNamespace(status=StateType.FINISHED)
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    service._schedule_inner_captured(
+        data, parent_data=None, callback_data={"child_root_id": "wrong_id", "child_state": StateType.FINISHED}
+    )
+
+    assert data.outputs.rollback_code == 0
+    mock_flowtree_get.assert_called_once_with(root_id="child_root_id")
+
+
+# ==================== Schedule: FlowTree polling ====================
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get")
+def test_flowtree_terminal_finishes_schedule(mock_flowtree_get):
+    mock_flowtree_get.return_value = SimpleNamespace(status=StateType.FINISHED)
+
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    service._schedule_inner_captured(data, parent_data=None)
+
+    assert data.outputs.rollback_code == 0
+    service.finish_schedule.assert_called_once()
+    mock_flowtree_get.assert_called_once_with(root_id="child_root_id")
+
+
+@pytest.mark.parametrize("status", [StateType.FAILED, StateType.REVOKED])
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get")
+def test_flowtree_failed_or_revoked_sets_code_1(mock_flowtree_get, status):
+    mock_flowtree_get.return_value = SimpleNamespace(status=status)
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    service._schedule_inner_captured(data, parent_data=None)
+
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get")
+def test_flowtree_running_keeps_polling(mock_flowtree_get):
+    """RUNNING child should not finish the schedule (keeps polling)."""
+    mock_flowtree_get.return_value = SimpleNamespace(status=StateType.RUNNING)
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    result = service._schedule_inner_captured(data, parent_data=None)
+
+    assert result is False
+    service.finish_schedule.assert_not_called()
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get",
+    side_effect=Exception("DoesNotExist"),
+)
+def test_flowtree_does_not_exist_keeps_polling(_mock):
+    """When FlowTree is not yet created, the schedule should keep polling."""
+    from backend.flow.models import FlowTree
+
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data()
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowTree.objects.get",
+        side_effect=FlowTree.DoesNotExist,
+    ):
+        result = service._schedule_inner_captured(data, parent_data=None)
+
+    assert result is True
+    service.finish_schedule.assert_not_called()
+
+
+# ==================== Schedule: edge cases ====================
+
+
+def test_schedule_no_child_root_id_finishes_immediately():
+    """When child_root_id is absent (execute failed early), schedule should finish."""
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = FakeData(outputs={"output_var": "rollback_code"})
+
+    result = service._schedule_inner_captured(data, parent_data=None)
+
+    assert result is True
+    service.finish_schedule.assert_called_once()
+
+
+def test_schedule_missing_start_time_sets_code_1():
+    """Missing start_time should produce an error with code=1."""
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = FakeData(outputs={"child_root_id": "child_root_id", "output_var": "rollback_code"})
+
+    service._schedule_inner_captured(data, parent_data=None)
+
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+
+
+# ==================== Schedule: timeout ====================
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.BambooEngine.revoke_pipeline",
+    return_value=EngineAPIResult(result=True, data={}, message=""),
+)
+def test_timeout_revoke_child_and_fail(_mock_revoke):
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data(start_delta_seconds=20, polling_timeout=10)
+
+    service._schedule_inner_captured(data, parent_data=None)
+
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+    _mock_revoke.assert_called_once()
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.BambooEngine.revoke_pipeline",
+    return_value=EngineAPIResult(result=False, data={}, message="revoke failed"),
+)
+def test_timeout_revoke_failure_still_sets_code_1(mock_revoke):
+    """Even if revoke fails, the runner should still set code=1 and finish."""
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data(start_delta_seconds=20, polling_timeout=10)
+
+    service._schedule_inner_captured(data, parent_data=None)
+
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+    mock_revoke.assert_called_once()
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.BambooEngine.revoke_pipeline",
+    side_effect=Exception("network error"),
+)
+def test_timeout_revoke_exception_still_sets_code_1(mock_revoke):
+    """Even if revoke raises an exception, the runner should still set code=1 and finish."""
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = _build_schedule_data(start_delta_seconds=20, polling_timeout=10)
+
+    service._schedule_inner_captured(data, parent_data=None)
+
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+
+
+# ==================== Execute ====================
+
+
+def test_execute_stores_child_flow_id_in_report():
+    service = RedisExerciseFlowRunnerService()
+    data = FakeData()
+    data.outputs = SimpleNamespace()
+    data.get_one_of_inputs = MagicMock(return_value=_build_execute_kwargs())
+
+    service._runtime_attrs = {"id": "runner_node_id", "root_pipeline_id": "parent_root_id"}
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.generate_root_id",
+        return_value="child_root_id",
+    ), patch(
+        "backend.flow.plugins.components.collections.redis."
+        "redis_rollback_exercise.RedisDataStructureFlow.redis_data_structure_flow"
+    ), patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Report.objects.filter"
+    ) as mock_filter, patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.cache.set"
+    ) as mock_cache_set:
+        mock_filter.return_value.update = MagicMock()
+        result = service._execute_inner_captured(data, parent_data=None)
+
+    assert result is True
+    mock_filter.return_value.update.assert_called_once_with(rollback_flow_obj_id="child_root_id")
+    mock_cache_set.assert_called_once_with(
+        f"{CHILD2RUNNER_CACHE_PREFIX}:child_root_id",
+        {"runner_node_id": "runner_node_id", "parent_root_id": "parent_root_id"},
+        3600,
+    )
+
+
+def test_execute_unknown_flow_identifier_sets_code_1():
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = FakeData()
+    data.outputs = SimpleNamespace()
+    data.get_one_of_inputs = MagicMock(return_value=_build_execute_kwargs(flow_identifier="nonexistent_flow"))
+    service._runtime_attrs = {"id": "n", "root_pipeline_id": "p"}
+
+    result = service._execute_inner_captured(data, parent_data=None)
+
+    assert result is True
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+
+
+def test_execute_flow_launch_exception_sets_code_1():
+    service = RedisExerciseFlowRunnerService()
+    service.finish_schedule = MagicMock()
+    data = FakeData()
+    data.outputs = SimpleNamespace()
+    data.get_one_of_inputs = MagicMock(return_value=_build_execute_kwargs())
+    service._runtime_attrs = {"id": "n", "root_pipeline_id": "p"}
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.generate_root_id",
+        return_value="child_root_id",
+    ), patch(
+        "backend.flow.plugins.components.collections.redis." "redis_rollback_exercise.RedisDataStructureFlow",
+        side_effect=RuntimeError("flow init failed"),
+    ):
+        result = service._execute_inner_captured(data, parent_data=None)
+
+    assert result is True
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+
+
+def test_execute_without_report_id_skips_report_update():
+    """When report_id is absent, the report update step should be skipped."""
+    service = RedisExerciseFlowRunnerService()
+    data = FakeData()
+    data.outputs = SimpleNamespace()
+    data.get_one_of_inputs = MagicMock(return_value=_build_execute_kwargs(report_id=None, flow_id_field=None))
+    service._runtime_attrs = {"id": "runner_node_id", "root_pipeline_id": "parent_root_id"}
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.generate_root_id",
+        return_value="child_root_id",
+    ), patch(
+        "backend.flow.plugins.components.collections.redis."
+        "redis_rollback_exercise.RedisDataStructureFlow.redis_data_structure_flow"
+    ), patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Report.objects.filter"
+    ) as mock_filter, patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.cache.set"
+    ):
+        result = service._execute_inner_captured(data, parent_data=None)
+
+    assert result is True
+    mock_filter.return_value.update.assert_not_called()

--- a/dbm-ui/backend/tests/flow/signal/__init__.py
+++ b/dbm-ui/backend/tests/flow/signal/__init__.py
@@ -8,6 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .task import init_redis_rollback_candidates, redis_rollback_exercise, repair_stuck_redis_rollback_exercise
-
-__all__ = ["init_redis_rollback_candidates", "redis_rollback_exercise", "repair_stuck_redis_rollback_exercise"]

--- a/dbm-ui/backend/tests/flow/signal/test_redis_rollback_exercise_handler.py
+++ b/dbm-ui/backend/tests/flow/signal/test_redis_rollback_exercise_handler.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bamboo_engine.api import EngineAPIResult
+
+from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.flow.consts import StateType
+from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import CHILD2RUNNER_CACHE_PREFIX
+from backend.flow.signal.callback_map import TICKET_TYPE_HANDLERS
+from backend.flow.signal.redis_rollback_exercise_handler import (
+    _resolve_runner_node_id,
+    redis_data_structure_callback_handler,
+    redis_data_structure_task_delete_callback_handler,
+    wakeup_redis_rollback_runner_by_child,
+)
+from backend.ticket.constants import TicketType
+
+pytestmark = pytest.mark.django_db
+
+
+# ==================== wakeup: cache hit path ====================
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Schedule.objects.filter")
+@patch(
+    "backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.callback",
+    return_value=EngineAPIResult(result=True, data={}, message=""),
+)
+def test_wakeup_cache_hit_skips_report_query(mock_callback, mock_schedule_filter, mock_cache_get):
+    mock_cache_get.return_value = {"parent_root_id": "parent_root_id", "runner_node_id": "runner_node_id"}
+    mock_schedule_filter.return_value.update = MagicMock(return_value=1)
+
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 1
+    mock_cache_get.assert_called_once_with(f"{CHILD2RUNNER_CACHE_PREFIX}:child_root_id")
+    mock_schedule_filter.assert_called_once_with(node_id="runner_node_id", scheduling=True, finished=False)
+    mock_schedule_filter.return_value.update.assert_called_once_with(scheduling=False)
+    mock_callback.assert_called_once_with(
+        node_id="runner_node_id",
+        desc={"child_root_id": "child_root_id", "child_state": StateType.FINISHED, "trigger": "unit_test"},
+    )
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Schedule.objects.filter")
+@patch(
+    "backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.callback",
+    return_value=EngineAPIResult(result=False, data={}, message="callback rejected"),
+)
+def test_wakeup_cache_hit_callback_fails_returns_0(mock_callback, mock_schedule_filter, mock_cache_get):
+    """When the callback itself returns result=False, wakeup should return 0."""
+    mock_cache_get.return_value = {"parent_root_id": "parent_root_id", "runner_node_id": "runner_node_id"}
+    mock_schedule_filter.return_value.update = MagicMock(return_value=1)
+
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 0
+    mock_callback.assert_called_once()
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Schedule.objects.filter")
+@patch(
+    "backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.callback",
+    side_effect=Exception("callback boom"),
+)
+def test_wakeup_cache_hit_callback_exception_returns_0(mock_callback, mock_schedule_filter, mock_cache_get):
+    """When the callback raises an exception, wakeup should catch it and return 0."""
+    mock_cache_get.return_value = {"parent_root_id": "parent_root_id", "runner_node_id": "runner_node_id"}
+    mock_schedule_filter.return_value.update = MagicMock(return_value=1)
+
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 0
+
+
+# ==================== wakeup: cache miss fallback path ====================
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get", return_value=None)
+@patch("backend.flow.signal.redis_rollback_exercise_handler._resolve_parent_root_id", return_value="parent_root_id")
+@patch("backend.flow.signal.redis_rollback_exercise_handler._resolve_runner_node_id", return_value="runner_node_id")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Schedule.objects.filter")
+@patch(
+    "backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.callback",
+    return_value=EngineAPIResult(result=True, data={}, message=""),
+)
+def test_wakeup_cache_miss_falls_back_to_report(
+    mock_callback, mock_schedule_filter, _mock_resolve_runner, _mock_resolve_parent, _mock_cache_get
+):
+    report = Report.objects.create(
+        cluster_id=1,
+        cluster_domain="d",
+        cluster_type="Redis",
+        instance_ip="127.0.0.1",
+        instance_port=6379,
+        redis_version="7.0",
+        ticket_id=1,
+        rollback_flow_obj_id="child_root_id",
+    )
+
+    mock_schedule_filter.return_value.update = MagicMock(return_value=1)
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 1
+    mock_callback.assert_called_once()
+    report.delete()
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get", return_value=None)
+def test_wakeup_cache_miss_no_report_returns_0(_mock_cache_get):
+    """When cache misses and no report matches, wakeup should return 0."""
+    result = wakeup_redis_rollback_runner_by_child("orphan_child_root_id", StateType.FINISHED, "unit_test")
+    assert result == 0
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get", return_value=None)
+@patch("backend.flow.signal.redis_rollback_exercise_handler._resolve_parent_root_id", return_value=None)
+def test_wakeup_cache_miss_no_parent_root_id_returns_0(_mock_resolve_parent, _mock_cache_get):
+    """When parent_root_id cannot be resolved, wakeup should return 0."""
+    report = Report.objects.create(
+        cluster_id=1,
+        cluster_domain="d",
+        cluster_type="Redis",
+        instance_ip="127.0.0.1",
+        instance_port=6379,
+        redis_version="7.0",
+        ticket_id=1,
+        rollback_flow_obj_id="child_root_id",
+    )
+
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 0
+    report.delete()
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get", return_value=None)
+@patch("backend.flow.signal.redis_rollback_exercise_handler._resolve_parent_root_id", return_value="parent_root_id")
+@patch("backend.flow.signal.redis_rollback_exercise_handler._resolve_runner_node_id", return_value=None)
+def test_wakeup_cache_miss_no_runner_node_id_returns_0(_mock_resolve_runner, _mock_resolve_parent, _mock_cache_get):
+    """When runner_node_id cannot be resolved, wakeup should return 0."""
+    report = Report.objects.create(
+        cluster_id=1,
+        cluster_domain="d",
+        cluster_type="Redis",
+        instance_ip="127.0.0.1",
+        instance_port=6379,
+        redis_version="7.0",
+        ticket_id=1,
+        rollback_flow_obj_id="child_root_id",
+    )
+
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 0
+    report.delete()
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.cache.get", return_value=None)
+def test_wakeup_cache_miss_report_without_ticket_id_returns_0(_mock_cache_get):
+    """When the matching report has ticket_id=0 (falsy), wakeup should return 0."""
+    report = Report.objects.create(
+        cluster_id=1,
+        cluster_domain="d",
+        cluster_type="Redis",
+        instance_ip="127.0.0.1",
+        instance_port=6379,
+        redis_version="7.0",
+        ticket_id=0,
+        rollback_flow_obj_id="child_root_id",
+    )
+
+    result = wakeup_redis_rollback_runner_by_child("child_root_id", StateType.FINISHED, "unit_test")
+
+    assert result == 0
+    report.delete()
+
+
+# ==================== handler registration ====================
+
+
+def test_redis_sub_ticket_handlers_registered():
+    assert TICKET_TYPE_HANDLERS.get(TicketType.REDIS_DATA_STRUCTURE.lower()) == redis_data_structure_callback_handler
+    assert (
+        TICKET_TYPE_HANDLERS.get(TicketType.REDIS_DATA_STRUCTURE_TASK_DELETE.lower())
+        == redis_data_structure_task_delete_callback_handler
+    )
+
+
+# ==================== _handle_redis_sub_ticket_callback ====================
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Ticket.objects.filter")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.wakeup_redis_rollback_runner_by_child")
+def test_callback_handler_terminal_state_with_drill_ticket(mock_wakeup, mock_ticket_filter):
+    mock_ticket_filter.return_value.only.return_value.first.return_value = MagicMock(
+        ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE
+    )
+    redis_data_structure_callback_handler(
+        node_id="node_id",
+        root_id="child_root_id",
+        status=StateType.FINISHED,
+        ticket_id=1,
+    )
+    mock_wakeup.assert_called_once_with(
+        child_root_id="child_root_id", child_state=StateType.FINISHED, trigger="post_set_state"
+    )
+
+
+@pytest.mark.parametrize("terminal_state", [StateType.FAILED, StateType.REVOKED])
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Ticket.objects.filter")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.wakeup_redis_rollback_runner_by_child")
+def test_callback_handler_failed_and_revoked_also_trigger_wakeup(mock_wakeup, mock_ticket_filter, terminal_state):
+    """FAILED and REVOKED are also terminal states that should trigger wakeup."""
+    mock_ticket_filter.return_value.only.return_value.first.return_value = MagicMock(
+        ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE
+    )
+    redis_data_structure_callback_handler(
+        node_id="node_id",
+        root_id="child_root_id",
+        status=terminal_state,
+        ticket_id=1,
+    )
+    mock_wakeup.assert_called_once_with(
+        child_root_id="child_root_id", child_state=terminal_state, trigger="post_set_state"
+    )
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Ticket.objects.filter")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.wakeup_redis_rollback_runner_by_child")
+def test_callback_handler_ignores_non_drill_or_non_terminal(mock_wakeup, mock_ticket_filter):
+    mock_ticket_filter.return_value.only.return_value.first.return_value = MagicMock(
+        ticket_type=TicketType.REDIS_DATA_STRUCTURE
+    )
+    redis_data_structure_task_delete_callback_handler(
+        node_id="node_id",
+        root_id="child_root_id",
+        status=StateType.FINISHED,
+        ticket_id=2,
+    )
+    mock_wakeup.assert_not_called()
+
+    mock_ticket_filter.return_value.only.return_value.first.return_value = MagicMock(
+        ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE
+    )
+    redis_data_structure_callback_handler(
+        node_id="node_id",
+        root_id="child_root_id",
+        status=StateType.RUNNING,
+        ticket_id=1,
+    )
+    mock_wakeup.assert_not_called()
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Ticket.objects.filter")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.wakeup_redis_rollback_runner_by_child")
+def test_callback_handler_no_ticket_id_returns_early(mock_wakeup, mock_ticket_filter):
+    """When ticket_id is 0 (falsy), the handler should return early without querying Ticket."""
+    redis_data_structure_callback_handler(
+        node_id="node_id",
+        root_id="child_root_id",
+        status=StateType.FINISHED,
+        ticket_id=0,
+    )
+    mock_ticket_filter.assert_not_called()
+    mock_wakeup.assert_not_called()
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.Ticket.objects.filter")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.wakeup_redis_rollback_runner_by_child")
+def test_callback_handler_ticket_not_found_returns_early(mock_wakeup, mock_ticket_filter):
+    """When ticket is not found in DB, handler should return without calling wakeup."""
+    mock_ticket_filter.return_value.only.return_value.first.return_value = None
+    redis_data_structure_callback_handler(
+        node_id="node_id",
+        root_id="child_root_id",
+        status=StateType.FINISHED,
+        ticket_id=999,
+    )
+    mock_wakeup.assert_not_called()
+
+
+# ==================== _resolve_runner_node_id ====================
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.get_node_output_data")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.FlowNode.objects.filter")
+def test_resolve_runner_node_id_scan(mock_node_filter, mock_get_node_output):
+    mock_node_filter.return_value.order_by.return_value.values_list.return_value = ["node_1", "node_2"]
+    mock_get_node_output.return_value = MagicMock(data={"child_root_id": "child_root_id"})
+
+    node_id = _resolve_runner_node_id(parent_root_id="parent_root_id", child_root_id="child_root_id")
+
+    assert node_id == "node_1"
+    mock_node_filter.assert_called_once_with(
+        root_id="parent_root_id", status__in=[StateType.RUNNING, StateType.CREATED, StateType.READY]
+    )
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.FlowNode.objects.filter")
+def test_resolve_runner_node_id_no_candidates_returns_none(mock_node_filter):
+    """When no candidate nodes exist, should return None."""
+    mock_node_filter.return_value.order_by.return_value.values_list.return_value = []
+
+    node_id = _resolve_runner_node_id(parent_root_id="parent_root_id", child_root_id="child_root_id")
+
+    assert node_id is None
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.get_node_output_data")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.FlowNode.objects.filter")
+def test_resolve_runner_node_id_no_matching_output_returns_none(mock_node_filter, mock_get_node_output):
+    """When no candidate node outputs match child_root_id, should return None."""
+    mock_node_filter.return_value.order_by.return_value.values_list.return_value = ["node_1", "node_2"]
+    mock_get_node_output.return_value = MagicMock(data={"child_root_id": "other_child_id"})
+
+    node_id = _resolve_runner_node_id(parent_root_id="parent_root_id", child_root_id="child_root_id")
+
+    assert node_id is None
+    assert mock_get_node_output.call_count == 2
+
+
+@patch("backend.flow.signal.redis_rollback_exercise_handler.BambooEngine.get_node_output_data")
+@patch("backend.flow.signal.redis_rollback_exercise_handler.FlowNode.objects.filter")
+def test_resolve_runner_node_id_output_exception_continues(mock_node_filter, mock_get_node_output):
+    """When get_node_output_data raises for one node, should continue scanning others."""
+    mock_node_filter.return_value.order_by.return_value.values_list.return_value = ["node_1", "node_2"]
+    mock_get_node_output.side_effect = [
+        Exception("node_1 failed"),
+        MagicMock(data={"child_root_id": "child_root_id"}),
+    ]
+
+    node_id = _resolve_runner_node_id(parent_root_id="parent_root_id", child_root_id="child_root_id")
+
+    assert node_id == "node_2"


### PR DESCRIPTION
### Redis 回档演练流程容错增强
背景：回档演练轮训flow有可能因为滚动更新等原因卡住

- 新增 子流程终态信号回调，主流程 Runner 节点可立即被唤醒，无需等待下次轮询
- 新增 周期兜底任务，每小时扫描超时卡住的演练报告并自动修复
- 超时后主动 revoke 子流程，防止僵尸子流程残留
- 新增 配套单测，覆盖信号处理、Runner 调度、周期修复三个层级