### PR TITLE
fix(redis): 传入类型不对 #16999

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/cluster_meta.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/cluster_meta.py
@@ -213,7 +213,7 @@ class RedisInstancesInputSerializer(serializers.Serializer):
     """Redis实例列表序列化器"""
 
     cluster_domain = serializers.CharField(help_text=_("集群域名"))
-    addrs = serializers.ListField(help_text=_("实例地址列表"), required=True)
+    addrs = serializers.ListField(child=serializers.CharField(), help_text=_("实例地址列表"), required=True)
 
 
 class BindEntrySerializer(serializers.Serializer):

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/get_source_access.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/get_source_access.py
@@ -17,12 +17,14 @@ class GetRedisSourceAccessInputSerializer(serializers.Serializer):
 
 
 class GetRedisSourceAccessOutputSerializer(serializers.Serializer):
-    report = serializers.ListField(help_text=_("处理后的用户来源列表，需要渲染成表格"))
-    failed_hosts = serializers.ListField(help_text=_("统计失败的主机列表。如果为空，不展示给用户。如果不为空，需要提示用户"))
+    report = serializers.ListField(child=serializers.DictField(), help_text=_("处理后的用户来源列表，需要渲染成表格"))
+    failed_hosts = serializers.ListField(
+        child=serializers.CharField(), help_text=_("统计失败的主机列表。如果为空，不展示给用户。如果不为空，需要提示用户")
+    )
 
 
 class GetRedisSourceAccessByKeyInputSerializer(GetRedisSourceAccessInputSerializer):
-    keyword_list = serializers.ListField(help_text=_("关键字列表，多个关键字之间是&的关系"))
+    keyword_list = serializers.ListField(child=serializers.CharField(), help_text=_("关键字列表，多个关键字之间是&的关系"))
     timeout = serializers.IntegerField(help_text=_("执行时长，不能超过300秒"), default=30)
     ins = serializers.CharField(help_text=_("指定实例, 格式为ip:port, 不传入代表抓所有接入层机器"), default="", allow_blank=True)
 

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_bill.py
@@ -63,7 +63,7 @@ class SubmitBillRedisDeleteKeyInputSerializer(SubmitBillRedisExtractKeyInputSeri
 
 
 class SubmitBillRedisCutoffInputSerializer(SubmitBillRedisBaseInputSerializer):
-    cutoff_ips = serializers.ListField(help_text=_("需要整机替换的ip列表"))
+    cutoff_ips = serializers.ListField(child=serializers.CharField(), help_text=_("需要整机替换的ip列表"))
 
 
 class SubmitBillRedisClusterScaleInputSerializer(SubmitBillRedisBaseInputSerializer):
@@ -71,16 +71,18 @@ class SubmitBillRedisClusterScaleInputSerializer(SubmitBillRedisBaseInputSeriali
 
 
 class SubmitBillRedisLoadModulesInputSerializer(SubmitBillRedisBaseInputSerializer):
-    modules = serializers.ListField(help_text=_("需要安装的插件列表，目前只支持redisbloom、redisell、redisjson"))
+    modules = serializers.ListField(
+        child=serializers.CharField(), help_text=_("需要安装的插件列表，目前只支持redisbloom、redisell、redisjson")
+    )
 
 
 class SubmitBillRedisKeyStatInputSerializer(SubmitBillRedisBaseInputSerializer):
-    ins = serializers.ListField(help_text=_("需要分析的实例列表"))
+    ins = serializers.ListField(child=serializers.CharField(), help_text=_("需要分析的实例列表"))
 
 
 class SubmitBillRedisAnalysisHotkeyInputSerializer(SubmitBillRedisBaseInputSerializer):
     analysis_time = serializers.IntegerField(help_text=_("分析时长，单位为秒。只允许10、30、60"), default="10")
-    ins = serializers.ListField(help_text=_("需要分析的实例列表。默认只分析proxy角色，除非指定实例"))
+    ins = serializers.ListField(child=serializers.CharField(), help_text=_("需要分析的实例列表。默认只分析proxy角色，除非指定实例"))
 
 
 class SubmitBillRedisVersionUpdateInputSerializer(SubmitBillRedisBaseInputSerializer):


### PR DESCRIPTION
# 修复后 —— 明确指定 child=serializers.CharField()，确保每个元素都是字符串
