### PR TITLE
fix(kafka): 修复 Kafka 仪表盘 JSON 文件 tags 为空的问题 #17003

### DIFF
--- a/dbm-ui/backend/bk_dataview/dashboards/json/kafka.json
+++ b/dbm-ui/backend/bk_dataview/dashboards/json/kafka.json
@@ -6247,7 +6247,7 @@
   ],
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [],
+  "tags": ["kafka"],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
close #17003

## 问题描述

`backend/bk_dataview/dashboards/json/kafka.json` 顶层 `tags` 字段为空数组 `[]`，导致在 Grafana 中无法通过标签筛选到该仪表盘。

## 修复内容

将 `tags` 从 `[]` 改为 `["kafka"]`，与其他同类仪表盘（如 es.json、redis.json 等）保持一致。

## 测试
- [x] JSON 格式校验通过
- [x] 手动确认 tags 字段已正确添加 "kafka" 标签
