### PR TITLE
fix(es): 修复 ES 仪表盘 JSON 文件 tags 为空的问题 #17009

### DIFF
--- a/dbm-ui/backend/bk_dataview/dashboards/json/es.json
+++ b/dbm-ui/backend/bk_dataview/dashboards/json/es.json
@@ -18323,7 +18323,7 @@
   ],
   "refresh": false,
   "schemaVersion": 39,
-  "tags": [],
+  "tags": ["es"],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
close #17009

## 问题描述

`backend/bk_dataview/dashboards/json/es.json` 顶层 `tags` 字段为空数组 `[]`，导致在 Grafana 中无法通过标签筛选到该仪表盘。

## 修复内容

将 `tags` 从 `[]` 改为 `["es"]`，与其他同类仪表盘（如 hdfs.json、influxdb.json 等）保持一致。

## 测试
- [x] JSON 格式校验通过
- [x] 手动确认 tags 字段已正确添加 "es" 标签
