### PR TITLE
fix(redis): preserve `save` config across CONFIG REWRITE on Redis < 6.2.2 #16997

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
@@ -35,6 +35,8 @@ type RedisClient struct {
 	nodesMu          *sync.Mutex                 // 写入/读取 AddrMapToNodes NodeIDMapToNodes 时加锁
 }
 
+const redisConfigRewriteSaveFixVersion = "6.2.2"
+
 // NewRedisClient 建redis客户端
 func NewRedisClient(addr, passwd string, db int, dbType string) (conn *RedisClient, err error) {
 	// 统一不使用智能client,一个连接固定到某个实例上
@@ -1136,11 +1138,27 @@ func (db *RedisClient) ConfigRewrite() (string, error) {
 	var err error
 	var data string
 	var ok bool
+	needSaveWorkaround := true
+	saveValue := ""
 	// 执行 config rewrite 命令只能用 普通redis client
 	if db.InstanceClient == nil {
 		err = fmt.Errorf("ConfigRewrite redis:%s must create a standalone client", db.Addr)
 		mylog.Logger.Error(err.Error())
 		return "", err
+	}
+	needSaveWorkaround, err = db.needSaveConfigRewriteWorkaround()
+	if err != nil {
+		mylog.Logger.Warn("check redis(%s) version for config rewrite workaround failed,err:%v,apply workaround", db.Addr, err)
+		needSaveWorkaround = true
+	}
+	if needSaveWorkaround {
+		saveMap, err := db.ConfigGet("save")
+		if err != nil {
+			err = fmt.Errorf("get redis save config failed before config rewrite,err:%v,addr:%s", err, db.Addr)
+			mylog.Logger.Error(err.Error())
+			return "", err
+		}
+		saveValue = getConfigValueIgnoreCase(saveMap, "save")
 	}
 	data, err = db.InstanceClient.ConfigRewrite(context.TODO()).Result()
 	if err != nil && strings.Contains(err.Error(), "ERR unknown command") {
@@ -1164,7 +1182,79 @@ func (db *RedisClient) ConfigRewrite() (string, error) {
 		mylog.Logger.Error(err.Error())
 		return "", err
 	}
+	if needSaveWorkaround {
+		err = db.ensureSaveConfigInConfFile(saveValue)
+		if err != nil {
+			return "", err
+		}
+	}
 	return data, nil
+}
+
+func (db *RedisClient) needSaveConfigRewriteWorkaround() (bool, error) {
+	infoMap, err := db.Info("server")
+	if err != nil {
+		return false, err
+	}
+	redisVersion, ok := infoMap["redis_version"]
+	if !ok || redisVersion == "" {
+		return false, fmt.Errorf("redis_version not found in info server,addr:%s", db.Addr)
+	}
+	return needSaveConfigRewriteWorkaroundByVersion(redisVersion)
+}
+
+func needSaveConfigRewriteWorkaroundByVersion(redisVersion string) (bool, error) {
+	runtimeBaseVersion, _, err := util.VersionParse(redisVersion)
+	if err != nil {
+		return false, err
+	}
+	fixedBaseVersion, _, err := util.VersionParse(redisConfigRewriteSaveFixVersion)
+	if err != nil {
+		return false, err
+	}
+	return runtimeBaseVersion < fixedBaseVersion, nil
+}
+
+func getConfigValueIgnoreCase(confMap map[string]string, confName string) string {
+	for k, v := range confMap {
+		if strings.EqualFold(k, confName) {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func formatSaveConfigValue(saveValue string) string {
+	if strings.TrimSpace(saveValue) == "" {
+		return `""`
+	}
+	return strings.TrimSpace(saveValue)
+}
+
+func (db *RedisClient) ensureSaveConfigInConfFile(saveValue string) (err error) {
+	_, port, err := util.AddrToIpPort(db.Addr)
+	if err != nil {
+		err = fmt.Errorf("parse redis addr(%s) failed,err:%v", db.Addr, err)
+		mylog.Logger.Error(err.Error())
+		return err
+	}
+
+	confFile := filepath.Join(consts.GetRedisDataDir(), "redis", strconv.Itoa(port), "redis.conf")
+	if !util.FileExists(confFile) {
+		confFile, err = GetRedisLoccalConfFile(port)
+		if err != nil {
+			return err
+		}
+	}
+	saveValue = formatSaveConfigValue(saveValue)
+	err = util.SaveKvToConfigFile(confFile, "save", saveValue)
+	if err != nil {
+		err = fmt.Errorf("save redis(%s) config to file(%s) failed,err:%v", db.Addr, confFile, err)
+		mylog.Logger.Error(err.Error())
+		return err
+	}
+	mylog.Logger.Info("save config persisted after rewrite,addr:%s,confFile:%s,save:%s", db.Addr, confFile, saveValue)
+	return nil
 }
 
 // SlaveOf 'slaveof' command

--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/client_test.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/client_test.go
@@ -1,0 +1,40 @@
+package myredis
+
+import (
+	"testing"
+
+	"dbm-services/redis/db-tools/dbactuator/mylog"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestNeedSaveConfigRewriteWorkaroundByVersion(t *testing.T) {
+	mylog.UnitTestInitLog()
+	convey.Convey("need save config rewrite workaround by version", t, func() {
+		need, err := needSaveConfigRewriteWorkaroundByVersion("6.0.16")
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(need, convey.ShouldBeTrue)
+
+		need, err = needSaveConfigRewriteWorkaroundByVersion("6.2.1")
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(need, convey.ShouldBeTrue)
+
+		need, err = needSaveConfigRewriteWorkaroundByVersion("6.2.2")
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(need, convey.ShouldBeFalse)
+
+		need, err = needSaveConfigRewriteWorkaroundByVersion("7.0.0")
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(need, convey.ShouldBeFalse)
+	})
+}
+
+func TestFormatSaveConfigValue(t *testing.T) {
+	mylog.UnitTestInitLog()
+	convey.Convey("format save config value", t, func() {
+		convey.So(formatSaveConfigValue(""), convey.ShouldEqual, `""`)
+		convey.So(formatSaveConfigValue("   "), convey.ShouldEqual, `""`)
+		convey.So(formatSaveConfigValue("900 1 300 10"), convey.ShouldEqual, "900 1 300 10")
+		convey.So(formatSaveConfigValue(" 900 1 "), convey.ShouldEqual, "900 1")
+	})
+}


### PR DESCRIPTION
应对 Redis < 6.2.2 的 `rewrite` bug，确保内存态的 `save` 参数能正常持久化