### PR TITLE
feat(redis): rate-limit agent checks and fix binlog day boundary #17238

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
@@ -1148,8 +1148,9 @@ func (db *RedisClient) ConfigRewrite() (string, error) {
 	}
 	needSaveWorkaround, err = db.needSaveConfigRewriteWorkaround()
 	if err != nil {
-		mylog.Logger.Warn("check redis(%s) version for config rewrite workaround failed,err:%v,apply workaround", db.Addr, err)
-		needSaveWorkaround = true
+		// 无法确认是否为受影响的 Redis 版本时, 不冒险改动本地配置文件, 避免误伤同机器其它实例.
+		mylog.Logger.Warn("check redis(%s) version for config rewrite workaround failed,err:%v,skip workaround", db.Addr, err)
+		needSaveWorkaround = false
 	}
 	if needSaveWorkaround {
 		saveMap, err := db.ConfigGet("save")
@@ -1192,13 +1193,21 @@ func (db *RedisClient) ConfigRewrite() (string, error) {
 }
 
 func (db *RedisClient) needSaveConfigRewriteWorkaround() (bool, error) {
+	if consts.IsTendisplusInstanceDbType(db.DbType) || consts.IsTendisSSDInstanceDbType(db.DbType) {
+		mylog.Logger.Info("dbType:%s is tendisplus/tendisSSD,skip save config workaround,addr:%s",
+			db.DbType, db.Addr)
+		return false, nil
+	}
 	infoMap, err := db.Info("server")
 	if err != nil {
 		return false, err
 	}
 	redisVersion, ok := infoMap["redis_version"]
 	if !ok || redisVersion == "" {
-		return false, fmt.Errorf("redis_version not found in info server,addr:%s", db.Addr)
+		// 非 Redis 实例 (例如 predixy/twemproxy 等 proxy) 的 INFO 里不会有 redis_version 字段.
+		// 该 workaround 只针对 Redis < 6.2.2 的 CONFIG REWRITE bug, 对 proxy 不适用, 跳过即可.
+		mylog.Logger.Info("redis_version not found in info server,skip save config workaround,addr:%s", db.Addr)
+		return false, nil
 	}
 	return needSaveConfigRewriteWorkaroundByVersion(redisVersion)
 }
@@ -1232,11 +1241,24 @@ func formatSaveConfigValue(saveValue string) string {
 }
 
 func (db *RedisClient) ensureSaveConfigInConfFile(saveValue string) (err error) {
-	_, port, err := util.AddrToIpPort(db.Addr)
+	ip, port, err := util.AddrToIpPort(db.Addr)
 	if err != nil {
 		err = fmt.Errorf("parse redis addr(%s) failed,err:%v", db.Addr, err)
 		mylog.Logger.Error(err.Error())
 		return err
+	}
+
+	// ConfigRewrite 可能在非目标 redis 所在机器上执行
+	// 只有当目标 redis 就在本机时才去修改本地 redis.conf
+	localIP, lerr := util.GetLocalIP()
+	if lerr != nil {
+		mylog.Logger.Warn("get local ip failed,skip save config workaround,addr:%s,err:%v", db.Addr, lerr)
+		return nil
+	}
+	if localIP != ip {
+		mylog.Logger.Warn("localIP:%s redisIP:%s not equal,skip save config workaround,addr:%s",
+			localIP, ip, db.Addr)
+		return nil
 	}
 
 	confFile := filepath.Join(consts.GetRedisDataDir(), "redis", strconv.Itoa(port), "redis.conf")
@@ -1245,6 +1267,14 @@ func (db *RedisClient) ensureSaveConfigInConfFile(saveValue string) (err error) 
 		if err != nil {
 			return err
 		}
+	}
+	// 匹配 save 后紧跟至少一个空白
+	sedCmd := fmt.Sprintf("sed -i -e '/^[Ss][Aa][Vv][Ee][[:space:]]\\+/d' %s", confFile)
+	mylog.Logger.Info(sedCmd)
+	if _, err = util.RunBashCmd(sedCmd, "", nil, 10*time.Second); err != nil {
+		err = fmt.Errorf("clean existing save lines in %s failed,err:%v,addr:%s", confFile, err, db.Addr)
+		mylog.Logger.Error(err.Error())
+		return err
 	}
 	saveValue = formatSaveConfigValue(saveValue)
 	err = util.SaveKvToConfigFile(confFile, "save", saveValue)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
@@ -10,8 +10,8 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 import time
-from datetime import timedelta
-from typing import Any
+from datetime import datetime, timedelta
+from typing import Any, Optional
 
 from django.db.models import Prefetch, Q
 from django.utils import timezone
@@ -56,6 +56,39 @@ def _extract_binlog_index(file_name: str, tendis_type: str) -> int:
     if is_tendisssd_instance_type(tendis_type):
         return int(parts[3])
     raise ValueError(f"unsupported tendis type for binlog index extraction: {tendis_type}")
+
+
+def _extract_binlog_timestamp(file_name: str, tendis_type: str) -> Optional[datetime]:
+    """Extract the binlog file rotation timestamp (its content cutoff time).
+
+    The trailing component of the filename is ``YYYYMMDDHHMMSS`` in local
+    time. The index of that component differs by tendis type because
+    TendisPlus filenames carry an extra ``kvstore`` field. Mirror the
+    layout documented on ``_extract_binlog_index`` above:
+
+        TendisSSD:  binlog-{ip}-{port}-{idx}-{ts}.log.zst        -> parts[4]
+        TendisPlus: binlog-{ip}-{port}-{kv}-{idx}-{ts}.log.zst   -> parts[5]
+
+    Examples:
+        TendisSSD:  binlog-1.2.3.4-30000-0014018-20251216171048.log.zst
+        TendisPlus: binlog-1.2.3.4-30000-5-0022670-20251216171459.log.zst
+
+    Returns a naive ``datetime`` representing local time, or ``None`` on
+    parse failure.  Callers treat unparseable entries as "not yesterday"
+    so that they are excluded from gap analysis (fail-safe: never causes
+    a false positive).
+    """
+    parts = file_name.split("-")
+    try:
+        if is_tendisplus_instance_type(tendis_type):
+            ts_str = parts[5].split(".")[0]
+        elif is_tendisssd_instance_type(tendis_type):
+            ts_str = parts[4].split(".")[0]
+        else:
+            return None
+        return datetime.strptime(ts_str, "%Y%m%d%H%M%S")
+    except (IndexError, ValueError):
+        return None
 
 
 def _find_missing_binlogs(
@@ -168,7 +201,7 @@ class CheckBinlogBackupTask:
         batch_ops.delete_today_records()
 
         cluster_ids = list(self._get_cluster_ids(config))
-        start_time, end_time = self._yesterday_time_range()
+        start_time, end_time, analysis_end_local = self._yesterday_time_range()
         cluster_state_total = {
             ReportStateType.NORMAL.value: 0,
             ReportStateType.WARNING.value: 0,
@@ -182,7 +215,9 @@ class CheckBinlogBackupTask:
 
             for cluster in batch_clusters:
                 total_num += 1
-                rows = self._check_cluster_with_retry(cluster, start_time, end_time, config)
+                rows = self._check_cluster_with_retry(
+                    cluster, start_time, end_time, config, analysis_end_local=analysis_end_local
+                )
                 if rows:
                     cluster_state_total[rows[0].state] += 1
                 for row in rows:
@@ -235,11 +270,15 @@ class CheckBinlogBackupTask:
         end_time,
         config: RedisBackupCheckConfig,
         max_retries: int = 3,
+        *,
+        analysis_end_local: Optional[datetime] = None,
     ):
         last_error = None
         for attempt in range(max_retries):
             try:
-                return self._check_cluster(cluster, start_time, end_time, config)
+                return self._check_cluster(
+                    cluster, start_time, end_time, config, analysis_end_local=analysis_end_local
+                )
             except Exception as e:
                 logger.error(
                     "CheckBinlogBackupTask cluster=%s attempt=%d/%d error: %s",
@@ -253,7 +292,15 @@ class CheckBinlogBackupTask:
         report = RedisBackupClusterReport(cluster, self.subtype)
         return report.make_error_record(f"system error after {max_retries} retries: {last_error}")
 
-    def _check_cluster(self, cluster: Cluster, start_time, end_time, config: RedisBackupCheckConfig):
+    def _check_cluster(
+        self,
+        cluster: Cluster,
+        start_time,
+        end_time,
+        config: RedisBackupCheckConfig,
+        *,
+        analysis_end_local: Optional[datetime] = None,
+    ):
         report = RedisBackupClusterReport(cluster, self.subtype)
 
         if cluster.bk_cloud_id not in config.target_bk_cloud_ids:
@@ -301,6 +348,7 @@ class CheckBinlogBackupTask:
                     port,
                     kvstorecount,
                     recently_switched=recently_switched.get(instance),
+                    analysis_end_local=analysis_end_local,
                 )
             except Exception as e:
                 logger.error(
@@ -353,7 +401,23 @@ class CheckBinlogBackupTask:
 
         return result
 
-    def _check_instance(self, report, bklogs, cluster, instance, ip, port, kvstorecount, *, recently_switched=None):
+    def _check_instance(
+        self,
+        report,
+        bklogs,
+        cluster,
+        instance,
+        ip,
+        port,
+        kvstorecount,
+        *,
+        recently_switched=None,
+        analysis_end_local: Optional[datetime] = None,
+    ):
+        # The "no logs found" check is done against the raw query window
+        # (pre-filter): if BKLog returned nothing at all for this instance
+        # within yesterday + 1h buffer, that itself is a strong abnormal
+        # signal regardless of content-time semantics.
         if not bklogs:
             if recently_switched is not None:
                 report.append(
@@ -365,15 +429,47 @@ class CheckBinlogBackupTask:
                 report.append(ReportStateType.ABNORMAL.value, instance, "no logs found")
             return
 
+        # Failed-task verification runs against the full window so that a
+        # success arriving in the buffer (today 00:00-01:00) can still
+        # promote a corresponding ``to_backup_system_start`` from yesterday.
         api_confirmed = find_and_verify_failed_tasks(bklogs)
 
+        # Filter to entries whose binlog content time falls in yesterday.
+        # Today's first-hour entries (caught by the 1h buffer) are
+        # excluded so that gap detection never uses them as a max
+        # boundary -- avoiding day-boundary false positives where a
+        # late-uploaded yesterday seq looks like an interior gap between
+        # an earlier yesterday seq and a today seq.  The excluded
+        # entries will be re-checked tomorrow as part of "yesterday".
+        #
+        # Timezone contract: both operands below are NAIVE local time.
+        # ``_extract_binlog_timestamp`` returns naive local per the
+        # backup-agent filename convention (YYYYMMDDHHMMSS in the local
+        # tz of the source host); ``analysis_end_local`` is naive local
+        # stripped from a Django timezone-aware ``localtime()``.  They
+        # are directly comparable only because both are local wall-clock.
+        # If a newly provisioned instance ever emits UTC timestamps in
+        # filenames, this comparison would silently mis-classify
+        # buffer-window entries -- revisit this contract then.
+        if analysis_end_local is not None:
+            yesterday_logs = [
+                e
+                for e in bklogs
+                if (
+                    (ts := _extract_binlog_timestamp(e.get("file_name", ""), cluster.cluster_type)) is not None
+                    and ts < analysis_end_local
+                )
+            ]
+        else:
+            yesterday_logs = bklogs
+
         _TERMINAL = ("to_backup_system_success", "to_backup_system_failed")
-        all_terminal = [e for e in bklogs if e.get("backup_status") in _TERMINAL]
-        success_entries = [e for e in bklogs if e.get("backup_status") == "to_backup_system_success"]
+        all_terminal = [e for e in yesterday_logs if e.get("backup_status") in _TERMINAL]
+        success_entries = [e for e in yesterday_logs if e.get("backup_status") == "to_backup_system_success"]
 
         api_promoted = [
             e
-            for e in bklogs
+            for e in yesterday_logs
             if e.get("backup_status") == "to_backup_system_start" and e.get("task_id", "") in api_confirmed
         ]
         if api_promoted:
@@ -476,12 +572,27 @@ class CheckBinlogBackupTask:
 
     @staticmethod
     def _yesterday_time_range():
+        """Compute the BKLog query window and the gap-analysis cutoff.
+
+        Returns ``(query_start, query_end, analysis_end_local)``:
+
+        - ``query_start``/``query_end``: aware UTC bounds for the BKLog
+          ES query.  Window is ``[yesterday 00:00, today 01:00)`` local
+          time.  The 1h tail buffer is intentional -- it captures
+          binlogs whose **content** belongs to yesterday but whose
+          upload completed slightly after midnight (slow uploads,
+          backup-system retries, ES ingestion delay).
+        - ``analysis_end_local``: naive local ``datetime`` representing
+          today 00:00:00.  Used downstream to filter out entries whose
+          content time falls in today's first hour -- those entries are
+          today's data that happen to fall inside the buffer window and
+          should not participate in yesterday's gap detection.  They
+          will be re-checked tomorrow as part of "yesterday" then.
+        """
         local_now = timezone.localtime()
-        yesterday = local_now - timedelta(days=1)
-        start = yesterday.replace(hour=0, minute=0, second=0, microsecond=0).astimezone(tz=timezone.utc)
-        # +1h buffer: binlog entries logged near 23:59 may be ingested into BKLog
-        # after midnight due to ES indexing delay.
-        end = yesterday.replace(hour=23, minute=59, second=59, microsecond=0).astimezone(tz=timezone.utc) + timedelta(
-            hours=1
-        )
-        return start, end
+        local_today_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        local_yesterday_start = local_today_start - timedelta(days=1)
+        query_start = local_yesterday_start.astimezone(tz=timezone.utc)
+        query_end = local_today_start.astimezone(tz=timezone.utc) + timedelta(hours=1)
+        analysis_end_local = local_today_start.replace(tzinfo=None)
+        return query_start, query_end, analysis_end_local

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/base.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field, fields
 from datetime import timedelta
 from typing import Callable, ClassVar
 
+from celery.exceptions import SoftTimeLimitExceeded
 from django.core.cache import cache
 from django.db.models import Q
 from django.utils import timezone
@@ -58,6 +59,44 @@ DISPATCH_EXPIRE_BUFFER_SECONDS = 60
 DISPATCH_SPREAD_SECONDS = DISPATCH_INTERVAL_SECONDS - DISPATCH_EXPIRE_BUFFER_SECONDS
 DISPATCH_RATE_LIMIT_COOLDOWN_SECONDS = 60
 DEFAULT_MAX_RATE_LIMIT_RETRIES = 3
+
+# Layered timeouts for a single agent check. Two invariants must hold:
+#   1. invoke_timeout < soft_time_limit < hard_time_limit
+#      SDK-level timeout aborts gracefully first, Celery's soft limit is the
+#      Python-level fallback, and the hard limit is the last-resort SIGKILL
+#      against native hangs.
+#   2. hard_time_limit <= DISPATCH_INTERVAL_SECONDS
+#      A cycle-N task must not occupy a worker slot past the start of
+#      cycle-(N+1). Otherwise slow stragglers silently reduce the capacity
+#      available to the next batch, because apply_async(expires=...) then
+#      drops fresh tasks in favor of finishing old ones.
+DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS = 540
+DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS = 570
+DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS = 600
+
+# Cap how many characters of an agent response we log. A single report is
+# typically ~400-600 chars; this leaves generous headroom for multi-table
+# outputs while preventing a runaway response from flooding the log pipeline.
+AGENT_RESPONSE_LOG_MAX_CHARS = 2000
+
+# Structured outcome tags for log aggregation. Every terminal log line
+# emitted by execute_agent_check, the task_failure handler in signals.py,
+# or start()'s dispatch loop carries `outcome=<one of the below>` so
+# external log platforms (ES/Datadog) can cleanly count per-cycle
+# distributions. When adding new outcomes, keep them snake_case and
+# document them here.
+OUTCOME_SUCCESS = "success"  # agent call returned normally
+OUTCOME_TIMEOUT_SOFT = "timeout_soft"  # Celery SoftTimeLimitExceeded fired
+OUTCOME_TIMEOUT_HARD = "timeout_hard"  # worker SIGKILLed at time_limit (WorkerLostError)
+OUTCOME_RATELIMIT_RETRY = "ratelimit_retry"  # 429 detected, celery retry scheduled
+OUTCOME_RATELIMIT_GAVE_UP = "ratelimit_gave_up"  # 429 but max retries reached
+OUTCOME_ERROR = "error"  # any other uncaught exception from the agent call
+OUTCOME_SKIPPED = "skipped"  # cluster skipped pre-agent; specific cause in the reason field
+# Dispatch-side outcomes: emitted by start(), not by the worker.
+OUTCOME_DISPATCH_OK = "dispatch_ok"
+OUTCOME_DISPATCH_FAILED = "dispatch_failed"
+OUTCOME_DISPATCH_DEDUP_SKIPPED = "dispatch_dedup_skipped"
+
 PRIORITY_ALARM_DAILY_DOMAIN_CACHE_KEY_PREFIX = "redis_agent_check_priority_alarm_domains"
 PRIORITY_ALARM_DAILY_DOMAIN_CACHE_LOCK_KEY_PREFIX = "redis_agent_check_priority_alarm_domains_lock"
 PRIORITY_ALARM_DAILY_CONSUME_LOCK_TTL_SECONDS = 15
@@ -70,18 +109,38 @@ def _is_rate_limit_error(exc: Exception) -> bool:
     return bool(_RATE_LIMIT_PATTERN.search(str(exc)))
 
 
+def _truncate_agent_response_for_log(response, max_chars: int = AGENT_RESPONSE_LOG_MAX_CHARS) -> str:
+    """Coerce an agent response to a bounded single-line repr for logging.
+
+    Non-string responses (None, dict, etc.) are passed through repr() unchanged
+    so unexpected upstream shapes stay debuggable. Long strings are truncated
+    with a trailing marker showing the original length.
+    """
+    if not isinstance(response, str):
+        return repr(response)
+    if len(response) <= max_chars:
+        return repr(response)
+    return f"{response[:max_chars]!r}...[truncated, total_len={len(response)}]"
+
+
 def _should_skip(config: "BaseCheckConfig", cluster: Cluster) -> tuple[bool, str]:
-    """Skip clusters that are young, offline, in ignore list, or have recent/active tickets."""
+    """Decide whether to skip this cluster.
+
+    Returns (skipped, human_reason). The outcome tag for all skip paths is
+    uniformly ``OUTCOME_SKIPPED``; the specific cause (young / offline /
+    ignored / busy) is carried in ``human_reason`` and emitted as a
+    ``reason=...`` field alongside ``outcome=skipped`` in logs.
+    """
     now = timezone.now()
 
     if cluster.create_at > now - timedelta(days=config.lookback_days):
-        return True, f"skipped: cluster younger than {config.lookback_days} days"
+        return True, f"cluster younger than {config.lookback_days} days"
 
     if cluster.phase != ClusterPhase.ONLINE.value:
-        return True, f"skipped: cluster phase={cluster.phase} is not online"
+        return True, f"cluster phase={cluster.phase} is not online"
 
     if cluster.immute_domain in config.ignore_cluster_domains:
-        return True, "skipped: cluster in ignore list"
+        return True, "cluster in ignore list"
 
     cutoff = now - timedelta(days=config.lookback_days)
     has_recent = (
@@ -93,7 +152,7 @@ def _should_skip(config: "BaseCheckConfig", cluster: Cluster) -> tuple[bool, str
         .exists()
     )
     if has_recent:
-        return True, "skipped: recent or active capacity/autofix/migrate ticket"
+        return True, "recent or active capacity/autofix/migrate ticket"
 
     return False, ""
 
@@ -111,38 +170,85 @@ def execute_agent_check(
     ``celery_task.retry(countdown=rate_limit_cooldown_seconds)`` instead of
     failing immediately.  The retried task may expire before execution,
     which is acceptable.
+
+    Failure semantics (intentional):
+      - ``OUTCOME_RATELIMIT_GAVE_UP`` (retries exhausted) is a **soft
+        failure** -- we log at ERROR and return normally without
+        re-raising.  The Celery task is therefore marked SUCCESS.
+        Downstream monitoring must tail the outcome tag in logs rather
+        than rely on Celery task failure state to detect this case.
+      - ``OUTCOME_TIMEOUT_SOFT`` (SoftTimeLimitExceeded) is also soft-
+        swallowed for the same reason: continued retries under rate
+        pressure rarely help and only amplify load.
+      - All other exceptions fall through to the generic ``logger.exception``
+        at the bottom, which similarly does not re-raise.  Celery retries
+        are only triggered explicitly via ``celery_task.retry`` in the
+        rate-limit path above.
     """
     task_label = celery_task.name if celery_task else str(agent_code)
 
     try:
         cluster = Cluster.objects.filter(id=cluster_id).first()
         if not cluster:
-            logger.warning("%s: cluster_id=%s not found", task_label, cluster_id)
+            logger.warning(
+                "%s: cluster_id=%s outcome=%s reason=%s",
+                task_label,
+                cluster_id,
+                OUTCOME_SKIPPED,
+                "cluster not found",
+            )
             return
 
-        skipped, reason = _should_skip(config, cluster)
+        skipped, skip_reason = _should_skip(config, cluster)
         if skipped:
-            logger.debug("%s: cluster_id=%s %s", task_label, cluster_id, reason)
+            logger.debug(
+                "%s: cluster_id=%s outcome=%s reason=%s",
+                task_label,
+                cluster_id,
+                OUTCOME_SKIPPED,
+                skip_reason,
+            )
             return
 
         from backend.dbm_aiagent.agent.handlers import AgentHandler
 
         content = prompt_template.format(cluster_domain=cluster.immute_domain)
-        AgentHandler.ask_agent_with_content(
+        ai_response = AgentHandler.ask_agent_with_content(
             agent_code=agent_code,
             content=content,
+            timeout=max(1, int(config.agent_invoke_timeout_seconds)),
         )
-        logger.info("%s: cluster_id=%s done", task_label, cluster_id)
+        logger.info(
+            "%s: cluster_id=%s outcome=%s agent_response=%s",
+            task_label,
+            cluster_id,
+            OUTCOME_SUCCESS,
+            _truncate_agent_response_for_log(ai_response),
+        )
 
+    except SoftTimeLimitExceeded as e:
+        # Celery soft-limit fired: SDK-level invoke_timeout did not abort in time.
+        # Log loudly and return — do NOT retry, as continued rate pressure is unlikely
+        # to help and may mask a broken upstream.
+        logger.error(
+            "%s: cluster_id=%s outcome=%s soft_time_limit=%ds invoke_timeout=%ds: %s",
+            task_label,
+            cluster_id,
+            OUTCOME_TIMEOUT_SOFT,
+            config.agent_soft_time_limit_seconds,
+            config.agent_invoke_timeout_seconds,
+            e,
+        )
     except Exception as e:
         if _is_rate_limit_error(e) and celery_task is not None:
             cooldown = max(1, config.rate_limit_cooldown_seconds)
             max_retries = max(0, config.max_rate_limit_retries)
             if celery_task.request.retries < max_retries:
                 logger.warning(
-                    "%s: cluster_id=%s hit rate limit (attempt %d/%d), retrying in %ds: %s",
+                    "%s: cluster_id=%s outcome=%s attempt=%d/%d cooldown=%ds: %s",
                     task_label,
                     cluster_id,
+                    OUTCOME_RATELIMIT_RETRY,
                     celery_task.request.retries + 1,
                     max_retries,
                     cooldown,
@@ -151,8 +257,26 @@ def execute_agent_check(
                 raise celery_task.retry(
                     countdown=cooldown, max_retries=max_retries, exc=e, expires=DISPATCH_INTERVAL_SECONDS
                 )
+            # Rate limit retries exhausted: tag separately so the generic
+            # ERROR bucket stays informative, and skip the logger.exception
+            # below to avoid a second log line for the same root cause.
+            logger.error(
+                "%s: cluster_id=%s outcome=%s attempts=%d: %s",
+                task_label,
+                cluster_id,
+                OUTCOME_RATELIMIT_GAVE_UP,
+                celery_task.request.retries,
+                e,
+            )
+            return
 
-        logger.exception("%s: cluster_id=%s failed: %s", task_label, cluster_id, e)
+        logger.exception(
+            "%s: cluster_id=%s outcome=%s: %s",
+            task_label,
+            cluster_id,
+            OUTCOME_ERROR,
+            e,
+        )
 
 
 @dataclass
@@ -166,7 +290,7 @@ class BaseCheckConfig:
     candidate_scan_multiplier: int = 2
     candidate_page_size: int = 200
     max_candidate_scan: int = 0
-    selection_strategy: str = "sequential"  # sequential | rotating
+    selection_strategy: str = "rotating"  # sequential | rotating
     # Keep rolling 24h behavior by default; calendar_day can be enabled later via config.
     recent_check_mode: str = "rolling_24h"  # rolling_24h | calendar_day
     # 0 means use fallback (lookback_days / 2) to preserve current behavior.
@@ -176,6 +300,11 @@ class BaseCheckConfig:
     inflight_lock_ttl_seconds: int = DISPATCH_INTERVAL_SECONDS
     rate_limit_cooldown_seconds: int = DISPATCH_RATE_LIMIT_COOLDOWN_SECONDS
     max_rate_limit_retries: int = DEFAULT_MAX_RATE_LIMIT_RETRIES
+    # Layered per-cluster timeouts. See DEFAULT_AGENT_* constants above for the
+    # invariant (invoke < soft < hard) and the reasoning behind each layer.
+    agent_invoke_timeout_seconds: int = DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS
+    agent_soft_time_limit_seconds: int = DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS
+    agent_hard_time_limit_seconds: int = DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS
     # Names are matched against the alert's strategy_name (the clean policy name),
     # not alert_name (which carries dynamic business-name suffixes at runtime).
     priority_alarm_names: list = field(default_factory=list)
@@ -236,15 +365,54 @@ class BaseRedisAgentCheckTask(ABC):
     def get_celery_task(self) -> Callable:
         """Return the bound Celery task function used to dispatch per-cluster work."""
 
+    def _resolve_agent_timeouts(self) -> tuple[int, int, int]:
+        """Return (invoke_timeout, soft_time_limit, hard_time_limit) from config.
+
+        Config is authoritative — values flow through unchanged so operators
+        can override at runtime via SystemSettings without us silently
+        rewriting their intent. Two invariants are checked and any violation
+        is logged as a warning so ops can spot misconfiguration:
+
+          1. invoke_timeout < soft_time_limit < hard_time_limit
+             (defense-in-depth layering; see DEFAULT_AGENT_* constants)
+          2. hard_time_limit <= DISPATCH_INTERVAL_SECONDS
+             (tasks should finish before the next dispatch cycle; exceeding
+             this lets slow stragglers occupy worker slots across cycles)
+
+        Only non-positive values are defensively coerced to 1 so apply_async
+        does not reject the dispatch entirely.
+        """
+        invoke = max(1, int(self.config.agent_invoke_timeout_seconds))
+        soft = max(1, int(self.config.agent_soft_time_limit_seconds))
+        hard = max(1, int(self.config.agent_hard_time_limit_seconds))
+
+        issues = []
+        if not (invoke < soft < hard):
+            issues.append(f"invoke<soft<hard violated (invoke={invoke}, soft={soft}, hard={hard})")
+        if hard > DISPATCH_INTERVAL_SECONDS:
+            issues.append(
+                f"hard_time_limit={hard}s exceeds "
+                f"DISPATCH_INTERVAL_SECONDS={DISPATCH_INTERVAL_SECONDS}s; "
+                "slow tasks may occupy worker slots across dispatch cycles"
+            )
+        if issues:
+            logger.warning(
+                "%s: agent timeout config issues: %s",
+                type(self).__name__,
+                "; ".join(issues),
+            )
+
+        return invoke, soft, hard
+
     def _resolve_selection_strategy(self) -> str:
-        strategy = (self.config.selection_strategy or "sequential").lower()
+        strategy = (self.config.selection_strategy or "rotating").lower()
         if strategy not in {"sequential", "rotating"}:
             logger.warning(
-                "%s: invalid selection_strategy=%s, fallback to sequential",
+                "%s: invalid selection_strategy=%s, fallback to rotating",
                 type(self).__name__,
                 self.config.selection_strategy,
             )
-            return "sequential"
+            return "rotating"
         return strategy
 
     def _resolve_max_candidate_scan(self) -> int:
@@ -592,8 +760,18 @@ class BaseRedisAgentCheckTask(ABC):
             return 0
 
         celery_task = self.get_celery_task()
+        # Config is the source of truth; _resolve_agent_timeouts only validates
+        # and warns on invariant violations. We intentionally do NOT rewrite
+        # config_dict so operator-set values propagate unchanged to the worker.
+        # The returned ``_invoke_timeout`` is discarded here because the
+        # worker reads it back from ``config.agent_invoke_timeout_seconds``
+        # inside ``execute_agent_check`` (see the ``ask_agent_with_content``
+        # call above); only soft/hard limits need to be passed to
+        # ``apply_async`` directly for Celery enforcement.
+        _invoke_timeout, soft_time_limit, hard_time_limit = self._resolve_agent_timeouts()
         config_dict = dataclasses.asdict(self.config)
-        dispatched = 0
+        dispatched_ok = 0
+        dispatch_failed = 0
         dedupe_skipped = 0
         count = len(cluster_ids)
         for idx, cluster_id in enumerate(cluster_ids):
@@ -604,24 +782,42 @@ class BaseRedisAgentCheckTask(ABC):
                     lock_ttl = max(1, int(self.config.inflight_lock_ttl_seconds))
                     if not cache.add(lock_key, 1, timeout=lock_ttl):
                         dedupe_skipped += 1
+                        logger.debug(
+                            "%s: cluster_id=%s outcome=%s",
+                            task_name,
+                            cluster_id,
+                            OUTCOME_DISPATCH_DEDUP_SKIPPED,
+                        )
                         continue
 
                 countdown = calculate_countdown(count=count, index=idx, duration=DISPATCH_SPREAD_SECONDS)
                 celery_task.apply_async(
-                    args=[cluster_id, config_dict], countdown=countdown, expires=DISPATCH_INTERVAL_SECONDS
+                    args=[cluster_id, config_dict],
+                    countdown=countdown,
+                    expires=DISPATCH_INTERVAL_SECONDS,
+                    soft_time_limit=soft_time_limit,
+                    time_limit=hard_time_limit,
                 )
-                dispatched += 1
+                dispatched_ok += 1
             except Exception as e:
                 if lock_key:
                     cache.delete(lock_key)
-                logger.error("%s: failed to dispatch cluster_id=%s: %s", task_name, cluster_id, e)
+                dispatch_failed += 1
+                logger.error(
+                    "%s: cluster_id=%s outcome=%s: %s",
+                    task_name,
+                    cluster_id,
+                    OUTCOME_DISPATCH_FAILED,
+                    e,
+                )
 
         logger.info(
-            "%s: dispatched %d/%d clusters (dedupe_skipped=%d, sample ids=%s)",
+            "%s: dispatch_summary requested=%d ok=%d failed=%d dedupe_skipped=%d sample_ids=%s",
             task_name,
-            dispatched,
             count,
+            dispatched_ok,
+            dispatch_failed,
             dedupe_skipped,
             cluster_ids[:5] if len(cluster_ids) >= 5 else cluster_ids,
         )
-        return dispatched
+        return dispatched_ok

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_backend_data_skew.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_backend_data_skew.py
@@ -16,6 +16,8 @@ from blueapps.core.celery.celery import app
 
 from backend.configuration.constants import SystemSettingsEnum
 from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base import (
+    DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+    DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
     BaseCheckConfig,
     BaseRedisAgentCheckTask,
     execute_agent_check,
@@ -45,7 +47,14 @@ class CheckBackendDataSkewTask(BaseRedisAgentCheckTask):
         return check_backend_data_skew_task
 
 
-@app.task(bind=True, rate_limit="5/m")
+# soft/hard limits below are a safety floor for direct invocations;
+# ``start()`` overrides them per call from ``BaseCheckConfig``.
+@app.task(
+    bind=True,
+    rate_limit="5/m",
+    soft_time_limit=DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+)
 def check_backend_data_skew_task(self, cluster_id: int, config_dict: dict):
     """Check a single Redis cluster's backend data skew using LLM agent."""
     config = BackendDataSkewCheckConfig.from_raw(config_dict)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_backend_load_skew.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_backend_load_skew.py
@@ -16,6 +16,8 @@ from blueapps.core.celery.celery import app
 
 from backend.configuration.constants import SystemSettingsEnum
 from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base import (
+    DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+    DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
     BaseCheckConfig,
     BaseRedisAgentCheckTask,
     execute_agent_check,
@@ -45,7 +47,14 @@ class CheckBackendLoadSkewTask(BaseRedisAgentCheckTask):
         return check_backend_load_skew_task
 
 
-@app.task(bind=True, rate_limit="5/m")
+# soft/hard limits below are a safety floor for direct invocations;
+# ``start()`` overrides them per call from ``BaseCheckConfig``.
+@app.task(
+    bind=True,
+    rate_limit="5/m",
+    soft_time_limit=DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+)
 def check_backend_load_skew_task(self, cluster_id: int, config_dict: dict):
     """Check a single Redis cluster's backend load skew using LLM agent."""
     config = BackendLoadSkewCheckConfig.from_raw(config_dict)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_cluster_capacity_growth.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_cluster_capacity_growth.py
@@ -16,6 +16,8 @@ from blueapps.core.celery.celery import app
 
 from backend.configuration.constants import SystemSettingsEnum
 from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base import (
+    DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+    DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
     BaseCheckConfig,
     BaseRedisAgentCheckTask,
     execute_agent_check,
@@ -45,7 +47,14 @@ class CheckClusterCapacityGrowthTask(BaseRedisAgentCheckTask):
         return check_cluster_capacity_growth_task
 
 
-@app.task(bind=True, rate_limit="5/m")
+# soft/hard limits below are a safety floor for direct invocations;
+# ``start()`` overrides them per call from ``BaseCheckConfig``.
+@app.task(
+    bind=True,
+    rate_limit="5/m",
+    soft_time_limit=DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+)
 def check_cluster_capacity_growth_task(self, cluster_id: int, config_dict: dict):
     """Check a single Redis cluster's capacity growth using LLM agent."""
     config = ClusterCapacityGrowthCheckConfig.from_raw(config_dict)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/signals.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/signals.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+# This module is intentionally agent-check-specific. If a second domain
+# (e.g. redis_backup) ever needs the same hard-timeout observability, do NOT
+# extend this module — extract a generic helper into db_periodic_task/ and
+# have both domains call it with their own outcome taxonomy.
+import logging
+
+from celery.signals import task_failure
+
+from .base import OUTCOME_ERROR, OUTCOME_TIMEOUT_HARD
+
+logger = logging.getLogger("root")
+
+
+def agent_check_task_failure_handler(sender=None, task_id=None, exception=None, **_kwargs):
+    """Log hard timeouts and unhandled errors for agent-check celery tasks.
+
+    Connected per-task via ``register_agent_check_failure_handlers``, so this
+    receiver only fires for the explicitly registered tasks. No name-based
+    filtering is needed.
+
+    The primary case is ``WorkerLostError``: Celery hits ``time_limit`` and
+    SIGKILLs the worker before any in-task ``try/except`` can run, so this
+    is the only place such failures can be observed in our logs.
+    """
+    # Lazy import: keeps module-load time low and avoids surprising failures
+    # when billiard is unavailable in non-celery test environments.
+    try:
+        from billiard.exceptions import WorkerLostError
+    except ImportError:
+        WorkerLostError = None
+
+    is_worker_lost = WorkerLostError is not None and isinstance(exception, WorkerLostError)
+    outcome = OUTCOME_TIMEOUT_HARD if is_worker_lost else OUTCOME_ERROR
+    task_name = getattr(sender, "name", "") or "<unknown>"
+    logger.error(
+        "%s: task_id=%s outcome=%s exc_type=%s: %s",
+        task_name,
+        task_id,
+        outcome,
+        type(exception).__name__ if exception else "None",
+        exception,
+    )
+
+
+def register_agent_check_failure_handlers():
+    """Connect the failure handler to each agent-check celery task explicitly.
+
+    Invoked at module import time (see bottom of this file) so registration
+    happens transparently when ``agent_checks`` is loaded — there is no
+    separate hookup step the operator has to remember.
+
+    Adding a new agent check requires appending its celery task to the
+    tuple below; forgetting to do so is intentional friction (the new
+    task simply will not have hard-timeout observability until registered).
+
+    Idempotent: ``dispatch_uid`` ensures repeated imports / calls do not
+    produce duplicate receivers, which matters for test environments where
+    modules may be reloaded.
+    """
+    from .check_backend_data_skew import check_backend_data_skew_task
+    from .check_backend_load_skew import check_backend_load_skew_task
+    from .check_cluster_capacity_growth import check_cluster_capacity_growth_task
+
+    agent_check_tasks = (
+        check_cluster_capacity_growth_task,
+        check_backend_data_skew_task,
+        check_backend_load_skew_task,
+    )
+    for task in agent_check_tasks:
+        task_failure.connect(
+            agent_check_task_failure_handler,
+            sender=task,
+            dispatch_uid=f"agent_check_task_failure:{task.name}",
+        )
+
+
+# Auto-register on module import.
+register_agent_check_failure_handlers()

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/task.py
@@ -48,7 +48,7 @@ def redis_backend_data_skew_check_task():
     CheckBackendDataSkewTask().start()
 
 
-@register_periodic_task(run_every=crontab(minute=5, hour=0))
+@register_periodic_task(run_every=crontab(minute=30, hour=9))
 def redis_agent_alarm_daily_domain_cache_build_task():
     """Build daily alert-domain cache for Redis agent checks. Runs once a day."""
     check_tasks = [CheckClusterCapacityGrowthTask, CheckBackendLoadSkewTask, CheckBackendDataSkewTask]
@@ -56,6 +56,7 @@ def redis_agent_alarm_daily_domain_cache_build_task():
         task_instance = task_cls()
         config = task_instance.config
         if not config.enabled or not config.priority_alarm_names:
+            logger.info("%s: disabled or no priority alarm names", task_cls.__name__)
             continue
 
         try:

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -217,6 +217,10 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
 
         if child_state in (StateType.FAILED, StateType.REVOKED):
             self.log_error(_("Child pipeline {} ended with status {}").format(child_root_id, child_state))
+            # FAILED means the pipeline errored out but sibling/pending nodes may still be running.
+            # Revoke to ensure the whole tree is terminated. REVOKED is already terminal, skip.
+            if child_state == StateType.FAILED:
+                self._terminate_child_pipeline(child_root_id)
             self._set_result(data, 1)
             self.finish_schedule()
             return True

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_binlog_backup.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_binlog_backup.py
@@ -8,7 +8,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from datetime import timedelta
+# Tests for CheckBinlogBackupTask — _check_instance and _check_cluster.
+#
+# Source-module imports are done lazily to avoid triggering the
+# ``local_tasks/__init__.py`` import chain.
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -16,13 +20,6 @@ import pytest
 from django.utils import timezone
 
 from .conftest import make_binlog_entry
-
-"""
-Tests for CheckBinlogBackupTask — _check_instance and _check_cluster.
-
-Source-module imports are done lazily to avoid triggering the
-``local_tasks/__init__.py`` import chain.
-"""
 
 pytestmark = pytest.mark.django_db
 
@@ -40,6 +37,15 @@ _PATCH_FETCH_INSTANCE = (
 
 _DUMMY_START = timezone.now()
 _DUMMY_END = timezone.now()
+
+
+def _yesterday_local():
+    """Today 00:00 local time as a naive datetime (used as analysis cutoff)."""
+    return timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+
+
+def _ts_str(dt: datetime) -> str:
+    return dt.strftime("%Y%m%d%H%M%S")
 
 
 def _task_cls():
@@ -108,13 +114,15 @@ def _make_slave_master(slave_ip, slave_port, master_ip, master_port, slave_age_h
     )
 
 
-def _run_check_instance(bklogs, cluster=None, kvstorecount=None, ip="3.3.3.2", port="30000"):
+def _run_check_instance(bklogs, cluster=None, kvstorecount=None, ip="3.3.3.2", port="30000", analysis_end_local=None):
     if cluster is None:
         cluster = _make_cluster()
     report = _report_cls()(cluster, "binlog_backup")
     instance = f"{ip}:{port}"
     with patch(_PATCH_FIND, return_value=set()):
-        _task()._check_instance(report, bklogs, cluster, instance, ip, port, kvstorecount)
+        _task()._check_instance(
+            report, bklogs, cluster, instance, ip, port, kvstorecount, analysis_end_local=analysis_end_local
+        )
     return report
 
 
@@ -264,6 +272,163 @@ def test_check_instance_tendisplus_kv_all_failed():
     records = report.records[ST.WARNING.value]
     assert len(records) == 1
     assert "failed" in records[0]["msg"]
+
+
+# ---------------------------------------------------------------------------
+# content-time filter (analysis_end_local) tests
+# ---------------------------------------------------------------------------
+def _ssd_filename(ip, port, idx, content_time):
+    return f"binlog-{ip}-{port}-{idx}-{_ts_str(content_time)}.log.zst"
+
+
+def _plus_filename(ip, port, kv, idx, content_time):
+    return f"binlog-{ip}-{port}-{kv}-{idx}-{_ts_str(content_time)}.log.zst"
+
+
+def test_check_instance_day_boundary_no_false_positive():
+    """User scenario: idx=2 yesterday is uploaded too late (out of window),
+    idx=3 today is in the buffer.  Without filter, [1, 3] would falsely
+    flag idx=2 as missing.  With filter, today's idx=3 is excluded and
+    only idx=1 remains -- no gap reported."""
+    ST = _state()
+    today_start = _yesterday_local()
+    yesterday_late = today_start - timedelta(minutes=10)
+    today_first_hour = today_start + timedelta(minutes=10)
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 1, yesterday_late),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 3, today_first_hour),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
+        report = _run_check_instance(logs, analysis_end_local=today_start)
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+    assert records[0]["msg"] == "ok"
+
+
+def test_check_instance_tail_missing_within_yesterday_still_detected():
+    """Genuine gap inside yesterday content (idx=3 missing between 1, 2, 4)
+    must still be flagged even with the content-time filter active."""
+    ST = _state()
+    today_start = _yesterday_local()
+    base = today_start - timedelta(hours=12)
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, idx, base + timedelta(minutes=10 * idx)),
+        )
+        for idx in (1, 2, 4)
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
+        report = _run_check_instance(logs, analysis_end_local=today_start)
+    records = report.records[ST.WARNING.value]
+    assert len(records) == 1
+    assert "seq gaps" in records[0]["msg"]
+    assert "3" in records[0]["msg"]
+
+
+def test_check_instance_late_uploaded_yesterday_seq_in_buffer_normal():
+    """idx=2 has yesterday content but uploaded after midnight (still in
+    the 1h buffer window).  Buffer brings it in, content-time filter
+    keeps it, no gap reported -- this validates the buffer's purpose."""
+    ST = _state()
+    today_start = _yesterday_local()
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 1, today_start - timedelta(minutes=20)),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 2, today_start - timedelta(minutes=5)),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 3, today_start + timedelta(minutes=15)),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
+        report = _run_check_instance(logs, analysis_end_local=today_start)
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+    assert records[0]["msg"] == "ok"
+
+
+def test_check_instance_filename_timestamp_unparseable_excluded():
+    """Entries whose file_name has an unparseable timestamp segment are
+    treated as 'not yesterday' and excluded from gap analysis."""
+    ST = _state()
+    today_start = _yesterday_local()
+    yest = today_start - timedelta(hours=2)
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 1, yest),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_ssd_filename("3.3.3.2", 30000, 2, yest + timedelta(minutes=10)),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name="binlog-3.3.3.2-30000-99-not_a_timestamp.log.zst",
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
+        report = _run_check_instance(logs, analysis_end_local=today_start)
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1, f"unexpected report: {report.records}"
+
+
+def test_check_instance_tendisplus_day_boundary_no_false_positive():
+    """Same false-positive scenario, TendisPlus per-kvstore variant."""
+    ST = _state()
+    CT = _cluster_type()
+    cluster = _make_cluster(CT.TendisPredixyTendisplusCluster.value)
+    today_start = _yesterday_local()
+    yest_late = today_start - timedelta(minutes=10)
+    today_first = today_start + timedelta(minutes=20)
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_plus_filename("3.3.3.2", 30000, 0, 1, yest_late),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_plus_filename("3.3.3.2", 30000, 0, 3, today_first),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=True), patch(_PATCH_IS_SSD, return_value=False):
+        report = _run_check_instance(logs, cluster=cluster, kvstorecount=1, analysis_end_local=today_start)
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
 
 
 def test_check_instance_api_promoted_counted():

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_helpers.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_helpers.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import datetime as _dt
 from unittest.mock import patch
 
 import pytest
@@ -66,6 +67,12 @@ def _extract_binlog_index(*a, **kw):
     from backend.db_periodic_task.local_tasks.redis_backup.check_binlog_backup import _extract_binlog_index
 
     return _extract_binlog_index(*a, **kw)
+
+
+def _extract_binlog_timestamp(*a, **kw):
+    from backend.db_periodic_task.local_tasks.redis_backup.check_binlog_backup import _extract_binlog_timestamp
+
+    return _extract_binlog_timestamp(*a, **kw)
 
 
 def _find_missing_binlogs(*a, **kw):
@@ -262,6 +269,36 @@ def test_extract_binlog_index_invalid_type():
     with patch(_IS_PLUS, return_value=False), patch(_IS_SSD, return_value=False):
         with pytest.raises(ValueError, match="unsupported"):
             _extract_binlog_index("binlog-a-b-c-d.log", "UnknownType")
+
+
+# ---------------------------------------------------------------------------
+# _extract_binlog_timestamp
+# ---------------------------------------------------------------------------
+def test_extract_binlog_timestamp_tendisplus():
+    with patch(_IS_PLUS, return_value=True), patch(_IS_SSD, return_value=False):
+        ts = _extract_binlog_timestamp("binlog-1.2.3.4-30000-5-0022670-20251216171459.log.zst", "TendisPlus")
+        assert ts == _dt.datetime(2025, 12, 16, 17, 14, 59)
+
+
+def test_extract_binlog_timestamp_tendisssd():
+    with patch(_IS_PLUS, return_value=False), patch(_IS_SSD, return_value=True):
+        ts = _extract_binlog_timestamp("binlog-1.3.3.79-30009-0014018-20251216171048.log.zst", "TendisSSD")
+        assert ts == _dt.datetime(2025, 12, 16, 17, 10, 48)
+
+
+def test_extract_binlog_timestamp_unparseable_returns_none():
+    with patch(_IS_PLUS, return_value=False), patch(_IS_SSD, return_value=True):
+        assert _extract_binlog_timestamp("binlog-ip-30000-99-not_a_timestamp.log.zst", "TendisSSD") is None
+
+
+def test_extract_binlog_timestamp_too_few_parts_returns_none():
+    with patch(_IS_PLUS, return_value=False), patch(_IS_SSD, return_value=True):
+        assert _extract_binlog_timestamp("binlog-only.log.zst", "TendisSSD") is None
+
+
+def test_extract_binlog_timestamp_unsupported_type_returns_none():
+    with patch(_IS_PLUS, return_value=False), patch(_IS_SSD, return_value=False):
+        assert _extract_binlog_timestamp("binlog-a-b-c-20251216171048.log.zst", "Unknown") is None
 
 
 # ---------------------------------------------------------------------------

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/__init__.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/__init__.py
@@ -8,11 +8,3 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-# Importing ``signals`` triggers ``register_agent_check_failure_handlers()``
-# at module load time, which connects the WorkerLost / unhandled-error
-# observability handler to each agent-check celery task.
-from . import signals  # noqa: F401
-from .base import DEFAULT_LOOKBACK_DAYS, BaseCheckConfig, BaseRedisAgentCheckTask  # noqa: F401
-from .check_backend_data_skew import CheckBackendDataSkewTask  # noqa: F401
-from .check_backend_load_skew import CheckBackendLoadSkewTask  # noqa: F401
-from .check_cluster_capacity_growth import CheckClusterCapacityGrowthTask  # noqa: F401

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/conftest.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/conftest.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+# Shared fixtures for agent_checks unit tests.
+#
+# ``base`` is imported lazily behind ``django_db_blocker.unblock`` (mirroring
+# the pattern used by ``local_tasks/redis_tasks/conftest.py``) because
+# importing the module triggers periodic-task registration and DB access.
+import importlib
+from dataclasses import dataclass
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def base(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        return importlib.import_module("backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base")
+
+
+@pytest.fixture(scope="module")
+def signals(base, django_db_blocker):
+    # ``signals`` re-exports the failure handler and registers it with celery's
+    # task_failure signal. Loading it transitively imports the concrete check_*
+    # modules, so we keep the same lazy-under-django-db-blocker pattern used
+    # for ``base`` to avoid touching the real DB at collection time.
+    with django_db_blocker.unblock():
+        return importlib.import_module("backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.signals")
+
+
+@pytest.fixture
+def make_config(base):
+    """Factory for a lightweight stand-in of ``BaseCheckConfig``.
+
+    Real ``BaseCheckConfig`` works fine for most tests, but a ``SimpleNamespace``
+    is friendlier when a test wants to override a single field without
+    listing every default.
+    """
+
+    def _make(**overrides):
+        defaults = dict(
+            lookback_days=14,
+            ignore_cluster_domains=[],
+            rate_limit_cooldown_seconds=60,
+            max_rate_limit_retries=3,
+            agent_invoke_timeout_seconds=base.DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS,
+            agent_soft_time_limit_seconds=base.DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
+            agent_hard_time_limit_seconds=base.DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    return _make
+
+
+@pytest.fixture
+def make_cluster():
+    """Factory for a fake Cluster row suitable for ``_should_skip`` / ``execute_agent_check``."""
+
+    def _make(
+        *,
+        cluster_id: int = 1,
+        domain: str = "r.test.db",
+        phase: str = "online",
+        age_days: int = 30,
+    ):
+        from django.utils import timezone
+
+        return SimpleNamespace(
+            id=cluster_id,
+            immute_domain=domain,
+            phase=phase,
+            create_at=timezone.now() - timedelta(days=age_days),
+        )
+
+    return _make
+
+
+@pytest.fixture
+def celery_task_mock():
+    """Mock bound Celery task: carries ``name``/``request.retries`` and a fake ``retry()``."""
+    task = MagicMock()
+    task.name = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.fake_task"
+    task.request.retries = 0
+
+    class _Retry(Exception):
+        pass
+
+    task.retry.side_effect = _Retry("retry scheduled")
+    task._retry_exc = _Retry
+    return task
+
+
+@dataclass
+class _ClusterIds:
+    ids: list
+
+
+@pytest.fixture
+def fake_task_instance(base, make_config):
+    """Build a minimal ``BaseRedisAgentCheckTask`` subclass instance for ``start()`` tests."""
+    from backend.db_report.enums.redis_sub_type import RedisCheckSubType
+    from backend.dbm_aiagent.agent.constants import DBMAgentCode
+
+    def _make(**config_overrides):
+        class _FakeTask(base.BaseRedisAgentCheckTask):
+            subtype = RedisCheckSubType.ClusterCapacityGrowthRisk
+            agent_code = DBMAgentCode.REDIS_CLUSTER_CAPACITY_GROWTH_CHECK
+            prompt_template = "cluster={cluster_domain}"
+
+            def load_config(self):
+                return base.BaseCheckConfig(enabled=True, **config_overrides)
+
+            def get_celery_task(self):
+                return MagicMock(name="fake_celery_task")
+
+        return _FakeTask()
+
+    return _make

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_base.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_base.py
@@ -1,0 +1,378 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+# Unit tests for ``agent_checks.base`` (and the ``signals`` sibling module).
+#
+# Covers:
+#   * ``_truncate_agent_response_for_log``
+#   * ``BaseRedisAgentCheckTask._resolve_agent_timeouts``
+#   * ``signals.agent_check_task_failure_handler`` (Celery task_failure signal)
+#   * ``signals.register_agent_check_failure_handlers``
+#   * ``_should_skip``
+#   * ``execute_agent_check`` outcome branches
+#   * ``BaseRedisAgentCheckTask.start`` dispatch counters
+#
+# All tests are pure-unit: the Cluster / ClusterOperateRecord / AgentHandler /
+# cache / celery_task touchpoints are patched so no DB or broker is needed.
+from unittest.mock import MagicMock, patch
+
+import pytest
+from celery.exceptions import SoftTimeLimitExceeded
+
+
+# ---------------------------------------------------------------------------
+# _truncate_agent_response_for_log
+# ---------------------------------------------------------------------------
+class TestTruncateAgentResponseForLog:
+    @pytest.mark.parametrize("value", [None, 42, {"a": 1}, ["x"]])
+    def test_non_string_uses_repr(self, base, value):
+        assert base._truncate_agent_response_for_log(value) == repr(value)
+
+    def test_short_string_returned_as_repr(self, base):
+        assert base._truncate_agent_response_for_log("hello") == repr("hello")
+
+    def test_exact_max_chars_not_truncated(self, base):
+        s = "a" * base.AGENT_RESPONSE_LOG_MAX_CHARS
+        assert base._truncate_agent_response_for_log(s) == repr(s)
+
+    def test_long_string_truncated_with_total_len_marker(self, base):
+        s = "a" * (base.AGENT_RESPONSE_LOG_MAX_CHARS + 500)
+        out = base._truncate_agent_response_for_log(s)
+        assert "truncated" in out
+        assert f"total_len={len(s)}" in out
+
+
+# ---------------------------------------------------------------------------
+# _resolve_agent_timeouts
+# ---------------------------------------------------------------------------
+class TestResolveAgentTimeouts:
+    """Invariant validation only; config values must flow through unchanged."""
+
+    def _invoke(self, base, make_config, caplog, **overrides):
+        fake_self = MagicMock(config=make_config(**overrides))
+        caplog.set_level("WARNING")
+        result = base.BaseRedisAgentCheckTask._resolve_agent_timeouts(fake_self)
+        return result, caplog.text
+
+    def test_default_config_no_warning(self, base, make_config, caplog):
+        (invoke, soft, hard), log = self._invoke(base, make_config, caplog)
+        assert (invoke, soft, hard) == (
+            base.DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS,
+            base.DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
+            base.DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
+        )
+        assert "timeout config issues" not in log
+
+    def test_invariant_violation_warns(self, base, make_config, caplog):
+        _, log = self._invoke(
+            base,
+            make_config,
+            caplog,
+            agent_invoke_timeout_seconds=600,
+            agent_soft_time_limit_seconds=300,
+            agent_hard_time_limit_seconds=400,
+        )
+        assert "invoke<soft<hard violated" in log
+
+    def test_hard_exceeds_dispatch_interval_warns(self, base, make_config, caplog):
+        _, log = self._invoke(
+            base,
+            make_config,
+            caplog,
+            agent_hard_time_limit_seconds=base.DISPATCH_INTERVAL_SECONDS + 1,
+        )
+        assert "exceeds" in log and "DISPATCH_INTERVAL_SECONDS" in log
+
+    def test_non_positive_values_coerced_to_one(self, base, make_config, caplog):
+        result, _ = self._invoke(
+            base,
+            make_config,
+            caplog,
+            agent_invoke_timeout_seconds=0,
+            agent_soft_time_limit_seconds=-10,
+            agent_hard_time_limit_seconds=-1,
+        )
+        assert result == (1, 1, 1)
+
+    def test_valid_config_returned_unchanged(self, base, make_config, caplog):
+        result, _ = self._invoke(
+            base,
+            make_config,
+            caplog,
+            agent_invoke_timeout_seconds=100,
+            agent_soft_time_limit_seconds=200,
+            agent_hard_time_limit_seconds=300,
+        )
+        assert result == (100, 200, 300)
+
+
+# ---------------------------------------------------------------------------
+# signals.agent_check_task_failure_handler
+# ---------------------------------------------------------------------------
+class TestAgentCheckTaskFailureHandler:
+    """Filtering by sender is delegated to celery's signal framework now,
+    so the handler itself only needs to classify exceptions and emit a log
+    line. The previous prefix-matching / sender-None branches no longer exist.
+    """
+
+    @staticmethod
+    def _sender():
+        s = MagicMock()
+        s.name = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.fake_task"
+        return s
+
+    @staticmethod
+    def _fire(signals, **kwargs):
+        signals.agent_check_task_failure_handler(task_id="tid", **kwargs)
+
+    def test_worker_lost_tagged_timeout_hard(self, base, signals, caplog):
+        from billiard.exceptions import WorkerLostError
+
+        caplog.set_level("ERROR")
+        self._fire(signals, sender=self._sender(), exception=WorkerLostError("killed"))
+        assert f"outcome={base.OUTCOME_TIMEOUT_HARD}" in caplog.text
+
+    def test_generic_exception_tagged_error(self, base, signals, caplog):
+        caplog.set_level("ERROR")
+        self._fire(signals, sender=self._sender(), exception=RuntimeError("boom"))
+        assert f"outcome={base.OUTCOME_ERROR}" in caplog.text
+
+    def test_no_exception_still_logs_without_crash(self, signals, caplog):
+        caplog.set_level("ERROR")
+        self._fire(signals, sender=self._sender(), exception=None)
+        assert "exc_type=None" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# signals.register_agent_check_failure_handlers
+# ---------------------------------------------------------------------------
+class TestRegisterAgentCheckFailureHandlers:
+    def test_connects_handler_to_each_agent_check_task(self, signals):
+        with patch.object(signals.task_failure, "connect") as mock_connect:
+            signals.register_agent_check_failure_handlers()
+
+        assert mock_connect.call_count == 3
+        for call in mock_connect.call_args_list:
+            assert call.args[0] is signals.agent_check_task_failure_handler
+            assert call.kwargs["sender"] is not None
+            assert call.kwargs["dispatch_uid"].startswith("agent_check_task_failure:")
+
+        sender_names = {call.kwargs["sender"].name for call in mock_connect.call_args_list}
+        assert len(sender_names) == 3  # three distinct celery task senders
+
+    def test_dispatch_uid_keeps_registration_idempotent(self, signals):
+        # Two consecutive registrations must produce the same dispatch_uid set
+        # so celery dedupes the receiver instead of double-firing.
+        with patch.object(signals.task_failure, "connect") as mock_connect:
+            signals.register_agent_check_failure_handlers()
+            uids_first = [c.kwargs["dispatch_uid"] for c in mock_connect.call_args_list]
+
+        with patch.object(signals.task_failure, "connect") as mock_connect:
+            signals.register_agent_check_failure_handlers()
+            uids_second = [c.kwargs["dispatch_uid"] for c in mock_connect.call_args_list]
+
+        assert uids_first == uids_second
+
+
+# ---------------------------------------------------------------------------
+# _should_skip
+# ---------------------------------------------------------------------------
+class TestShouldSkip:
+    _ORM = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.ClusterOperateRecord"
+
+    @pytest.fixture
+    def no_recent_tickets(self):
+        with patch(self._ORM) as mod:
+            mod.objects.filter.return_value.filter.return_value.exists.return_value = False
+            yield
+
+    def test_young_cluster(self, base, make_config, make_cluster):
+        skipped, reason = base._should_skip(make_config(lookback_days=30), make_cluster(age_days=3))
+        assert skipped and "younger" in reason
+
+    def test_offline_cluster(self, base, make_config, make_cluster, no_recent_tickets):
+        skipped, reason = base._should_skip(make_config(), make_cluster(phase="offline"))
+        assert skipped and "not online" in reason
+
+    def test_in_ignore_list(self, base, make_config, make_cluster, no_recent_tickets):
+        skipped, reason = base._should_skip(
+            make_config(ignore_cluster_domains=["r.test.db"]),
+            make_cluster(domain="r.test.db"),
+        )
+        assert skipped and "ignore list" in reason
+
+    def test_busy_with_recent_or_active_ticket(self, base, make_config, make_cluster):
+        with patch(self._ORM) as mod:
+            mod.objects.filter.return_value.filter.return_value.exists.return_value = True
+            skipped, reason = base._should_skip(make_config(), make_cluster())
+        assert skipped and "recent or active" in reason
+
+    def test_normal_cluster_not_skipped(self, base, make_config, make_cluster, no_recent_tickets):
+        skipped, reason = base._should_skip(make_config(), make_cluster())
+        assert (skipped, reason) == (False, "")
+
+
+# ---------------------------------------------------------------------------
+# execute_agent_check outcome branches
+# ---------------------------------------------------------------------------
+class TestExecuteAgentCheck:
+    _CLUSTER = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.Cluster"
+    _HANDLER = "backend.dbm_aiagent.agent.handlers.AgentHandler"
+
+    @pytest.fixture
+    def invoke(self, base, make_config, make_cluster):
+        """Tiny DSL: ``invoke(...)`` runs ``execute_agent_check`` with all external
+        collaborators (Cluster ORM, AgentHandler, _should_skip) patched.
+        """
+
+        def _call(
+            *,
+            cluster="default",
+            should_skip=(False, ""),
+            agent_return="normal report",
+            agent_side_effect=None,
+            config=None,
+            celery_task=None,
+            caplog=None,
+        ):
+            resolved_cluster = make_cluster() if cluster == "default" else cluster
+            if config is None:
+                config = make_config()
+            with patch(self._CLUSTER) as cluster_cls, patch(self._HANDLER) as handler_cls, patch.object(
+                base, "_should_skip", return_value=should_skip
+            ):
+                cluster_cls.objects.filter.return_value.first.return_value = resolved_cluster
+                if agent_side_effect is not None:
+                    handler_cls.ask_agent_with_content.side_effect = agent_side_effect
+                else:
+                    handler_cls.ask_agent_with_content.return_value = agent_return
+                if caplog is not None:
+                    caplog.set_level("DEBUG")
+                base.execute_agent_check(
+                    agent_code="ai-x",
+                    prompt_template="cluster={cluster_domain}",
+                    config=config,
+                    cluster_id=getattr(resolved_cluster, "id", 0) or 0,
+                    celery_task=celery_task,
+                )
+
+        return _call
+
+    def test_success(self, base, invoke, caplog):
+        invoke(agent_return="normal report", caplog=caplog)
+        assert f"outcome={base.OUTCOME_SUCCESS}" in caplog.text
+        assert "normal report" in caplog.text
+
+    def test_cluster_not_found(self, base, invoke, caplog):
+        invoke(cluster=None, caplog=caplog)
+        assert f"outcome={base.OUTCOME_SKIPPED}" in caplog.text
+        assert "cluster not found" in caplog.text
+
+    def test_skipped_carries_reason(self, base, invoke, caplog):
+        invoke(should_skip=(True, "cluster younger than 14 days"), caplog=caplog)
+        assert f"outcome={base.OUTCOME_SKIPPED}" in caplog.text
+        assert "younger" in caplog.text
+
+    def test_soft_timeout(self, base, invoke, caplog):
+        invoke(agent_side_effect=SoftTimeLimitExceeded("stl"), caplog=caplog)
+        assert f"outcome={base.OUTCOME_TIMEOUT_SOFT}" in caplog.text
+
+    def test_rate_limit_retry_reschedules(self, base, invoke, make_config, celery_task_mock, caplog):
+        celery_task_mock.request.retries = 0
+        with pytest.raises(celery_task_mock._retry_exc):
+            invoke(
+                agent_side_effect=Exception("HTTP 429 too many requests"),
+                config=make_config(max_rate_limit_retries=3),
+                celery_task=celery_task_mock,
+                caplog=caplog,
+            )
+        celery_task_mock.retry.assert_called_once()
+        assert f"outcome={base.OUTCOME_RATELIMIT_RETRY}" in caplog.text
+
+    def test_rate_limit_gave_up_after_max_retries(self, base, invoke, make_config, celery_task_mock, caplog):
+        celery_task_mock.request.retries = 3
+        invoke(
+            agent_side_effect=Exception("429 rate limit"),
+            config=make_config(max_rate_limit_retries=3),
+            celery_task=celery_task_mock,
+            caplog=caplog,
+        )
+        celery_task_mock.retry.assert_not_called()
+        assert f"outcome={base.OUTCOME_RATELIMIT_GAVE_UP}" in caplog.text
+        assert f"outcome={base.OUTCOME_ERROR}" not in caplog.text  # not double-logged
+
+    def test_generic_error(self, base, invoke, caplog):
+        invoke(agent_side_effect=RuntimeError("boom"), caplog=caplog)
+        assert f"outcome={base.OUTCOME_ERROR}" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# BaseRedisAgentCheckTask.start
+# ---------------------------------------------------------------------------
+class TestStartDispatch:
+    _CACHE = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.cache"
+
+    def _prepare(self, fake_task_instance, *, cluster_ids=(1, 2, 3), apply_async=None, **config_overrides):
+        task = fake_task_instance(**config_overrides)
+        task.get_clusters_to_check = lambda: list(cluster_ids)
+        celery_task = MagicMock()
+        if apply_async is not None:
+            celery_task.apply_async.side_effect = apply_async
+        task.get_celery_task = lambda: celery_task
+        return task, celery_task
+
+    def test_disabled_returns_zero(self, fake_task_instance):
+        task = fake_task_instance()
+        task.config.enabled = False
+        assert task.start() == 0
+
+    def test_no_candidates_returns_zero(self, fake_task_instance):
+        task = fake_task_instance()
+        task.get_clusters_to_check = lambda: []
+        assert task.start() == 0
+
+    def test_all_dispatched_ok(self, fake_task_instance, caplog):
+        task, celery_task = self._prepare(fake_task_instance, cluster_ids=[10, 11])
+        caplog.set_level("INFO")
+        assert task.start() == 2
+        assert celery_task.apply_async.call_count == 2
+        assert "ok=2 failed=0" in caplog.text
+
+    def test_apply_async_kwargs_include_time_limits(self, base, fake_task_instance):
+        task, celery_task = self._prepare(fake_task_instance, cluster_ids=[1])
+        task.start()
+        _args, kwargs = celery_task.apply_async.call_args
+        assert kwargs["soft_time_limit"] == base.DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS
+        assert kwargs["time_limit"] == base.DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS
+        assert kwargs["expires"] == base.DISPATCH_INTERVAL_SECONDS
+
+    def test_dispatch_failure_counted_separately(self, base, fake_task_instance, caplog):
+        calls = {"n": 0}
+
+        def flaky(*_a, **_kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("broker down")
+
+        task, celery_task = self._prepare(fake_task_instance, cluster_ids=[1, 2], apply_async=flaky)
+        caplog.set_level("INFO")
+        assert task.start() == 1
+        assert "ok=1 failed=1" in caplog.text
+        assert f"outcome={base.OUTCOME_DISPATCH_FAILED}" in caplog.text
+
+    def test_dedupe_lock_skips_dispatch(self, base, fake_task_instance, caplog):
+        task, celery_task = self._prepare(fake_task_instance, cluster_ids=[1, 2], enable_inflight_dedupe=True)
+        with patch(self._CACHE) as cache_mod:
+            cache_mod.add.side_effect = [True, False]  # second cluster already in-flight
+            caplog.set_level("DEBUG")
+            assert task.start() == 1
+        assert celery_task.apply_async.call_count == 1
+        assert "dedupe_skipped=1" in caplog.text
+        assert f"outcome={base.OUTCOME_DISPATCH_DEDUP_SKIPPED}" in caplog.text


### PR DESCRIPTION
- agent check 通过新增 `signals.py` + 周期任务入口的 in-flight 互斥，避免上一轮未结束时被 celery 再次触发，消除请求堆积的可能
- 三个 agent check（`backend_data_skew` / `backend_load_skew` / `cluster_capacity_growth`）和基类同步接入新的频控保护
- binlog 检查保留 1h buffer，但 gap 分析仅作用于"内容时间属于昨天"的 entry：修掉昨天尾部 seq 因上传延迟落到 buffer 外被误报成 missing 的 day-boundary 误判
- 补齐 agent check 基类（`tests/.../agent_checks/`）与 binlog 边界判定（`_extract_binlog_timestamp` + `_check_instance` filter）的单测