### PR TITLE
feat(redis): add dispatch-time extra_skip_check hook for agent checks #17336

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/base.py
@@ -382,6 +382,8 @@ class BaseRedisAgentCheckTask(ABC):
       1. Create a thin subclass declaring `subtype`, `agent_code`, `prompt_template`, and `load_config()`.
       2. Define a bound Celery task that calls ``execute_agent_check()`` with explicit params.
       3. Register a periodic task in task.py.
+      4. Optionally override ``extra_skip_check()`` to express check-specific
+         dispatch-time skip rules (e.g. dbconfig-driven policy checks).
     """
 
     # Subclasses must declare these:
@@ -399,6 +401,34 @@ class BaseRedisAgentCheckTask(ABC):
     @abstractmethod
     def get_celery_task(self) -> Callable:
         """Return the bound Celery task function used to dispatch per-cluster work."""
+
+    def extra_skip_check(self, cluster: Cluster) -> tuple[bool, str]:
+        """Subclass-specific dispatch-time skip rule. Default: never skip.
+
+        Override on a subclass to express skip rules that the generic
+        ``_should_skip`` cannot capture (e.g. configuration-driven skips
+        that need a dbconfig lookup, like Redis ``maxmemory-policy``).
+
+        The hook runs inside ``get_clusters_to_check`` after the busy-
+        ticket filter and *before* Celery dispatch, so a skip here frees
+        the worker slot for another candidate instead of paying the
+        round-trip cost of a noop task.
+
+        Must fail open: ``get_clusters_to_check`` catches any exception
+        raised here and treats the cluster as eligible. Otherwise a
+        misbehaving rule could silently suppress an entire check across
+        the fleet.
+        """
+        return False, ""
+
+    def _has_extra_skip_check(self) -> bool:
+        """True iff a subclass actually overrides ``extra_skip_check``.
+
+        Used by ``get_clusters_to_check`` to skip the per-page Cluster
+        fetch when no subclass cares, keeping the default-path query
+        cost identical to before this hook existed.
+        """
+        return type(self).extra_skip_check is not BaseRedisAgentCheckTask.extra_skip_check
 
     def _resolve_agent_timeouts(self) -> tuple[int, int, int]:
         """Return (invoke_timeout, soft_time_limit, hard_time_limit) from config.
@@ -736,6 +766,9 @@ class BaseRedisAgentCheckTask(ABC):
         result = []
         scanned = 0
         busy_hits = 0
+        extra_skip_hits = 0
+        task_name = type(self).__name__
+        has_extra_skip = self._has_extra_skip_check()
         early_stop_reason = "exhausted_candidates"
 
         for idx in range(0, len(candidate_ids), page_size):
@@ -755,8 +788,18 @@ class BaseRedisAgentCheckTask(ABC):
             )
             busy_hits += len(page_busy_ids)
 
+            page_extra_skipped_ids = self._apply_extra_skip_check(
+                task_name=task_name,
+                page_ids=page_ids,
+                page_busy_ids=page_busy_ids,
+                has_extra_skip=has_extra_skip,
+            )
+            extra_skip_hits += len(page_extra_skipped_ids)
+
             for cluster_id in page_ids:
                 if cluster_id in page_busy_ids:
+                    continue
+                if cluster_id in page_extra_skipped_ids:
                     continue
                 result.append(cluster_id)
                 if len(result) >= batch_size:
@@ -764,14 +807,15 @@ class BaseRedisAgentCheckTask(ABC):
                     break
 
         logger.info(
-            "%s: selected=%d requested=%d scanned=%d busy_hits=%d "
+            "%s: selected=%d requested=%d scanned=%d busy_hits=%d extra_skip_hits=%d "
             "priority_hits=%d priority_consumed=%d "
             "priority_dropped=%d priority_dropped_domains=%s strategy=%s stop=%s",
-            type(self).__name__,
+            task_name,
             len(result),
             batch_size,
             scanned,
             busy_hits,
+            extra_skip_hits,
             len(priority_ids),
             len(consumed_domains),
             len(dropped_domains),
@@ -780,6 +824,61 @@ class BaseRedisAgentCheckTask(ABC):
             early_stop_reason,
         )
         return result
+
+    def _apply_extra_skip_check(
+        self,
+        *,
+        task_name: str,
+        page_ids: list,
+        page_busy_ids: set,
+        has_extra_skip: bool,
+    ) -> set:
+        """Run the subclass ``extra_skip_check`` on the non-busy IDs of a page.
+
+        Returns the subset of ``page_ids`` that the subclass asked to skip.
+        Cleanly short-circuits to an empty set when no subclass overrides
+        the hook so the default path is identical to pre-hook behavior.
+
+        Per-cluster failures are logged at WARNING and treated as "do not
+        skip" (fail open) so a transient dbconfig hiccup never converts
+        into a fleet-wide skip.
+        """
+        if not has_extra_skip:
+            return set()
+
+        keep_ids = [cid for cid in page_ids if cid not in page_busy_ids]
+        if not keep_ids:
+            return set()
+
+        clusters_by_id = {c.id: c for c in Cluster.objects.filter(id__in=keep_ids)}
+        skipped_ids: set = set()
+        for cluster_id in keep_ids:
+            cluster = clusters_by_id.get(cluster_id)
+            if cluster is None:
+                # Cluster vanished between the candidate scan and now;
+                # let the worker-side ``cluster not found`` branch handle
+                # logging consistently.
+                continue
+            try:
+                skipped, reason = self.extra_skip_check(cluster)
+            except Exception as exc:
+                logger.warning(
+                    "%s: cluster_id=%s extra_skip_check raised, dispatching anyway: %s",
+                    task_name,
+                    cluster_id,
+                    exc,
+                )
+                continue
+            if skipped:
+                skipped_ids.add(cluster_id)
+                logger.info(
+                    "%s: cluster_id=%s outcome=%s reason=%s",
+                    task_name,
+                    cluster_id,
+                    OUTCOME_SKIPPED,
+                    reason,
+                )
+        return skipped_ids
 
     def start(self) -> int:
         """Dispatch a batch of clusters for LLM analysis. Returns the number dispatched."""

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_cluster_capacity_growth.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_cluster_capacity_growth.py
@@ -14,7 +14,10 @@ from typing import Callable, ClassVar
 
 from blueapps.core.celery.celery import app
 
+from backend.components import DBConfigApi
+from backend.components.dbconfig.constants import FormatType, LevelName
 from backend.configuration.constants import SystemSettingsEnum
+from backend.db_meta.models import Cluster
 from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base import (
     DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
     DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
@@ -24,8 +27,40 @@ from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base import (
 )
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.dbm_aiagent.agent.constants import DBMAgentCode
+from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
 
 logger = logging.getLogger("root")
+
+# Capacity-growth analysis is only meaningful when the cluster cannot evict
+# data on its own. Any non-noeviction policy means Redis silently drops keys
+# under memory pressure, so a "growing" working set is expected behavior and
+# the LLM has nothing actionable to say. The dbconfig default is "noeviction"
+# (see components/dbconfig/migrations/.../dbconf/Redis-*.json), so a missing
+# value -- or any lookup failure -- conservatively keeps the cluster in scope.
+MAXMEMORY_POLICY_CONF_NAME = "maxmemory-policy"
+MAXMEMORY_POLICY_NOEVICTION = "noeviction"
+
+
+def _query_maxmemory_policy(cluster: Cluster) -> str:
+    """Return the cluster's effective ``maxmemory-policy`` from dbconfig.
+
+    Empty string signals "unknown" to the caller (lookup returned nothing
+    or the key is absent); the caller treats unknown as "do not skip".
+    """
+    data = DBConfigApi.query_conf_item(
+        params={
+            "bk_biz_id": str(cluster.bk_biz_id),
+            "level_name": LevelName.CLUSTER,
+            "level_value": cluster.immute_domain,
+            "level_info": {"module": str(DEFAULT_DB_MODULE_ID)},
+            "conf_file": cluster.major_version,
+            "conf_type": ConfigTypeEnum.DBConf,
+            "namespace": cluster.cluster_type,
+            "format": FormatType.MAP,
+        }
+    )
+    content = (data or {}).get("content") or {}
+    return str(content.get(MAXMEMORY_POLICY_CONF_NAME, "")).strip().lower()
 
 
 @dataclass
@@ -45,6 +80,21 @@ class CheckClusterCapacityGrowthTask(BaseRedisAgentCheckTask):
 
     def get_celery_task(self) -> Callable:
         return check_cluster_capacity_growth_task
+
+    def extra_skip_check(self, cluster: Cluster) -> tuple[bool, str]:
+        """Skip clusters whose maxmemory-policy enables eviction.
+
+        Capacity-growth signal is meaningless when Redis evicts keys
+        under pressure, so dispatching the LLM call would only burn
+        quota. ``get_clusters_to_check`` runs this at dispatch time and
+        catches any exception, so we don't need to add another safety
+        layer here -- but unknown / absent policies fall through to "do
+        not skip" because the dbconfig default is ``noeviction``.
+        """
+        policy = _query_maxmemory_policy(cluster)
+        if not policy or policy == MAXMEMORY_POLICY_NOEVICTION:
+            return False, ""
+        return True, f"maxmemory-policy={policy} enables eviction"
 
 
 # soft/hard limits below are a safety floor for direct invocations;

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_base.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_base.py
@@ -21,6 +21,7 @@ specific language governing permissions and limitations under the License.
 #
 # All tests are pure-unit: the Cluster / ClusterOperateRecord / AgentHandler /
 # cache / celery_task touchpoints are patched so no DB or broker is needed.
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -311,6 +312,132 @@ class TestExecuteAgentCheck:
     def test_generic_error(self, base, invoke, caplog):
         invoke(agent_side_effect=RuntimeError("boom"), caplog=caplog)
         assert f"outcome={base.OUTCOME_ERROR}" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# BaseRedisAgentCheckTask.extra_skip_check + _apply_extra_skip_check
+# ---------------------------------------------------------------------------
+class TestApplyExtraSkipCheck:
+    """Dispatch-time per-page filtering driven by ``extra_skip_check``."""
+
+    _CLUSTER = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.Cluster"
+
+    def _make_task_with_override(self, base, hook):
+        """Return a task whose ``extra_skip_check`` is the supplied hook.
+
+        Bypasses ``__init__`` so we don't need a populated config; the
+        helpers under test only need ``self.extra_skip_check``.
+        """
+        from backend.db_report.enums.redis_sub_type import RedisCheckSubType
+        from backend.dbm_aiagent.agent.constants import DBMAgentCode
+
+        class _Task(base.BaseRedisAgentCheckTask):
+            subtype = RedisCheckSubType.ClusterCapacityGrowthRisk
+            agent_code = DBMAgentCode.REDIS_CLUSTER_CAPACITY_GROWTH_CHECK
+            prompt_template = "x"
+
+            def load_config(self):
+                return base.BaseCheckConfig()
+
+            def get_celery_task(self):
+                return MagicMock()
+
+            extra_skip_check = hook
+
+        return _Task.__new__(_Task)
+
+    def test_default_hook_returns_no_skip(self, base, fake_task_instance):
+        # The base no-op must short-circuit so default-path callers don't
+        # accidentally pay for the cluster fetch.
+        task = fake_task_instance()
+        assert task._has_extra_skip_check() is False
+        assert task.extra_skip_check(MagicMock()) == (False, "")
+
+    def test_no_override_short_circuits(self, base, fake_task_instance):
+        # When the subclass doesn't override, we must not even hit the ORM.
+        task = fake_task_instance()
+        with patch(self._CLUSTER) as cluster_cls:
+            result = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1, 2, 3],
+                page_busy_ids=set(),
+                has_extra_skip=False,
+            )
+        assert result == set()
+        cluster_cls.objects.filter.assert_not_called()
+
+    def test_override_filters_eligible_ids(self, base, caplog):
+        # Page has 4 ids; one is busy (skipped before us), two should be
+        # filtered by the hook, one survives.
+        task = self._make_task_with_override(
+            base,
+            lambda self, cluster: (cluster.id in {2, 3}, f"policy-skip-{cluster.id}"),
+        )
+        clusters = [SimpleNamespace(id=i) for i in (1, 2, 3)]  # busy=4 already excluded
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = clusters
+            caplog.set_level("INFO")
+            skipped = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1, 2, 3, 4],
+                page_busy_ids={4},
+                has_extra_skip=True,
+            )
+        assert skipped == {2, 3}
+        assert "policy-skip-2" in caplog.text
+        assert "policy-skip-3" in caplog.text
+
+    def test_override_only_fetches_non_busy_ids(self, base):
+        # Avoid wasting a Cluster.objects.filter on rows we already know
+        # we'll skip via the busy filter.
+        task = self._make_task_with_override(base, lambda self, cluster: (False, ""))
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = []
+            task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1, 2, 3, 4],
+                page_busy_ids={2, 4},
+                has_extra_skip=True,
+            )
+        passed_ids = list(cluster_cls.objects.filter.call_args.kwargs["id__in"])
+        assert sorted(passed_ids) == [1, 3]
+
+    def test_override_exception_fails_open(self, base, caplog):
+        # Hook misbehavior must never silently suppress the entire fleet --
+        # exceptions are logged and the cluster proceeds to dispatch.
+        def boom(self, _cluster):
+            raise RuntimeError("dbconfig 500")
+
+        task = self._make_task_with_override(base, boom)
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+            caplog.set_level("WARNING")
+            skipped = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1, 2],
+                page_busy_ids=set(),
+                has_extra_skip=True,
+            )
+        assert skipped == set()
+        assert "extra_skip_check raised" in caplog.text
+
+    def test_vanished_cluster_is_silently_passed_through(self, base):
+        # Cluster row gone between candidate scan and skip-check fetch:
+        # don't skip here -- let the worker's "cluster not found" branch
+        # log it consistently.
+        task = self._make_task_with_override(
+            base,
+            lambda self, cluster: (True, "should-not-fire"),  # would skip if called
+        )
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = []  # nothing returned for [1, 2]
+            skipped = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1, 2],
+                page_busy_ids=set(),
+                has_extra_skip=True,
+            )
+        assert skipped == set()
 
 
 # ---------------------------------------------------------------------------

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_check_cluster_capacity_growth.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_check_cluster_capacity_growth.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+# Unit tests for the capacity-growth check's eviction-policy skip strategy.
+#
+# Covers:
+#   * ``_query_maxmemory_policy`` parsing of dbconfig responses
+#   * ``CheckClusterCapacityGrowthTask.extra_skip_check`` skip / proceed decisions
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def cap_growth(django_db_setup, django_db_blocker):
+    """Lazy import mirroring conftest's pattern for ``base``.
+
+    Importing the module triggers periodic-task registration so we keep it
+    behind ``django_db_blocker.unblock`` to avoid touching the real DB.
+    """
+    with django_db_blocker.unblock():
+        return importlib.import_module(
+            "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.check_cluster_capacity_growth"
+        )
+
+
+@pytest.fixture
+def fake_cluster():
+    return SimpleNamespace(
+        id=42,
+        bk_biz_id=1001,
+        immute_domain="cache.test.db",
+        major_version="Redis-6",
+        cluster_type="TwemproxyRedisInstance",
+    )
+
+
+@pytest.fixture
+def task(cap_growth):
+    """Build the task without invoking ``__init__`` (which would touch SystemSettings)."""
+    return cap_growth.CheckClusterCapacityGrowthTask.__new__(cap_growth.CheckClusterCapacityGrowthTask)
+
+
+# ---------------------------------------------------------------------------
+# _query_maxmemory_policy
+# ---------------------------------------------------------------------------
+class TestQueryMaxmemoryPolicy:
+    _API = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks." "check_cluster_capacity_growth.DBConfigApi"
+
+    def test_returns_lowercased_value(self, cap_growth, fake_cluster):
+        with patch(self._API) as api:
+            api.query_conf_item.return_value = {"content": {"maxmemory-policy": "AllKeys-LRU"}}
+            assert cap_growth._query_maxmemory_policy(fake_cluster) == "allkeys-lru"
+
+    def test_missing_key_returns_empty_string(self, cap_growth, fake_cluster):
+        with patch(self._API) as api:
+            api.query_conf_item.return_value = {"content": {"maxmemory": "0"}}
+            assert cap_growth._query_maxmemory_policy(fake_cluster) == ""
+
+    def test_none_payload_returns_empty_string(self, cap_growth, fake_cluster):
+        with patch(self._API) as api:
+            api.query_conf_item.return_value = None
+            assert cap_growth._query_maxmemory_policy(fake_cluster) == ""
+
+    def test_passes_cluster_metadata_to_api(self, cap_growth, fake_cluster):
+        with patch(self._API) as api:
+            api.query_conf_item.return_value = {"content": {"maxmemory-policy": "noeviction"}}
+            cap_growth._query_maxmemory_policy(fake_cluster)
+        params = api.query_conf_item.call_args.kwargs["params"]
+        assert params["bk_biz_id"] == "1001"
+        assert params["level_value"] == "cache.test.db"
+        assert params["conf_file"] == "Redis-6"
+        assert params["namespace"] == "TwemproxyRedisInstance"
+
+
+# ---------------------------------------------------------------------------
+# CheckClusterCapacityGrowthTask.extra_skip_check
+# ---------------------------------------------------------------------------
+class TestExtraSkipCheckOverride:
+    @staticmethod
+    def _patch_policy(cap_growth, value):
+        return patch.object(cap_growth, "_query_maxmemory_policy", return_value=value)
+
+    def test_overrides_base_no_op(self, cap_growth, task):
+        # The override must actually replace the base no-op so the
+        # dispatcher's ``_has_extra_skip_check`` short-circuit does the
+        # right thing.
+        from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks import base
+
+        assert task._has_extra_skip_check() is True
+        assert (
+            cap_growth.CheckClusterCapacityGrowthTask.extra_skip_check
+            is not base.BaseRedisAgentCheckTask.extra_skip_check
+        )
+
+    def test_noeviction_does_not_skip(self, cap_growth, task, fake_cluster):
+        with self._patch_policy(cap_growth, "noeviction"):
+            assert task.extra_skip_check(fake_cluster) == (False, "")
+
+    def test_unknown_policy_does_not_skip(self, cap_growth, task, fake_cluster):
+        # Empty result means dbconfig didn't return the key; default is noeviction
+        # (see Redis dbconf migration), so we must not skip.
+        with self._patch_policy(cap_growth, ""):
+            assert task.extra_skip_check(fake_cluster) == (False, "")
+
+    @pytest.mark.parametrize(
+        "policy",
+        ["allkeys-lru", "allkeys-lfu", "volatile-lru", "volatile-lfu", "allkeys-random", "volatile-ttl"],
+    )
+    def test_eviction_policy_skips(self, cap_growth, task, fake_cluster, policy):
+        with self._patch_policy(cap_growth, policy):
+            skipped, reason = task.extra_skip_check(fake_cluster)
+        assert skipped is True
+        assert policy in reason
+        assert "eviction" in reason


### PR DESCRIPTION
- `BaseRedisAgentCheckTask` 新增可重写的 `extra_skip_check(cluster)` 钩子
- `ClusterCapacityCheckTask` 跳过配置了 `maxmemory-eviction-policy` 的集群