### PR TITLE
fix(kafka): 修复kafka bk_pull采集url

### DIFF
--- a/dbm-ui/backend/db_monitor/tpls/alarm/kafka/Kafka 主机活跃网络连接数.json
+++ b/dbm-ui/backend/db_monitor/tpls/alarm/kafka/Kafka 主机活跃网络连接数.json
@@ -267,11 +267,11 @@
     "edit_allowed": true,
     "metric_type": "time_series",
     "data_source_type": "监控采集指标",
-    "is_enabled": true
+    "is_enabled": false
   },
-  "is_enabled": true,
+  "is_enabled": false,
   "monitor_indicator": "Kafka 主机活跃网络连接数",
-  "version": 2,
+  "version": 3,
   "alert_source": "time_series",
   "custom_conditions": [],
   "export_at": "2024-12-13T15:07:45+08:00"

--- a/dbm-ui/backend/db_monitor/tpls/collect/dbm_kafka_bkpull.json
+++ b/dbm-ui/backend/db_monitor/tpls/collect/dbm_kafka_bkpull.json
@@ -31,7 +31,7 @@
         "period": 60,
         "password": false,
         "bk_username": "",
-        "metrics_url": "http://localhost:7071"
+        "metrics_url": "http://localhost:7071/metrics"
       },
       "target_node_type": "TOPO",
       "target_object_type": "SERVICE"
@@ -39,7 +39,7 @@
     "plugin_id": "dbm_kafka_bkpull"
   },
   "db_type": "kafka",
-  "version": 18,
+  "version": 19,
   "machine_types": [],
   "plugin_id": "dbm_kafka_bkpull"
 }


### PR DESCRIPTION
1. 修复kafka bk_pull采集url
2. kafka的告警策略 网络连接数 改为默认禁用