### PR TITLE
feat(mysql): disable-dbha-autofix-by-app #17403

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_grant.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_grant.go
@@ -37,21 +37,20 @@ func VerifyGrantPrivFile(conn *sqlx.Conn, filePath string, dstVer int64) error {
 		actual, queryErr := queryShowGrants(ctx, conn, user, host)
 		if queryErr != nil {
 			logger.Error("SHOW GRANTS FOR %s: %v", userHost, queryErr)
-			mismatches = append(mismatches, fmt.Sprintf("%s: SHOW GRANTS failed: %v", userHost, queryErr))
-			continue
+			return fmt.Errorf("query error: SHOW GRANTS FOR %s: %w", userHost, queryErr)
 		}
 
 		for scope, exp := range scopeMap {
 			if _, isAll := exp.privs["ALL PRIVILEGES"]; isAll && scope == "*.*" && dstVer >= 8000000 {
 				if missing, verifyErr := verifyAllStaticPrivs(ctx, conn, user, host); verifyErr != nil {
-					mismatches = append(mismatches, fmt.Sprintf("%s: verify ALL static privs failed: %v", userHost, verifyErr))
+					return fmt.Errorf("query error: verify ALL static privs for %s: %w", userHost, verifyErr)
 				} else if len(missing) > 0 {
 					mismatches = append(mismatches, fmt.Sprintf("%s: scope *.* static privs not 'Y': %v", userHost, missing))
 				}
 
 				if exp.grantOption {
 					if grantPriv, verifyErr := queryGrantPriv(ctx, conn, user, host); verifyErr != nil {
-						mismatches = append(mismatches, fmt.Sprintf("%s: query Grant_priv failed: %v", userHost, verifyErr))
+						return fmt.Errorf("query error: query Grant_priv for %s: %w", userHost, verifyErr)
 					} else if grantPriv != "Y" {
 						mismatches = append(mismatches, fmt.Sprintf("%s: scope *.* missing GRANT OPTION", userHost))
 					}

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_user.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/clone_grants_from_file/internal/checker/verify_user.go
@@ -31,8 +31,7 @@ func VerifyCreateUserFile(conn *sqlx.Conn, filePath string, dstVer int64) error 
 		exists, pwMatch, rlMatch, checkErr := CheckAccountOnTarget(ctx, conn, line, dstVer)
 		if checkErr != nil {
 			logger.Error("verify line %d: %v", ls.LineNo(), checkErr)
-			mismatches = append(mismatches, fmt.Sprintf("line %d: check error: %v", ls.LineNo(), checkErr))
-			continue
+			return fmt.Errorf("query error at line %d: %w", ls.LineNo(), checkErr)
 		}
 
 		if !exists {

--- a/dbm-ui/backend/configuration/constants.py
+++ b/dbm-ui/backend/configuration/constants.py
@@ -203,6 +203,13 @@ class SystemSettingsEnum(StrStructuredEnum):
     DBM_DAILY_TODO_REMIND = EnumField("DBM_DAILY_TODO_REMIND", _("每日代办提醒配置"))
     # 代办类型和用户映射信息
     DBM_USER_TODO_TYPE_MAP = EnumField("DBM_USER_TODO_TYPE_MAP", _("代办类型和用户映射信息"))
+    DISABLE_DBHA_AUTOFIX_APPS = EnumField("DISABLE_DBHA_AUTOFIX_APPS", _("DBHA业务自动修复开关"))
+
+
+class DisableDBHAAutofixLevel(StrStructuredEnum):
+    CLUSTER_TYPE = EnumField("cluster_type", _("集群类型"))
+    CLUSTER = EnumField("cluster", _("集群"))
+    MACHINE_TYPE = EnumField("machine_type", _("机器类型"))
 
 
 class BizSettingsEnum(StrStructuredEnum):
@@ -361,6 +368,15 @@ DEFAULT_SETTINGS = [
     # [SystemSettingsEnum.REVERSE_REPORT_EVENT_TYPES, "list", DEFAULT_REVERSE_REPORT_EVENT_TYPES, _("反向上报事件类型")],
     [SystemSettingsEnum.OPERATION_DATA_SWITCH.value, "bool", False, _("运营数据开关")],
     [SystemSettingsEnum.AI_CODE_SCENE_MAP.value, "str", DEFAULT_AI_CODE_SCENE_MAP, _("智能体code场景映射关系表")],
+    # list[dict], 每条规则: {
+    #     "bk_biz_id": int,                 (必填) 业务ID
+    #     "cluster_type": str,              (必填) 集群类型, 如 "tendbha", "tendbcluster"
+    #     "disable_level": str,             (必填) DisableDBHAAutofixLevel 枚举值: "cluster_type" | "cluster" | "machine_type"
+    #     "disable_value": str/int,         disable_level 为 "cluster_type" 时无意义;
+    #                                       为 "cluster" 时填 cluster_id;
+    #                                       为 "machine_type" 时填 machine_type 字符串, 如 "proxy", "backend"
+    # }
+    [SystemSettingsEnum.DISABLE_DBHA_AUTOFIX_APPS, "list", [], _("禁用DBHA自动修复配置")],
 ]
 
 # 环境配置项 是否支持DNS解析 pulsar flow used

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/ticket_operation.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/ticket_operation.py
@@ -14,7 +14,7 @@ import time
 from django.utils.translation import gettext_lazy as _
 from rest_framework.response import Response
 
-from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import auth_parse_bizs, auth_parse_ticket_biz
+from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import auth_parse_ticket_biz
 from backend.dbm_aiagent.mcp_tools.common.impl.ticket_list import ticket_list
 from backend.dbm_aiagent.mcp_tools.common.serializers.ticket_list import (
     TicketListInputSerializer,
@@ -47,7 +47,7 @@ class TicketOperationMcpToolsViewSet(McpToolsViewSet):
         response_slz=TicketListOutputSerializer,
         tags=[DBMMCPTags.READ],
         permission_classes=[McpDBManagePermission],
-        mcp_auth_parser=auth_parse_bizs,
+        mcp_auth_parser=auth_parse_ticket_biz,
         mcp=[DBMMcpTools.TICKET_OP, DBMMcpTools.DBM_PUBLIC_MARKET],
         name_prefix="ticket_op",
     )

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/autofix/mysql_dbha_af_todo_register.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/autofix/mysql_dbha_af_todo_register.py
@@ -15,12 +15,50 @@ from django.db import transaction
 from django.utils.translation import gettext as _
 from pipeline.component_framework.component import Component
 
+from backend.configuration.constants import DisableDBHAAutofixLevel, SystemSettingsEnum
+from backend.configuration.models import SystemSettings
 from backend.db_meta.enums import MachineType
 from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_monitor.models import MySQLDBHAEvent
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 
 logger = logging.getLogger("celery")
+
+
+def is_autofix_disabled(row: dict, cluster_obj) -> bool:
+    """
+    判断该事件是否命中自愈禁用规则。
+
+    rules 来自 SystemSettings DISABLE_DBHA_AUTOFIX_APPS, 结构为 list[dict]:
+    [
+        {
+            "bk_biz_id": int,             # (必填) 业务ID
+            "cluster_type": str,          # (必填) 集群类型, 如 "tendbha", "tendbcluster"
+            "disable_level": str,         # (必填) 禁用级别: "cluster_type" | "cluster" | "machine_type"
+            "disable_value": str/int,     # disable_level 为 "cluster_type" 时无意义;
+                                          #   为 "cluster" 时填 cluster_id;
+                                          #   为 "machine_type" 时填 machine_type 字符串, 如 "proxy", "backend"
+        }
+    ]
+    """
+    rules: list[dict] = SystemSettings.get_setting_value(SystemSettingsEnum.DISABLE_DBHA_AUTOFIX_APPS.value) or []
+    for rule in rules:
+        if rule["bk_biz_id"] != row["bk_biz_id"]:
+            continue
+        if rule["cluster_type"] != cluster_obj.cluster_type:
+            continue
+
+        level = rule["disable_level"]
+        value = rule.get("disable_value", "")
+
+        if level == DisableDBHAAutofixLevel.CLUSTER_TYPE:
+            return True
+        elif level == DisableDBHAAutofixLevel.CLUSTER and value == cluster_obj.pk:
+            return True
+        elif level == DisableDBHAAutofixLevel.MACHINE_TYPE and value == row["machine_type"]:
+            return True
+
+    return False
 
 
 class MySQLDBHAAFTodoRegisterService(BaseService):
@@ -34,6 +72,12 @@ class MySQLDBHAAFTodoRegisterService(BaseService):
             cluster_obj = Cluster.objects.get(
                 bk_cloud_id=row["bk_cloud_id"], bk_biz_id=row["bk_biz_id"], immute_domain=row["immute_domain"]
             )
+
+            if is_autofix_disabled(row, cluster_obj):
+                self.log_info(
+                    "[{}] mysql autofix info row: {} skipped by disable rule".format(kwargs["node_name"], row)
+                )
+                continue
 
             if row["machine_type"] in [MachineType.PROXY, MachineType.SPIDER]:
                 ProxyInstance.objects.get(cluster=cluster_obj, machine__ip=row["ip"], port=row["port"])


### PR DESCRIPTION
1. 修复权限克隆底层错误被误判为权限不一致的问题
2. 修复ticket list鉴权问题
3. 增加屏蔽dbha自愈的功能

通过 SystemSettings DISABLE_DBHA_AUTOFIX_APPS 配置规则列表控制自愈禁用。
每条规则必填 bk_biz_id 和 cluster_type，通过 disable_level 指定禁用粒度：
- cluster_type: 禁用该业务下该集群类型的所有自愈
- cluster: 禁用指定集群的自愈，disable_value 为 cluster_id
- machine_type: 禁用该集群类型下指定机器类型的自愈，disable_value 为 proxy/backend 等

事件写入 MySQLDBHAEvent 前通过 is_autofix_disabled 匹配规则，命中则跳过。