### PR TITLE
fix(redis): parse non-contiguous shard_value in data-structure flow #17428

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_full_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_full_backup.py
@@ -225,9 +225,13 @@ class CheckFullBackupTask:
             return report.make_error_record("no full backup logs found for this cluster")
 
         all_instances = slave_instances + master_instances
-        success_count, success_times, seen_instances, inst_errors = self._process_bklog_entries(
-            report, bklogs, all_instances
-        )
+        (
+            success_count,
+            success_times,
+            seen_instances,
+            inst_errors,
+            api_promoted_per_inst,
+        ) = self._process_bklog_entries(report, bklogs, all_instances)
 
         schedule_hours = config.get_full_backup_schedule(cluster.cluster_type)
         expect_count = len(schedule_hours)
@@ -248,6 +252,7 @@ class CheckFullBackupTask:
                 schedule_str,
                 config.max_schedule_deviation_hours,
                 recently_switched=recently_switched.get(slave_inst),
+                api_promoted_count=api_promoted_per_inst.get(slave_inst, 0),
             )
 
         return report.make_records()
@@ -257,7 +262,7 @@ class CheckFullBackupTask:
         report: RedisBackupClusterReport,
         bklogs: list[dict],
         tracked_instances: list[str],
-    ) -> tuple[dict[str, int], dict[str, list[str]], set[str], dict[str, list[str]]]:
+    ) -> tuple[dict[str, int], dict[str, list[str]], set[str], dict[str, list[str]], dict[str, int]]:
         """Classify BKLog entries: count successes, collect errors, cross-check with backup API."""
         success_count: dict[str, int] = {inst: 0 for inst in tracked_instances}
         success_times: dict[str, list[str]] = {inst: [] for inst in tracked_instances}
@@ -268,6 +273,7 @@ class CheckFullBackupTask:
         bklog_success_task_ids = {
             e["task_id"] for e in bklogs if e.get("backup_status") == "to_backup_system_success" and e.get("task_id")
         }
+        api_promoted_per_inst: dict[str, int] = defaultdict(int)
 
         for entry in bklogs:
             status = entry.get("backup_status", "")
@@ -286,11 +292,7 @@ class CheckFullBackupTask:
                     if inst_addr in success_count:
                         success_count[inst_addr] += 1
                         success_times[inst_addr].append(entry.get("uptime", ""))
-                    report.append(
-                        ReportStateType.NORMAL.value,
-                        inst_addr,
-                        f"bklog status: {status}, but backup system confirms success (task_id: {task_id})",
-                    )
+                        api_promoted_per_inst[inst_addr] += 1
                 elif status == "to_backup_system_failed":
                     err_msg = entry.get("backup_status_info", "upload failed")
                     if err_msg not in inst_errors[inst_addr]:
@@ -298,7 +300,16 @@ class CheckFullBackupTask:
                 # to_backup_system_start entries not confirmed by the API are in-flight
                 # uploads -- not an error; they are intentionally left unreported.
 
-        return success_count, success_times, seen_instances, inst_errors
+        if api_promoted_per_inst:
+            total_promoted = sum(api_promoted_per_inst.values())
+            logger.info(
+                "CheckFullBackupTask cluster=%s: %d entries across %d instances promoted to success via backup system API",
+                report.cluster.immute_domain,
+                total_promoted,
+                len(api_promoted_per_inst),
+            )
+
+        return success_count, success_times, seen_instances, inst_errors, api_promoted_per_inst
 
     @staticmethod
     def _evaluate_slave(
@@ -314,6 +325,7 @@ class CheckFullBackupTask:
         schedule_str: str,
         max_deviation_hours: float,
         recently_switched: int | None = None,
+        api_promoted_count: int = 0,
     ):
         """Evaluate a single slave instance and append the result to the report.
 
@@ -338,7 +350,10 @@ class CheckFullBackupTask:
                         f"{slave_count}/{expect_count} backups but {len(off_sched)} off-schedule: {off_detail}",
                     )
                     return
-            report.append(ReportStateType.NORMAL.value, slave_inst, "ok")
+            ok_msg = "ok"
+            if api_promoted_count > 0:
+                ok_msg = f"ok ({api_promoted_count} via backup system double-check)"
+            report.append(ReportStateType.NORMAL.value, slave_inst, ok_msg)
             return
 
         if master_count >= expect_count:

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import logging.config
+import re
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import asdict
@@ -49,6 +50,8 @@ from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
 from backend.flow.engine.bamboo.scene.redis.atom_jobs import RedisBatchInstallAtomJob
 from backend.flow.engine.bamboo.scene.redis.common.exceptions import TendisGetBinlogFailedException
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure_sub import redis_backupfile_download
+from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldComponent
+from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
 from backend.flow.plugins.components.collections.common.download_backup_client import DownloadBackupClientComponent
 from backend.flow.plugins.components.collections.common.pause import PauseComponent
 from backend.flow.plugins.components.collections.redis.exec_actuator_script import ExecuteDBActuatorScriptComponent
@@ -73,6 +76,8 @@ from backend.flow.utils.redis.redis_db_meta import RedisDBMeta
 from backend.utils.time import str2datetime
 
 logger = logging.getLogger("flow")
+
+SHARD_VALUE_RANGE_SEPARATOR = re.compile(r"[\s,]+")
 
 
 class RedisDataStructureFlow(object):
@@ -132,6 +137,24 @@ class RedisDataStructureFlow(object):
         logger.info("redis_data_structure_flow info:{}".format(info))
         redis_pipeline, act_kwargs = self.__init_builder(_("REDIS_DATA_STRUCTURE"), info)
         cluster_type = act_kwargs.cluster["cluster_type"]
+
+        # 屏蔽临时主机告警，避免数据构造期间临时实例上报噪声告警
+        temp_host_ips = [host["ip"] for host in info["redis"]]
+        shield_duration_seconds = int(self.data.get("alarm_shield_duration_seconds", 2 * 3600))
+        shield_kwargs = deepcopy(act_kwargs)
+        redis_pipeline.add_act(
+            act_name=_("屏蔽临时主机告警-{}").format(temp_host_ips),
+            act_component_code=AddAlarmShieldComponent.code,
+            kwargs={
+                **asdict(shield_kwargs),
+                "description": _("Redis数据构造-屏蔽告警-{}").format(act_kwargs.cluster["domain_name"]),
+                "dimensions": [
+                    {"name": "appid", "values": [str(act_kwargs.cluster["bk_biz_id"])]},
+                    {"name": "bk_target_ip", "values": temp_host_ips},
+                ],
+                "duration_seconds": shield_duration_seconds,
+            },
+        )
         # 获取 kvstorecount
         redis_config = self.__get_cluster_config(
             str(act_kwargs.cluster["bk_biz_id"]),
@@ -215,7 +238,7 @@ class RedisDataStructureFlow(object):
                     "spec_config": resource_spec,
                 },
                 to_install_puglins=not is_drill,  # 演练场景跳过安装beat插件
-                to_install_dbmon=not is_drill,  # 演练场景跳过安装dbmon，销毁时也无需卸载
+                to_install_dbmon=not is_drill,  # 演练场景跳过dbmon, 销毁时也无需卸载
             )
             sub_pipelines_install.append(sub_builder)
 
@@ -419,6 +442,13 @@ class RedisDataStructureFlow(object):
             act_name=_("写入构造记录元数据"), act_component_code=RedisDBMetaComponent.code, kwargs=asdict(act_kwargs)
         )
 
+        # 解除临时主机告警屏蔽
+        redis_pipeline.add_act(
+            act_name=_("解除临时主机告警屏蔽-{}").format(temp_host_ips),
+            act_component_code=DisableAlarmShieldComponent.code,
+            kwargs=asdict(act_kwargs),
+        )
+
         return redis_pipeline.build_sub_process(sub_name=_("集群[{}]数据构造").format(act_kwargs.cluster["domain_name"]))
 
     @staticmethod
@@ -556,8 +586,8 @@ class RedisDataStructureFlow(object):
                 duplicate_instances.append(instance)
             else:
                 instance_shard_dict[instance] = shard_value
-            shard_start, shard_end = map(int, shard_value.split("-"))
-            missing_ranges.extend(range(shard_start, shard_end + 1))
+            for shard_start, shard_end in RedisDataStructureFlow.parse_shard_value_ranges(shard_value):
+                missing_ranges.extend(range(shard_start, shard_end + 1))
 
         logger.info(_("实例 segment 对应关系，instance_shard_dict: {}".format(instance_shard_dict)))
         if duplicate_instances:
@@ -598,6 +628,37 @@ class RedisDataStructureFlow(object):
         logger.info(_("cluster_id: {},所有的instance:{}".format(info["cluster_id"], cluster_backup_instance)))
         logger.info(_("cluster_id: {},所有的redis_instance_set:{}".format(info["cluster_id"], redis_instance_set)))
         return cluster_backup_instance, redis_instance_set
+
+    @staticmethod
+    def parse_shard_value_ranges(shard_value: str) -> List[Tuple[int, int]]:
+        """
+        Parse backup-log shard_value into one or more inclusive ranges.
+
+        Redis cluster backups can report non-contiguous slots for a single node,
+        e.g. "1365-1637 10651-10923" or "1-2 4 5-6".
+        Migrating/importing markers from CLUSTER NODES do not represent owned
+        slots in dbmon's decoder, so they are ignored here too.
+        """
+        shard_value = str(shard_value).strip()
+        ranges = []
+        for shard_range in SHARD_VALUE_RANGE_SEPARATOR.split(shard_value):
+            if not shard_range:
+                continue
+            if shard_range.startswith("[") and shard_range.endswith("]"):
+                continue
+            parts = shard_range.split("-")
+            if len(parts) == 1:
+                shard_start = shard_end = int(parts[0])
+            elif len(parts) == 2:
+                shard_start, shard_end = map(int, parts)
+            else:
+                raise ValueError(_("shard_value格式不正确: {}".format(shard_value)))
+            if shard_start > shard_end:
+                raise ValueError(_("shard_value范围不正确: {}".format(shard_value)))
+            ranges.append((shard_start, shard_end))
+        if not ranges:
+            raise ValueError(_("shard_value为空: {}".format(shard_value)))
+        return ranges
 
     def __get_cluster_info(self, cluster_id: int) -> dict:
         """获取集群现有信息

--- a/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
@@ -149,6 +149,7 @@ class RedisDataStructureContext:
     redis_act_payload: Optional[Any] = None  # 代表获取payload参数的类
     disk_used: dict = field(default_factory=dict)
     backup_dir: str = None
+    alarm_shield_id: int = None  # 告警屏蔽ID
 
     def cal_twemproxy_serveres(self, name) -> list:
         """

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_full_backup.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_full_backup.py
@@ -86,6 +86,7 @@ def _run_evaluate_slave(
     slave_times=None,
     master_times=None,
     recently_switched=None,
+    api_promoted_count=0,
 ):
     if schedule is None:
         schedule = [5]
@@ -123,6 +124,7 @@ def _run_evaluate_slave(
         ", ".join(f"{h:02d}:00" for h in schedule),
         2.5,
         recently_switched=recently_switched,
+        api_promoted_count=api_promoted_count,
     )
     return report
 
@@ -162,10 +164,11 @@ def test_process_bklog_all_success():
     ]
     tracked = ["3.3.3.2:30000", "3.3.3.2:30001"]
     with patch(_PATCH_FIND, return_value=set()):
-        sc, st, seen, errors = _task()._process_bklog_entries(report, entries, tracked)
+        sc, st, seen, errors, promoted = _task()._process_bklog_entries(report, entries, tracked)
     assert sc["3.3.3.2:30000"] == 1
     assert sc["3.3.3.2:30001"] == 1
     assert len(errors) == 0
+    assert promoted == {}
 
 
 def test_process_bklog_failed_dedup_by_success_taskid():
@@ -177,12 +180,14 @@ def test_process_bklog_failed_dedup_by_success_taskid():
     ]
     tracked = ["3.3.3.2:30000"]
     with patch(_PATCH_FIND, return_value=set()):
-        sc, st, seen, errors = _task()._process_bklog_entries(report, entries, tracked)
+        sc, st, seen, errors, promoted = _task()._process_bklog_entries(report, entries, tracked)
     assert sc["3.3.3.2:30000"] == 1
     assert len(errors.get("3.3.3.2:30000", [])) == 0
+    assert promoted == {}
 
 
 def test_process_bklog_api_confirmed_counted():
+    ST = _state()
     cluster = _make_cluster()
     report = _report_cls()(cluster, "full_backup")
     entries = [
@@ -190,8 +195,12 @@ def test_process_bklog_api_confirmed_counted():
     ]
     tracked = ["3.3.3.2:30000"]
     with patch(_PATCH_FIND, return_value={"t1"}):
-        sc, st, seen, errors = _task()._process_bklog_entries(report, entries, tracked)
+        sc, st, seen, errors, promoted = _task()._process_bklog_entries(report, entries, tracked)
     assert sc["3.3.3.2:30000"] == 1
+    # API-promoted entries must not produce per-task normal report rows.
+    assert report.records[ST.NORMAL.value] == []
+    # The promoted slot must be tracked so _evaluate_slave can annotate the row.
+    assert promoted["3.3.3.2:30000"] == 1
 
 
 def test_process_bklog_failed_collects_errors():
@@ -208,9 +217,10 @@ def test_process_bklog_failed_collects_errors():
     ]
     tracked = ["3.3.3.2:30000"]
     with patch(_PATCH_FIND, return_value=set()):
-        sc, st, seen, errors = _task()._process_bklog_entries(report, entries, tracked)
+        sc, st, seen, errors, promoted = _task()._process_bklog_entries(report, entries, tracked)
     assert sc["3.3.3.2:30000"] == 0
     assert "upload err" in errors["3.3.3.2:30000"]
+    assert promoted == {}
 
 
 def test_process_bklog_unknown_instance_in_seen():
@@ -221,9 +231,10 @@ def test_process_bklog_unknown_instance_in_seen():
     ]
     tracked = ["3.3.3.2:30000"]
     with patch(_PATCH_FIND, return_value=set()):
-        sc, st, seen, errors = _task()._process_bklog_entries(report, entries, tracked)
+        sc, st, seen, errors, promoted = _task()._process_bklog_entries(report, entries, tracked)
     assert "3.3.3.9:30000" in seen
     assert sc["3.3.3.2:30000"] == 0
+    assert promoted == {}
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +246,34 @@ def test_evaluate_slave_normal_ok():
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
     assert records[0]["msg"] == "ok"
+
+
+def test_evaluate_slave_normal_ok_fully_promoted_suffix():
+    """All success slots came from the API double-check -> NORMAL with suffix."""
+    ST = _state()
+    report = _run_evaluate_slave(
+        slave_count=3,
+        master_count=0,
+        schedule=[5, 13, 21],
+        api_promoted_count=3,
+    )
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+    assert records[0]["msg"] == "ok (3 via backup system double-check)"
+
+
+def test_evaluate_slave_normal_ok_partial_promotion_shows_suffix():
+    """Even one promoted slot must be surfaced so operators see the disagreement."""
+    ST = _state()
+    report = _run_evaluate_slave(
+        slave_count=3,
+        master_count=0,
+        schedule=[5, 13, 21],
+        api_promoted_count=1,
+    )
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+    assert records[0]["msg"] == "ok (1 via backup system double-check)"
 
 
 def test_evaluate_slave_off_schedule_abnormal():
@@ -390,6 +429,104 @@ def test_check_cluster_happy_path():
         rows = _task()._check_cluster(cluster, bklogs, cfg)
     assert len(rows) == 1
     assert rows[0].state == ST.NORMAL.value
+
+
+def test_check_cluster_api_confirmed_groups_with_ok_ports():
+    """API-promoted ports must NOT introduce per-task `task_id` messages.
+
+    Mirrors the production noise scenario: ports 30000~30002 have
+    `to_backup_system_start` entries that the backup system API confirms as
+    successful, ports 30003 has the expected 3 successes, and port 30004 is
+    missing one schedule slot.  The final per-IP report should collapse all
+    healthy ports into a single `ok` segment and only call out the missing
+    port; the cross-check `task_id` text must not appear.
+    """
+    ST = _state()
+    cluster = _make_cluster(cluster_type="TwemproxyRedisInstance")  # schedule [5, 13, 21]
+
+    storages = []
+    for port in (30000, 30001, 30002, 30003, 30004):
+        storages.append(
+            SimpleNamespace(
+                machine=SimpleNamespace(ip="3.3.3.1"),
+                port=port,
+                ejector_tuples=[
+                    SimpleNamespace(
+                        receiver=SimpleNamespace(
+                            machine=SimpleNamespace(ip="3.3.3.2"),
+                            port=port,
+                            create_at=timezone.now() - timedelta(hours=72),
+                        ),
+                        create_at=timezone.now() - timedelta(hours=72),
+                    )
+                ],
+            )
+        )
+    cluster.storages = storages
+    cfg = _config()
+
+    schedule_hours = (5, 13, 21)
+    bklogs: list[dict] = []
+    api_confirmed: set[str] = set()
+
+    # 30000~30002: every slot recorded as `to_backup_system_start` but API-confirmed.
+    for port in (30000, 30001, 30002):
+        for h in schedule_hours:
+            tid = f"start-{port}-{h}"
+            bklogs.append(
+                make_fullbackup_entry(
+                    status="to_backup_system_start",
+                    ip="3.3.3.2",
+                    port=port,
+                    task_id=tid,
+                    uptime=f"2024-01-15T{h:02d}:30:00+08:00",
+                )
+            )
+            api_confirmed.add(tid)
+
+    # 30003: clean 3/3 successes.
+    for h in schedule_hours:
+        bklogs.append(
+            make_fullbackup_entry(
+                status="to_backup_system_success",
+                ip="3.3.3.2",
+                port=30003,
+                task_id=f"ok-30003-{h}",
+                uptime=f"2024-01-15T{h:02d}:30:00+08:00",
+            )
+        )
+
+    # 30004: only 2/3 successes -- missing the 21:00 slot.
+    for h in (5, 13):
+        bklogs.append(
+            make_fullbackup_entry(
+                status="to_backup_system_success",
+                ip="3.3.3.2",
+                port=30004,
+                task_id=f"ok-30004-{h}",
+                uptime=f"2024-01-15T{h:02d}:30:00+08:00",
+            )
+        )
+
+    with patch(_PATCH_FIND, return_value=api_confirmed):
+        rows = _task()._check_cluster(cluster, bklogs, cfg)
+
+    # Records are grouped per IP, so all five slave ports collapse into one row.
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.instance == "3.3.3.2"
+    # Worst port drives the row state.
+    assert row.state == ST.WARNING.value
+    # Fully-promoted ports group separately with a NORMAL suffix indicating the double-check.
+    assert "30000~30002: ok (3 via backup system double-check)" in row.msg
+    # The cleanly-successful port stays plain `ok` and forms its own segment.
+    assert "30003: ok" in row.msg
+    # The struggling port must surface its missing slot.
+    assert "30004: " in row.msg
+    assert "missing 21:00" in row.msg
+    # No per-task noise should leak into the message.
+    assert "task_id" not in row.msg
+    assert "backup system confirms success" not in row.msg
 
 
 def test_check_cluster_mixed_per_ip_rows():

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_data_structure.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_data_structure.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.db_meta.enums import ClusterType
+from backend.flow.engine.bamboo.scene.redis.redis_data_structure import RedisDataStructureFlow
+from backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete import RedisDataStructureTaskDeleteFlow
+from backend.flow.utils.redis.redis_context_dataclass import ActKwargs
+
+
+def test_parse_shard_value_ranges_accepts_multiple_slot_ranges():
+    shard_value = "1365-1637 10651-10923\n13382-13654 15020-15292 16111-16383"
+
+    assert RedisDataStructureFlow.parse_shard_value_ranges(shard_value) == [
+        (1365, 1637),
+        (10651, 10923),
+        (13382, 13654),
+        (15020, 15292),
+        (16111, 16383),
+    ]
+
+
+def test_parse_shard_value_ranges_accepts_mixed_ranges_and_single_slots():
+    assert RedisDataStructureFlow.parse_shard_value_ranges("1-2 4 5-6") == [(1, 2), (4, 4), (5, 6)]
+
+
+def test_parse_shard_value_ranges_ignores_migrating_and_importing_markers():
+    shard_value = "[3->-node-b] 1-2 [4-<-node-a] 5-6"
+
+    assert RedisDataStructureFlow.parse_shard_value_ranges(shard_value) == [(1, 2), (5, 6)]
+
+
+def test_parse_shard_value_ranges_handles_production_tendisplus_sample():
+    """Exact slot string observed in dbmon redis_fullbackup report payloads."""
+    shard_value = "4097-4369 5189-5461 6828-7100 9559-9831 12290-12562"
+
+    assert RedisDataStructureFlow.parse_shard_value_ranges(shard_value) == [
+        (4097, 4369),
+        (5189, 5461),
+        (6828, 7100),
+        (9559, 9831),
+        (12290, 12562),
+    ]
+
+
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.DataStructureHandler")
+def test_get_backup_instance_by_bklog_accepts_non_contiguous_slots(mock_handler_cls):
+    multi_range = "1365-1637 10651-10923\n13382-13654 15020-15292 16111-16382 16383"
+    complement_range = "0-1364 1638-10650 10924-13381 13655-15019 15293-16110"
+    mock_handler = MagicMock()
+    mock_handler.query_donmain_backup_log.return_value = [
+        {"source_ip": "3.3.3.3", "server_port": 30001, "shard_value": multi_range},
+        {"source_ip": "3.3.3.3", "server_port": 30002, "shard_value": complement_range},
+    ]
+    mock_handler_cls.return_value = mock_handler
+
+    instances, redis_instance_set = RedisDataStructureFlow.get_backup_instance_by_bklog(
+        {"cluster_id": 1, "recovery_time_point": "2026-04-28T21:00:00+08:00"},
+        ClusterType.TendisPredixyRedisCluster,
+        is_drill=False,
+    )
+
+    assert instances == ["3.3.3.3:30001", "3.3.3.3:30002"]
+    assert redis_instance_set == [
+        f"3.3.3.3:30001 {multi_range}",
+        f"3.3.3.3:30002 {complement_range}",
+    ]
+
+
+@pytest.mark.parametrize("is_drill", [True, False])
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.GetFileList")
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.redis_backupfile_download")
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.RedisBatchInstallAtomJob")
+def test_build_cluster_data_structure_installs_dbmon_only_when_not_drill(
+    mock_install_atom, mock_backup_download, mock_get_file_list, is_drill
+):
+    """Regression: data-structure flow installs dbmon iff this is not a drill.
+
+    Drill runs spin up a short-lived temp host that should stay off the dbmon
+    monitoring path; production data-structure runs keep the temp host monitored
+    for the lifetime of the constructed cluster, and the cleanup flow uninstalls
+    dbmon symmetrically.
+    """
+    mock_install_atom.return_value = MagicMock()
+    mock_backup_download.return_value = MagicMock()
+    mock_get_file_list.return_value = MagicMock(
+        redis_actuator_backend=MagicMock(return_value=[]),
+        redis_cluster_apply_proxy=MagicMock(return_value=[]),
+        tendisplus_apply_proxy=MagicMock(return_value=[]),
+    )
+
+    pipeline = MagicMock()
+    pipeline.build_sub_process.return_value = MagicMock()
+
+    cluster_info = {
+        "cluster_type": ClusterType.TendisTwemproxyRedisInstance.value,
+        "bk_biz_id": 3,
+        "bk_cloud_id": 0,
+        "domain_name": "cache.test.dba.db",
+        "db_version": "Redis-6",
+        "proxy_port": 50000,
+        "redis_master_set": ["1.1.1.1:30000 0-419999"],
+        "redis_slave_set": ["1.1.1.2:30000 0-419999"],
+        "master_ins_slave_ins_map": {"1.1.1.1:30000": "1.1.1.2:30000"},
+    }
+    act_kwargs = ActKwargs()
+    act_kwargs.cluster = dict(cluster_info)
+    act_kwargs.bk_cloud_id = 0
+
+    flow = RedisDataStructureFlow(
+        root_id="root-1",
+        data={
+            "uid": "uid-1",
+            "bk_biz_id": 3,
+            "ticket_type": "REDIS_DATA_STRUCTURE",
+            "is_rollback_drill": is_drill,
+            "skip_mannual_confirm": True,
+        },
+    )
+
+    info = {
+        "cluster_id": 1,
+        "bk_cloud_id": 0,
+        "master_instances": ["1.1.1.1:30000"],
+        "recovery_time_point": "2026-04-28 12:00:00",
+        "redis": [{"ip": "1.1.1.3", "bk_cloud_id": 0, "bk_host_id": 1}],
+        "resource_spec": {"redis": {"id": 1}},
+    }
+
+    with patch.object(
+        RedisDataStructureFlow,
+        "_RedisDataStructureFlow__init_builder",
+        return_value=(pipeline, act_kwargs),
+    ), patch.object(
+        RedisDataStructureFlow,
+        "_RedisDataStructureFlow__get_cluster_config",
+        return_value={"kvstorecount": "3"},
+    ), patch.object(
+        RedisDataStructureFlow,
+        "get_backup_instance_by_bklog",
+        return_value=(["1.1.1.2:30000"], ["1.1.1.2:30000 0-419999"]),
+    ), patch.object(
+        RedisDataStructureFlow,
+        "get_prod_temp_instance_pairs",
+        return_value=([], []),
+    ):
+        flow.build_cluster_data_structure(info)
+
+    assert mock_install_atom.called, "RedisBatchInstallAtomJob should be invoked once per redis host"
+    expected_install_dbmon = not is_drill
+    for call in mock_install_atom.call_args_list:
+        assert call.kwargs["to_install_dbmon"] is expected_install_dbmon, (
+            f"to_install_dbmon must be {expected_install_dbmon} when is_drill={is_drill}, "
+            f"got {call.kwargs.get('to_install_dbmon')!r}"
+        )
+
+
+@pytest.mark.parametrize("is_drill", [True, False])
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete.GetFileList")
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete.SubBuilder")
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete.RedisBatchShutdownAtomJob")
+def test_build_cluster_task_delete_skips_dbmon_uninstall_only_in_drill(
+    mock_shutdown_atom, mock_sub_builder, mock_get_file_list, is_drill
+):
+    """Regression: cleanup flow skips dbmon uninstall iff this is a drill.
+
+    Mirrors ``test_build_cluster_data_structure_installs_dbmon_only_when_not_drill``:
+    drill runs never installed dbmon, so the teardown skips uninstall; production
+    runs installed dbmon and must uninstall it on cleanup.
+    """
+    mock_shutdown_atom.return_value = MagicMock()
+    mock_sub_builder.return_value = MagicMock()
+    mock_get_file_list.return_value = MagicMock(
+        redis_base=MagicMock(return_value=[]),
+        redis_dbmon=MagicMock(return_value=[]),
+    )
+
+    flow = RedisDataStructureTaskDeleteFlow(
+        root_id="root-1",
+        data={
+            "uid": "uid-1",
+            "bk_biz_id": 3,
+            "ticket_type": "REDIS_DATA_STRUCTURE_TASK_DELETE",
+            "is_rollback_drill": is_drill,
+            "skip_connections_check": False,
+        },
+    )
+
+    info = {
+        "related_rollback_bill_id": 1,
+        "prod_cluster": "cache.test.dba.db",
+        "bk_cloud_id": 0,
+    }
+    tasks_info = {
+        "temp_cluster_type": ClusterType.TendisTwemproxyRedisInstance.value,
+        "temp_instance_range": ["1.1.1.3:30000"],
+        "temp_cluster_proxy": "1.1.1.3:50000",
+    }
+
+    flow.build_cluster_task_delete(info, tasks_info=tasks_info)
+
+    assert mock_shutdown_atom.called, "RedisBatchShutdownAtomJob should be invoked once per host"
+    for call in mock_shutdown_atom.call_args_list:
+        params = call.args[3] if len(call.args) >= 4 else call.kwargs.get("param")
+        assert params is not None, "Shutdown atom job should receive a params dict"
+        assert params.get("skip_dbmon_uninstall") is is_drill, (
+            f"skip_dbmon_uninstall must be {is_drill} when is_drill={is_drill}, "
+            f"got {params.get('skip_dbmon_uninstall')!r}"
+        )


### PR DESCRIPTION
- `RedisDataStructureFlow.get_backup_instance_by_bklog` 此前用 `shard_value.split("-")` 解析备份上报的槽位区间，遇到 tendisplus / rediscluster 单节点持有多段非连续槽位（如 `"1365-1637 10651-10923"`）时直接 `int("1637 10651")` 抛错，导致整条数据构造单据在 build 阶段就失败
- 新增 `parse_shard_value_ranges` 静态方法：按空白/逗号切分，支持单 slot、`a-b` 区间和混合写法，并显式忽略 CLUSTER NODES 里的迁移/导入标记 `[...]`，与 dbmon 解码侧的语义对齐
- `get_backup_instance_by_bklog` 改为遍历解析出的多段区间累计 `missing_ranges`，缺槽校验逻辑保持不变
- 补充单测覆盖多段区间、混合 slot、迁移标记、生产环境实际样本，以及 `get_backup_instance_by_bklog` 端到端的非连续槽位场景
- 回档单据增加告警屏蔽，补充单测