### PR TITLE
feat(redis): add leading-hour buffer to binlog day-boundary check #17498

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
@@ -95,12 +95,24 @@ def _find_missing_binlogs(
     all_terminal_entries: list[dict],
     success_entries: list[dict],
     tendis_type: str,
+    buffer_success_entries: Optional[list[dict]] = None,
 ) -> list[int]:
     """Find all binlog indexes that are not successfully backed up.
 
     Detects:
     - Failed uploads: indexes present in terminal entries but absent from success
     - Interior gaps: indexes between the observed min/max that appear in no entry
+
+    *buffer_success_entries* (optional) are successful uploads whose
+    binlog content time falls in one of the buffer hours (leading
+    day-before-yesterday last hour, or trailing today first hour).
+    Their indexes can fill GAPS -- indexes that would otherwise be
+    flagged as interior gaps in yesterday's range -- but they do NOT
+    override known FAILURES (indexes present in ``all_terminal_entries``
+    but absent from ``success_entries``), because a failed upload in
+    yesterday and a buffer-day file with a colliding index are
+    different binlog files.
+
     Returns a sorted list of missing indexes, or [-1] on parse error.
     """
     if not all_terminal_entries:
@@ -129,6 +141,17 @@ def _find_missing_binlogs(
             gap_end = all_indexes[i + 1]
             if gap_end > gap_start:
                 missing.update(range(gap_start, gap_end))
+
+    if buffer_success_entries:
+        buffer_indexes: set[int] = set()
+        for e in buffer_success_entries:
+            try:
+                buffer_indexes.add(_extract_binlog_index(e["file_name"], tendis_type))
+            except (IndexError, ValueError, KeyError):
+                pass
+        all_terminal_set = set(all_indexes)
+        fillable = buffer_indexes - all_terminal_set
+        missing -= fillable
 
     return sorted(missing)
 
@@ -201,7 +224,7 @@ class CheckBinlogBackupTask:
         batch_ops.delete_today_records()
 
         cluster_ids = list(self._get_cluster_ids(config))
-        start_time, end_time, analysis_end_local = self._yesterday_time_range()
+        start_time, end_time, analysis_start_local, analysis_end_local = self._yesterday_time_range()
         cluster_state_total = {
             ReportStateType.NORMAL.value: 0,
             ReportStateType.WARNING.value: 0,
@@ -216,7 +239,12 @@ class CheckBinlogBackupTask:
             for cluster in batch_clusters:
                 total_num += 1
                 rows = self._check_cluster_with_retry(
-                    cluster, start_time, end_time, config, analysis_end_local=analysis_end_local
+                    cluster,
+                    start_time,
+                    end_time,
+                    config,
+                    analysis_start_local=analysis_start_local,
+                    analysis_end_local=analysis_end_local,
                 )
                 if rows:
                     cluster_state_total[rows[0].state] += 1
@@ -271,13 +299,19 @@ class CheckBinlogBackupTask:
         config: RedisBackupCheckConfig,
         max_retries: int = 3,
         *,
+        analysis_start_local: Optional[datetime] = None,
         analysis_end_local: Optional[datetime] = None,
     ):
         last_error = None
         for attempt in range(max_retries):
             try:
                 return self._check_cluster(
-                    cluster, start_time, end_time, config, analysis_end_local=analysis_end_local
+                    cluster,
+                    start_time,
+                    end_time,
+                    config,
+                    analysis_start_local=analysis_start_local,
+                    analysis_end_local=analysis_end_local,
                 )
             except Exception as e:
                 logger.error(
@@ -299,6 +333,7 @@ class CheckBinlogBackupTask:
         end_time,
         config: RedisBackupCheckConfig,
         *,
+        analysis_start_local: Optional[datetime] = None,
         analysis_end_local: Optional[datetime] = None,
     ):
         report = RedisBackupClusterReport(cluster, self.subtype)
@@ -348,6 +383,7 @@ class CheckBinlogBackupTask:
                     port,
                     kvstorecount,
                     recently_switched=recently_switched.get(instance),
+                    analysis_start_local=analysis_start_local,
                     analysis_end_local=analysis_end_local,
                 )
             except Exception as e:
@@ -412,12 +448,14 @@ class CheckBinlogBackupTask:
         kvstorecount,
         *,
         recently_switched=None,
+        analysis_start_local: Optional[datetime] = None,
         analysis_end_local: Optional[datetime] = None,
     ):
         # The "no logs found" check is done against the raw query window
         # (pre-filter): if BKLog returned nothing at all for this instance
-        # within yesterday + 1h buffer, that itself is a strong abnormal
-        # signal regardless of content-time semantics.
+        # within the leading 1h buffer + yesterday + trailing 1h buffer
+        # window, that itself is a strong abnormal signal regardless of
+        # content-time semantics.
         if not bklogs:
             if recently_switched is not None:
                 report.append(
@@ -429,36 +467,46 @@ class CheckBinlogBackupTask:
                 report.append(ReportStateType.ABNORMAL.value, instance, "no logs found")
             return
 
-        # Failed-task verification runs against the full window so that a
-        # success arriving in the buffer (today 00:00-01:00) can still
-        # promote a corresponding ``to_backup_system_start`` from yesterday.
+        # Failed-task verification runs against the full window so that
+        # success entries arriving in either buffer hour can still
+        # promote a corresponding ``to_backup_system_start`` whose
+        # content time belongs to yesterday.
         api_confirmed = find_and_verify_failed_tasks(bklogs)
 
-        # Filter to entries whose binlog content time falls in yesterday.
-        # Today's first-hour entries (caught by the 1h buffer) are
-        # excluded so that gap detection never uses them as a max
-        # boundary -- avoiding day-boundary false positives where a
-        # late-uploaded yesterday seq looks like an interior gap between
-        # an earlier yesterday seq and a today seq.  The excluded
-        # entries will be re-checked tomorrow as part of "yesterday".
+        # Filter to entries whose binlog content time falls in
+        # yesterday's wall-clock day.  Today's first-hour entries
+        # (caught by the trailing 1h buffer) AND day-before-yesterday's
+        # last-hour entries (caught by the leading 1h buffer) are
+        # excluded so that gap detection never uses them as min/max
+        # boundaries -- avoiding day-boundary false positives where a
+        # late-uploaded neighbouring-day seq looks like an interior gap
+        # next to a real yesterday seq.  The excluded entries will be
+        # re-checked on the appropriate day's run.
         #
         # Timezone contract: both operands below are NAIVE local time.
         # ``_extract_binlog_timestamp`` returns naive local per the
         # backup-agent filename convention (YYYYMMDDHHMMSS in the local
-        # tz of the source host); ``analysis_end_local`` is naive local
-        # stripped from a Django timezone-aware ``localtime()``.  They
-        # are directly comparable only because both are local wall-clock.
-        # If a newly provisioned instance ever emits UTC timestamps in
-        # filenames, this comparison would silently mis-classify
-        # buffer-window entries -- revisit this contract then.
-        if analysis_end_local is not None:
+        # tz of the source host); ``analysis_start_local`` /
+        # ``analysis_end_local`` are naive local stripped from Django
+        # timezone-aware ``localtime()``.  They are directly comparable
+        # only because both are local wall-clock.  If a newly
+        # provisioned instance ever emits UTC timestamps in filenames,
+        # this comparison would silently mis-classify buffer-window
+        # entries -- revisit this contract then.
+        def _in_window(ts: Optional[datetime]) -> bool:
+            if ts is None:
+                return False
+            if analysis_start_local is not None and ts < analysis_start_local:
+                return False
+            if analysis_end_local is not None and ts >= analysis_end_local:
+                return False
+            return True
+
+        if analysis_start_local is not None or analysis_end_local is not None:
             yesterday_logs = [
                 e
                 for e in bklogs
-                if (
-                    (ts := _extract_binlog_timestamp(e.get("file_name", ""), cluster.cluster_type)) is not None
-                    and ts < analysis_end_local
-                )
+                if _in_window(_extract_binlog_timestamp(e.get("file_name", ""), cluster.cluster_type))
             ]
         else:
             yesterday_logs = bklogs
@@ -480,6 +528,23 @@ class CheckBinlogBackupTask:
                 instance,
                 len(api_promoted),
             )
+
+        # Buffer entries: in the BKLog query window but outside yesterday's
+        # wall-clock day (content time falls in the leading or trailing
+        # buffer hour).  Successful buffer uploads can fill what would
+        # otherwise look like interior gaps in yesterday's index range
+        # -- e.g. a binlog whose content time slipped into the leading
+        # buffer hour but whose index sits between two yesterday seqs.
+        # They never override a known yesterday-side failure (handled by
+        # `_find_missing_binlogs`).
+        yesterday_ids = {id(e) for e in yesterday_logs}
+        buffer_logs = [e for e in bklogs if id(e) not in yesterday_ids]
+        buffer_success_entries = [
+            e
+            for e in buffer_logs
+            if e.get("backup_status") == "to_backup_system_success"
+            or (e.get("backup_status") == "to_backup_system_start" and e.get("task_id", "") in api_confirmed)
+        ]
 
         all_files = {e.get("file_name", "") for e in all_terminal}
         success_files = {e.get("file_name", "") for e in success_entries}
@@ -504,6 +569,7 @@ class CheckBinlogBackupTask:
                 kvstore_filter = f"{ip}-{port}-{kv_idx}-"
                 kv_terminal = [e for e in all_terminal if kvstore_filter in e.get("file_name", "")]
                 kv_success = [e for e in success_entries if kvstore_filter in e.get("file_name", "")]
+                kv_buffer = [e for e in buffer_success_entries if kvstore_filter in e.get("file_name", "")]
 
                 if not kv_terminal:
                     continue
@@ -511,7 +577,12 @@ class CheckBinlogBackupTask:
                     kv_issues.append(f"kv{kv_idx}(all upload failed)")
                     continue
 
-                missing = _find_missing_binlogs(kv_terminal, kv_success, cluster.cluster_type)
+                missing = _find_missing_binlogs(
+                    kv_terminal,
+                    kv_success,
+                    cluster.cluster_type,
+                    buffer_success_entries=kv_buffer,
+                )
                 if missing:
                     kv_issues.append(f"kv{kv_idx}({_format_ranges(_compress_ranges(missing))})")
 
@@ -526,7 +597,12 @@ class CheckBinlogBackupTask:
             report.append(ReportStateType.WARNING.value, instance, ", ".join(parts))
 
         elif is_tendisssd_instance_type(cluster.cluster_type):
-            missing = _find_missing_binlogs(all_terminal, success_entries, cluster.cluster_type)
+            missing = _find_missing_binlogs(
+                all_terminal,
+                success_entries,
+                cluster.cluster_type,
+                buffer_success_entries=buffer_success_entries,
+            )
 
             if not missing:
                 report.append(ReportStateType.NORMAL.value, instance, "ok")
@@ -572,27 +648,39 @@ class CheckBinlogBackupTask:
 
     @staticmethod
     def _yesterday_time_range():
-        """Compute the BKLog query window and the gap-analysis cutoff.
+        """Compute the BKLog query window and the gap-analysis bounds.
 
-        Returns ``(query_start, query_end, analysis_end_local)``:
+        Returns ``(query_start, query_end, analysis_start_local, analysis_end_local)``:
 
         - ``query_start``/``query_end``: aware UTC bounds for the BKLog
-          ES query.  Window is ``[yesterday 00:00, today 01:00)`` local
-          time.  The 1h tail buffer is intentional -- it captures
-          binlogs whose **content** belongs to yesterday but whose
-          upload completed slightly after midnight (slow uploads,
-          backup-system retries, ES ingestion delay).
-        - ``analysis_end_local``: naive local ``datetime`` representing
-          today 00:00:00.  Used downstream to filter out entries whose
-          content time falls in today's first hour -- those entries are
-          today's data that happen to fall inside the buffer window and
-          should not participate in yesterday's gap detection.  They
-          will be re-checked tomorrow as part of "yesterday" then.
+          ES query.  Window is ``[yesterday 00:00 - 1h, today 00:00 + 1h)``
+          local time.  The symmetric 1h buffers are intentional:
+
+          * The trailing buffer captures binlogs whose **content**
+            belongs to yesterday but whose upload completed slightly
+            after midnight (slow uploads, backup-system retries, ES
+            ingestion delay).
+          * The leading buffer captures the mirror case at the start of
+            yesterday -- binlogs whose content belongs to
+            day-before-yesterday but whose upload arrived just after
+            yesterday 00:00.  Including them lets cross-day failed-task
+            promotion match ``to_backup_system_start`` ↔
+            ``to_backup_system_success`` pairs that straddle the
+            day-before-yesterday/yesterday boundary.
+        - ``analysis_start_local``/``analysis_end_local``: naive local
+          ``datetime`` bounds of yesterday's wall-clock day
+          (``[yesterday 00:00, today 00:00)``).  Used downstream to
+          drop entries whose content time falls in either buffer hour
+          from yesterday's gap detection -- those entries belong to a
+          neighbouring day and would otherwise create phantom min/max
+          boundaries.  They will be re-checked on the appropriate
+          day's run.
         """
         local_now = timezone.localtime()
         local_today_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
         local_yesterday_start = local_today_start - timedelta(days=1)
-        query_start = local_yesterday_start.astimezone(tz=timezone.utc)
+        query_start = local_yesterday_start.astimezone(tz=timezone.utc) - timedelta(hours=1)
         query_end = local_today_start.astimezone(tz=timezone.utc) + timedelta(hours=1)
+        analysis_start_local = local_yesterday_start.replace(tzinfo=None)
         analysis_end_local = local_today_start.replace(tzinfo=None)
-        return query_start, query_end, analysis_end_local
+        return query_start, query_end, analysis_start_local, analysis_end_local

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_binlog_backup.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_binlog_backup.py
@@ -10,6 +10,21 @@ specific language governing permissions and limitations under the License.
 """
 # Tests for CheckBinlogBackupTask — _check_instance and _check_cluster.
 #
+# Tests are organised into six categories that mirror the distinct
+# responsibilities exercised by the implementation:
+#
+#   A. Input-shape preconditions for _check_instance
+#      (early-return branches: no logs, no terminal entries, all failed)
+#   B. Yesterday-only gap detection
+#      (_find_missing_binlogs over yesterday's content, no buffer involved)
+#   C. Content-time filtering
+#      (_in_window excludes leading/trailing buffer entries from yesterday_logs)
+#   D. Buffer-fill defensive behaviour
+#      (the missing -= fillable subtraction in _find_missing_binlogs)
+#   E. API promotion via find_and_verify_failed_tasks
+#   F. _check_cluster orchestration
+#      (skip rules, error paths, end-to-end runs, tiered fetch fallback)
+#
 # Source-module imports are done lazily to avoid triggering the
 # ``local_tasks/__init__.py`` import chain.
 from datetime import datetime, timedelta
@@ -38,10 +53,21 @@ _PATCH_FETCH_INSTANCE = (
 _DUMMY_START = timezone.now()
 _DUMMY_END = timezone.now()
 
+# Sentinel timestamp for tests where filename content time is irrelevant
+# (the content-time filter is inactive because analysis_*_local is None).
+_DONT_CARE_TS = datetime(2024, 1, 1, 12, 0, 0)
 
-def _yesterday_local():
-    """Today 00:00 local time as a naive datetime (used as analysis cutoff)."""
-    return timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+
+def _yesterday_start_local():
+    """Yesterday 00:00 local time as a naive datetime.
+
+    Mirrors the production ``analysis_start_local``.  Tests derive
+    ``today_start = yesterday_start + timedelta(days=1)`` when they need
+    the upper bound, so all timing anchors are expressed relative to
+    the same reference point.
+    """
+    today_start = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+    return today_start - timedelta(days=1)
 
 
 def _ts_str(dt: datetime) -> str:
@@ -114,14 +140,30 @@ def _make_slave_master(slave_ip, slave_port, master_ip, master_port, slave_age_h
     )
 
 
-def _run_check_instance(bklogs, cluster=None, kvstorecount=None, ip="3.3.3.2", port="30000", analysis_end_local=None):
+def _run_check_instance(
+    bklogs,
+    cluster=None,
+    kvstorecount=None,
+    ip="3.3.3.2",
+    port="30000",
+    analysis_start_local=None,
+    analysis_end_local=None,
+):
     if cluster is None:
         cluster = _make_cluster()
     report = _report_cls()(cluster, "binlog_backup")
     instance = f"{ip}:{port}"
     with patch(_PATCH_FIND, return_value=set()):
         _task()._check_instance(
-            report, bklogs, cluster, instance, ip, port, kvstorecount, analysis_end_local=analysis_end_local
+            report,
+            bklogs,
+            cluster,
+            instance,
+            ip,
+            port,
+            kvstorecount,
+            analysis_start_local=analysis_start_local,
+            analysis_end_local=analysis_end_local,
         )
     return report
 
@@ -134,10 +176,41 @@ def _cluster_with_slave(cluster_type=None):
     return cluster
 
 
-# ---------------------------------------------------------------------------
-# _check_instance
-# ---------------------------------------------------------------------------
-def test_check_instance_no_bklogs_abnormal():
+def _binlog_filename(cluster_type, ip, port, idx, content_time, kv=0):
+    """Build a binlog filename matching the cluster type's layout.
+
+    TendisSSD:  binlog-{ip}-{port}-{idx}-{ts}.log.zst
+    TendisPlus: binlog-{ip}-{port}-{kv}-{idx}-{ts}.log.zst
+    """
+    if cluster_type == _cluster_type().TendisPredixyTendisplusCluster.value:
+        return f"binlog-{ip}-{port}-{kv}-{idx}-{_ts_str(content_time)}.log.zst"
+    return f"binlog-{ip}-{port}-{idx}-{_ts_str(content_time)}.log.zst"
+
+
+# Variant fixtures for tests that should exercise both SSD and TendisPlus
+# code paths with the same scenario shape.  ``is_plus`` toggles the
+# ``is_tendisplus_instance_type`` / ``is_tendisssd_instance_type``
+# patches; ``kvstorecount`` is None for SSD and 1 for TendisPlus.
+_VARIANT_PARAMS = [
+    pytest.param(False, None, id="ssd"),
+    pytest.param(True, 1, id="tendisplus"),
+]
+
+
+def _variant_cluster(is_plus):
+    CT = _cluster_type()
+    if is_plus:
+        return _make_cluster(CT.TendisPredixyTendisplusCluster.value)
+    return _make_cluster(CT.TwemproxyTendisSSDInstance.value)
+
+
+# ===========================================================================
+# Class A: input-shape preconditions for _check_instance
+# ===========================================================================
+def test_input_no_bklogs_abnormal():
+    """Empty ``bklogs`` is the strongest abnormal signal: BKLog returned
+    nothing for the instance even after the 1h leading and trailing
+    buffer hours, so report ABNORMAL ``no logs found``."""
     ST = _state()
     report = _run_check_instance([])
     records = report.records[ST.ABNORMAL.value]
@@ -145,7 +218,10 @@ def test_check_instance_no_bklogs_abnormal():
     assert "no logs found" in records[0]["msg"]
 
 
-def test_check_instance_no_terminal_entries_warning():
+def test_input_only_non_terminal_warning():
+    """All entries are ``to_backup_system_start`` with no terminal
+    statuses anywhere -- nothing to verify.  Report WARNING ``no
+    terminal binlog status found``."""
     ST = _state()
     logs = [make_binlog_entry(status="to_backup_system_start", ip="3.3.3.2", port=30000)]
     report = _run_check_instance(logs)
@@ -154,179 +230,101 @@ def test_check_instance_no_terminal_entries_warning():
     assert "no terminal" in records[0]["msg"]
 
 
-def test_check_instance_all_failed_warning():
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_input_all_uploads_failed_warning(is_plus, kvstorecount):
+    """Every terminal entry is ``to_backup_system_failed`` -- the
+    ``success_count == 0`` branch fires before any cluster-type-specific
+    logic, so both SSD and TendisPlus produce the same WARNING."""
     ST = _state()
+    cluster = _variant_cluster(is_plus)
     logs = [
         make_binlog_entry(
             status="to_backup_system_failed",
             ip="3.3.3.2",
             port=30000,
-            file_name="binlog-3.3.3.2-30000-1-1234.log.zst",
+            file_name=_binlog_filename(cluster.cluster_type, "3.3.3.2", 30000, 1, _DONT_CARE_TS),
         )
     ]
-    report = _run_check_instance(logs)
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(logs, cluster=cluster, kvstorecount=kvstorecount)
     records = report.records[ST.WARNING.value]
     assert len(records) == 1
     assert "all" in records[0]["msg"] and "failed" in records[0]["msg"]
 
 
-def test_check_instance_ssd_no_missing_normal():
+# ===========================================================================
+# Class B: yesterday-only gap detection
+# ===========================================================================
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_yesterday_no_gap_normal(is_plus, kvstorecount):
+    """Contiguous successful indexes produce NORMAL for both cluster
+    types."""
     ST = _state()
+    cluster = _variant_cluster(is_plus)
     logs = [
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=f"binlog-3.3.3.2-30000-{i}-1234.log.zst",
-        )
-        for i in range(5)
-    ]
-    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
-        report = _run_check_instance(logs)
-    records = report.records[ST.NORMAL.value]
-    assert len(records) == 1
-    assert records[0]["msg"] == "ok"
-
-
-def test_check_instance_ssd_with_gaps_warning():
-    ST = _state()
-    logs = [
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-1-1234.log.zst",
-        ),
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-5-1234.log.zst",
-        ),
-    ]
-    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
-        report = _run_check_instance(logs)
-    records = report.records[ST.WARNING.value]
-    assert len(records) == 1
-    assert "seq gaps" in records[0]["msg"]
-
-
-def test_check_instance_tendisplus_all_ok():
-    ST = _state()
-    CT = _cluster_type()
-    cluster = _make_cluster(CT.TendisPredixyTendisplusCluster.value)
-    logs = [
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name=f"binlog-3.3.3.2-30000-0-{i}-1234.log.zst",
+            file_name=_binlog_filename(cluster.cluster_type, "3.3.3.2", 30000, i, _DONT_CARE_TS),
         )
         for i in range(3)
     ]
-    with patch(_PATCH_IS_PLUS, return_value=True), patch(_PATCH_IS_SSD, return_value=False):
-        report = _run_check_instance(logs, cluster=cluster, kvstorecount=1)
-    records = report.records[ST.NORMAL.value]
-    assert len(records) == 1
-
-
-def test_check_instance_tendisplus_kv_gaps_warning():
-    ST = _state()
-    CT = _cluster_type()
-    cluster = _make_cluster(CT.TendisPredixyTendisplusCluster.value)
-    logs = [
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-0-1-1234.log.zst",
-        ),
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-0-5-1234.log.zst",
-        ),
-    ]
-    with patch(_PATCH_IS_PLUS, return_value=True), patch(_PATCH_IS_SSD, return_value=False):
-        report = _run_check_instance(logs, cluster=cluster, kvstorecount=1)
-    records = report.records[ST.WARNING.value]
-    assert len(records) == 1
-    assert "kv0" in records[0]["msg"]
-
-
-def test_check_instance_tendisplus_kv_all_failed():
-    ST = _state()
-    CT = _cluster_type()
-    cluster = _make_cluster(CT.TendisPredixyTendisplusCluster.value)
-    logs = [
-        make_binlog_entry(
-            status="to_backup_system_failed",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-0-1-1234.log.zst",
-        )
-    ]
-    with patch(_PATCH_IS_PLUS, return_value=True), patch(_PATCH_IS_SSD, return_value=False):
-        report = _run_check_instance(logs, cluster=cluster, kvstorecount=1)
-    records = report.records[ST.WARNING.value]
-    assert len(records) == 1
-    assert "failed" in records[0]["msg"]
-
-
-# ---------------------------------------------------------------------------
-# content-time filter (analysis_end_local) tests
-# ---------------------------------------------------------------------------
-def _ssd_filename(ip, port, idx, content_time):
-    return f"binlog-{ip}-{port}-{idx}-{_ts_str(content_time)}.log.zst"
-
-
-def _plus_filename(ip, port, kv, idx, content_time):
-    return f"binlog-{ip}-{port}-{kv}-{idx}-{_ts_str(content_time)}.log.zst"
-
-
-def test_check_instance_day_boundary_no_false_positive():
-    """User scenario: idx=2 yesterday is uploaded too late (out of window),
-    idx=3 today is in the buffer.  Without filter, [1, 3] would falsely
-    flag idx=2 as missing.  With filter, today's idx=3 is excluded and
-    only idx=1 remains -- no gap reported."""
-    ST = _state()
-    today_start = _yesterday_local()
-    yesterday_late = today_start - timedelta(minutes=10)
-    today_first_hour = today_start + timedelta(minutes=10)
-    logs = [
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 1, yesterday_late),
-        ),
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 3, today_first_hour),
-        ),
-    ]
-    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
-        report = _run_check_instance(logs, analysis_end_local=today_start)
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(logs, cluster=cluster, kvstorecount=kvstorecount)
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
     assert records[0]["msg"] == "ok"
 
 
-def test_check_instance_tail_missing_within_yesterday_still_detected():
-    """Genuine gap inside yesterday content (idx=3 missing between 1, 2, 4)
-    must still be flagged even with the content-time filter active."""
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_yesterday_with_gap_warning(is_plus, kvstorecount):
+    """An interior gap between the observed min and max indexes is
+    flagged for both cluster types.  TendisPlus reports the gap
+    per-kvstore (``kv0(...)``); SSD reports it as ``seq gaps``."""
     ST = _state()
-    today_start = _yesterday_local()
-    base = today_start - timedelta(hours=12)
+    cluster = _variant_cluster(is_plus)
     logs = [
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, idx, base + timedelta(minutes=10 * idx)),
+            file_name=_binlog_filename(cluster.cluster_type, "3.3.3.2", 30000, idx, _DONT_CARE_TS),
+        )
+        for idx in (1, 5)
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(logs, cluster=cluster, kvstorecount=kvstorecount)
+    records = report.records[ST.WARNING.value]
+    assert len(records) == 1
+    if is_plus:
+        assert "kv0" in records[0]["msg"]
+    else:
+        assert "seq gaps (2-4)" in records[0]["msg"]
+
+
+def test_yesterday_real_gap_detected_with_filter():
+    """Genuine interior gap in yesterday content (idx=3 missing between
+    1, 2, 4) must still be flagged when the content-time filter is
+    active -- the filter removes neighbouring-day boundary noise but
+    must not hide real gaps."""
+    ST = _state()
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    base = today_start - timedelta(hours=12)
+    CT = _cluster_type()
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                CT.TwemproxyTendisSSDInstance.value,
+                "3.3.3.2",
+                30000,
+                idx,
+                base + timedelta(minutes=10 * idx),
+            ),
         )
         for idx in (1, 2, 4)
     ]
@@ -338,30 +336,136 @@ def test_check_instance_tail_missing_within_yesterday_still_detected():
     assert "3" in records[0]["msg"]
 
 
-def test_check_instance_late_uploaded_yesterday_seq_in_buffer_normal():
-    """idx=2 has yesterday content but uploaded after midnight (still in
-    the 1h buffer window).  Buffer brings it in, content-time filter
-    keeps it, no gap reported -- this validates the buffer's purpose."""
+# ===========================================================================
+# Class C: content-time filtering (_in_window)
+# ===========================================================================
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_filter_excludes_trailing_buffer(is_plus, kvstorecount):
+    """User scenario: idx=2 yesterday is uploaded too late (out of
+    window), idx=3 today is in the trailing buffer.  Without the
+    filter, [1, 3] would falsely flag idx=2 as missing.  With the
+    filter, today's idx=3 is excluded and only idx=1 remains -- no
+    gap reported.  Exercised for both SSD and TendisPlus."""
     ST = _state()
-    today_start = _yesterday_local()
+    cluster = _variant_cluster(is_plus)
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    yest_late = today_start - timedelta(minutes=10)
+    today_first = today_start + timedelta(minutes=20)
     logs = [
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 1, today_start - timedelta(minutes=20)),
+            file_name=_binlog_filename(cluster.cluster_type, "3.3.3.2", 30000, 1, yest_late),
         ),
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 2, today_start - timedelta(minutes=5)),
+            file_name=_binlog_filename(cluster.cluster_type, "3.3.3.2", 30000, 3, today_first),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(
+            logs,
+            cluster=cluster,
+            kvstorecount=kvstorecount,
+            analysis_end_local=today_start,
+        )
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+
+
+def test_filter_excludes_leading_buffer():
+    """Mirror of the trailing-buffer case for the leading edge.
+
+    idx=1 is day-before-yesterday content that landed in the leading
+    buffer hour, idx=3 is yesterday content.  Without the filter,
+    [1, 3] would falsely flag idx=2 as missing.  With the filter,
+    idx=1 is excluded and only idx=3 remains in yesterday_logs -- no
+    gap reported.
+    """
+    ST = _state()
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    dby_late = yesterday_start - timedelta(minutes=10)
+    yest_mid = yesterday_start + timedelta(hours=12)
+    CT = _cluster_type()
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(CT.TwemproxyTendisSSDInstance.value, "3.3.3.2", 30000, 1, dby_late),
         ),
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 3, today_start + timedelta(minutes=15)),
+            file_name=_binlog_filename(CT.TwemproxyTendisSSDInstance.value, "3.3.3.2", 30000, 3, yest_mid),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
+        report = _run_check_instance(
+            logs,
+            analysis_start_local=yesterday_start,
+            analysis_end_local=today_start,
+        )
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+    assert records[0]["msg"] == "ok"
+
+
+def test_filter_retains_yesterday_late_content():
+    """Yesterday-late content (just before midnight) must be retained
+    and today-first-hour content must be excluded.
+
+    Yesterday content [1, 2] is contiguous, so there is no gap to
+    fill -- this test asserts the filter's *retention* behaviour for
+    yesterday-late uploads alongside its *exclusion* behaviour for
+    today's first-hour entries.
+    """
+    ST = _state()
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    CT = _cluster_type()
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                CT.TwemproxyTendisSSDInstance.value,
+                "3.3.3.2",
+                30000,
+                1,
+                today_start - timedelta(minutes=20),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                CT.TwemproxyTendisSSDInstance.value,
+                "3.3.3.2",
+                30000,
+                2,
+                today_start - timedelta(minutes=5),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                CT.TwemproxyTendisSSDInstance.value,
+                "3.3.3.2",
+                30000,
+                3,
+                today_start + timedelta(minutes=15),
+            ),
         ),
     ]
     with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
@@ -371,24 +475,35 @@ def test_check_instance_late_uploaded_yesterday_seq_in_buffer_normal():
     assert records[0]["msg"] == "ok"
 
 
-def test_check_instance_filename_timestamp_unparseable_excluded():
-    """Entries whose file_name has an unparseable timestamp segment are
-    treated as 'not yesterday' and excluded from gap analysis."""
+def test_filter_excludes_unparseable_filename():
+    """Entries whose ``file_name`` has an unparseable timestamp segment
+    are treated as 'not yesterday' and excluded from gap analysis
+    via the ``ts is None`` short-circuit in ``_in_window``.  This is
+    fail-safe: an unparseable filename can never cause a false
+    positive."""
     ST = _state()
-    today_start = _yesterday_local()
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
     yest = today_start - timedelta(hours=2)
+    CT = _cluster_type()
     logs = [
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 1, yest),
+            file_name=_binlog_filename(CT.TwemproxyTendisSSDInstance.value, "3.3.3.2", 30000, 1, yest),
         ),
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_ssd_filename("3.3.3.2", 30000, 2, yest + timedelta(minutes=10)),
+            file_name=_binlog_filename(
+                CT.TwemproxyTendisSSDInstance.value,
+                "3.3.3.2",
+                30000,
+                2,
+                yest + timedelta(minutes=10),
+            ),
         ),
         make_binlog_entry(
             status="to_backup_system_success",
@@ -403,35 +518,214 @@ def test_check_instance_filename_timestamp_unparseable_excluded():
     assert len(records) == 1, f"unexpected report: {report.records}"
 
 
-def test_check_instance_tendisplus_day_boundary_no_false_positive():
-    """Same false-positive scenario, TendisPlus per-kvstore variant."""
+# ===========================================================================
+# Class D: buffer-fill defensive behaviour (missing -= fillable)
+# ===========================================================================
+#
+# Note on the two ``*_fills_gap_defensive`` tests below: under
+# monotonic binlog rotation (T_i < T_j whenever i < j), neither
+# scenario can physically occur.  They construct invariant-violating
+# orderings (idx=2 with content time earlier than idx=1) on purpose,
+# to validate the defensive ``missing -= fillable`` subtraction in
+# ``_find_missing_binlogs``.  If the buffer-fill subtraction were
+# removed, these tests would fail; in real-world traffic where
+# monotonicity holds, that line is a no-op.
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_buffer_leading_fills_gap_defensive(is_plus, kvstorecount):
+    """Defensive scenario: idx=1 yesterday, idx=2 in the leading buffer
+    (DBY content), idx=3 yesterday.  This ordering cannot occur under
+    monotonic rotation; the test exists to ensure ``missing -=
+    fillable`` continues to suppress the would-be gap so a future
+    invariant violation (e.g. counter reset, clock skew) does not
+    cause a false positive."""
     ST = _state()
-    CT = _cluster_type()
-    cluster = _make_cluster(CT.TendisPredixyTendisplusCluster.value)
-    today_start = _yesterday_local()
-    yest_late = today_start - timedelta(minutes=10)
-    today_first = today_start + timedelta(minutes=20)
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    cluster = _variant_cluster(is_plus)
     logs = [
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_plus_filename("3.3.3.2", 30000, 0, 1, yest_late),
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                1,
+                yesterday_start + timedelta(minutes=5),
+            ),
         ),
         make_binlog_entry(
             status="to_backup_system_success",
             ip="3.3.3.2",
             port=30000,
-            file_name=_plus_filename("3.3.3.2", 30000, 0, 3, today_first),
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                2,
+                yesterday_start - timedelta(minutes=5),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                3,
+                yesterday_start + timedelta(minutes=10),
+            ),
         ),
     ]
-    with patch(_PATCH_IS_PLUS, return_value=True), patch(_PATCH_IS_SSD, return_value=False):
-        report = _run_check_instance(logs, cluster=cluster, kvstorecount=1, analysis_end_local=today_start)
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(
+            logs,
+            cluster=cluster,
+            kvstorecount=kvstorecount,
+            analysis_start_local=yesterday_start,
+            analysis_end_local=today_start,
+        )
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
+    assert records[0]["msg"] == "ok"
 
 
-def test_check_instance_api_promoted_counted():
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_buffer_trailing_fills_gap_defensive(is_plus, kvstorecount):
+    """Mirror of the leading-buffer defensive case, on the trailing
+    edge.  Same invariant-violating ordering (idx=2 with content time
+    later than idx=3) -- not physically possible under monotonic
+    rotation, but kept as a safety net for the buffer-fill
+    subtraction."""
+    ST = _state()
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    cluster = _variant_cluster(is_plus)
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                1,
+                today_start - timedelta(minutes=10),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                2,
+                today_start + timedelta(minutes=10),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                3,
+                today_start - timedelta(minutes=5),
+            ),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(
+            logs,
+            cluster=cluster,
+            kvstorecount=kvstorecount,
+            analysis_start_local=yesterday_start,
+            analysis_end_local=today_start,
+        )
+    records = report.records[ST.NORMAL.value]
+    assert len(records) == 1
+    assert records[0]["msg"] == "ok"
+
+
+@pytest.mark.parametrize("is_plus,kvstorecount", _VARIANT_PARAMS)
+def test_buffer_does_not_mask_yesterday_failure(is_plus, kvstorecount):
+    """Buffer-success entries must NOT suppress a known yesterday
+    failure.  If idx=2 is FAILED in yesterday and a same-index entry
+    appears as success in the buffer (different binlog file, content
+    time in DBY), the failure stays reported -- this guards against
+    the buffer-fill subtraction over-reaching into known failures.
+    """
+    ST = _state()
+    yesterday_start = _yesterday_start_local()
+    today_start = yesterday_start + timedelta(days=1)
+    cluster = _variant_cluster(is_plus)
+    logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                1,
+                yesterday_start + timedelta(minutes=5),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_failed",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                2,
+                yesterday_start + timedelta(minutes=10),
+            ),
+        ),
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name=_binlog_filename(
+                cluster.cluster_type,
+                "3.3.3.2",
+                30000,
+                2,
+                yesterday_start - timedelta(minutes=10),
+            ),
+        ),
+    ]
+    with patch(_PATCH_IS_PLUS, return_value=is_plus), patch(_PATCH_IS_SSD, return_value=not is_plus):
+        report = _run_check_instance(
+            logs,
+            cluster=cluster,
+            kvstorecount=kvstorecount,
+            analysis_start_local=yesterday_start,
+            analysis_end_local=today_start,
+        )
+    records = report.records[ST.WARNING.value]
+    assert len(records) == 1
+    assert "2" in records[0]["msg"]
+
+
+# ===========================================================================
+# Class E: API promotion via find_and_verify_failed_tasks
+# ===========================================================================
+def test_api_promoted_task_counted_as_success():
+    """A ``to_backup_system_start`` entry with no terminal sibling can
+    still count as success when the backup-system API confirms the
+    task_id -- exercises the promotion path that injects API-confirmed
+    starts into both ``all_terminal`` and ``success_entries``."""
     ST = _state()
     logs = [
         make_binlog_entry(
@@ -454,10 +748,10 @@ def test_check_instance_api_promoted_counted():
     assert len(records) == 1
 
 
-# ---------------------------------------------------------------------------
-# _check_cluster
-# ---------------------------------------------------------------------------
-def test_check_cluster_cloud_id_skip(mock_config):
+# ===========================================================================
+# Class F: _check_cluster orchestration
+# ===========================================================================
+def test_cluster_skips_unmatched_cloud_id(mock_config):
     cluster = _cluster_with_slave()
     mock_config.target_bk_cloud_ids = [99]
     rows = _task()._check_cluster(cluster, _DUMMY_START, _DUMMY_END, mock_config)
@@ -465,7 +759,7 @@ def test_check_cluster_cloud_id_skip(mock_config):
     assert "skipped" in rows[0].msg
 
 
-def test_check_cluster_no_eligible_slaves(mock_config):
+def test_cluster_skips_when_no_eligible_slaves(mock_config):
     cluster = _make_cluster()
     cluster.storages = [_make_slave_master("3.3.3.2", 30000, "3.3.3.1", 30000, slave_age_hours=1)]
     rows = _task()._check_cluster(cluster, _DUMMY_START, _DUMMY_END, mock_config)
@@ -473,7 +767,7 @@ def test_check_cluster_no_eligible_slaves(mock_config):
     assert "no eligible" in rows[0].msg
 
 
-def test_check_cluster_kvstorecount_failure(mock_config):
+def test_cluster_kvstorecount_fetch_failure_abnormal(mock_config):
     CT = _cluster_type()
     cluster = _cluster_with_slave(CT.TendisPredixyTendisplusCluster.value)
     with patch(_PATCH_IS_PLUS, return_value=True), patch(_PATCH_CLUSTER_CONFIG, side_effect=Exception("boom")):
@@ -483,7 +777,7 @@ def test_check_cluster_kvstorecount_failure(mock_config):
     assert "kvstorecount" in rows[0].msg
 
 
-def test_check_cluster_normal_summary(mock_config):
+def test_cluster_normal_end_to_end(mock_config):
     ST = _state()
     cluster = _cluster_with_slave()
     logs = [
@@ -505,7 +799,7 @@ def test_check_cluster_normal_summary(mock_config):
     assert rows[0].state == ST.NORMAL.value
 
 
-def test_check_cluster_mixed_per_ip(mock_config):
+def test_cluster_mixed_per_ip_end_to_end(mock_config):
     ST = _state()
     cluster = _make_cluster()
     cluster.storages = [
@@ -531,75 +825,43 @@ def test_check_cluster_mixed_per_ip(mock_config):
     assert rows[0].state == ST.ABNORMAL.value
 
 
-def test_check_cluster_tiered_no_fallback(mock_config):
-    """When cluster-level fetch is not truncated, no per-IP/instance calls."""
+@pytest.mark.parametrize(
+    "cluster_truncated,ip_truncated,expected_ip_calls,expected_inst_calls",
+    [
+        pytest.param(False, False, 0, 0, id="no_fallback"),
+        pytest.param(True, False, 1, 0, id="fallback_to_ip"),
+        pytest.param(True, True, 1, 1, id="fallback_to_instance"),
+    ],
+)
+def test_cluster_tiered_fetch_fallback(
+    mock_config, cluster_truncated, ip_truncated, expected_ip_calls, expected_inst_calls
+):
+    """Tiered BKLog fetch narrows scope on truncation:
+    cluster -> per-IP -> per-instance.  At each truncation level the
+    next tier is invoked exactly once per IP/instance; at the
+    not-truncated tier the deeper tiers are not called."""
     cluster = _make_cluster()
-    cluster.storages = [
-        _make_slave_master("3.3.3.2", 30000, "3.3.3.1", 30000),
-        _make_slave_master("3.3.3.3", 30001, "3.3.3.1", 30001),
+    cluster.storages = [_make_slave_master("3.3.3.2", 30000, "3.3.3.1", 30000)]
+    success_logs = [
+        make_binlog_entry(
+            status="to_backup_system_success",
+            ip="3.3.3.2",
+            port=30000,
+            file_name="binlog-3.3.3.2-30000-1-1234.log.zst",
+        )
     ]
+    cluster_logs = [] if cluster_truncated else success_logs
+    ip_logs = [] if ip_truncated else success_logs
     with (
-        patch(_PATCH_FETCH_CLUSTER, return_value=([], False)) as mock_cluster,
-        patch(_PATCH_FETCH_IP) as mock_ip,
-        patch(_PATCH_FETCH_INSTANCE) as mock_inst,
+        patch(_PATCH_FETCH_CLUSTER, return_value=(cluster_logs, cluster_truncated)) as mock_cluster,
+        patch(_PATCH_FETCH_IP, return_value=(ip_logs, ip_truncated)) as mock_ip,
+        patch(_PATCH_FETCH_INSTANCE, return_value=success_logs) as mock_inst,
         patch(_PATCH_FIND, return_value=set()),
+        patch(_PATCH_IS_PLUS, return_value=False),
+        patch(_PATCH_IS_SSD, return_value=True),
     ):
-        _task()._check_cluster(cluster, _DUMMY_START, _DUMMY_END, mock_config)
+        rows = _task()._check_cluster(cluster, _DUMMY_START, _DUMMY_END, mock_config)
     assert mock_cluster.call_count == 1
-    assert mock_ip.call_count == 0
-    assert mock_inst.call_count == 0
-
-
-def test_check_cluster_tiered_fallback_to_ip(mock_config):
-    """Cluster truncated -> falls back to per-IP; no per-instance calls."""
-    cluster = _make_cluster()
-    cluster.storages = [
-        _make_slave_master("3.3.3.2", 30000, "3.3.3.1", 30000),
-    ]
-    ip_logs = [
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-1-1234.log.zst",
-        )
-    ]
-    with (
-        patch(_PATCH_FETCH_CLUSTER, return_value=([], True)),
-        patch(_PATCH_FETCH_IP, return_value=(ip_logs, False)) as mock_ip,
-        patch(_PATCH_FETCH_INSTANCE) as mock_inst,
-        patch(_PATCH_FIND, return_value=set()),
-        patch(_PATCH_IS_PLUS, return_value=False),
-        patch(_PATCH_IS_SSD, return_value=True),
-    ):
-        rows = _task()._check_cluster(cluster, _DUMMY_START, _DUMMY_END, mock_config)
-    assert mock_ip.call_count == 1
-    assert mock_inst.call_count == 0
-    assert rows[0].state == _state().NORMAL.value
-
-
-def test_check_cluster_tiered_fallback_to_instance(mock_config):
-    """Cluster and IP both truncated -> falls back to per-instance."""
-    cluster = _make_cluster()
-    cluster.storages = [
-        _make_slave_master("3.3.3.2", 30000, "3.3.3.1", 30000),
-    ]
-    inst_logs = [
-        make_binlog_entry(
-            status="to_backup_system_success",
-            ip="3.3.3.2",
-            port=30000,
-            file_name="binlog-3.3.3.2-30000-1-1234.log.zst",
-        )
-    ]
-    with (
-        patch(_PATCH_FETCH_CLUSTER, return_value=([], True)),
-        patch(_PATCH_FETCH_IP, return_value=([], True)),
-        patch(_PATCH_FETCH_INSTANCE, return_value=inst_logs) as mock_inst,
-        patch(_PATCH_FIND, return_value=set()),
-        patch(_PATCH_IS_PLUS, return_value=False),
-        patch(_PATCH_IS_SSD, return_value=True),
-    ):
-        rows = _task()._check_cluster(cluster, _DUMMY_START, _DUMMY_END, mock_config)
-    assert mock_inst.call_count == 1
+    assert mock_ip.call_count == expected_ip_calls
+    assert mock_inst.call_count == expected_inst_calls
     assert rows[0].state == _state().NORMAL.value


### PR DESCRIPTION
- BKLog 查询窗口由 `[昨天 00:00, 今天 01:00)` 扩成对称的 `[昨天 00:00 - 1h, 今天 00:00 + 1h)`，新增前置 1h buffer，捕获"内容属于前天、上传刚跨过昨天 00:00"的镜像场景，让跨天 `to_backup_system_start ↔ success` 的 failed-task 提升能匹配上
- `_yesterday_time_range` 增加返回 `analysis_start_local`，`_check_instance` 用统一的 `_in_window(ts)` 同时剔除前/后 buffer 中"内容时间不属于昨天"的 entry，避免它们成为 gap 检测的 min/max 边界，消除 day-boundary 误报
- `_find_missing_binlogs` 新增 `buffer_success_entries` 参数：buffer 时段的成功上传可填补昨天序号区间内的"假 gap"，但绝不覆盖昨天侧已知的 failed 索引；TendisPlus 按 kv 维度同样生效
- 测试整体重组为 A–F 六类（input 前置 / yesterday gap / 内容时间过滤 / buffer 防御 / API 提升 / `_check_cluster` 编排），SSD 与 TendisPlus 用 `_VARIANT_PARAMS` 参数化共用同一场景，新增 leading buffer、buffer 填洞防御、unparseable 过滤等用例