### PR TITLE
feat(mysql): add-more-param-in-drs-mysql-rpc-v2 #17515

### DIFF
--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/makeconnection.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/makeconnection.go
@@ -14,40 +14,65 @@ import (
 )
 
 // makeConnection 创建数据库连接，处理 default 字符集的特殊逻辑
-func makeConnection(ctx context.Context, addr, user, password, timezone, charset string, timeout int) (*sqlx.DB, error) {
-	// 如果不是 default 字符集，直接连接
-	if charset != "default" {
-		return connectWithRetry(ctx, addr, user, password, timezone, charset, timeout)
+func makeConnection(ctx context.Context, addr, user, password, timezone, charset string, timeout int, preHookCmds []string, skipSetNames bool) (*sqlx.DB, error) {
+	if skipSetNames {
+		return connectWithRetry(ctx, addr, user, password, timezone, "", timeout, preHookCmds)
 	}
 
-	// 处理 default 字符集：先建立临时连接获取服务器字符集
-	tempDB, err := connectWithRetry(ctx, addr, user, password, timezone, "", timeout)
+	if charset != "default" {
+		return connectWithRetry(ctx, addr, user, password, timezone, charset, timeout, preHookCmds)
+	}
+
+	db, err := connectWithRetry(ctx, addr, user, password, timezone, "", timeout, preHookCmds)
 	if err != nil {
 		return nil, err
 	}
 
-	// 查询服务器字符集
 	var serverCharset string
-	err = tempDB.QueryRowContext(ctx, `SELECT @@character_set_server`).Scan(&serverCharset)
-	// 无论成功与否，都关闭临时连接
-	_ = tempDB.Close()
-
+	err = db.QueryRowContext(ctx, `SELECT @@character_set_server`).Scan(&serverCharset)
 	if err != nil {
+		_ = db.Close()
 		return nil, fmt.Errorf("query server charset failed: %w", err)
 	}
 
-	// 使用实际字符集重新连接
-	return connectWithRetry(ctx, addr, user, password, timezone, serverCharset, timeout)
+	slog.Info("mysql server charset", slog.String("addr", addr), slog.String("charset", serverCharset))
+	_, err = db.ExecContext(ctx, fmt.Sprintf("SET NAMES '%s'", serverCharset))
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("set names %s failed: %w", serverCharset, err)
+	}
+
+	return db, nil
 }
 
 // connectWithRetry 带重试的数据库连接（纯粹的连接逻辑，不处理 default 字符集）
-func connectWithRetry(ctx context.Context, addr, user, password, timezone, charset string, timeout int) (db *sqlx.DB, err error) {
-	dsn, safeDSN := buildDSN(addr, user, password, timezone, charset, timeout)
+func connectWithRetry(ctx context.Context, addr, user, password, timezone, charset string, timeout int, preHookCmds []string) (db *sqlx.DB, err error) {
+	dsn, safeDSN := buildDSN(addr, user, password, timezone, timeout)
 
 	err = retry.Do(
 		func() error {
 			db, err = sqlx.ConnectContext(ctx, "mysql", dsn)
-			return err
+			if err != nil {
+				return err
+			}
+
+			for _, cmd := range preHookCmds {
+				if _, execErr := db.ExecContext(ctx, cmd); execErr != nil {
+					_ = db.Close()
+					db = nil
+					return execErr
+				}
+			}
+
+			if charset != "" {
+				if _, execErr := db.ExecContext(ctx, fmt.Sprintf("SET NAMES '%s'", charset)); execErr != nil {
+					_ = db.Close()
+					db = nil
+					return execErr
+				}
+			}
+
+			return nil
 		},
 		retry.Context(ctx),
 		retry.Attempts(3),
@@ -55,7 +80,6 @@ func connectWithRetry(ctx context.Context, addr, user, password, timezone, chars
 		retry.DelayType(retry.FixedDelay),
 	)
 	if err != nil {
-		// 注意: 这里只能打 safeDSN, 真实 dsn 含明文密码绝不能进日志
 		slog.Error(
 			"v2 mysql failed to connect",
 			slog.String("error", err.Error()),
@@ -73,13 +97,10 @@ func connectWithRetry(ctx context.Context, addr, user, password, timezone, chars
 //
 // 任何对外可见的位置 (日志/metric/error message) 都只能用 safeDSN,
 // 真实 dsn 仅作为 sqlx.Connect 的入参.
-func buildDSN(addr, user, password, timezone, charset string, timeout int) (dsn, safeDSN string) {
+func buildDSN(addr, user, password, timezone string, timeout int) (dsn, safeDSN string) {
 	tail := fmt.Sprintf(`@tcp(%s)/?timeout=%ds`, addr, timeout)
 	if timezone != "" {
 		tail += fmt.Sprintf("&time_zone=%s", url.QueryEscape(fmt.Sprintf(`'%s'`, timezone)))
-	}
-	if charset != "" {
-		tail += fmt.Sprintf("&charset=%s", charset)
 	}
 
 	dsn = fmt.Sprintf(`%s:%s%s`, user, password, tail)

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/prepare.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/internal/impl/prepare.go
@@ -16,8 +16,8 @@ import (
 // 返回值约定:
 //   - 成功: db, conn, connID 都非空, 调用方需要在用完后调用 Clean
 //   - 失败: 全部为 nil/0, Prepare 内部已经清理了任何中间产物, 调用方不需要再调 Clean
-func Prepare(ctx context.Context, addr, user, password, timezone, charset string, timeout int) (*sqlx.DB, *sqlx.Conn, int64, error) {
-	db, err := makeConnection(ctx, addr, user, password, timezone, charset, timeout)
+func Prepare(ctx context.Context, addr, user, password, timezone, charset string, timeout int, preHookCmds []string, skipSetNames bool) (*sqlx.DB, *sqlx.Conn, int64, error) {
+	db, err := makeConnection(ctx, addr, user, password, timezone, charset, timeout, preHookCmds, skipSetNames)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/handler.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/handler.go
@@ -39,6 +39,8 @@ func makeHandler(endpoint string, account func() (user, password string)) gin.Ha
 			slog.String("addresses", strings.Join(req.Addresses, ",")),
 			slog.String("cmds", strings.Join(req.Cmds, ",")),
 			slog.Bool("force", req.Force),
+			slog.String("pre_hook_cmds", strings.Join(req.PreHookCmds, ",")),
+			slog.Bool("skip_set_names", req.SkipSetNames),
 		)
 
 		start := time.Now()

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/init.go
@@ -16,6 +16,8 @@ type MySQLRPCRequest struct {
 	Timezone       string   `form:"timezone" json:"timezone"`
 	Charset        string   `form:"charset" json:"charset"`
 	TraceId        string   `form:"trace_id" json:"trace_id"`
+	PreHookCmds    []string `form:"pre_hook_cmds" json:"pre_hook_cmds"`
+	SkipSetNames   bool     `form:"skip_set_names" json:"skip_set_names"`
 }
 
 func (c *MySQLRPCRequest) TrimSpace() {

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/oneaddr.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/rpc/oneaddr.go
@@ -12,7 +12,7 @@ func (c *MySQLRPCRequest) executeCmds(ctx context.Context, addr, user, password 
 	db, conn, connId, err := impl.Prepare(
 		ctx,
 		addr, user, password,
-		c.Timezone, c.Charset, c.ConnectTimeout,
+		c.Timezone, c.Charset, c.ConnectTimeout, c.PreHookCmds, c.SkipSetNames,
 	)
 	if err != nil {
 		slog.Error("v2 mysql prepare connection failed",

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/handler.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/handler.go
@@ -153,7 +153,7 @@ func (s *wsSession) handleConnect(body json.RawMessage) ([]byte, error) {
 	s.db, s.conn, s.connID, err = impl.Prepare(
 		ctx,
 		connectReq.Address, s.user, s.password,
-		connectReq.Timezone, connectReq.Charset, connectReq.Timeout,
+		connectReq.Timezone, connectReq.Charset, connectReq.Timeout, connectReq.PreHookCmds, connectReq.SkipSetNames,
 	)
 	if err != nil {
 		slog.Error("v2 ws connect failed",

--- a/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/init.go
+++ b/dbm-services/mysql/db-remote-service/pkg/v2/mysql/websocket/init.go
@@ -8,10 +8,12 @@ type WSBaseRequest struct {
 }
 
 type WSConnectRequest struct {
-	Address  string `json:"address"`
-	Charset  string `json:"charset"`
-	Timezone string `json:"timezone"`
-	Timeout  int    `json:"timeout"`
+	Address      string   `json:"address"`
+	Charset      string   `json:"charset"`
+	Timezone     string   `json:"timezone"`
+	Timeout      int      `json:"timeout"`
+	PreHookCmds  []string `json:"pre_hook_cmds"`
+	SkipSetNames bool     `json:"skip_set_names"`
 }
 
 type WSCommandRequest struct {


### PR DESCRIPTION
mysql rpc v2 新增 
1. pre_hook_cmds: List[str] = []
2. skip_set_names: bool = False

两个参数
---------
drs 连接过程变为
1. sqlx.Open
2. db.Query('select 1') // 代替 db.ping
3. db.Execute(pre_hook_cmds)
4. sqlx dsn 中的 connect params

提供了一种非常前置的行为注入, 但是有可能被 connect params 覆盖

---------
skip_set_names = True 时, 完成前述连接过程后, 不执行 db.Execute('set names xxx') 操作