### PR TITLE
fix(redis): detect tendisplus/tendisSSD at runtime in config rewrite workaround #17528

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
@@ -334,6 +334,18 @@ func (db *RedisClient) Info(section string) (infoRet map[string]string, err erro
 	return
 }
 
+// tendisTypeByRedisVersion 根据 'INFO server' 返回的 redis_version 字符串推断 redis 类型,
+// 返回 TendisTypeTendisplusInsance / TendisTypeTendisSSDInsance / TendisTypeRedisInstance.
+func tendisTypeByRedisVersion(redisVersion string) string {
+	if strings.Contains(redisVersion, "-rocksdb-") {
+		return consts.TendisTypeTendisplusInsance
+	}
+	if strings.Contains(redisVersion, "-TRedis-") {
+		return consts.TendisTypeTendisSSDInsance
+	}
+	return consts.TendisTypeRedisInstance
+}
+
 // GetTendisType 获取redis类型,返回RedisInstance or TendisplusInstance or TendisSSDInsance
 func (db *RedisClient) GetTendisType() (dbType string, err error) {
 	var infoRet map[string]string
@@ -341,14 +353,7 @@ func (db *RedisClient) GetTendisType() (dbType string, err error) {
 	if err != nil {
 		return
 	}
-	version := infoRet["redis_version"]
-	if strings.Contains(version, "-rocksdb-") {
-		dbType = consts.TendisTypeTendisplusInsance
-	} else if strings.Contains(version, "-TRedis-") {
-		dbType = consts.TendisTypeTendisSSDInsance
-	} else {
-		dbType = consts.TendisTypeRedisInstance
-	}
+	dbType = tendisTypeByRedisVersion(infoRet["redis_version"])
 	return
 }
 
@@ -1193,11 +1198,6 @@ func (db *RedisClient) ConfigRewrite() (string, error) {
 }
 
 func (db *RedisClient) needSaveConfigRewriteWorkaround() (bool, error) {
-	if consts.IsTendisplusInstanceDbType(db.DbType) || consts.IsTendisSSDInstanceDbType(db.DbType) {
-		mylog.Logger.Info("dbType:%s is tendisplus/tendisSSD,skip save config workaround,addr:%s",
-			db.DbType, db.Addr)
-		return false, nil
-	}
 	infoMap, err := db.Info("server")
 	if err != nil {
 		return false, err
@@ -1207,6 +1207,14 @@ func (db *RedisClient) needSaveConfigRewriteWorkaround() (bool, error) {
 		// 非 Redis 实例 (例如 predixy/twemproxy 等 proxy) 的 INFO 里不会有 redis_version 字段.
 		// 该 workaround 只针对 Redis < 6.2.2 的 CONFIG REWRITE bug, 对 proxy 不适用, 跳过即可.
 		mylog.Logger.Info("redis_version not found in info server,skip save config workaround,addr:%s", db.Addr)
+		return false, nil
+	}
+	// 通过 redis_version 实时识别 tendisplus / tendisSSD, 避免依赖 db.DbType
+	// (该字段在 NewRedisClient 中被强制改写为 RedisInstance, 不可信).
+	realDbType := tendisTypeByRedisVersion(redisVersion)
+	if consts.IsTendisplusInstanceDbType(realDbType) || consts.IsTendisSSDInstanceDbType(realDbType) {
+		mylog.Logger.Info("redis_version:%s -> dbType:%s is tendisplus/tendisSSD,skip save config workaround,addr:%s",
+			redisVersion, realDbType, db.Addr)
 		return false, nil
 	}
 	return needSaveConfigRewriteWorkaroundByVersion(redisVersion)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
@@ -206,6 +207,19 @@ def _get_cluster_config(domain_name: str, db_version: str, conf_type: str, names
     return data["content"]
 
 
+@dataclass(frozen=True)
+class AnalysisWindow:
+    """Yesterday's wall-clock day as a half-open interval ``[start, end)``"""
+
+    start: datetime
+    end: datetime
+
+    def contains(self, ts: Optional[datetime]) -> bool:
+        if ts is None:
+            return False
+        return self.start <= ts < self.end
+
+
 class CheckBinlogBackupTask:
     """Binlog backup check for TendisPlus and TendisSSD clusters.
 
@@ -224,7 +238,7 @@ class CheckBinlogBackupTask:
         batch_ops.delete_today_records()
 
         cluster_ids = list(self._get_cluster_ids(config))
-        start_time, end_time, analysis_start_local, analysis_end_local = self._yesterday_time_range()
+        start_time, end_time, analysis_window = self._yesterday_time_range()
         cluster_state_total = {
             ReportStateType.NORMAL.value: 0,
             ReportStateType.WARNING.value: 0,
@@ -243,8 +257,7 @@ class CheckBinlogBackupTask:
                     start_time,
                     end_time,
                     config,
-                    analysis_start_local=analysis_start_local,
-                    analysis_end_local=analysis_end_local,
+                    analysis_window=analysis_window,
                 )
                 if rows:
                     cluster_state_total[rows[0].state] += 1
@@ -299,8 +312,7 @@ class CheckBinlogBackupTask:
         config: RedisBackupCheckConfig,
         max_retries: int = 3,
         *,
-        analysis_start_local: Optional[datetime] = None,
-        analysis_end_local: Optional[datetime] = None,
+        analysis_window: Optional[AnalysisWindow] = None,
     ):
         last_error = None
         for attempt in range(max_retries):
@@ -310,8 +322,7 @@ class CheckBinlogBackupTask:
                     start_time,
                     end_time,
                     config,
-                    analysis_start_local=analysis_start_local,
-                    analysis_end_local=analysis_end_local,
+                    analysis_window=analysis_window,
                 )
             except Exception as e:
                 logger.error(
@@ -333,8 +344,7 @@ class CheckBinlogBackupTask:
         end_time,
         config: RedisBackupCheckConfig,
         *,
-        analysis_start_local: Optional[datetime] = None,
-        analysis_end_local: Optional[datetime] = None,
+        analysis_window: Optional[AnalysisWindow] = None,
     ):
         report = RedisBackupClusterReport(cluster, self.subtype)
 
@@ -383,8 +393,7 @@ class CheckBinlogBackupTask:
                     port,
                     kvstorecount,
                     recently_switched=recently_switched.get(instance),
-                    analysis_start_local=analysis_start_local,
-                    analysis_end_local=analysis_end_local,
+                    analysis_window=analysis_window,
                 )
             except Exception as e:
                 logger.error(
@@ -448,8 +457,7 @@ class CheckBinlogBackupTask:
         kvstorecount,
         *,
         recently_switched=None,
-        analysis_start_local: Optional[datetime] = None,
-        analysis_end_local: Optional[datetime] = None,
+        analysis_window: Optional[AnalysisWindow] = None,
     ):
         # The "no logs found" check is done against the raw query window
         # (pre-filter): if BKLog returned nothing at all for this instance
@@ -483,30 +491,22 @@ class CheckBinlogBackupTask:
         # next to a real yesterday seq.  The excluded entries will be
         # re-checked on the appropriate day's run.
         #
-        # Timezone contract: both operands below are NAIVE local time.
+        # Timezone contract: both operands compared via
+        # ``analysis_window.contains`` are NAIVE local time.
         # ``_extract_binlog_timestamp`` returns naive local per the
         # backup-agent filename convention (YYYYMMDDHHMMSS in the local
-        # tz of the source host); ``analysis_start_local`` /
-        # ``analysis_end_local`` are naive local stripped from Django
-        # timezone-aware ``localtime()``.  They are directly comparable
-        # only because both are local wall-clock.  If a newly
-        # provisioned instance ever emits UTC timestamps in filenames,
-        # this comparison would silently mis-classify buffer-window
-        # entries -- revisit this contract then.
-        def _in_window(ts: Optional[datetime]) -> bool:
-            if ts is None:
-                return False
-            if analysis_start_local is not None and ts < analysis_start_local:
-                return False
-            if analysis_end_local is not None and ts >= analysis_end_local:
-                return False
-            return True
-
-        if analysis_start_local is not None or analysis_end_local is not None:
+        # tz of the source host); ``analysis_window`` carries naive
+        # local bounds stripped from Django timezone-aware
+        # ``localtime()``.  They are directly comparable only because
+        # both are local wall-clock.  If a newly provisioned instance
+        # ever emits UTC timestamps in filenames, this comparison would
+        # silently mis-classify buffer-window entries -- revisit this
+        # contract then.
+        if analysis_window is not None:
             yesterday_logs = [
                 e
                 for e in bklogs
-                if _in_window(_extract_binlog_timestamp(e.get("file_name", ""), cluster.cluster_type))
+                if analysis_window.contains(_extract_binlog_timestamp(e.get("file_name", ""), cluster.cluster_type))
             ]
         else:
             yesterday_logs = bklogs
@@ -650,7 +650,7 @@ class CheckBinlogBackupTask:
     def _yesterday_time_range():
         """Compute the BKLog query window and the gap-analysis bounds.
 
-        Returns ``(query_start, query_end, analysis_start_local, analysis_end_local)``:
+        Returns ``(query_start, query_end, analysis_window)``:
 
         - ``query_start``/``query_end``: aware UTC bounds for the BKLog
           ES query.  Window is ``[yesterday 00:00 - 1h, today 00:00 + 1h)``
@@ -667,20 +667,21 @@ class CheckBinlogBackupTask:
             promotion match ``to_backup_system_start`` ↔
             ``to_backup_system_success`` pairs that straddle the
             day-before-yesterday/yesterday boundary.
-        - ``analysis_start_local``/``analysis_end_local``: naive local
-          ``datetime`` bounds of yesterday's wall-clock day
-          (``[yesterday 00:00, today 00:00)``).  Used downstream to
-          drop entries whose content time falls in either buffer hour
-          from yesterday's gap detection -- those entries belong to a
-          neighbouring day and would otherwise create phantom min/max
-          boundaries.  They will be re-checked on the appropriate
-          day's run.
+        - ``analysis_window``: naive-local ``AnalysisWindow`` bounding
+          yesterday's wall-clock day (``[yesterday 00:00, today 00:00)``).
+          Used downstream to drop entries whose content time falls in
+          either buffer hour from yesterday's gap detection -- those
+          entries belong to a neighbouring day and would otherwise
+          create phantom min/max boundaries.  They will be re-checked
+          on the appropriate day's run.
         """
         local_now = timezone.localtime()
         local_today_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
         local_yesterday_start = local_today_start - timedelta(days=1)
         query_start = local_yesterday_start.astimezone(tz=timezone.utc) - timedelta(hours=1)
         query_end = local_today_start.astimezone(tz=timezone.utc) + timedelta(hours=1)
-        analysis_start_local = local_yesterday_start.replace(tzinfo=None)
-        analysis_end_local = local_today_start.replace(tzinfo=None)
-        return query_start, query_end, analysis_start_local, analysis_end_local
+        analysis_window = AnalysisWindow(
+            start=local_yesterday_start.replace(tzinfo=None),
+            end=local_today_start.replace(tzinfo=None),
+        )
+        return query_start, query_end, analysis_window

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_binlog_backup.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_binlog_backup.py
@@ -61,7 +61,7 @@ _DONT_CARE_TS = datetime(2024, 1, 1, 12, 0, 0)
 def _yesterday_start_local():
     """Yesterday 00:00 local time as a naive datetime.
 
-    Mirrors the production ``analysis_start_local``.  Tests derive
+    Mirrors the production ``analysis_window.start``.  Tests derive
     ``today_start = yesterday_start + timedelta(days=1)`` when they need
     the upper bound, so all timing anchors are expressed relative to
     the same reference point.
@@ -78,6 +78,18 @@ def _task_cls():
     from backend.db_periodic_task.local_tasks.redis_backup.check_binlog_backup import CheckBinlogBackupTask
 
     return CheckBinlogBackupTask
+
+
+def _analysis_window(start, end):
+    """Build an ``AnalysisWindow`` with a lazy import.
+
+    Mirrors the lazy-import pattern used elsewhere in this module to
+    avoid triggering the ``local_tasks/__init__.py`` chain at test
+    collection time.
+    """
+    from backend.db_periodic_task.local_tasks.redis_backup.check_binlog_backup import AnalysisWindow
+
+    return AnalysisWindow(start=start, end=end)
 
 
 def _report_cls():
@@ -146,8 +158,7 @@ def _run_check_instance(
     kvstorecount=None,
     ip="3.3.3.2",
     port="30000",
-    analysis_start_local=None,
-    analysis_end_local=None,
+    analysis_window=None,
 ):
     if cluster is None:
         cluster = _make_cluster()
@@ -162,8 +173,7 @@ def _run_check_instance(
             ip,
             port,
             kvstorecount,
-            analysis_start_local=analysis_start_local,
-            analysis_end_local=analysis_end_local,
+            analysis_window=analysis_window,
         )
     return report
 
@@ -329,7 +339,7 @@ def test_yesterday_real_gap_detected_with_filter():
         for idx in (1, 2, 4)
     ]
     with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
-        report = _run_check_instance(logs, analysis_end_local=today_start)
+        report = _run_check_instance(logs, analysis_window=_analysis_window(yesterday_start, today_start))
     records = report.records[ST.WARNING.value]
     assert len(records) == 1
     assert "seq gaps" in records[0]["msg"]
@@ -371,7 +381,7 @@ def test_filter_excludes_trailing_buffer(is_plus, kvstorecount):
             logs,
             cluster=cluster,
             kvstorecount=kvstorecount,
-            analysis_end_local=today_start,
+            analysis_window=_analysis_window(yesterday_start, today_start),
         )
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
@@ -409,8 +419,7 @@ def test_filter_excludes_leading_buffer():
     with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
         report = _run_check_instance(
             logs,
-            analysis_start_local=yesterday_start,
-            analysis_end_local=today_start,
+            analysis_window=_analysis_window(yesterday_start, today_start),
         )
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
@@ -469,7 +478,7 @@ def test_filter_retains_yesterday_late_content():
         ),
     ]
     with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
-        report = _run_check_instance(logs, analysis_end_local=today_start)
+        report = _run_check_instance(logs, analysis_window=_analysis_window(yesterday_start, today_start))
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
     assert records[0]["msg"] == "ok"
@@ -513,7 +522,7 @@ def test_filter_excludes_unparseable_filename():
         ),
     ]
     with patch(_PATCH_IS_PLUS, return_value=False), patch(_PATCH_IS_SSD, return_value=True):
-        report = _run_check_instance(logs, analysis_end_local=today_start)
+        report = _run_check_instance(logs, analysis_window=_analysis_window(yesterday_start, today_start))
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1, f"unexpected report: {report.records}"
 
@@ -585,8 +594,7 @@ def test_buffer_leading_fills_gap_defensive(is_plus, kvstorecount):
             logs,
             cluster=cluster,
             kvstorecount=kvstorecount,
-            analysis_start_local=yesterday_start,
-            analysis_end_local=today_start,
+            analysis_window=_analysis_window(yesterday_start, today_start),
         )
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
@@ -647,8 +655,7 @@ def test_buffer_trailing_fills_gap_defensive(is_plus, kvstorecount):
             logs,
             cluster=cluster,
             kvstorecount=kvstorecount,
-            analysis_start_local=yesterday_start,
-            analysis_end_local=today_start,
+            analysis_window=_analysis_window(yesterday_start, today_start),
         )
     records = report.records[ST.NORMAL.value]
     assert len(records) == 1
@@ -710,8 +717,7 @@ def test_buffer_does_not_mask_yesterday_failure(is_plus, kvstorecount):
             logs,
             cluster=cluster,
             kvstorecount=kvstorecount,
-            analysis_start_local=yesterday_start,
-            analysis_end_local=today_start,
+            analysis_window=_analysis_window(yesterday_start, today_start),
         )
     records = report.records[ST.WARNING.value]
     assert len(records) == 1


### PR DESCRIPTION
- `needSaveConfigRewriteWorkaround` 不再依赖 `db.DbType` 判断引擎类型——`NewRedisClient*` 会把该字段强制改写为 `RedisInstance`，导致 tendisplus / tendisSSD 实例无法命中跳过分支，错误触发 save 配置回写
- 改为基于 `INFO server` 返回的 `redis_version`（`-rocksdb-` / `-TRedis-` 后缀）实时识别真实引擎类型，复用已 fetch 的 `infoMap`，不增加额外往返
- 抽出纯函数 `tendisTypeByRedisVersion` 并让 `GetTendisType` 复用，保证两处类型判定逻辑同源
- 顺便重构 binlog backup check 的分析窗口：把 `analysis_start_local` / `analysis_end_local` 两个裸 `datetime` 参数合并为 frozen 的 `AnalysisWindow` dataclass，配 `.contains(ts)` 方法，调用链与单测同步收敛