### PR TITLE
fix(redis): harden rollback drill cleanup #17673

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
@@ -170,7 +170,7 @@ METRIC_REGISTRY = {
             "))"
         ),
         "aggregation": {
-            "overall": AggFunction.MAX,
+            "overall": AggFunction.SUM,
             "stats": [AggFunction.MIN, AggFunction.MAX, AggFunction.AVG, AggFunction.STDDEV],
         },
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.INSTANCE],
@@ -349,7 +349,7 @@ METRIC_REGISTRY = {
             "))"
         ),
         "aggregation": {
-            "overall": AggFunction.MAX,
+            "overall": AggFunction.SUM,
             "stats": [AggFunction.MIN, AggFunction.MAX, AggFunction.AVG, AggFunction.STDDEV],
         },
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.INSTANCE],
@@ -534,7 +534,7 @@ METRIC_REGISTRY = {
             "))"
         ),
         "aggregation": {
-            "overall": AggFunction.MAX,
+            "overall": AggFunction.SUM,
             "stats": [AggFunction.MIN, AggFunction.MAX, AggFunction.AVG, AggFunction.STDDEV],
         },
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.INSTANCE],

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
@@ -133,28 +133,29 @@ class RedisDataStructureFlow(object):
         Can be embedded into another pipeline (e.g. rollback exercise)
         without spawning a separate FlowTree.
         """
-        is_drill = self.data.get("is_rollback_drill", False)
         logger.info("redis_data_structure_flow info:{}".format(info))
-        redis_pipeline, act_kwargs = self.__init_builder(_("REDIS_DATA_STRUCTURE"), info)
+        redis_pipeline, act_kwargs, cluster_ticket_data = self.__init_builder(_("REDIS_DATA_STRUCTURE"), info)
+        is_drill = cluster_ticket_data.get("is_rollback_drill", False)
         cluster_type = act_kwargs.cluster["cluster_type"]
 
-        # 屏蔽临时主机告警，避免数据构造期间临时实例上报噪声告警
         temp_host_ips = [host["ip"] for host in info["redis"]]
-        shield_duration_seconds = int(self.data.get("alarm_shield_duration_seconds", 2 * 3600))
-        shield_kwargs = deepcopy(act_kwargs)
-        redis_pipeline.add_act(
-            act_name=_("屏蔽临时主机告警-{}").format(temp_host_ips),
-            act_component_code=AddAlarmShieldComponent.code,
-            kwargs={
-                **asdict(shield_kwargs),
-                "description": _("Redis数据构造-屏蔽告警-{}").format(act_kwargs.cluster["domain_name"]),
-                "dimensions": [
-                    {"name": "appid", "values": [str(act_kwargs.cluster["bk_biz_id"])]},
-                    {"name": "bk_target_ip", "values": temp_host_ips},
-                ],
-                "duration_seconds": shield_duration_seconds,
-            },
-        )
+        if not is_drill:
+            # 屏蔽临时主机告警，避免数据构造期间临时实例上报噪声告警
+            shield_duration_seconds = int(cluster_ticket_data.get("alarm_shield_duration_seconds", 2 * 3600))
+            shield_kwargs = deepcopy(act_kwargs)
+            redis_pipeline.add_act(
+                act_name=_("屏蔽临时主机告警-{}").format(temp_host_ips),
+                act_component_code=AddAlarmShieldComponent.code,
+                kwargs={
+                    **asdict(shield_kwargs),
+                    "description": _("Redis数据构造-屏蔽告警-{}").format(act_kwargs.cluster["domain_name"]),
+                    "dimensions": [
+                        {"name": "appid", "values": [str(act_kwargs.cluster["bk_biz_id"])]},
+                        {"name": "bk_target_ip", "values": temp_host_ips},
+                    ],
+                    "duration_seconds": shield_duration_seconds,
+                },
+            )
         # 获取 kvstorecount
         redis_config = self.__get_cluster_config(
             str(act_kwargs.cluster["bk_biz_id"]),
@@ -167,7 +168,7 @@ class RedisDataStructureFlow(object):
         if is_tendisplus_instance_type(act_kwargs.cluster["cluster_type"]):
             logger.info("redis_data_structure_flow kvstorecount:{}".format(redis_config["kvstorecount"]))
             act_kwargs.cluster["kvstorecount"] = redis_config["kvstorecount"]
-        act_kwargs.cluster["ticket_type"] = self.data["ticket_type"]
+        act_kwargs.cluster["ticket_type"] = cluster_ticket_data["ticket_type"]
 
         cluster_kwargs = deepcopy(act_kwargs)
         # 源节点列表
@@ -226,7 +227,7 @@ class RedisDataStructureFlow(object):
             instance_numb = avg + 1 if index < remainder else avg
             sub_builder = RedisBatchInstallAtomJob(
                 self.root_id,
-                self.data,  # ticket-based biz id
+                cluster_ticket_data,  # ticket/global data scoped to current cluster
                 act_kwargs,  # cluster-based biz id
                 {
                     "ip": new_master,
@@ -303,7 +304,7 @@ class RedisDataStructureFlow(object):
             kwargs=asdict(
                 DownloadBackupClientKwargs(
                     bk_cloud_id=act_kwargs.cluster["bk_cloud_id"],
-                    bk_biz_id=int(self.data["bk_biz_id"]),
+                    bk_biz_id=int(cluster_ticket_data["bk_biz_id"]),
                     ip_list=new_master_list,
                 ),
             ),
@@ -362,7 +363,7 @@ class RedisDataStructureFlow(object):
             # 这里可以一次下载，不用按端口分批下载
             sub_builder = redis_backupfile_download(
                 self.root_id,
-                self.data,
+                cluster_ticket_data,
                 info,
                 {
                     "source_ip": data_params["source_ip"],
@@ -395,7 +396,7 @@ class RedisDataStructureFlow(object):
         # # ### cc 转移机器模块完成 ############################################################
 
         # 人工确认文件下发完成的节点
-        if not self.data.get("skip_mannual_confirm", False):
+        if not cluster_ticket_data.get("skip_mannual_confirm", False):
             redis_pipeline.add_act(act_name=_("人工确认"), act_component_code=PauseComponent.code, kwargs={})
 
         # ### 如果是tendisplus,需要构建tendis cluster关系 ############################################################
@@ -442,12 +443,13 @@ class RedisDataStructureFlow(object):
             act_name=_("写入构造记录元数据"), act_component_code=RedisDBMetaComponent.code, kwargs=asdict(act_kwargs)
         )
 
-        # 解除临时主机告警屏蔽
-        redis_pipeline.add_act(
-            act_name=_("解除临时主机告警屏蔽-{}").format(temp_host_ips),
-            act_component_code=DisableAlarmShieldComponent.code,
-            kwargs=asdict(act_kwargs),
-        )
+        if not is_drill:
+            # 解除临时主机告警屏蔽
+            redis_pipeline.add_act(
+                act_name=_("解除临时主机告警屏蔽-{}").format(temp_host_ips),
+                act_component_code=DisableAlarmShieldComponent.code,
+                kwargs=asdict(act_kwargs),
+            )
 
         return redis_pipeline.build_sub_process(sub_name=_("集群[{}]数据构造").format(act_kwargs.cluster["domain_name"]))
 
@@ -730,10 +732,11 @@ class RedisDataStructureFlow(object):
         logger.info(_("__init_builder_cluster_info: {}".format(cluster_info)))
 
         ticket_bk_biz_id = self.data["bk_biz_id"]
-        self.data.update(cluster_info)
-        self.data["bk_biz_id"] = ticket_bk_biz_id  # 保留原始业务ID
+        cluster_ticket_data = deepcopy(self.data)
+        cluster_ticket_data.update(cluster_info)
+        cluster_ticket_data["bk_biz_id"] = ticket_bk_biz_id  # 保留原始业务ID
 
-        redis_pipeline = SubBuilder(root_id=self.root_id, data=self.data)
+        redis_pipeline = SubBuilder(root_id=self.root_id, data=cluster_ticket_data)
         trans_files = GetFileList(db_type=DBType.Redis)
         act_kwargs = ActKwargs()
         act_kwargs.set_trans_data_dataclass = RedisDataStructureContext.__name__
@@ -749,7 +752,7 @@ class RedisDataStructureFlow(object):
         redis_pipeline.add_act(
             act_name=_("初始化配置"), act_component_code=GetRedisActPayloadComponent.code, kwargs=asdict(act_kwargs)
         )
-        return redis_pipeline, act_kwargs
+        return redis_pipeline, act_kwargs, cluster_ticket_data
 
     def __get_cluster_config(
         self, bk_biz_id: str, domain_name: str, db_version: str, conf_type: str, namespace: str

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 import copy
 import logging
+import shlex
 from datetime import datetime
 from typing import Optional
 
@@ -353,20 +354,12 @@ class RedisExerciseFlowRunnerComponent(Component):
     bound_service = RedisExerciseFlowRunnerService
 
 
-_KILL_SCRIPT = (
-    "pkill -f redis-server || true; "
-    "pkill -f tendisplus || true; "
-    "pkill -f nutcracker || true; "
-    "pkill -f predixy || true"
-)
-
-
 class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobService):
     """Best-effort cleanup for exercise failures.
 
     Runs at the main pipeline level after all per-cluster sub-flows complete.
     Uses BkJobService's built-in __need_schedule__ + _schedule polling to:
-      1. Submit a pkill job targeting all temp hosts (_execute_inner_captured)
+      1. Submit a guarded per-port cleanup job targeting temp hosts (_execute_inner_captured)
       2. Poll until the job completes (_schedule from BkJobService)
       3. After job completes: decommission metadata, clean TbTendisRollbackTasks,
          reconcile reports (last, to capture as many logs as possible)
@@ -377,47 +370,284 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
     __need_schedule__ = True
     interval = StaticIntervalGenerator(5)
 
-    def _execute_inner_captured(self, data, parent_data) -> bool:
-        global_data = data.get_one_of_inputs("global_data")
-        infos = global_data.get("infos", [])
+    @staticmethod
+    def _parse_ip_port(instance):
+        if not isinstance(instance, str):
+            return None
+        ip, sep, port = instance.rpartition(":")
+        if not sep:
+            return None
+        try:
+            return ip, int(port)
+        except (TypeError, ValueError):
+            return None
 
-        self.log_info(_("Step 1/4: Collecting cleanup targets from StorageInstance metadata"))
+    @classmethod
+    def _parse_instance_set(cls, instances) -> set:
+        parsed = set()
+        if isinstance(instances, dict):
+            iterator = []
+            for key, value in instances.items():
+                if isinstance(key, str):
+                    iterator.append(key)
+                if isinstance(value, (list, tuple, set)):
+                    iterator.extend(value)
+                else:
+                    iterator.append(value)
+        elif isinstance(instances, (list, tuple, set)):
+            iterator = instances
+        else:
+            iterator = []
+
+        for instance in iterator:
+            parsed_instance = cls._parse_ip_port(instance)
+            if parsed_instance:
+                parsed.add(parsed_instance)
+        return parsed
+
+    @classmethod
+    def _parse_prod_temp_pairs(cls, pairs) -> tuple:
+        prod_addrs, temp_addrs = set(), set()
+        if isinstance(pairs, dict):
+            iterator = pairs.items()
+        elif isinstance(pairs, (list, tuple, set)):
+            iterator = pairs
+        else:
+            iterator = []
+
+        for pair in iterator:
+            if not isinstance(pair, (list, tuple)) or len(pair) < 2:
+                continue
+            prod_addr = cls._parse_ip_port(pair[0])
+            temp_addr = cls._parse_ip_port(pair[1])
+            if prod_addr:
+                prod_addrs.add(prod_addr)
+            if temp_addr:
+                temp_addrs.add(temp_addr)
+        return prod_addrs, temp_addrs
+
+    def _get_task_temp_ports(self, ticket_id, bk_biz_id, cluster_id, temp_host_ip: str) -> list:
+        if not ticket_id or not bk_biz_id or not cluster_id:
+            return []
+        tasks = TbTendisRollbackTasks.objects.filter(
+            related_rollback_bill_id=ticket_id,
+            bk_biz_id=bk_biz_id,
+            prod_cluster_id=cluster_id,
+        )
+        ports = set()
+        for task in tasks:
+            task_temp_addrs = self._parse_instance_set(task.temp_instance_range)
+            task_prod_addrs = self._parse_instance_set(task.prod_instance_range)
+            pair_prod_addrs, pair_temp_addrs = self._parse_prod_temp_pairs(task.prod_temp_instance_pairs)
+            if not pair_temp_addrs:
+                self.log_warning(
+                    _("Rollback task {} has no prod/temp instance pairs, skipping work-dir cleanup").format(task.id)
+                )
+                continue
+
+            allowed_temp_addrs = task_temp_addrs & pair_temp_addrs
+            unsafe_addrs = allowed_temp_addrs & (task_prod_addrs | pair_prod_addrs)
+            if unsafe_addrs:
+                self.log_warning(
+                    _("Rollback task {} temp addresses overlap source/prod addresses {}, skipping them").format(
+                        task.id, sorted("{}:{}".format(ip, port) for ip, port in unsafe_addrs)
+                    )
+                )
+                allowed_temp_addrs -= unsafe_addrs
+
+            for ip, port in allowed_temp_addrs:
+                if ip == temp_host_ip:
+                    ports.add(port)
+        return sorted(ports)
+
+    def _collect_cleanup_hosts(self, global_data: dict) -> list:
+        ticket_id = global_data.get("uid")
+        ticket_bk_biz_id = global_data.get("bk_biz_id")
         cleanup_hosts = []
-        for info in infos:
+
+        for info in global_data.get("infos", []):
             resource_applied = info.get("redis", [])
             if not resource_applied:
                 continue
             temp_host_ip = resource_applied[0]["ip"]
-            cluster = Cluster.objects.get(id=info["cluster_id"])
-            bk_cloud_id = cluster.bk_cloud_id
 
-            instances = StorageInstance.objects.filter(machine__ip=temp_host_ip, machine__bk_cloud_id=bk_cloud_id)
-            if not instances.exists():
-                cleanup_hosts.append({"ip": temp_host_ip, "bk_cloud_id": bk_cloud_id, "ports": []})
-                self.log_warning(
-                    _("No StorageInstance on {}, but will still send kill job in case processes are running").format(
-                        temp_host_ip
+            try:
+                cluster = Cluster.objects.get(id=info["cluster_id"])
+            except Exception as e:
+                self.log_warning(_("Failed to load cluster {}: {}").format(info.get("cluster_id"), e))
+                continue
+
+            instances = list(
+                StorageInstance.objects.filter(machine__ip=temp_host_ip, machine__bk_cloud_id=cluster.bk_cloud_id)
+            )
+            has_unexpected_cluster_binding = False
+            for inst in instances:
+                bound_cluster_ids = set(inst.cluster.values_list("id", flat=True))
+                unexpected_cluster_ids = bound_cluster_ids - {cluster.id}
+                if unexpected_cluster_ids:
+                    self.log_warning(
+                        _(
+                            "StorageInstance {}:{} is associated with unexpected cluster(s) {}, "
+                            "skipping cleanup to protect production data"
+                        ).format(temp_host_ip, inst.port, sorted(unexpected_cluster_ids))
                     )
+                    has_unexpected_cluster_binding = True
+                    break
+            if has_unexpected_cluster_binding:
+                continue
+
+            ports = self._get_task_temp_ports(ticket_id, ticket_bk_biz_id, cluster.id, temp_host_ip)
+            source_instance = self._parse_ip_port("{}:{}".format(info.get("instance_ip"), info.get("instance_port")))
+            if source_instance and source_instance[0] == temp_host_ip and source_instance[1] in ports:
+                self.log_warning(
+                    _(
+                        "Cleanup target {}:{} matches the drill source instance, "
+                        "removing it from work-dir cleanup targets"
+                    ).format(source_instance[0], source_instance[1])
+                )
+                ports = [port for port in ports if port != source_instance[1]]
+            if not ports:
+                self.log_warning(
+                    _("No rollback task temp ports found for {}, skipping work-dir cleanup").format(temp_host_ip)
                 )
                 continue
 
-            has_cluster_binding = False
-            for inst in instances:
-                if inst.cluster.count() > 0:
-                    self.log_warning(
-                        _(
-                            "StorageInstance {}:{} is associated with a cluster, "
-                            "skipping cleanup to protect production data"
-                        ).format(temp_host_ip, inst.port)
-                    )
-                    has_cluster_binding = True
-                    break
-            if has_cluster_binding:
-                continue
+            cleanup_hosts.append({"ip": temp_host_ip, "bk_cloud_id": cluster.bk_cloud_id, "ports": ports})
+            self.log_info(
+                _("Will clean up {} in bk_cloud_id {} (ports: {})").format(temp_host_ip, cluster.bk_cloud_id, ports)
+            )
 
-            ports = list(instances.values_list("port", flat=True))  # len(ports) should be 1
-            cleanup_hosts.append({"ip": temp_host_ip, "bk_cloud_id": bk_cloud_id, "ports": ports})
-            self.log_info(_("Will clean up {} (ports: {})").format(temp_host_ip, ports))
+        return cleanup_hosts
+
+    @staticmethod
+    def _build_cleanup_script(cleanup_hosts: list) -> str:
+        host_cases = []
+        for host in cleanup_hosts:
+            ports = " ".join(str(port) for port in sorted(host["ports"]))
+            host_cases.append(
+                "    {}) cleanup_ports={}; matched_ip={}; break ;;".format(
+                    shlex.quote(host["ip"]),
+                    shlex.quote(ports),
+                    shlex.quote(host["ip"]),
+                )
+            )
+        case_body = "\n".join(host_cases) or "    *) cleanup_ports='' ;;"
+
+        return """current_ips="$(hostname -I 2>/dev/null || true)"
+if command -v ip >/dev/null 2>&1; then
+  current_ips="$current_ips $(ip -o -4 addr show 2>/dev/null | awk '{{print $4}}' | cut -d/ -f1 || true)"
+fi
+cleanup_ports=""
+matched_ip=""
+for current_ip in $current_ips; do
+  case "$current_ip" in
+{case_body}
+  esac
+done
+
+if [ -z "$cleanup_ports" ]; then
+  echo "No allowlisted redis work dirs for this host, skip work-dir cleanup"
+  exit 0
+fi
+
+if [ -n "$REDIS_DATA_DIR" ]; then
+  data_root="$REDIS_DATA_DIR"
+elif [ -d /data1/redis ]; then
+  data_root="/data1"
+elif [ -d /data/redis ]; then
+  data_root="/data"
+else
+  echo "No redis data dir found on $matched_ip, skip work-dir cleanup"
+  exit 0
+fi
+
+redis_dir="$data_root/redis"
+backend_pattern=""
+for port in $cleanup_ports; do
+  if [ -z "$backend_pattern" ]; then
+    backend_pattern="$matched_ip:$port"
+  else
+    backend_pattern="$backend_pattern|$matched_ip:$port"
+  fi
+done
+
+for port in $cleanup_ports; do
+  case "$port" in
+    ""|*[!0-9]*)
+      echo "Skip invalid redis port: $port"
+      continue
+      ;;
+  esac
+
+  inst_dir="$redis_dir/$port"
+  case "$inst_dir" in
+    "$redis_dir"/[0-9]*) ;;
+    *)
+      echo "Unsafe redis work dir $inst_dir, skip"
+      continue
+      ;;
+  esac
+
+  if [ ! -d "$inst_dir" ]; then
+    echo "Redis work dir $inst_dir does not exist, skip"
+    continue
+  fi
+
+  conf_file="$inst_dir/redis.conf"
+  if [ -f "$conf_file" ] && ! grep -Eq "^[[:space:]]*port[[:space:]]+$port([[:space:]]|$)" "$conf_file"; then
+    echo "Redis work dir $inst_dir has mismatched redis.conf port, skip"
+    continue
+  fi
+
+  echo "Stop allowlisted redis processes for $inst_dir / port $port"
+  pkill -f "$inst_dir" 2>/dev/null || true
+  pkill -f "(redis-server|tendis[a-z_+-]*).*[.:]$port([^0-9]|$)" 2>/dev/null || true
+  pkill -f "$data_root/(predixy|twemproxy-0.2.4)/[0-9]+/" 2>/dev/null || true
+  sleep 3
+
+  if ps -ef | grep -E "($inst_dir|(redis-server|tendis[a-z_+-]*).*[.:]$port([^0-9]|$))" | grep -v grep; then
+    echo "Allowlisted redis process still exists for port $port, skip $inst_dir"
+    continue
+  fi
+
+  echo "Remove allowlisted redis work dir $inst_dir"
+  rm -rf -- "$inst_dir"
+done
+
+for proxy_dir in /data1/predixy/[0-9]* /data/predixy/[0-9]* /data1/twemproxy-0.2.4/[0-9]* /data/twemproxy-0.2.4/[0-9]*; do
+  [ -d "$proxy_dir" ] || continue
+  case "$proxy_dir" in
+    /data1/predixy/[0-9]*|/data/predixy/[0-9]*|/data1/twemproxy-0.2.4/[0-9]*|/data/twemproxy-0.2.4/[0-9]*) ;;
+    *)
+      echo "Unsafe proxy work dir $proxy_dir, skip"
+      continue
+      ;;
+  esac
+  if ! grep -RqsE "$backend_pattern" "$proxy_dir"; then
+    echo "Proxy work dir $proxy_dir does not reference allowlisted backends, skip"
+    continue
+  fi
+
+  echo "Stop allowlisted proxy process for $proxy_dir"
+  pkill -f "$proxy_dir/" 2>/dev/null || true
+  sleep 2
+  if ps -ef | grep -F "$proxy_dir/" | grep -v grep; then
+    echo "Proxy process still exists for $proxy_dir, skip removal"
+    continue
+  fi
+
+  echo "Remove allowlisted proxy work dir $proxy_dir"
+  rm -rf -- "$proxy_dir"
+done
+""".format(
+            case_body=case_body,
+        )
+
+    def _execute_inner_captured(self, data, parent_data) -> bool:
+        global_data = data.get_one_of_inputs("global_data") or {}
+
+        self.log_info(_("Step 1/4: Collecting cleanup targets from rollback task metadata"))
+        cleanup_hosts = self._collect_cleanup_hosts(global_data)
 
         data.outputs.cleanup_hosts = cleanup_hosts
 
@@ -432,7 +662,7 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
             "bk_scope_type": "biz_set",
             "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
             "task_name": "DBM_drill_cleanup",
-            "script_content": base64_encode(_KILL_SCRIPT),
+            "script_content": base64_encode(self._build_cleanup_script(cleanup_hosts)),
             "script_language": 1,
             "target_server": {"ip_list": target_ips},
         }

--- a/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_db_meta.py
@@ -42,6 +42,7 @@ from backend.db_meta.models import (
     CLBEntryDetail,
     Cluster,
     ClusterEntry,
+    ClusterMonitorTopo,
     Machine,
     PolarisEntryDetail,
     ProxyInstance,
@@ -100,6 +101,9 @@ class RedisDBMeta(object):
             return getattr(self, function_name)()
 
         logger.error(_("找不到单据类型需要查询的cmdb函数，请联系系统管理员"))
+
+    def _get_install_cluster_type(self) -> str:
+        return self.cluster.get("cluster_type") or self.ticket_data.get("cluster_type") or ""
 
     def proxy_install(self) -> bool:
         """
@@ -249,10 +253,7 @@ class RedisDBMeta(object):
         ips = [self.cluster["master_ip"], self.cluster["slave_ip"]]
         m = Machine.objects.filter(ip__in=ips).values("ip")
         if len(m) != 2:
-            if "cluster_type" in self.ticket_data:
-                cluster_type = self.ticket_data["cluster_type"]
-            else:
-                cluster_type = self.cluster["cluster_type"]
+            cluster_type = self._get_install_cluster_type()
 
             if is_redis_instance_type(cluster_type):
                 machine_type = MachineType.TENDISCACHE.value
@@ -306,11 +307,8 @@ class RedisDBMeta(object):
         else:
             bk_cloud_id = self.cluster["bk_cloud_id"]
 
-        machines, ins, cluster_type = [], [], ""
-        if "cluster_type" in self.ticket_data:
-            cluster_type = self.ticket_data["cluster_type"]
-        else:
-            cluster_type = self.cluster["cluster_type"]
+        machines, ins = [], []
+        cluster_type = self._get_install_cluster_type()
 
         if is_redis_instance_type(cluster_type):
             machine_type = MachineType.TENDISCACHE.value
@@ -855,6 +853,35 @@ class RedisDBMeta(object):
             cluster = Cluster.objects.get(
                 bk_cloud_id=self.cluster["bk_cloud_id"], immute_domain=self.cluster["immute_domain"]
             )
+            available_machine_types = list(
+                ClusterMonitorTopo.objects.filter(cluster_id=cluster.id)
+                .values_list("machine_type", flat=True)
+                .distinct()
+            )
+            missing_type_instances = {}
+            for receiver_obj in receiver_objs:
+                if receiver_obj.machine_type not in available_machine_types:
+                    missing_type_instances.setdefault(receiver_obj.machine_type, []).append(
+                        "{}{}{}".format(receiver_obj.machine.ip, IP_PORT_DIVIDER, receiver_obj.port)
+                    )
+            if missing_type_instances:
+                temp_details = "; ".join(
+                    [
+                        "machine_type={}, instances={}".format(machine_type, instances)
+                        for machine_type, instances in missing_type_instances.items()
+                    ]
+                )
+                raise Exception(
+                    _(
+                        "Redis数据构造临时节点无法转移到源集群CC模块: cluster_id={}, domain={}, "
+                        "临时实例及machine_type={}, 源集群可用machine_type={}".format(
+                            cluster.id,
+                            cluster.immute_domain,
+                            temp_details,
+                            sorted(available_machine_types),
+                        )
+                    )
+                )
             RedisCCTopoOperator(cluster).transfer_instances_to_cluster_module(receiver_objs)
         return True
 

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_db_meta.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_db_meta.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from backend.db_meta.enums import ClusterType, MachineType
+from backend.flow.utils.redis.redis_db_meta import RedisDBMeta
+
+
+class _DistinctValues(list):
+    def distinct(self):
+        return self
+
+
+class _ClusterMonitorTopoQuery:
+    def __init__(self, machine_types):
+        self.machine_types = machine_types
+
+    def values_list(self, *_args, **_kwargs):
+        return _DistinctValues(self.machine_types)
+
+
+class _EmptyMachineQuery:
+    def values(self, *_args, **_kwargs):
+        return []
+
+
+def test_redis_install_prefers_activity_cluster_type_over_ticket_data():
+    ticket_data = {
+        "bk_biz_id": 3,
+        "bk_cloud_id": 0,
+        "created_by": "admin",
+        "cluster_type": ClusterType.TendisRedisInstance.value,
+    }
+    activity_cluster = {
+        "bk_cloud_id": 0,
+        "cluster_type": ClusterType.TendisPredixyTendisplusCluster.value,
+        "new_master_ips": ["1.1.1.3"],
+        "new_slave_ips": [],
+        "inst_num": 1,
+        "start_port": 30000,
+        "spec_id": 1,
+        "spec_config": {"cpu": 1},
+    }
+
+    with patch("backend.flow.utils.redis.redis_db_meta.atomic", return_value=nullcontext()), patch(
+        "backend.flow.utils.redis.redis_db_meta.api.machine.create"
+    ) as mock_machine_create, patch("backend.flow.utils.redis.redis_db_meta.api.storage_instance.create"):
+        RedisDBMeta(ticket_data=ticket_data, cluster=activity_cluster).redis_install()
+
+    machines = mock_machine_create.call_args.kwargs["machines"]
+    assert machines[0]["machine_type"] == MachineType.TENDISPLUS.value
+
+
+def test_redis_install_append_prefers_activity_cluster_type_over_ticket_data():
+    ticket_data = {
+        "bk_biz_id": 3,
+        "bk_cloud_id": 0,
+        "created_by": "admin",
+        "cluster_type": ClusterType.TendisRedisInstance.value,
+    }
+    activity_cluster = {
+        "bk_cloud_id": 0,
+        "cluster_type": ClusterType.TendisPredixyTendisplusCluster.value,
+        "master_ip": "1.1.1.3",
+        "slave_ip": "1.1.1.4",
+        "ports": [30000],
+        "spec_id": 1,
+        "spec_config": {"cpu": 1},
+    }
+
+    with patch("backend.flow.utils.redis.redis_db_meta.atomic", return_value=nullcontext()), patch(
+        "backend.flow.utils.redis.redis_db_meta.Machine.objects.filter", return_value=_EmptyMachineQuery()
+    ), patch("backend.flow.utils.redis.redis_db_meta.api.machine.create") as mock_machine_create, patch(
+        "backend.flow.utils.redis.redis_db_meta.api.storage_instance.create"
+    ):
+        RedisDBMeta(ticket_data=ticket_data, cluster=activity_cluster).redis_install_append()
+
+    machine_types = {machine["machine_type"] for machine in mock_machine_create.call_args.kwargs["machines"]}
+    assert machine_types == {MachineType.TENDISPLUS.value}
+
+
+def test_redis_rollback_host_transfer_rejects_missing_cluster_module_before_calling_cc():
+    ticket_data = {"bk_biz_id": 3, "created_by": "admin"}
+    activity_cluster = {
+        "bk_cloud_id": 0,
+        "immute_domain": "plus.test.dba.db",
+        "tendiss": [{"receiver": {"ip": "1.1.1.3", "port": 30000}}],
+    }
+    temp_instance = SimpleNamespace(
+        machine=SimpleNamespace(ip="1.1.1.3", bk_host_id=123),
+        port=30000,
+        machine_type=MachineType.TENDISCACHE.value,
+    )
+    source_cluster = SimpleNamespace(id=101, immute_domain="plus.test.dba.db")
+
+    with patch("backend.flow.utils.redis.redis_db_meta.atomic", return_value=nullcontext()), patch(
+        "backend.flow.utils.redis.redis_db_meta.StorageInstance.objects.get", return_value=temp_instance
+    ), patch("backend.flow.utils.redis.redis_db_meta.Cluster.objects.get", return_value=source_cluster), patch(
+        "backend.flow.utils.redis.redis_db_meta.ClusterMonitorTopo.objects.filter",
+        return_value=_ClusterMonitorTopoQuery([MachineType.PREDIXY.value, MachineType.TENDISPLUS.value]),
+    ), patch(
+        "backend.flow.utils.redis.redis_db_meta.RedisCCTopoOperator"
+    ) as mock_cc_operator:
+        with pytest.raises(Exception) as exc_info:
+            RedisDBMeta(ticket_data=ticket_data, cluster=activity_cluster).redis_rollback_host_transfer()
+
+    error_message = str(exc_info.value)
+    assert "cluster_id=101" in error_message
+    assert "domain=plus.test.dba.db" in error_message
+    assert "1.1.1.3:30000" in error_message
+    assert MachineType.TENDISCACHE.value in error_message
+    assert MachineType.TENDISPLUS.value in error_message
+    mock_cc_operator.assert_not_called()

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
@@ -18,16 +18,21 @@ from bamboo_engine.api import EngineAPIResult
 from backend.flow.consts import StateType
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
     CHILD2RUNNER_CACHE_PREFIX,
+    RedisExerciseBestEffortCleanupService,
     RedisExerciseFlowRunnerService,
 )
 
 
 class FakeData:
-    def __init__(self, outputs=None):
+    def __init__(self, outputs=None, inputs=None):
         self.outputs = SimpleNamespace(**(outputs or {}))
+        self.inputs = SimpleNamespace(**(inputs or {}))
 
     def get_one_of_outputs(self, key):
         return getattr(self.outputs, key, None)
+
+    def get_one_of_inputs(self, key):
+        return getattr(self.inputs, key, None)
 
 
 def _build_schedule_data(start_delta_seconds=10, polling_timeout=3600, child_root_id="child_root_id"):
@@ -367,3 +372,187 @@ def test_execute_without_report_id_skips_report_update():
 
     assert result is True
     mock_filter.return_value.update.assert_not_called()
+
+
+# ==================== Best-effort cleanup guards ====================
+
+
+def _cleanup_service():
+    service = RedisExerciseBestEffortCleanupService()
+    service.log_info = MagicMock()
+    service.log_warning = MagicMock()
+    return service
+
+
+def _cleanup_global_data():
+    return {
+        "uid": 123,
+        "bk_biz_id": 3,
+        "infos": [
+            {
+                "cluster_id": 101,
+                "instance_ip": "1.1.1.4",
+                "instance_port": 30000,
+                "redis": [{"ip": "1.1.1.3"}],
+            }
+        ],
+    }
+
+
+def _storage_instance(port, cluster_ids=None):
+    cluster = SimpleNamespace(values_list=MagicMock(return_value=cluster_ids or []))
+    return SimpleNamespace(port=port, cluster=cluster)
+
+
+def _rollback_task(temp_range=None, prod_range=None, pairs=None):
+    return SimpleNamespace(
+        id=1,
+        temp_instance_range=temp_range if temp_range is not None else ["1.1.1.3:30000"],
+        prod_instance_range=prod_range if prod_range is not None else ["1.1.1.4:30000"],
+        prod_temp_instance_pairs=pairs if pairs is not None else [["1.1.1.4:30000", "1.1.1.3:30000"]],
+    )
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_use_rollback_task_ports_not_all_storage_ports(
+    mock_cluster_get, mock_storage_filter, mock_task_filter
+):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = [_storage_instance(30000), _storage_instance(39999)]
+    mock_task_filter.return_value = [
+        _rollback_task(
+            temp_range=["1.1.1.3:30001", "2.2.2.2:30000", "1.1.1.3:30000"],
+            prod_range=["1.1.1.4:30000", "1.1.1.4:30001"],
+            pairs=[
+                ["1.1.1.4:30000", "1.1.1.3:30000"],
+                ["1.1.1.4:30001", "1.1.1.3:30001"],
+                ["1.1.1.4:30002", "2.2.2.2:30000"],
+            ],
+        )
+    ]
+
+    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+
+    assert cleanup_hosts == [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000, 30001]}]
+    mock_task_filter.assert_called_once_with(related_rollback_bill_id=123, bk_biz_id=3, prod_cluster_id=101)
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_allow_expected_source_cluster_binding(
+    mock_cluster_get, mock_storage_filter, mock_task_filter
+):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = [_storage_instance(30000, cluster_ids=[101])]
+    mock_task_filter.return_value = [_rollback_task()]
+
+    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+
+    assert cleanup_hosts == [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000]}]
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_skip_unexpected_cluster_bound_storage(
+    mock_cluster_get, mock_storage_filter, mock_task_filter
+):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = [_storage_instance(30000, cluster_ids=[202])]
+    mock_task_filter.return_value = [_rollback_task()]
+
+    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+
+    assert cleanup_hosts == []
+    mock_task_filter.assert_not_called()
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_skip_when_no_matching_rollback_task(mock_cluster_get, mock_storage_filter, mock_task_filter):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = []
+    mock_task_filter.return_value = [
+        _rollback_task(temp_range=["2.2.2.2:30000"], pairs=[["1.1.1.4:30000", "2.2.2.2:30000"]])
+    ]
+
+    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+
+    assert cleanup_hosts == []
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_exclude_source_prod_addresses(mock_cluster_get, mock_storage_filter, mock_task_filter):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = []
+    mock_task_filter.return_value = [
+        _rollback_task(
+            temp_range=["1.1.1.3:30000", "1.1.1.3:30001"],
+            prod_range=["1.1.1.4:30000", "1.1.1.3:30001"],
+            pairs=[
+                ["1.1.1.4:30000", "1.1.1.3:30000"],
+                ["1.1.1.3:30001", "1.1.1.3:30001"],
+            ],
+        )
+    ]
+
+    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+
+    assert cleanup_hosts == [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000]}]
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_require_prod_temp_pairs(mock_cluster_get, mock_storage_filter, mock_task_filter):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = []
+    mock_task_filter.return_value = [_rollback_task(pairs=[])]
+
+    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+
+    assert cleanup_hosts == []
+
+
+def test_cleanup_script_removes_only_allowlisted_work_dirs():
+    script = RedisExerciseBestEffortCleanupService._build_cleanup_script(
+        [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000, 30001]}]
+    )
+
+    assert "30000 30001" in script
+    assert "39999" not in script
+    assert "/data/redis/*" not in script
+    assert "/data1/redis/*" not in script
+    assert 'pkill -f "$inst_dir"' in script
+    assert "pkill -f redis-server || true" not in script
+    assert "pkill -f predixy || true" not in script
+    assert "tendis[a-z_+-]*" in script
+    assert "/data/predixy/[0-9]*" in script
+    assert "/data1/predixy/[0-9]*" in script
+    assert "twemproxy-0.2.4" in script
+    assert 'grep -RqsE "$backend_pattern" "$proxy_dir"' in script
+    assert "Unsafe proxy work dir $proxy_dir, skip" in script
+    assert 'rm -rf -- "$proxy_dir"' in script
+    assert "Unsafe redis work dir $inst_dir, skip" in script
+    assert 'rm -rf -- "$inst_dir"' in script
+    assert "lsof" not in script
+    assert "Allowlisted redis process still exists" in script
+    assert 'case "$current_ip" in' in script

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_data_structure.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_data_structure.py
@@ -6,6 +6,8 @@ import pytest
 from backend.db_meta.enums import ClusterType
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure import RedisDataStructureFlow
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete import RedisDataStructureTaskDeleteFlow
+from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldComponent
+from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
 from backend.flow.utils.redis.redis_context_dataclass import ActKwargs
 
 
@@ -68,6 +70,54 @@ def test_get_backup_instance_by_bklog_accepts_non_contiguous_slots(mock_handler_
     ]
 
 
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.GetFileList")
+@patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.SubBuilder")
+def test_init_builder_uses_isolated_cluster_global_data(mock_sub_builder, mock_get_file_list):
+    mock_sub_builder.return_value = MagicMock()
+    mock_get_file_list.return_value = MagicMock(redis_base=MagicMock(return_value=[]))
+
+    source_ticket_data = {
+        "uid": "uid-1",
+        "bk_biz_id": 3,
+        "ticket_type": "REDIS_DATA_STRUCTURE",
+        "infos": [{"cluster_id": 1}, {"cluster_id": 2}],
+    }
+    cluster_infos = [
+        {
+            "cluster_type": ClusterType.TendisPredixyTendisplusCluster.value,
+            "bk_biz_id": 100,
+            "bk_cloud_id": 0,
+            "immute_domain": "plus.test.dba.db",
+            "domain_name": "plus.test.dba.db",
+        },
+        {
+            "cluster_type": ClusterType.TendisRedisInstance.value,
+            "bk_biz_id": 200,
+            "bk_cloud_id": 0,
+            "immute_domain": "cache.test.dba.db",
+            "domain_name": "cache.test.dba.db",
+        },
+    ]
+
+    flow = RedisDataStructureFlow(root_id="root-1", data=source_ticket_data)
+    with patch.object(RedisDataStructureFlow, "_RedisDataStructureFlow__get_cluster_info", side_effect=cluster_infos):
+        _, first_kwargs, first_global_data = flow._RedisDataStructureFlow__init_builder(
+            "REDIS_DATA_STRUCTURE", {"cluster_id": 1}
+        )
+        _, second_kwargs, second_global_data = flow._RedisDataStructureFlow__init_builder(
+            "REDIS_DATA_STRUCTURE", {"cluster_id": 2}
+        )
+
+    assert "cluster_type" not in source_ticket_data
+    assert first_global_data is not second_global_data
+    assert first_global_data["bk_biz_id"] == 3
+    assert second_global_data["bk_biz_id"] == 3
+    assert first_global_data["cluster_type"] == ClusterType.TendisPredixyTendisplusCluster.value
+    assert second_global_data["cluster_type"] == ClusterType.TendisRedisInstance.value
+    assert first_kwargs.cluster["cluster_type"] == ClusterType.TendisPredixyTendisplusCluster.value
+    assert second_kwargs.cluster["cluster_type"] == ClusterType.TendisRedisInstance.value
+
+
 @pytest.mark.parametrize("is_drill", [True, False])
 @patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.GetFileList")
 @patch("backend.flow.engine.bamboo.scene.redis.redis_data_structure.redis_backupfile_download")
@@ -107,6 +157,14 @@ def test_build_cluster_data_structure_installs_dbmon_only_when_not_drill(
     act_kwargs = ActKwargs()
     act_kwargs.cluster = dict(cluster_info)
     act_kwargs.bk_cloud_id = 0
+    cluster_global_data = {
+        "uid": "uid-1",
+        "bk_biz_id": 3,
+        "ticket_type": "REDIS_DATA_STRUCTURE",
+        "cluster_type": ClusterType.TendisTwemproxyRedisInstance.value,
+        "is_rollback_drill": is_drill,
+        "skip_mannual_confirm": True,
+    }
 
     flow = RedisDataStructureFlow(
         root_id="root-1",
@@ -131,7 +189,7 @@ def test_build_cluster_data_structure_installs_dbmon_only_when_not_drill(
     with patch.object(
         RedisDataStructureFlow,
         "_RedisDataStructureFlow__init_builder",
-        return_value=(pipeline, act_kwargs),
+        return_value=(pipeline, act_kwargs, cluster_global_data),
     ), patch.object(
         RedisDataStructureFlow,
         "_RedisDataStructureFlow__get_cluster_config",
@@ -150,10 +208,15 @@ def test_build_cluster_data_structure_installs_dbmon_only_when_not_drill(
     assert mock_install_atom.called, "RedisBatchInstallAtomJob should be invoked once per redis host"
     expected_install_dbmon = not is_drill
     for call in mock_install_atom.call_args_list:
+        assert call.args[1] is cluster_global_data
+        assert call.args[1]["cluster_type"] == ClusterType.TendisTwemproxyRedisInstance.value
         assert call.kwargs["to_install_dbmon"] is expected_install_dbmon, (
             f"to_install_dbmon must be {expected_install_dbmon} when is_drill={is_drill}, "
             f"got {call.kwargs.get('to_install_dbmon')!r}"
         )
+    component_codes = [call.kwargs.get("act_component_code") for call in pipeline.add_act.call_args_list]
+    assert (AddAlarmShieldComponent.code in component_codes) is (not is_drill)
+    assert (DisableAlarmShieldComponent.code in component_codes) is (not is_drill)
 
 
 @pytest.mark.parametrize("is_drill", [True, False])


### PR DESCRIPTION
- 数据构造改为按集群隔离 global data，并在回滚演练场景跳过临时主机告警屏蔽
- 回滚演练清理改为基于 rollback task 的临时实例端口白名单
- Redis 元数据写入优先使用 activity cluster_type，并在转移临时节点到源集群模块前校验 CC 拓扑 machine_type
- Redis agent 的连接数 overall 聚合由 MAX 调整为 SUM，更符合多实例汇总语义
- 补齐回滚演练清理、数据构造隔离、元数据写入保护相关单测