### PR TITLE
fix(mongodb): 删除/data1/mongolog中的旧日志文件 #16054

### DIFF
--- a/dbm-services/mongodb/db-tools/dbmon/cmd/backupjob/backup_job.go
+++ b/dbm-services/mongodb/db-tools/dbmon/cmd/backupjob/backup_job.go
@@ -94,7 +94,7 @@ func (job *BackupJob) Run() {
 			svrItem.MetaRole == consts.MetaRoleShardsvrBackupNewName {
 
 			// 如果屏蔽告警，也不发起备份.
-			if config.IsAlaramShield(&svrItem,
+			if config.IsAlarmShield(&svrItem,
 				"skip backup because Shielded", job.Logger) {
 				continue
 			}

--- a/dbm-services/mongodb/db-tools/dbmon/cmd/checkhealthjob/check_health_job.go
+++ b/dbm-services/mongodb/db-tools/dbmon/cmd/checkhealthjob/check_health_job.go
@@ -1,9 +1,9 @@
 package checkhealthjob
 
 import (
-	"bk-dbconfig/pkg/core/logger"
 	"dbm-services/common/go-pubpkg/mycmd"
 	"dbm-services/mongodb/db-tools/dbmon/cmd/basejob"
+	"dbm-services/mongodb/db-tools/dbmon/mylog"
 	"dbm-services/mongodb/db-tools/dbmon/pkg/linuxproc"
 	"fmt"
 	"os"
@@ -19,7 +19,6 @@ import (
 
 	"dbm-services/mongodb/db-tools/dbmon/config"
 	"dbm-services/mongodb/db-tools/dbmon/embedfiles"
-	"dbm-services/mongodb/db-tools/dbmon/mylog"
 	"dbm-services/mongodb/db-tools/dbmon/pkg/consts"
 
 	"github.com/pkg/errors"
@@ -66,8 +65,8 @@ func (job *CheckHealthJob) Run() {
 		return
 	}
 	logger.Info("start", zap.Int("loopTimes", int(job.LoopTimes)))
-	for _, svrItem := range job.MyConf.Servers {
-		job.runOneServer(&svrItem)
+	for i := range job.MyConf.Servers {
+		job.runOneServer(&job.MyConf.Servers[i])
 	}
 	logger.Info("done", zap.Int("loopTimes", int(job.LoopTimes)), zap.Error(job.Err))
 }
@@ -89,7 +88,7 @@ func (job *CheckHealthJob) runOneServer(svrItem *config.ConfServerItem) {
 
 	startTime := time.Now()
 
-	loginTimeout := getLoginTimeout(svrItem)
+	loginTimeout := getLoginTimeout(svrItem, logger)
 	err := checkService(mongoBin, loginTimeout, svrItem, logger)
 	logger.Info("checkService result", zap.Int("loginTimeout", loginTimeout), zap.Any("err", err))
 	if err == nil {
@@ -128,15 +127,17 @@ func (job *CheckHealthJob) runOneServer(svrItem *config.ConfServerItem) {
 	}
 
 	// 如果已屏蔽告警，不会尝试拉起进程
-	if config.IsAlaramShield(svrItem,
-		"skip to start mongo because isAlaramShield", job.Logger) {
+	if config.IsAlarmShield(svrItem,
+		"skip to start mongo because isAlarmShield", job.Logger) {
 		return
 	}
 
 	// 进程不存在，尝试启动
 	// 启动成功: 发送消息LoginSuccess
 	// 启动失败: 发送消息LoginFailed
-	startMongo(svrItem.Port, logger)
+	if err := startMongo(svrItem.Port, logger); err != nil {
+		logger.Warn("startMongo failed", zap.Error(err))
+	}
 	startTime = time.Now()
 	job.Err = checkService(mongoBin, loginTimeout, svrItem, logger)
 	logger.Info(fmt.Sprintf("checkService again,  cost %0.1f seconds, err: %v",
@@ -154,17 +155,17 @@ func (job *CheckHealthJob) runOneServer(svrItem *config.ConfServerItem) {
 
 }
 
-func getLoginTimeout(svrItem *config.ConfServerItem) int {
+func getLoginTimeout(svrItem *config.ConfServerItem, logger *zap.Logger) int {
 	loginTimeoutVal, err := config.ClusterConfig.GetInt64(svrItem, config.SegmentMonitor, config.KeyLoginTimeout, 10)
 	if err != nil {
-		logger.Error("get loginTimeout from config failed", zap.Error(err))
+		logger.Warn("get loginTimeout from config failed, use default 10", zap.Error(err))
 		return 10
 	}
-	// loginTimeoutVal < 5, loginTimeoutVal = 5
+	// 有效值为 [5, 360]，与 cluster_config 注释一致
 	if loginTimeoutVal < 5 {
 		loginTimeoutVal = 5
-	} else if loginTimeoutVal > 300 {
-		loginTimeoutVal = 300
+	} else if loginTimeoutVal > 360 {
+		loginTimeoutVal = 360
 	}
 	return int(loginTimeoutVal)
 }
@@ -172,21 +173,28 @@ func getLoginTimeout(svrItem *config.ConfServerItem) int {
 const secondsDay = 86400
 
 // removeOldMongoLogFiles 删除旧文件
+// 删除/data/mongolog/port/mongo.log* 和 /data1/mongolog/port/mongo.log*文件，保留配置天数前的文件（默认15天，最小2天）.
 func removeOldMongoLogFiles(svrItem *config.ConfServerItem, logger *zap.Logger) {
-	logPattern := path.Join("/data/mongolog", strconv.Itoa(svrItem.Port), "mongo.log*")
-	logMaxTime, _ := config.ClusterConfig.GetInt64(svrItem, "log", "maxtime", secondsDay*15)
+	logMaxTime, err := config.ClusterConfig.GetInt64(svrItem, config.SegmentLog, config.KeyMaxTime, secondsDay*15)
+	if err != nil {
+		logger.Warn("get log maxtime from config failed, use default 15 days", zap.Error(err))
+		logMaxTime = secondsDay * 15
+	}
 	if logMaxTime < secondsDay*2 {
 		logMaxTime = secondsDay * 2
 	}
-	err := removeOldFile(logPattern, logMaxTime, logger)
-	if err != nil {
-		logger.Error(fmt.Sprintf("remove old file failed: %v", err))
+	portStr := strconv.Itoa(svrItem.Port)
+	for _, baseDir := range []string{"/data/mongolog", "/data1/mongolog"} {
+		logPattern := path.Join(baseDir, portStr, "mongo.log*")
+		if err := removeOldFile(logPattern, logMaxTime, logger); err != nil {
+			logger.Error("remove old file failed", zap.String("pattern", logPattern), zap.Error(err))
+		}
 	}
 }
 
-// RemoveOldFile removes the old file that matches the pattern.
-// 1. delete file if modTime < now - maxTimeSeconds
-// 2. delete 1 oldest file if totalSize > maxTotalSize (delete the oldest file first)
+// removeOldFile removes old files that match the pattern.
+// Delete file if modTime < now - maxTimeSeconds.
+// Single file failure (e.g. Stat/Remove) is logged and does not stop other files.
 func removeOldFile(pattern string, maxTimeSeconds int64, logger *zap.Logger) error {
 	files, err := filepath.Glob(pattern)
 	if err != nil {
@@ -197,16 +205,16 @@ func removeOldFile(pattern string, maxTimeSeconds int64, logger *zap.Logger) err
 	for _, file := range files {
 		fileInfo, err := os.Stat(file)
 		if err != nil {
-			return err
+			logger.Warn("stat file failed, skip", zap.String("file", file), zap.Error(err))
+			continue
 		}
 
 		if now-fileInfo.ModTime().Unix() > maxTimeSeconds {
-			err = os.Remove(file)
-			logger.Info(fmt.Sprintf("remove old file %s", file))
-			if err != nil {
-				return err
+			if err := os.Remove(file); err != nil {
+				logger.Warn("remove old file failed", zap.String("file", file), zap.Error(err))
+				continue
 			}
-			continue
+			logger.Info("remove old file", zap.String("file", file))
 		}
 	}
 	return nil
@@ -261,9 +269,9 @@ func checkService(bin string, loginTimeout int, svrItem *config.ConfServerItem, 
 		} else if strings.Contains(line, "auth_success 1") {
 			authSuccess = true
 		} else if strings.Contains(line, "state ") {
-			parts := strings.Split(line, " ")
-			if len(parts) == 2 {
-				stateVal = strings.TrimSpace(parts[1])
+			parts := strings.Fields(line)
+			if len(parts) >= 2 && parts[0] == "state" {
+				stateVal = parts[1]
 				stateOK = (stateVal == "1" || stateVal == "2" || stateVal == "7")
 			}
 		}

--- a/dbm-services/mongodb/db-tools/dbmon/config/alarm_util.go
+++ b/dbm-services/mongodb/db-tools/dbmon/config/alarm_util.go
@@ -33,11 +33,11 @@ func GetBkMonitorBeatSender(beatConf *BkMonitorBeatConfig, serverConf *ConfServe
 	return
 }
 
-// isAlaramShield 是否屏蔽告警. 如果配置了屏蔽，则不发送告警
+// isAlarmShield 是否屏蔽告警. 如果配置了屏蔽，则不发送告警
 // 如果屏蔽返回异常，则继续发送告警. 记录一个Error日志
-func IsAlaramShield(serverConf *ConfServerItem, msg string, logger *zap.Logger) bool {
+func IsAlarmShield(serverConf *ConfServerItem, msg string, logger *zap.Logger) bool {
 	alarmShield, err := NewAlarmConfig(ClusterConfig).IsAlarmShield(serverConf)
-	logger.Debug("isAlaramShield", zap.Bool("alarm.shielded", alarmShield), zap.Error(err))
+	logger.Debug("isAlarmShield", zap.Bool("alarm.shielded", alarmShield), zap.Error(err))
 	if err != nil {
 		logger.Error("get alarm shield failed", zap.Error(err))
 		return false
@@ -57,7 +57,7 @@ func SendEvent(conf *BkMonitorBeatConfig, serverConf *ConfServerItem,
 		return errors.Wrap(err, "NewBkMonitorEventSender failed")
 	}
 
-	if IsAlaramShield(serverConf,
+	if IsAlarmShield(serverConf,
 		fmt.Sprintf("eventName: %s warnLevel: %s warnMsg: %s ", eventName, warnMsg, warnLevel), logger) {
 		return nil
 	}


### PR DESCRIPTION
基于最新 `v1.5.0` 重新提交 #16060 的变更（原 PR 的 base 已严重落后导致冲突，重开后基线干净）。

#16054

## 变更

`dbm-services/mongodb/db-tools/dbmon/`:

1. **主修复**: `removeOldMongoLogFiles` 现在同时清理 `/data/mongolog/<port>/mongo.log*` 和 `/data1/mongolog/<port>/mongo.log*`，不再只清理前者。
2. **拼写修复**: `IsAlaramShield` → `IsAlarmShield`（同步更新调用点和日志/注释）。
3. **range 取地址修复**: `for _, svrItem := range ... { f(&svrItem) }` 改为 `for i := range ...; f(&Servers[i])`，避免共享循环变量地址的潜在问题。
4. **错误处理细化**:
   - `getLoginTimeout` 拿不到配置时由 `Error` 改为 `Warn`（有默认值 10 秒兜底）。
   - `removeOldMongoLogFiles` 同样改为 `Warn`（默认 15 天兜底）。
   - `removeOldFile` 单文件 `Stat`/`Remove` 失败由 `return err` 改为 `Warn` + `continue`，避免一个失败文件中断整批清理。
   - `startMongo` 返回值不再被丢弃。
5. **解析鲁棒性**: `checkService` 解析 `state` 行使用 `strings.Fields` 并校验首字段，避免多空格 / 行前缀干扰。
6. **配置常量化**: 用 `config.SegmentLog` / `config.KeyMaxTime` / `config.SegmentMonitor` / `config.KeyLoginTimeout` 替代硬编码字符串。
7. **修正错误的 import**: `bk-dbconfig/pkg/core/logger` → `dbm-services/mongodb/db-tools/dbmon/mylog`（IDE 自动补全误选）。
8. **`getLoginTimeout` 上限**: 300 → 360（与 cluster_config 注释一致）。

## 验证

- `go build ./...` 通过
- `go vet ./cmd/backupjob/... ./cmd/checkhealthjob/... ./config/...` 通过
- 与 #16060 的最终代码在 3 个文件上逐字节一致

## 关闭

替代 #16060（原 PR 因 base 落后冲突无法干净 merge）。

Made with [Cursor](https://cursor.com)