### PR TITLE
feat(redis): harden rollback exercise cleanup #17753

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
@@ -26,6 +26,7 @@ from backend.components import DBConfigApi
 from backend.components.dbconfig.constants import FormatType, LevelName
 from backend.db_meta.enums import ClusterPhase, DestroyedStatus, InstanceInnerRole
 from backend.db_meta.models import Cluster, StorageInstance
+from backend.db_periodic_task.local_tasks.redis_backup.config import RedisBackupCheckConfig
 from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.db_services.redis.rollback.handlers import DataStructureHandler
@@ -216,6 +217,7 @@ class RedisRollbackExercise:
                     backup_check_instance.port,
                     cluster,
                     rollback_days=self.config.rollback_days,
+                    backup_check_instance=backup_check_instance,
                 )
 
                 if is_valid:
@@ -362,15 +364,21 @@ class RedisRollbackExercise:
                 return self._consume_from_queue(num)
 
     def _validate_instance(
-        self, instance_ip: str, instance_port: int, cluster: Cluster, rollback_days: List[int]
+        self,
+        instance_ip: str,
+        instance_port: int,
+        cluster: Cluster,
+        rollback_days: List[int],
+        backup_check_instance: Optional[StorageInstance] = None,
     ) -> tuple:
         """
         Validate if instance is suitable for rollback exercise.
 
         Validations:
         1. Backup availability (full backup + binlog when applicable)
-        2. No existing temp instance (not destroyed) in tb_tendis_rollback_tasks
-        3. No undone conflicting ticket
+        2. Recent master-slave switch downgrades missing backup to skipped
+        3. No existing temp instance (not destroyed) in tb_tendis_rollback_tasks
+        4. No undone conflicting ticket
 
         Returns:
             tuple: (is_valid, full_backup_log, days_used, recovery_time_point,
@@ -400,6 +408,13 @@ class RedisRollbackExercise:
             fail_reason = _("Instance {}:{} - No valid backup across rollback days {}: {}").format(
                 instance_ip, instance_port, rollback_days, backup_fail_reason or _("unknown")
             )
+            switch_hours = self._recent_master_slave_switch_hours(backup_check_instance)
+            if switch_hours is not None:
+                fail_reason = _(
+                    "{} (possible recent master-slave switch, {}h ago; backup file may be missing)"
+                ).format(fail_reason, switch_hours)
+                return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SKIPPED
+            # No recent switch — genuine backup missing.
             return False, None, None, None, None, fail_reason, ValidationFailureKind.BACKUP_INVALID
 
         # 2. Temp instance check
@@ -433,6 +448,22 @@ class RedisRollbackExercise:
             return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SKIPPED
 
         return True, full_backup, days_used, recovery_time_point, binlog_summary, None, None
+
+    @staticmethod
+    def _recent_master_slave_switch_hours(slave_instance: Optional[StorageInstance]) -> Optional[int]:
+        """Return tuple age in hours when the slave was attached after a recent switch."""
+        if slave_instance is None:
+            return None
+
+        tuple_obj = slave_instance.as_receiver.order_by("-create_at").first()
+        if tuple_obj is None:
+            return None
+
+        threshold_hours = RedisBackupCheckConfig.from_settings().min_instance_age_hours
+        tuple_age = django_timezone.now() - tuple_obj.create_at
+        if tuple_age < timedelta(hours=threshold_hours):
+            return int(tuple_age.total_seconds() // 3600)
+        return None
 
     def _create_ticket(self, valid_instances: List[dict]):
         """

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
@@ -116,7 +116,6 @@ class RedisRollbackExerciseFlow(object):
         at the main pipeline level always runs.
         """
         cluster_id = info["cluster_id"]
-        cluster = Cluster.objects.get(id=cluster_id)
         instance_ip = info["instance_ip"]
         instance_port = info["instance_port"]
         report_id = info["report_id"]
@@ -128,6 +127,14 @@ class RedisRollbackExerciseFlow(object):
         error_ignorable = config.get("error_ignorable", True)
 
         report = Report.objects.get(id=report_id)
+        try:
+            cluster = Cluster.objects.get(id=cluster_id)
+        except Cluster.DoesNotExist:
+            task_message = _("源集群 {} 不存在，跳过回档演练").format(cluster_id)
+            logger.warning(task_message)
+            report.mark(TaskStage.SKIPPED, task_message=task_message)
+            return None
+
         if not resource_applied or len(resource_applied) != 1:
             logger.warning(_("Resource applied is abnormal: {}").format(resource_applied or "None"))
             report.mark(TaskStage.RESOURCE_APPLI_FAILED, task_message=_("资源申请异常"))

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/revoke/__init__.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/revoke/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/revoke/redis_rollback_exercise_revoke_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/revoke/redis_rollback_exercise_revoke_flow.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import copy
+
+from django.utils.translation import gettext as _
+
+from backend.flow.engine.bamboo.scene.common.builder import Builder
+from backend.flow.engine.revoke.base import RevokeFlowBase
+from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
+    RedisExerciseBestEffortCleanupComponent,
+    RedisExerciseRevokeAppliedHostsComponent,
+)
+from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
+
+
+class RedisRollbackExerciseRevokeFlow(RevokeFlowBase):
+    """Cleanup flow used by RECYCLE_APPLY_HOST after rollback exercise ticket termination."""
+
+    def revoke_flow(self):
+        ticket_data = copy.deepcopy(self.data)
+        if ticket_data.get("parent_ticket"):
+            ticket_data["uid"] = ticket_data["parent_ticket"]
+
+        revoke_pipeline = Builder(root_id=self.root_id, data=ticket_data)
+        revoke_pipeline.add_act(
+            act_name=_("最佳尝试清理回档演练临时资源"),
+            act_component_code=RedisExerciseBestEffortCleanupComponent.code,
+            kwargs={"set_trans_data_dataclass": RedisRollbackExerciseContext.__name__},
+            error_ignorable=True,
+        )
+        revoke_pipeline.add_act(
+            act_name=_("输出回档演练待退回资源主机"),
+            act_component_code=RedisExerciseRevokeAppliedHostsComponent.code,
+            kwargs={"set_trans_data_dataclass": RedisRollbackExerciseContext.__name__},
+        )
+        revoke_pipeline.run_pipeline(init_trans_data_class=RedisRollbackExerciseContext())

--- a/dbm-ui/backend/flow/engine/controller/redis.py
+++ b/dbm-ui/backend/flow/engine/controller/redis.py
@@ -66,6 +66,9 @@ from backend.flow.engine.bamboo.scene.redis.redis_storages_client_conns_kill imp
     RedisStoragesClientConnsKillSceneFlow,
 )
 from backend.flow.engine.bamboo.scene.redis.redis_twemproxy_cluster_apply_flow import RedisClusterApplyFlow
+from backend.flow.engine.bamboo.scene.redis.revoke.redis_rollback_exercise_revoke_flow import (
+    RedisRollbackExerciseRevokeFlow,
+)
 from backend.flow.engine.bamboo.scene.redis.single_proxy_shutdown import SingleProxyShutdownFlow
 from backend.flow.engine.bamboo.scene.redis.tendisplus_lightning_data import TendisPlusLightningData
 from backend.flow.engine.bamboo.scene.redis.validate.redis_keystat_validator import RedisKeyStatFlowValidator
@@ -74,6 +77,7 @@ from backend.flow.engine.bamboo.scene.redis.validate.redis_migrate_validator imp
     RedisSingleInsMigrateFlowValidator,
 )
 from backend.flow.engine.controller.base import BaseController
+from backend.flow.engine.revoke.base import revoke_with
 from backend.flow.engine.validate.base_validate import validates_with
 
 
@@ -476,6 +480,7 @@ class RedisController(BaseController):
         flow = FailoverDrillFlow(root_id=self.root_id, data=self.ticket_data)
         flow.failover_drill()
 
+    @revoke_with(RedisRollbackExerciseRevokeFlow)
     def redis_rollback_exercise(self):
         """
         redis 回档演练

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -28,11 +28,13 @@ from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
 from backend.flow.consts import StateType
 from backend.flow.engine.bamboo.engine import BambooEngine
+from backend.flow.engine.bamboo.scene.common.machine_os_init import RecycleOutputContext
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure import RedisDataStructureFlow
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure_task_delete import RedisDataStructureTaskDeleteFlow
 from backend.flow.models import FlowTree
 from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldService
 from backend.flow.plugins.components.collections.common.base_service import BaseService, BkJobService
+from backend.flow.utils.base.flow_output import FlowOutputHandler
 from backend.flow.utils.redis import redis_context_dataclass as flow_context
 from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
 from backend.flow.utils.redis.redis_script_template import redis_fast_execute_script_common_kwargs
@@ -85,11 +87,9 @@ class RedisLogCapturingService(BaseService):
         self._append_to_task_info(msg, "warning")
 
     def log_error(self, msg: str):
-        """Override to auto-capture error logs and set error_occurred flag"""
+        """Override to auto-capture error logs"""
         super().log_error(msg)
         self._append_to_task_info(msg, "error")
-        if self.trans_data is not None:
-            self.trans_data.error_occurred = True
 
     def log_debug(self, msg: str):
         """Override to auto-capture debug logs"""
@@ -352,6 +352,67 @@ class RedisExerciseFlowRunnerComponent(Component):
     name = __name__
     code = "redis_exercise_flow_runner"
     bound_service = RedisExerciseFlowRunnerService
+
+
+class RedisExerciseRevokeAppliedHostsService(RedisLogCapturingService):
+    """Publish rollback exercise resource hosts for the standard RECYCLE_APPLY_HOST flow."""
+
+    @staticmethod
+    def _normalize_recycle_host(host: dict) -> Optional[dict]:
+        if not isinstance(host, dict):
+            return None
+
+        ip = host.get("ip")
+        bk_cloud_id = host.get("bk_cloud_id")
+        bk_host_id = host.get("bk_host_id") or host.get("host_id")
+        if not (ip and bk_cloud_id is not None and bk_host_id is not None):
+            return None
+
+        return {
+            "ip": ip,
+            "bk_cloud_id": bk_cloud_id,
+            "bk_host_id": bk_host_id,
+            "remark": host.get("remark", _("Redis rollback exercise revoked")),
+        }
+
+    @classmethod
+    def _collect_recycle_hosts(cls, infos: list) -> list:
+        hosts_by_id = {}
+        for info in infos or []:
+            for host in info.get("redis", []) or []:
+                normalized = cls._normalize_recycle_host(host)
+                if normalized is not None:
+                    host_id = normalized["bk_host_id"]
+                    if host_id not in hosts_by_id:
+                        hosts_by_id[host_id] = normalized
+                    else:
+                        hosts_by_id[host_id].update(
+                            {
+                                key: value
+                                for key, value in normalized.items()
+                                if value and not hosts_by_id[host_id].get(key)
+                            }
+                        )
+        return list(hosts_by_id.values())
+
+    def _execute_inner_captured(self, data, parent_data) -> bool:
+        global_data = data.get_one_of_inputs("global_data") or {}
+        recycle_hosts = self._collect_recycle_hosts(global_data.get("infos", []))
+        if not recycle_hosts:
+            self.log_info(_("No applied redis hosts found for revoke recycle output"))
+        else:
+            self.log_info(_("Published {} redis host(s) for revoke recycle").format(len(recycle_hosts)))
+
+        FlowOutputHandler(RecycleOutputContext.ToResourceSerializer).insert_data(
+            global_data["job_root_id"], recycle_hosts
+        )
+        return True
+
+
+class RedisExerciseRevokeAppliedHostsComponent(Component):
+    name = __name__
+    code = "redis_exercise_revoke_applied_hosts"
+    bound_service = RedisExerciseRevokeAppliedHostsService
 
 
 class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobService):

--- a/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
@@ -195,7 +195,6 @@ class RedisRollbackExerciseContext:
 
     alarm_shield_id: int = None  # 告警屏蔽ID
     task_msg: list = field(default_factory=list)  # 执行情况
-    error_occurred: bool = False  # 发生异常
 
 
 @dataclass()

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise.py
@@ -514,10 +514,13 @@ class TestValidateInstance:
         exercise = _make_exercise()
         cluster = _make_cluster_mock(ClusterType.TwemproxyTendisSSDInstance.value)
 
-        with patch.object(
-            _exercise_cls(),
-            "_instance_has_backup",
-            return_value=(False, None, None, None, None, "no full backup"),
+        with (
+            patch.object(
+                _exercise_cls(),
+                "_instance_has_backup",
+                return_value=(False, None, None, None, None, "no full backup"),
+            ),
+            patch.object(_exercise_cls(), "_recent_master_slave_switch_hours", return_value=None),
         ):
             (
                 is_valid,
@@ -538,6 +541,62 @@ class TestValidateInstance:
         assert failure_kind == _failure_kind().BACKUP_INVALID
         assert full_backup is None and days_used is None and rtp is None and binlog_summary is None
         assert fail_reason and "no full backup" in fail_reason
+
+    def test_backup_missing_after_recent_switch_returns_env_skipped(self):
+        exercise = _make_exercise()
+        cluster = _make_cluster_mock(ClusterType.TwemproxyTendisSSDInstance.value)
+        backup_check_instance = SimpleNamespace(ip_port="3.3.3.3:30000")
+
+        with (
+            patch.object(
+                _exercise_cls(),
+                "_instance_has_backup",
+                return_value=(False, None, None, None, None, "no full backup"),
+            ),
+            patch.object(_exercise_cls(), "_recent_master_slave_switch_hours", return_value=6),
+        ):
+            (
+                is_valid,
+                full_backup,
+                days_used,
+                rtp,
+                binlog_summary,
+                fail_reason,
+                failure_kind,
+            ) = exercise._validate_instance(
+                instance_ip="3.3.3.3",
+                instance_port=30000,
+                cluster=cluster,
+                rollback_days=[1],
+                backup_check_instance=backup_check_instance,
+            )
+
+        assert is_valid is False
+        assert failure_kind == _failure_kind().ENV_SKIPPED
+        assert full_backup is None and days_used is None and rtp is None and binlog_summary is None
+        assert "possible recent master-slave switch" in fail_reason
+        assert "6h ago" in fail_reason
+        assert "backup file may be missing" in fail_reason
+
+    def test_recent_master_slave_switch_uses_latest_receiver_tuple(self):
+        tuple_qs = MagicMock()
+        tuple_qs.order_by.return_value.first.return_value = SimpleNamespace(
+            create_at=timezone.now() - timedelta(seconds=1)
+        )
+        slave_instance = SimpleNamespace(as_receiver=tuple_qs)
+
+        switch_hours = _exercise_cls()._recent_master_slave_switch_hours(slave_instance)
+
+        assert switch_hours == 0
+        tuple_qs.order_by.assert_called_once_with("-create_at")
+
+    def test_recent_master_slave_switch_returns_none_without_receiver_tuple(self):
+        tuple_qs = MagicMock()
+        tuple_qs.order_by.return_value.first.return_value = None
+        slave_instance = SimpleNamespace(as_receiver=tuple_qs)
+
+        assert _exercise_cls()._recent_master_slave_switch_hours(slave_instance) is None
+        tuple_qs.order_by.assert_called_once_with("-create_at")
 
     def test_temp_instance_present_returns_env_skipped(self):
         exercise = _make_exercise()

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from backend.db_meta.models import Cluster
+from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
+from backend.flow.engine.bamboo.scene.redis.redis_rollback_exercise import RedisRollbackExerciseFlow
+from backend.flow.engine.bamboo.scene.redis.revoke.redis_rollback_exercise_revoke_flow import (
+    RedisRollbackExerciseRevokeFlow,
+)
+from backend.flow.engine.controller.redis import RedisController
+from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
+    RedisExerciseBestEffortCleanupComponent,
+    RedisExerciseRevokeAppliedHostsComponent,
+    RedisExerciseRevokeAppliedHostsService,
+)
+from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
+
+
+class FakeData:
+    def __init__(self, inputs=None):
+        self.inputs = SimpleNamespace(**(inputs or {}))
+
+    def get_one_of_inputs(self, key):
+        return getattr(self.inputs, key, None)
+
+
+class FakeBuilder:
+    instances = []
+
+    def __init__(self, root_id, data):
+        self.root_id = root_id
+        self.data = data
+        self.acts = []
+        self.run_kwargs = None
+        self.__class__.instances.append(self)
+
+    def add_act(self, act_name, act_component_code, kwargs, **extra):
+        self.acts.append(
+            {
+                "act_name": act_name,
+                "act_component_code": act_component_code,
+                "kwargs": kwargs,
+                "extra": extra,
+            }
+        )
+
+    def run_pipeline(self, **kwargs):
+        self.run_kwargs = kwargs
+
+
+@patch("backend.flow.engine.bamboo.scene.redis.redis_rollback_exercise.Report.objects.get")
+@patch("backend.flow.engine.bamboo.scene.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_build_exercise_sub_flow_missing_cluster_marks_report_skipped(mock_cluster_get, mock_report_get):
+    mock_cluster_get.side_effect = Cluster.DoesNotExist
+    report = MagicMock()
+    mock_report_get.return_value = report
+    info = {
+        "cluster_id": 123,
+        "instance_ip": "1.1.1.1",
+        "instance_port": 30000,
+        "report_id": 456,
+        "redis": [{"ip": "2.2.2.2"}],
+    }
+    flow = RedisRollbackExerciseFlow(
+        root_id="root-id",
+        data={"infos": [info], "drill_config": {}, "bk_biz_id": 100, "created_by": "system"},
+    )
+
+    result = flow._build_exercise_sub_flow(info)
+
+    assert result is None
+    mock_report_get.assert_called_once_with(id=456)
+    mock_cluster_get.assert_called_once_with(id=123)
+    report.mark.assert_called_once()
+    assert report.mark.call_args.args[0] == TaskStage.SKIPPED
+    assert "123" in report.mark.call_args.kwargs["task_message"]
+
+
+def test_redis_rollback_exercise_controller_exposes_revoke_flow():
+    assert hasattr(RedisController.redis_rollback_exercise, "revoke_flow")
+    assert RedisController.redis_rollback_exercise.revoke_flow == RedisRollbackExerciseRevokeFlow.revoke_flow
+
+
+@patch("backend.flow.engine.bamboo.scene.redis.revoke.redis_rollback_exercise_revoke_flow.Builder", FakeBuilder)
+def test_redis_rollback_revoke_flow_runs_best_effort_before_recycle_output():
+    FakeBuilder.instances = []
+    flow = RedisRollbackExerciseRevokeFlow(
+        root_id="revoke-root",
+        ticket_data={"uid": 999, "parent_ticket": 123, "infos": [], "bk_biz_id": 100},
+    )
+
+    flow.revoke_flow()
+
+    builder = FakeBuilder.instances[0]
+    assert builder.root_id == "revoke-root"
+    assert builder.data["uid"] == 123
+    assert [act["act_component_code"] for act in builder.acts] == [
+        RedisExerciseBestEffortCleanupComponent.code,
+        RedisExerciseRevokeAppliedHostsComponent.code,
+    ]
+    assert builder.acts[0]["extra"]["error_ignorable"] is True
+    assert isinstance(builder.run_kwargs["init_trans_data_class"], RedisRollbackExerciseContext)
+
+
+def test_revoke_applied_hosts_service_outputs_unique_redis_hosts():
+    service = RedisExerciseRevokeAppliedHostsService()
+    data = FakeData(
+        {
+            "global_data": {
+                "job_root_id": "root-1",
+                "infos": [
+                    {
+                        "redis": [
+                            {
+                                "ip": "1.1.1.1",
+                                "bk_cloud_id": 0,
+                                "bk_host_id": 101,
+                                "city": "sz",
+                            }
+                        ]
+                    },
+                    {"redis": [{"ip": "1.1.1.1", "bk_cloud_id": 0, "bk_host_id": 101}]},
+                    {"redis": [{"ip": "2.2.2.2", "bk_cloud_id": 0}]},
+                ],
+            }
+        }
+    )
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowOutputHandler"
+    ) as handler:
+        service._execute_inner_captured(data, parent_data=None)
+
+    handler.return_value.insert_data.assert_called_once()
+    root_id, hosts = handler.return_value.insert_data.call_args.args
+    assert root_id == "root-1"
+    assert hosts == [
+        {
+            "ip": "1.1.1.1",
+            "bk_cloud_id": 0,
+            "bk_host_id": 101,
+            "remark": "Redis rollback exercise revoked",
+        }
+    ]
+
+
+def test_revoke_applied_hosts_service_outputs_empty_table_when_no_redis_hosts():
+    service = RedisExerciseRevokeAppliedHostsService()
+    data = FakeData({"global_data": {"job_root_id": "root-1", "infos": [{"redis": []}, {}]}})
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowOutputHandler"
+    ) as handler:
+        service._execute_inner_captured(data, parent_data=None)
+
+    handler.return_value.insert_data.assert_called_once_with("root-1", [])


### PR DESCRIPTION
- Redis 回档演练补充近期主从切换识别，备份缺失但 tuple 在阈值内重建时标记为 SKIPPED，避免误报 BACKUP_INVALID
- 构建演练子流程时如果源集群已不存在，跳过该实例并将报告标记为 SKIPPED，避免单个缺失集群阻断整体流程
- 为 Redis 回档演练接入 `@revoke_with`，手动终止后可走现有 `RECYCLE_APPLY_HOST` 回收链路
- revoke flow 复用现有 best-effort cleanup 组件清理临时实例/元数据，再输出已申请主机给标准回收流程
- 补充回档演练校验、缺失集群跳过、revoke cleanup 编排和主机输出相关单测