### PR TITLE
fix(redis): correct rollback drill recycle flow #17832

### DIFF
--- a/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/mongo_data_export.go
+++ b/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/mongo_data_export.go
@@ -222,10 +222,10 @@ func (s *mongoDataExport) Run() error {
 		return err
 	}
 
-	// Upload tar file to bkrepo.
+	// Upload archive file to bkrepo.
 	if err := s.ConfParams.UploadDetail.Upload(s.OutputPath); err != nil {
-		s.runtime.Logger.Error("Failed to upload result tar file: %v", err)
-		return errors.Wrap(err, "uploadTarFile")
+		s.runtime.Logger.Error("Failed to upload result archive file: %v", err)
+		return errors.Wrap(err, "uploadArchiveFile")
 	}
 	s.runtime.Logger.Info("Upload to to %s successfully", s.ConfParams.UploadDetail.FileServer.URL)
 
@@ -256,7 +256,7 @@ func (s *mongoDataExport) doDumpData(outputPath string) error {
 	return err
 }
 
-// Upload uploads "<filename>.tar" to bkrepo
+// Upload uploads the exported archive to bkrepo.
 func (c UploadBkRepoParam) Upload(filePath string) (err error) {
 	if reflect.DeepEqual(c.FileServer, FileServer{}) {
 		return fmt.Errorf("file server is empty")
@@ -441,17 +441,20 @@ func (s *mongoDataExport) validateParams() error {
 
 // compressOutput compresses the outputPath and then remove it
 func (s *mongoDataExport) compressOutput(outputPath string) error {
-	// Create tar file
+	// Create gzip-compressed tar file.
 	targetFolder := path.Base(outputPath)
-	tarFile := fmt.Sprintf("%s.tar", targetFolder)
+	tarFile := fmt.Sprintf("%s.tar.gz", targetFolder)
 	tarPath := path.Join(path.Dir(outputPath), tarFile)
 
-	tarCmd := mycmd.New("tar", "cvf", tarPath, "-C", path.Dir(outputPath), targetFolder)
+	tarCmd := mycmd.New("tar", "czvf", tarPath, "-C", path.Dir(outputPath), targetFolder)
 	execResult, err := tarCmd.Run(time.Hour * 2)
 	s.runtime.Logger.Info("exec cmd: %q, exitCode:%d, err:%v", tarCmd.GetCmdLine2(true), execResult.ExitCode, err)
 
 	if execResult.ExitCode != 0 {
-		return errors.Wrap(err, "tar compression failed")
+		if err != nil {
+			return errors.Wrap(err, "tar compression failed")
+		}
+		return errors.Errorf("tar compression failed, exitCode:%d", execResult.ExitCode)
 	}
 
 	// Remove original directory after successful compression

--- a/dbm-ui/backend/db_meta/api/cluster/nosqlcomm/decommission.py
+++ b/dbm-ui/backend/db_meta/api/cluster/nosqlcomm/decommission.py
@@ -190,6 +190,12 @@ def decommission_instances(ip: str, bk_cloud_id: int, ports: List) -> bool:
     """
 
     machine_obj = Machine.objects.filter(ip=ip, bk_cloud_id=bk_cloud_id).first()
+    if not machine_obj:
+        logger.warning(
+            "no machine matched for decommission ip={} bk_cloud_id={}, ports={}, skip".format(ip, bk_cloud_id, ports)
+        )
+        return True
+
     keep_machine = False
     cc_manage = CcManage(machine_obj.bk_biz_id, machine_obj.cluster_type)
     if machine_obj.access_layer == AccessLayer.PROXY:

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
@@ -376,7 +376,7 @@ class RedisAffinityChecker:
         """
         target_subzone_id = expected_subzone_id
         if target_subzone_id is None:
-            target_subzone_id, _ = max(
+            target_subzone_id, _x = max(
                 sorted(machines_map.items(), key=lambda item: str(item[0])),
                 key=lambda item: item[1],
             )
@@ -386,7 +386,7 @@ class RedisAffinityChecker:
         replace_count = total_proxy_count - target_subzone_count
 
         non_target_ips = []
-        for (subzone_id, _), ips in sorted(ips_map.items(), key=lambda item: (str(item[0][0]), str(item[0][1]))):
+        for (subzone_id, _x), ips in sorted(ips_map.items(), key=lambda item: (str(item[0][0]), str(item[0][1]))):
             if subzone_id != target_subzone_id:
                 non_target_ips.extend(sorted(ips))
 
@@ -439,15 +439,20 @@ class RedisAffinityChecker:
         slave_obj: StorageInstance,
         affinity_level: str,
         target_rule_desc: str,
+        machines_to_move: Optional[List[Tuple[str, StorageInstance]]] = None,
     ) -> str:
         """
-        Suggest replacing/migrating slave machine for master-slave topology violations.
+        Suggest replacing/migrating the wrongly placed machine for master-slave topology violations.
         """
-        return _("后端主从对 ({}, {}) 不满足亲和级别 '{}'，请将副节点机器 {} 替换或迁移到 {}").format(
+        machines_to_move = machines_to_move or [(_("副节点"), slave_obj)]
+        machine_desc = str(_(" 和 ")).join(
+            _("{}机器 {}").format(role, storage_obj.machine.ip) for role, storage_obj in machines_to_move
+        )
+        return _("后端主从对 ({}, {}) 不满足亲和级别 '{}'，请将{} 替换或迁移到 {}").format(
             master_obj.machine.ip,
             slave_obj.machine.ip,
             affinity_level,
-            slave_obj.machine.ip,
+            machine_desc,
             target_rule_desc,
         )
 
@@ -719,11 +724,19 @@ class RedisAffinityChecker:
                 if expected_display
                 else _("与主节点 {} 位于同一园区且不同机架").format(master_obj.machine.ip)
             )
+            machines_to_move = None
+            if expected_subzone_id is not None:
+                machines_to_move = []
+                if master_subzone_id != expected_subzone_id:
+                    machines_to_move.append((_("主节点"), master_obj))
+                if slave_subzone_id != expected_subzone_id:
+                    machines_to_move.append((_("副节点"), slave_obj))
             suggestion = cls._build_backend_replace_slave_suggestion(
                 master_obj=master_obj,
                 slave_obj=slave_obj,
                 affinity_level=AffinityEnum.SAME_SUBZONE_CROSS_SWTICH.value,
                 target_rule_desc=target_rule_desc,
+                machines_to_move=machines_to_move,
             )
             return cls._append_suggestion(violation_msg, suggestion)
 
@@ -741,6 +754,7 @@ class RedisAffinityChecker:
                 slave_obj=slave_obj,
                 affinity_level=AffinityEnum.SAME_SUBZONE_CROSS_SWTICH.value,
                 target_rule_desc=_("园区({}) 且不同机架").format(expected_subzone_display),
+                machines_to_move=[(_("主节点"), master_obj), (_("副节点"), slave_obj)],
             )
             return cls._append_suggestion(violation_msg, suggestion)
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
@@ -14,7 +14,6 @@ import json
 import logging
 import math
 import random
-from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import StrEnum
 from typing import List, Optional, Set, Tuple
@@ -29,6 +28,7 @@ from backend.db_meta.models import Cluster, StorageInstance
 from backend.db_periodic_task.local_tasks.redis_backup.config import RedisBackupCheckConfig
 from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.db_services.redis.rollback.config import RedisRollbackExerciseConfig, RedisRollbackExerciseMode
 from backend.db_services.redis.rollback.handlers import DataStructureHandler
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
 from backend.db_services.redis.util import (
@@ -39,8 +39,8 @@ from backend.db_services.redis.util import (
 from backend.exceptions import AppBaseException
 from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
 from backend.ticket.builders.common.base import ClusterType, IpSource
-from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
-from backend.ticket.models import ClusterOperateRecord, SystemSettings, Ticket
+from backend.ticket.constants import TicketType
+from backend.ticket.models import ClusterOperateRecord, Ticket
 from backend.utils.redis import RedisConn
 from backend.utils.time import datetime2str, str2datetime
 
@@ -60,84 +60,17 @@ REDIS_LOCK_TIMEOUT = 600  # 10 minutes
 RPUSH_BATCH_SIZE = 500
 
 
-class RedisRollbackExerciseMode(StrEnum):
-    SPECIFIED = "specified"
-    RANDOM = "random"
-
-
 class ValidationFailureKind(StrEnum):
     """Why a candidate failed pre-flight validation.
 
     BACKUP_INVALID is treated as ABNORMAL on the report (real data-protection issue);
     ENV_SKIPPED is treated as SKIPPED -> WARNING (transient/environmental).
+    ENV_SUPPRESSED is logged only because it is expected busy-cluster noise.
     """
 
     BACKUP_INVALID = "backup_invalid"
     ENV_SKIPPED = "env_skipped"
-
-
-@dataclass
-class RedisRollbackExerciseConfig:
-    """
-    Configuration of Redis rollback exericse.
-
-    In SPECIFIED mode, ``specified_domains`` and ``specified_bizs`` combine as:
-    - domains set, bizs unset: exercise every listed domain (legacy behavior).
-    - domains set, bizs set: exercise only listed domains in those bizs.
-    - domains unset, bizs set: discover ONLINE candidate clusters in those bizs.
-    - domains unset, bizs unset: warn and skip.
-    """
-
-    # Meta Configs
-    enabled: bool = False
-    mode: RedisRollbackExerciseMode = RedisRollbackExerciseMode.RANDOM
-    bk_biz_id: int = 0  # The biz where the drill ticket locates
-
-    # Mode - Specifed
-    specified_domains: Optional[List[str]] = None  # Customed targets [clusters]
-    # Allowlist for SPECIFIED mode: filters specified_domains to clusters in these bizs;
-    # when specified_domains is empty, discovers ONLINE clusters in these bizs instead.
-    specified_bizs: Optional[List[int]] = None
-
-    # Mode - Random
-    batch_size: int = 2000  # Count of clusters to exercise each week
-    bizs_high_priority: Optional[List[int]] = None  # Customed bizs with high priority
-    clusters_ignored: Optional[List[int]] = None  # Customed clusters(id) to ignore
-    bizs_ignored: Optional[List[int]] = None  # Customed bizs to ignore
-    cluster_types: List[str] = field(
-        default_factory=lambda: [
-            ClusterType.TendisTwemproxyRedisInstance.value,  # TendisCache 集群
-            ClusterType.TwemproxyTendisSSDInstance.value,  # TendisSSD 集群
-            ClusterType.TendisRedisInstance.value,  # Redis 主从
-            ClusterType.TendisPredixyRedisCluster.value,
-            ClusterType.TendisPredixyTendisplusCluster.value,
-        ]
-    )  # Customed ClusterTypes to exercise
-
-    # Weighted selection: probability multipliers (how many times more likely to be selected)
-    # Combined effect is multiplicative, e.g., high_priority + failed = 2.0 * 3.0 = 6x more likely
-    weight_multiplier_high_priority_biz: float = 2.0  # 2x more likely than default
-    weight_multiplier_previously_failed: float = 3.0  # 3x more likely than default
-    weight_multiplier_not_exercised: float = 2.0  # 2x more likely for clusters not exercised recently
-    not_exercised_days_threshold: int = 180  # Days threshold for "not exercised" status
-
-    # Error handling
-    error_ignorable: bool = True  # Continue exercising other clusters when one rollback fails
-
-    # Extra
-    max_instances: int = 10  # Each round
-    rollback_days: List[int] = field(default_factory=lambda: [0.1, 0.2, 0.3, 0.4, 0.5, 1, 2])  # Rollback days
-    polling_interval: int = 10  # sec
-    polling_timeout: int = 3600  # sec
-
-    # Recovery time-point offset (after the chosen full backup uptime).
-    # SSD / Tendisplus default ~23h50m so we exercise almost a full day of binlog
-    # (daily full backup at ~05:00 -> rollback target lands ~04:50 of next day,
-    # safely before the next full backup window).
-    binlog_replay_minutes: int = 1430
-    # Cluster types without binlog (cache / redis main-slave / predixy redis cluster)
-    # only need a small offset past the full backup uptime.
-    no_binlog_offset_minutes: int = 30
+    ENV_SUPPRESSED = "env_suppressed"
 
 
 class RedisRollbackExercise:
@@ -150,8 +83,7 @@ class RedisRollbackExercise:
 
     def _init_config(self) -> RedisRollbackExerciseConfig:
         """Initialize configuration from system settings"""
-        config_dict = SystemSettings.get_setting_value("REDIS_ROLLBACK_EXERCISE", {})
-        config = RedisRollbackExerciseConfig(**config_dict) if config_dict else RedisRollbackExerciseConfig()
+        config = RedisRollbackExerciseConfig.from_settings()
         logger.info(_("Redis rollback exercise settings: {}").format(config))
         return config
 
@@ -201,8 +133,6 @@ class RedisRollbackExercise:
                 "backup_check_instance", instance
             )  # Slave for backup check
 
-            report = self._create_report(cluster, instance)
-
             try:
                 (
                     is_valid,
@@ -219,49 +149,9 @@ class RedisRollbackExercise:
                     rollback_days=self.config.rollback_days,
                     backup_check_instance=backup_check_instance,
                 )
-
-                if is_valid:
-                    report.backup_info = json.dumps(
-                        {
-                            "full_backup": full_backup,
-                            "binlog_summary": binlog_summary,
-                            "recovery_time_point": datetime2str(recovery_time_point),
-                            "tendis_type": self._resolve_tendis_type(cluster.cluster_type),
-                            "kvstorecount": (
-                                self._get_kvstorecount(cluster)
-                                if is_tendisplus_instance_type(cluster.cluster_type)
-                                else None
-                            ),
-                        },
-                        indent=2,
-                        ensure_ascii=False,
-                    )
-                    report.save(update_fields=["backup_info", "update_at"])
-
-                    valid_instances.append(
-                        {
-                            "cluster": cluster,
-                            "instance": instance,
-                            "full_backup": full_backup,
-                            "days_used": days_used,
-                            "recovery_time_point": recovery_time_point,
-                            "binlog_summary": binlog_summary,
-                            "report": report,
-                        }
-                    )
-                else:
-                    stage = (
-                        TaskStage.BACKUP_INVALID
-                        if failure_kind == ValidationFailureKind.BACKUP_INVALID
-                        else TaskStage.SKIPPED
-                    )
-                    report.mark(
-                        stage,
-                        task_message=_fmt_task_msg(_("Validation failed: {}").format(fail_reason)),
-                    )
-
             except AppBaseException as e:
                 logger.exception(_("Backup validation error for instance {} {}").format(instance.ip_port, str(e)))
+                report = self._create_report(cluster, instance)
                 report.mark(
                     TaskStage.BACKUP_INVALID,
                     task_message=_fmt_task_msg(_("Backup validation error: {}").format(str(e))),
@@ -269,11 +159,57 @@ class RedisRollbackExercise:
                 continue
             except Exception as e:
                 logger.exception(_("Error validating instance {} {}").format(instance.ip_port, str(e)))
+                report = self._create_report(cluster, instance)
                 report.mark(
                     TaskStage.SKIPPED,
                     task_message=_fmt_task_msg(_("Exception during validation: {}").format(str(e))),
                 )
                 continue
+
+            if is_valid:
+                report = self._create_report(cluster, instance)
+                report.backup_info = json.dumps(
+                    {
+                        "full_backup": full_backup,
+                        "binlog_summary": binlog_summary,
+                        "recovery_time_point": datetime2str(recovery_time_point),
+                        "tendis_type": self._resolve_tendis_type(cluster.cluster_type),
+                        "kvstorecount": (
+                            self._get_kvstorecount(cluster)
+                            if is_tendisplus_instance_type(cluster.cluster_type)
+                            else None
+                        ),
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+                report.save(update_fields=["backup_info", "update_at"])
+
+                valid_instances.append(
+                    {
+                        "cluster": cluster,
+                        "instance": instance,
+                        "full_backup": full_backup,
+                        "days_used": days_used,
+                        "recovery_time_point": recovery_time_point,
+                        "binlog_summary": binlog_summary,
+                        "report": report,
+                    }
+                )
+                continue
+
+            if failure_kind == ValidationFailureKind.ENV_SUPPRESSED:
+                logger.info(_("Validation skipped without report: {}").format(fail_reason))
+                continue
+
+            report = self._create_report(cluster, instance)
+            stage = (
+                TaskStage.BACKUP_INVALID if failure_kind == ValidationFailureKind.BACKUP_INVALID else TaskStage.SKIPPED
+            )
+            report.mark(
+                stage,
+                task_message=_fmt_task_msg(_("Validation failed: {}").format(fail_reason)),
+            )
 
         if not valid_instances:
             logger.info(_("No instances with valid backup found"))
@@ -375,10 +311,10 @@ class RedisRollbackExercise:
         Validate if instance is suitable for rollback exercise.
 
         Validations:
-        1. Backup availability (full backup + binlog when applicable)
-        2. Recent master-slave switch downgrades missing backup to skipped
-        3. No existing temp instance (not destroyed) in tb_tendis_rollback_tasks
-        4. No undone conflicting ticket
+        1. No existing temp instance (not destroyed) in tb_tendis_rollback_tasks
+        2. No undone conflicting ticket
+        3. Backup availability (full backup + binlog when applicable)
+        4. Recent master-slave switch downgrades missing backup to skipped
 
         Returns:
             tuple: (is_valid, full_backup_log, days_used, recovery_time_point,
@@ -387,10 +323,35 @@ class RedisRollbackExercise:
             ``failure_kind`` is a ``ValidationFailureKind`` (or None when valid):
             - BACKUP_INVALID -> caller should mark report as BACKUP_INVALID (ABNORMAL)
             - ENV_SKIPPED    -> caller should mark report as SKIPPED (WARNING)
+            - ENV_SUPPRESSED -> caller should log only, without report noise
         """
         cluster_id = cluster.id
 
-        # 1. Backup check (full + binlog when applicable)
+        # 1. Temp instance check
+        existing_temp_instances = TbTendisRollbackTasks.objects.filter(
+            prod_cluster_id=cluster_id,
+            destroyed_status__in=[DestroyedStatus.NOT_DESTROYED, DestroyedStatus.DESTROYING],
+        )
+        if existing_temp_instances.exists():
+            fail_reason = _("Cluster {} has existing temp instances (not destroyed)").format(cluster_id)
+            return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SUPPRESSED
+
+        # 2. Undone exclusive ticket check
+        exclusive_infos = ClusterOperateRecord.objects.has_exclusive_operations_with_lock(
+            TicketType.REDIS_ROLLBACK_EXERCISE,
+            cluster_id,
+        )
+        if exclusive_infos:
+            exclusive_tickets = [
+                "{}({})".format(info["exclusive_ticket"].ticket_type, info["exclusive_ticket"].id)
+                for info in exclusive_infos
+            ]
+            fail_reason = _("Cluster {} has exclusive active tickets: {}").format(
+                cluster_id, ", ".join(exclusive_tickets)
+            )
+            return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SUPPRESSED
+
+        # 3. Backup check (full + binlog when applicable)
         (
             has_backup,
             full_backup,
@@ -416,36 +377,6 @@ class RedisRollbackExercise:
                 return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SKIPPED
             # No recent switch — genuine backup missing.
             return False, None, None, None, None, fail_reason, ValidationFailureKind.BACKUP_INVALID
-
-        # 2. Temp instance check
-        existing_temp_instances = TbTendisRollbackTasks.objects.filter(
-            prod_cluster_id=cluster_id,
-            destroyed_status__in=[DestroyedStatus.NOT_DESTROYED, DestroyedStatus.DESTROYING],
-        )
-        if existing_temp_instances.exists():
-            fail_reason = _("Cluster {} has existing temp instances (not destroyed)").format(cluster_id)
-            return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SKIPPED
-
-        # 3. Undone ticket check
-        conflicting_ticket_type = [
-            TicketType.REDIS_ROLLBACK_EXERCISE,
-            TicketType.REDIS_DATA_STRUCTURE,
-            TicketType.REDIS_DATA_STRUCTURE_TASK_DELETE,
-        ]
-        undone_record = (
-            ClusterOperateRecord.objects.filter(
-                cluster_id=cluster_id,
-                ticket__ticket_type__in=conflicting_ticket_type,
-                ticket__status__in=TICKET_RUNNING_STATUS_SET,
-            )
-            .select_related("ticket")
-            .first()
-        )
-        if undone_record:
-            fail_reason = _("Cluster {} has undone {} ticket {}").format(
-                cluster_id, undone_record.ticket.ticket_type, undone_record.ticket.id
-            )
-            return False, None, None, None, None, fail_reason, ValidationFailureKind.ENV_SKIPPED
 
         return True, full_backup, days_used, recovery_time_point, binlog_summary, None, None
 
@@ -571,6 +502,9 @@ class RedisRollbackExercise:
 
         if self.config.bizs_ignored:
             queryset = queryset.exclude(bk_biz_id__in=self.config.bizs_ignored)
+
+        if self.config.bk_cloud_ids:
+            queryset = queryset.filter(bk_cloud_id__in=self.config.bk_cloud_ids)
 
         if self.config.cluster_types:
             queryset = queryset.filter(cluster_type__in=self.config.cluster_types)
@@ -745,6 +679,7 @@ class RedisRollbackExercise:
         skipped_clusters: List[tuple] = []
         domains = self.config.specified_domains or []
         bizs: Set[int] = set(self.config.specified_bizs or [])
+        bk_cloud_ids: Set[int] = set(self.config.bk_cloud_ids or [])
 
         if domains:
             for domain in domains:
@@ -752,6 +687,12 @@ class RedisRollbackExercise:
                 if bizs and cluster.bk_biz_id not in bizs:
                     skip_msg = _("Cluster {} bk_biz_id {} not in specified_bizs {}").format(
                         cluster.immute_domain, cluster.bk_biz_id, sorted(bizs)
+                    )
+                    skipped_clusters.append((cluster, skip_msg))
+                    continue
+                if bk_cloud_ids and cluster.bk_cloud_id not in bk_cloud_ids:
+                    skip_msg = _("Cluster {} bk_cloud_id {} not in bk_cloud_ids {}").format(
+                        cluster.immute_domain, cluster.bk_cloud_id, sorted(bk_cloud_ids)
                     )
                     skipped_clusters.append((cluster, skip_msg))
                     continue
@@ -828,6 +769,12 @@ class RedisRollbackExercise:
             try:
                 cluster_id = int(candidate_data)
                 cluster = Cluster.objects.get(id=cluster_id)
+                if self.config.bk_cloud_ids and cluster.bk_cloud_id not in self.config.bk_cloud_ids:
+                    skip_msg = _("Cluster {} bk_cloud_id {} not in bk_cloud_ids {}").format(
+                        cluster.immute_domain, cluster.bk_cloud_id, sorted(self.config.bk_cloud_ids)
+                    )
+                    skipped_clusters.append((cluster, skip_msg))
+                    continue
                 if cluster.phase != ClusterPhase.ONLINE.value:
                     skip_msg = _("Cluster {} is offline (phase: {})").format(cluster.immute_domain, cluster.phase)
                     skipped_clusters.append((cluster, skip_msg))

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/base.py
@@ -98,6 +98,7 @@ OUTCOME_SKIPPED = "skipped"  # cluster skipped pre-agent; specific cause in the 
 OUTCOME_DISPATCH_OK = "dispatch_ok"
 OUTCOME_DISPATCH_FAILED = "dispatch_failed"
 OUTCOME_DISPATCH_DEDUP_SKIPPED = "dispatch_dedup_skipped"
+SKIP_REPORT_MSG_PREFIX = "skipped:"
 
 PRIORITY_ALARM_DAILY_DOMAIN_CACHE_KEY_PREFIX = "redis_agent_check_priority_alarm_domains"
 PRIORITY_ALARM_DAILY_DOMAIN_CACHE_LOCK_KEY_PREFIX = "redis_agent_check_priority_alarm_domains_lock"
@@ -420,6 +421,10 @@ class BaseRedisAgentCheckTask(ABC):
         the fleet.
         """
         return False, ""
+
+    def persist_extra_skip_report(self, cluster: Cluster, reason: str) -> None:
+        """Persist subclass-specific skip evidence. Default: no report."""
+        return None
 
     def _has_extra_skip_check(self) -> bool:
         """True iff a subclass actually overrides ``extra_skip_check``.
@@ -878,6 +883,15 @@ class BaseRedisAgentCheckTask(ABC):
                     OUTCOME_SKIPPED,
                     reason,
                 )
+                try:
+                    self.persist_extra_skip_report(cluster, reason)
+                except Exception as exc:
+                    logger.warning(
+                        "%s: cluster_id=%s persist_extra_skip_report raised: %s",
+                        task_name,
+                        cluster_id,
+                        exc,
+                    )
         return skipped_ids
 
     def start(self) -> int:

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_cluster_capacity_growth.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/agent_checks/check_cluster_capacity_growth.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Callable, ClassVar
 
 from blueapps.core.celery.celery import app
+from django.utils import timezone
 
 from backend.components import DBConfigApi
 from backend.components.dbconfig.constants import FormatType, LevelName
@@ -21,13 +22,16 @@ from backend.db_meta.models import Cluster
 from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base import (
     DEFAULT_AGENT_HARD_TIME_LIMIT_SECONDS,
     DEFAULT_AGENT_SOFT_TIME_LIMIT_SECONDS,
+    SKIP_REPORT_MSG_PREFIX,
     BaseCheckConfig,
     BaseRedisAgentCheckTask,
     execute_agent_check,
 )
+from backend.db_report.enums import ReportStateType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.dbm_aiagent.agent.constants import DBMAgentCode
 from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
+from backend.flow.utils.redis.redis_report_utils import RedisReportWriter
 
 logger = logging.getLogger("root")
 
@@ -80,6 +84,23 @@ class CheckClusterCapacityGrowthTask(BaseRedisAgentCheckTask):
 
     def get_celery_task(self) -> Callable:
         return check_cluster_capacity_growth_task
+
+    def persist_extra_skip_report(self, cluster: Cluster, reason: str) -> None:
+        report_day = int(timezone.now().strftime("%Y%m%d"))
+        RedisReportWriter().write_redis_report(
+            cluster_id=cluster.id,
+            subtype=self.subtype.value,
+            cluster=cluster.immute_domain,
+            cluster_type=cluster.cluster_type,
+            bk_biz_id=cluster.bk_biz_id,
+            bk_cloud_id=cluster.bk_cloud_id,
+            report_day=report_day,
+            creator="",
+            state=ReportStateType.NORMAL.value,
+            msg=f"{SKIP_REPORT_MSG_PREFIX} {reason}",
+            shard="all",
+            instance="all",
+        )
 
     def extra_skip_check(self, cluster: Cluster) -> tuple[bool, str]:
         """Skip clusters whose maxmemory-policy enables eviction.

--- a/dbm-ui/backend/db_report/views/redis/redis_recover_drill_view.py
+++ b/dbm-ui/backend/db_report/views/redis/redis_recover_drill_view.py
@@ -10,7 +10,9 @@ specific language governing permissions and limitations under the License.
 """
 
 import logging
+from functools import cached_property
 
+from django.db.models import OuterRef, Subquery
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
@@ -20,7 +22,10 @@ from backend.db_report.models import RedisRollbackExerciseReport
 from backend.db_report.register import register_drill_report
 from backend.db_report.serializers import ReportCommonFieldSerializerMixin
 from backend.db_report.views.revover_drill_report_view import RecoverDrillTaskViewSet
+from backend.db_services.redis.rollback.config import RedisRollbackExerciseConfig
 from backend.env import BK_SAAS_HOST
+from backend.ticket.constants import FlowType
+from backend.ticket.models import Flow
 
 logger = logging.getLogger("root")
 
@@ -32,7 +37,7 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
     recover_duration = serializers.SerializerMethodField(help_text=_("恢复花费时间(分钟)"))
     rollback_flow_link = serializers.SerializerMethodField(help_text=_("构造流程链接"))
     delete_flow_link = serializers.SerializerMethodField(help_text=_("销毁流程链接"))
-    ticket_link = serializers.SerializerMethodField(help_text=_("单据链接"))
+    ticket_flow_link = serializers.SerializerMethodField(help_text=_("单据流程链接"))
 
     def get_instance(self, obj):
         """Combine ip:port as instance"""
@@ -47,23 +52,37 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
             return round(duration.total_seconds() / 60, 2)
         return None
 
+    @cached_property
+    def rollback_exercise_bk_biz_id(self):
+        """Load once per serializer; rollback/delete flows live in the exercise ticket biz."""
+        return RedisRollbackExerciseConfig.from_settings().bk_biz_id
+
+    def get_rollback_exercise_flow_biz_id(self, obj):
+        """Use configured exercise biz for child flows, fallback to report biz if unset."""
+        return self.rollback_exercise_bk_biz_id or obj.bk_biz_id
+
     def get_rollback_flow_link(self, obj):
         """Generate rollback flow link"""
-        if not obj.rollback_flow_obj_id or not obj.bk_biz_id:
+        bk_biz_id = self.get_rollback_exercise_flow_biz_id(obj)
+        if not obj.rollback_flow_obj_id or not bk_biz_id:
             return None
-        return f"{BK_SAAS_HOST}/{obj.bk_biz_id}/task-history/detail/{obj.rollback_flow_obj_id}?from=taskHistoryList"
+        return f"{BK_SAAS_HOST}/{bk_biz_id}/task-history/detail/{obj.rollback_flow_obj_id}?from=taskHistoryList"
 
     def get_delete_flow_link(self, obj):
         """Generate delete flow link"""
-        if not obj.delete_flow_obj_id or not obj.bk_biz_id:
+        bk_biz_id = self.get_rollback_exercise_flow_biz_id(obj)
+        if not obj.delete_flow_obj_id or not bk_biz_id:
             return None
-        return f"{BK_SAAS_HOST}/{obj.bk_biz_id}/task-history/detail/{obj.delete_flow_obj_id}?from=taskHistoryList"
+        return f"{BK_SAAS_HOST}/{bk_biz_id}/task-history/detail/{obj.delete_flow_obj_id}?from=taskHistoryList"
 
-    def get_ticket_link(self, obj):
-        """Generate ticket link"""
-        if not obj.ticket_id:
+    def get_ticket_flow_link(self, obj):
+        """Generate ticket flow link"""
+        if not obj.ticket_id or not obj.bk_biz_id:
             return None
-        return f"{BK_SAAS_HOST}/ticket/{obj.ticket_id}"
+        flow_obj_id = getattr(obj, "ticket_flow_obj_id", "")
+        if not flow_obj_id:
+            return None
+        return f"{BK_SAAS_HOST}/{obj.bk_biz_id}/task-history/detail/{flow_obj_id}?from=taskHistoryList"
 
     class Meta:
         model = RedisRollbackExerciseReport
@@ -77,7 +96,7 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
             "recover_start_time",
             "recover_duration",
             "state",
-            "ticket_link",
+            "ticket_flow_link",
             "rollback_flow_link",
             "delete_flow_link",
             "task_message",
@@ -89,17 +108,24 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
 class RedisRecoverDrillTaskViewSet(RecoverDrillTaskViewSet):
     """Redis recover drill task viewset"""
 
-    queryset = RedisRollbackExerciseReport.objects.filter(
-        task_stage__in=[
-            RedisRollbackExerciseTaskStage.DONE,
-            RedisRollbackExerciseTaskStage.TICKET_GEN_FAILED,
-            RedisRollbackExerciseTaskStage.RESOURCE_APPLI_FAILED,
-            RedisRollbackExerciseTaskStage.ROLLBACK_FAILED,
-            RedisRollbackExerciseTaskStage.CLEANUP_FAILED,
-            RedisRollbackExerciseTaskStage.SKIPPED,
-            RedisRollbackExerciseTaskStage.BACKUP_INVALID,
-        ]
-    ).order_by("-update_at")
+    ticket_flow_obj_id_subquery = Flow.objects.filter(
+        ticket_id=OuterRef("ticket_id"), flow_type=FlowType.INNER_FLOW
+    ).values("flow_obj_id")[:1]
+    queryset = (
+        RedisRollbackExerciseReport.objects.filter(
+            task_stage__in=[
+                RedisRollbackExerciseTaskStage.DONE,
+                RedisRollbackExerciseTaskStage.TICKET_GEN_FAILED,
+                RedisRollbackExerciseTaskStage.RESOURCE_APPLI_FAILED,
+                RedisRollbackExerciseTaskStage.ROLLBACK_FAILED,
+                RedisRollbackExerciseTaskStage.CLEANUP_FAILED,
+                RedisRollbackExerciseTaskStage.SKIPPED,
+                RedisRollbackExerciseTaskStage.BACKUP_INVALID,
+            ]
+        )
+        .annotate(ticket_flow_obj_id=Subquery(ticket_flow_obj_id_subquery))
+        .order_by("-update_at")
+    )
     serializer_class = RedisRecoverDrillTaskSerializer
 
     filter_fields = {
@@ -164,8 +190,8 @@ class RedisRecoverDrillTaskViewSet(RecoverDrillTaskViewSet):
             "format": ReportFieldFormat.STATUS.value,
         },
         {
-            "name": "ticket_link",
-            "display_name": _("单据链接"),
+            "name": "ticket_flow_link",
+            "display_name": _("单据流程链接"),
             "format": ReportFieldFormat.LINK.value,
         },
         {

--- a/dbm-ui/backend/db_services/redis/rollback/config.py
+++ b/dbm-ui/backend/db_services/redis/rollback/config.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+from dataclasses import asdict, dataclass, field, fields
+from enum import StrEnum
+from typing import List, Optional
+
+from backend.configuration.constants import SystemSettingsEnum
+from backend.ticket.builders.common.base import ClusterType
+from backend.ticket.models import SystemSettings
+
+logger = logging.getLogger("root")
+
+
+class RedisRollbackExerciseMode(StrEnum):
+    SPECIFIED = "specified"
+    RANDOM = "random"
+
+
+@dataclass
+class RedisRollbackExerciseConfig:
+    """
+    Configuration of Redis rollback exericse.
+
+    In SPECIFIED mode, ``specified_domains`` and ``specified_bizs`` combine as:
+    - domains set, bizs unset: exercise every listed domain (legacy behavior).
+    - domains set, bizs set: exercise only listed domains in those bizs.
+    - domains unset, bizs set: discover ONLINE candidate clusters in those bizs.
+    - domains unset, bizs unset: warn and skip.
+    """
+
+    # Meta Configs
+    enabled: bool = False
+    mode: RedisRollbackExerciseMode = RedisRollbackExerciseMode.RANDOM
+    bk_biz_id: int = 0  # The biz where the drill ticket locates
+    bk_cloud_ids: Optional[List[int]] = None  # Only exercise clusters in these cloud areas
+
+    # Mode - Specifed
+    specified_domains: Optional[List[str]] = None  # Customed targets [clusters]
+    # Allowlist for SPECIFIED mode: filters specified_domains to clusters in these bizs;
+    # when specified_domains is empty, discovers ONLINE clusters in these bizs instead.
+    specified_bizs: Optional[List[int]] = None
+
+    # Mode - Random
+    batch_size: int = 2000  # Count of clusters to exercise each week
+    bizs_high_priority: Optional[List[int]] = None  # Customed bizs with high priority
+    clusters_ignored: Optional[List[int]] = None  # Customed clusters(id) to ignore
+    bizs_ignored: Optional[List[int]] = None  # Customed bizs to ignore
+    cluster_types: List[str] = field(
+        default_factory=lambda: [
+            ClusterType.TendisTwemproxyRedisInstance.value,  # TendisCache 集群
+            ClusterType.TwemproxyTendisSSDInstance.value,  # TendisSSD 集群
+            ClusterType.TendisRedisInstance.value,  # Redis 主从
+            ClusterType.TendisPredixyRedisCluster.value,
+            ClusterType.TendisPredixyTendisplusCluster.value,
+        ]
+    )  # Customed ClusterTypes to exercise
+
+    # Weighted selection: probability multipliers (how many times more likely to be selected)
+    # Combined effect is multiplicative, e.g., high_priority + failed = 2.0 * 3.0 = 6x more likely
+    weight_multiplier_high_priority_biz: float = 2.0  # 2x more likely than default
+    weight_multiplier_previously_failed: float = 3.0  # 3x more likely than default
+    weight_multiplier_not_exercised: float = 2.0  # 2x more likely for clusters not exercised recently
+    not_exercised_days_threshold: int = 180  # Days threshold for "not exercised" status
+
+    # Error handling
+    error_ignorable: bool = True  # Continue exercising other clusters when one rollback fails
+
+    # Extra
+    max_instances: int = 10  # Each round
+    rollback_days: List[int] = field(default_factory=lambda: [0.1, 0.2, 0.3, 0.4, 0.5, 1, 2])  # Rollback days
+    polling_interval: int = 10  # sec
+    polling_timeout: int = 3600  # sec
+
+    # Recovery time-point offset (after the chosen full backup uptime).
+    # SSD / Tendisplus default ~23h50m so we exercise almost a full day of binlog
+    # (daily full backup at ~05:00 -> rollback target lands ~04:50 of next day,
+    # safely before the next full backup window).
+    binlog_replay_minutes: int = 1430
+    # Cluster types without binlog (cache / redis main-slave / predixy redis cluster)
+    # only need a small offset past the full backup uptime.
+    no_binlog_offset_minutes: int = 30
+
+    @classmethod
+    def from_settings(cls) -> "RedisRollbackExerciseConfig":
+        """Load config from SystemSettings with dataclass defaults for missing keys."""
+        raw = SystemSettings.get_setting_value(SystemSettingsEnum.REDIS_ROLLBACK_EXERCISE.value, default={})
+        if not isinstance(raw, dict):
+            if raw:
+                logger.warning("RedisRollbackExerciseConfig: expected dict, got %s", type(raw).__name__)
+            return cls()
+
+        valid_keys = {f.name for f in fields(cls)}
+        return cls(**{key: value for key, value in raw.items() if key in valid_keys})
+
+    def save_to_settings(self, user: str = "admin") -> None:
+        """Persist this config to SystemSettings for shell_plus maintenance."""
+        SystemSettings.insert_setting_value(
+            key=SystemSettingsEnum.REDIS_ROLLBACK_EXERCISE.value,
+            value=asdict(self),
+            value_type="dict",
+            user=user,
+        )

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/revoke/redis_rollback_exercise_revoke_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/revoke/redis_rollback_exercise_revoke_flow.py
@@ -26,8 +26,6 @@ class RedisRollbackExerciseRevokeFlow(RevokeFlowBase):
 
     def revoke_flow(self):
         ticket_data = copy.deepcopy(self.data)
-        if ticket_data.get("parent_ticket"):
-            ticket_data["uid"] = ticket_data["parent_ticket"]
 
         revoke_pipeline = Builder(root_id=self.root_id, data=ticket_data)
         revoke_pipeline.add_act(

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -25,6 +25,7 @@ from backend.db_meta.api.cluster.nosqlcomm.decommission import decommission_inst
 from backend.db_meta.models import Cluster, StorageInstance
 from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.db_services.dbresource.handlers import ResourceHandler
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
 from backend.flow.consts import StateType
 from backend.flow.engine.bamboo.engine import BambooEngine
@@ -368,12 +369,29 @@ class RedisExerciseRevokeAppliedHostsService(RedisLogCapturingService):
         if not (ip and bk_cloud_id is not None and bk_host_id is not None):
             return None
 
-        return {
+        normalized = {
             "ip": ip,
             "bk_cloud_id": bk_cloud_id,
             "bk_host_id": bk_host_id,
             "remark": host.get("remark", _("Redis rollback exercise revoked")),
         }
+        return normalized
+
+    @staticmethod
+    def _standardize_recycle_hosts(recycle_hosts: list) -> list:
+        if not recycle_hosts:
+            return []
+
+        remarks = {host["bk_host_id"]: host.get("remark", "") for host in recycle_hosts}
+        standardized_hosts = ResourceHandler.standardized_resource_host(recycle_hosts)
+        if len(standardized_hosts) < len(recycle_hosts):
+            missing_host_ids = {host["bk_host_id"] for host in recycle_hosts} - {
+                host["bk_host_id"] for host in standardized_hosts
+            }
+            logger.warning("Recycle hosts dropped after CMDB normalization: %s", sorted(missing_host_ids))
+        for host in standardized_hosts:
+            host["remark"] = remarks.get(host["bk_host_id"], "")
+        return standardized_hosts
 
     @classmethod
     def _collect_recycle_hosts(cls, infos: list) -> list:
@@ -393,7 +411,7 @@ class RedisExerciseRevokeAppliedHostsService(RedisLogCapturingService):
                                 if value and not hosts_by_id[host_id].get(key)
                             }
                         )
-        return list(hosts_by_id.values())
+        return cls._standardize_recycle_hosts(list(hosts_by_id.values()))
 
     def _execute_inner_captured(self, data, parent_data) -> bool:
         global_data = data.get_one_of_inputs("global_data") or {}
@@ -521,8 +539,12 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
                     ports.add(port)
         return sorted(ports)
 
+    @staticmethod
+    def _get_rollback_task_ticket_id(global_data: dict):
+        return global_data.get("parent_ticket") or global_data.get("uid")
+
     def _collect_cleanup_hosts(self, global_data: dict) -> list:
-        ticket_id = global_data.get("uid")
+        ticket_id = self._get_rollback_task_ticket_id(global_data)
         ticket_bk_biz_id = global_data.get("bk_biz_id")
         cleanup_hosts = []
 
@@ -743,7 +765,7 @@ done
             return result
 
         global_data = data.get_one_of_inputs("global_data")
-        ticket_id = global_data.get("uid")
+        ticket_id = self._get_rollback_task_ticket_id(global_data)
         cleanup_hosts = data.get_one_of_outputs("cleanup_hosts") or []
 
         self.log_info(_("Step 3/4: Decommissioning StorageInstance metadata"))

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def redis_affinity_module(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        return importlib.import_module(
+            "backend.db_periodic_task.local_tasks.db_meta.db_meta_check.redis_cluster_check.check_affinity"
+        )
+
+
+def _storage(ip: str, subzone_id: int, rack_id: str):
+    return SimpleNamespace(machine=SimpleNamespace(ip=ip, bk_sub_zone_id=subzone_id, bk_rack_id=rack_id))
+
+
+def test_same_subzone_cross_switch_suggests_moving_slave_to_expected_subzone(redis_affinity_module):
+    checker = redis_affinity_module.RedisAffinityChecker
+    checker._subzone_map_cache = {1: "test-subzone-a", 2: "test-subzone-b"}
+
+    msg = checker._check_backend_same_subzone(
+        master_obj=_storage("1.1.1.1", 1, "rack-a"),
+        slave_obj=_storage("1.1.1.2", 2, "rack-b"),
+        expected_subzone_id=1,
+    )
+
+    assert "请将副节点机器 1.1.1.2 替换或迁移到 园区(test-subzone-a) 且不同机架" in msg
+    assert "主节点机器 1.1.1.1 替换" not in msg
+
+
+def test_same_subzone_cross_switch_suggests_moving_master_when_slave_is_in_expected_subzone(redis_affinity_module):
+    checker = redis_affinity_module.RedisAffinityChecker
+    checker._subzone_map_cache = {1: "test-subzone-a", 2: "test-subzone-b"}
+
+    msg = checker._check_backend_same_subzone(
+        master_obj=_storage("1.1.1.2", 2, "rack-b"),
+        slave_obj=_storage("1.1.1.1", 1, "rack-a"),
+        expected_subzone_id=1,
+    )
+
+    assert "请将主节点机器 1.1.1.2 替换或迁移到 园区(test-subzone-a) 且不同机架" in msg
+    assert "副节点机器 1.1.1.1 替换" not in msg

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise.py
@@ -47,6 +47,7 @@ pytestmark = pytest.mark.django_db
 
 # String path used by `patch(...)` decorators below — `patch` resolves lazily.
 BASE_MODULE = "backend.db_periodic_task.local_tasks.redis_backup_rollback.base"
+CONFIG_MODULE = "backend.db_services.redis.rollback.config"
 
 # Aware ISO timestamps so str2datetime's aware_check passes.
 FULL_BK_UPTIME = "2026-04-15T05:01:23+08:00"
@@ -109,11 +110,12 @@ def _make_cluster_mock(cluster_type: str, id_: int = 1):
     return cluster
 
 
-def _fake_cluster(cluster_id: int, bk_biz_id: int, immute_domain: str) -> MagicMock:
+def _fake_cluster(cluster_id: int, bk_biz_id: int, immute_domain: str, bk_cloud_id: int = 0) -> MagicMock:
     """Lightweight cluster mock for SPECIFIED-mode tests (only id/biz/domain matter)."""
     cluster = MagicMock(name=f"Cluster<{immute_domain}>")
     cluster.id = cluster_id
     cluster.bk_biz_id = bk_biz_id
+    cluster.bk_cloud_id = bk_cloud_id
     cluster.immute_domain = immute_domain
     return cluster
 
@@ -239,6 +241,41 @@ class TestPureHelpers:
         cfg = _config_cls()()
         assert cfg.binlog_replay_minutes == 1430
         assert cfg.no_binlog_offset_minutes == 30
+        assert cfg.bk_cloud_ids is None
+
+    def test_config_from_settings_ignores_unknown_keys(self):
+        """shell_plus-friendly loader should tolerate stale keys in SystemSettings."""
+        with patch(
+            f"{CONFIG_MODULE}.SystemSettings.get_setting_value",
+            return_value={"enabled": True, "max_instances": 3, "bk_cloud_ids": [0, 2000000], "stale_key": "ignored"},
+        ) as mock_get:
+            cfg = _config_cls().from_settings()
+
+        assert cfg.enabled is True
+        assert cfg.max_instances == 3
+        assert cfg.bk_cloud_ids == [0, 2000000]
+        assert not hasattr(cfg, "stale_key")
+        mock_get.assert_called_once()
+
+    def test_config_from_settings_non_dict_uses_defaults(self):
+        with patch(f"{CONFIG_MODULE}.SystemSettings.get_setting_value", return_value="bad"):
+            cfg = _config_cls().from_settings()
+
+        assert cfg == _config_cls()()
+
+    def test_config_save_to_settings(self):
+        cfg = _config_cls()(enabled=True, max_instances=7)
+
+        with patch(f"{CONFIG_MODULE}.SystemSettings.insert_setting_value") as mock_insert:
+            cfg.save_to_settings(user="tester")
+
+        mock_insert.assert_called_once()
+        call_kwargs = mock_insert.call_args.kwargs
+        assert call_kwargs["key"] == "REDIS_ROLLBACK_EXERCISE"
+        assert call_kwargs["value_type"] == "dict"
+        assert call_kwargs["user"] == "tester"
+        assert call_kwargs["value"]["enabled"] is True
+        assert call_kwargs["value"]["max_instances"] == 7
 
 
 # ---------------------------------------------------------------------------
@@ -520,8 +557,11 @@ class TestValidateInstance:
                 "_instance_has_backup",
                 return_value=(False, None, None, None, None, "no full backup"),
             ),
+            patch(f"{BASE_MODULE}.TbTendisRollbackTasks.objects.filter") as mock_temp_filter,
+            patch(f"{BASE_MODULE}.ClusterOperateRecord.objects.has_exclusive_operations_with_lock", return_value=[]),
             patch.object(_exercise_cls(), "_recent_master_slave_switch_hours", return_value=None),
         ):
+            mock_temp_filter.return_value.exists.return_value = False
             (
                 is_valid,
                 full_backup,
@@ -553,8 +593,11 @@ class TestValidateInstance:
                 "_instance_has_backup",
                 return_value=(False, None, None, None, None, "no full backup"),
             ),
+            patch(f"{BASE_MODULE}.TbTendisRollbackTasks.objects.filter") as mock_temp_filter,
+            patch(f"{BASE_MODULE}.ClusterOperateRecord.objects.has_exclusive_operations_with_lock", return_value=[]),
             patch.object(_exercise_cls(), "_recent_master_slave_switch_hours", return_value=6),
         ):
+            mock_temp_filter.return_value.exists.return_value = False
             (
                 is_valid,
                 full_backup,
@@ -602,14 +645,11 @@ class TestValidateInstance:
         exercise = _make_exercise()
         cluster = _make_cluster_mock(ClusterType.TwemproxyTendisSSDInstance.value)
 
-        rtp = timezone.now() + timedelta(hours=1)
-        backup_ok = (True, _make_full_backup_log(), 1, rtp, {"count": 2, "total_size_bytes": 300}, None)
-
         temp_qs = MagicMock()
         temp_qs.exists.return_value = True
 
         with (
-            patch.object(_exercise_cls(), "_instance_has_backup", return_value=backup_ok),
+            patch.object(_exercise_cls(), "_instance_has_backup") as mock_has_backup,
             patch(f"{BASE_MODULE}.TbTendisRollbackTasks") as mock_temp_model,
         ):
             mock_temp_model.objects.filter.return_value = temp_qs
@@ -622,33 +662,29 @@ class TestValidateInstance:
             )
 
         assert is_valid is False
-        assert failure_kind == _failure_kind().ENV_SKIPPED
+        assert failure_kind == _failure_kind().ENV_SUPPRESSED
         assert "temp instances" in fail_reason
+        mock_has_backup.assert_not_called()
 
-    def test_undone_ticket_returns_env_skipped(self):
+    def test_exclusive_ticket_returns_env_suppressed(self):
         exercise = _make_exercise()
         cluster = _make_cluster_mock(ClusterType.TwemproxyTendisSSDInstance.value)
-
-        rtp = timezone.now() + timedelta(hours=1)
-        backup_ok = (True, _make_full_backup_log(), 1, rtp, {"count": 2, "total_size_bytes": 300}, None)
 
         temp_qs = MagicMock()
         temp_qs.exists.return_value = False
 
-        # ClusterOperateRecord -> .filter().select_related().first()
-        undone = MagicMock()
-        undone.ticket.ticket_type = "REDIS_DATA_STRUCTURE"
-        undone.ticket.id = 999
-        cluster_qs = MagicMock()
-        cluster_qs.select_related.return_value.first.return_value = undone
+        exclusive_ticket = SimpleNamespace(ticket_type="REDIS_DATA_STRUCTURE", id=999)
+        exclusive_infos = [{"exclusive_ticket": exclusive_ticket, "root_id": "root-1"}]
 
         with (
-            patch.object(_exercise_cls(), "_instance_has_backup", return_value=backup_ok),
+            patch.object(_exercise_cls(), "_instance_has_backup") as mock_has_backup,
             patch(f"{BASE_MODULE}.TbTendisRollbackTasks") as mock_temp_model,
-            patch(f"{BASE_MODULE}.ClusterOperateRecord") as mock_record_model,
+            patch(
+                f"{BASE_MODULE}.ClusterOperateRecord.objects.has_exclusive_operations_with_lock",
+                return_value=exclusive_infos,
+            ) as mock_exclusive,
         ):
             mock_temp_model.objects.filter.return_value = temp_qs
-            mock_record_model.objects.filter.return_value = cluster_qs
 
             is_valid, _, _, _, _, fail_reason, failure_kind = exercise._validate_instance(
                 instance_ip="3.3.3.3",
@@ -658,8 +694,10 @@ class TestValidateInstance:
             )
 
         assert is_valid is False
-        assert failure_kind == _failure_kind().ENV_SKIPPED
-        assert "undone" in fail_reason and "999" in fail_reason
+        assert failure_kind == _failure_kind().ENV_SUPPRESSED
+        assert "exclusive active tickets" in fail_reason and "999" in fail_reason
+        mock_exclusive.assert_called_once()
+        mock_has_backup.assert_not_called()
 
     def test_all_clear_returns_valid(self):
         exercise = _make_exercise()
@@ -672,16 +710,13 @@ class TestValidateInstance:
 
         temp_qs = MagicMock()
         temp_qs.exists.return_value = False
-        cluster_qs = MagicMock()
-        cluster_qs.select_related.return_value.first.return_value = None
 
         with (
             patch.object(_exercise_cls(), "_instance_has_backup", return_value=backup_ok),
             patch(f"{BASE_MODULE}.TbTendisRollbackTasks") as mock_temp_model,
-            patch(f"{BASE_MODULE}.ClusterOperateRecord") as mock_record_model,
+            patch(f"{BASE_MODULE}.ClusterOperateRecord.objects.has_exclusive_operations_with_lock", return_value=[]),
         ):
             mock_temp_model.objects.filter.return_value = temp_qs
-            mock_record_model.objects.filter.return_value = cluster_qs
 
             (
                 is_valid,
@@ -714,7 +749,66 @@ class TestValidateInstance:
 
 
 # ---------------------------------------------------------------------------
-# 5) SPECIFIED mode dispatch and discovery
+# 5) start() report creation behavior
+# ---------------------------------------------------------------------------
+
+
+class TestStartReportSuppression:
+    """Verify start() skips noisy report rows only for explicitly suppressed failures."""
+
+    @staticmethod
+    def _selected_item():
+        cluster = _make_cluster_mock(ClusterType.TwemproxyTendisSSDInstance.value)
+        instance = SimpleNamespace(
+            machine=SimpleNamespace(ip="3.3.3.3"),
+            port=30000,
+            ip_port="3.3.3.3:30000",
+        )
+        return {"cluster": cluster, "instance": instance, "backup_check_instance": instance}
+
+    def test_start_does_not_create_report_for_suppressed_skip(self):
+        exercise = _make_exercise(enabled=True)
+        selected_item = self._selected_item()
+
+        with (
+            patch.object(exercise, "_pick_target_instances", return_value=([selected_item], [])),
+            patch.object(
+                exercise,
+                "_validate_instance",
+                return_value=(False, None, None, None, None, "cluster busy", _failure_kind().ENV_SUPPRESSED),
+            ),
+            patch.object(exercise, "_create_report") as mock_create_report,
+        ):
+            exercise.start()
+
+        mock_create_report.assert_not_called()
+
+    def test_start_creates_report_for_backup_invalid(self):
+        exercise = _make_exercise(enabled=True)
+        selected_item = self._selected_item()
+        report = MagicMock()
+
+        with (
+            patch.object(exercise, "_pick_target_instances", return_value=([selected_item], [])),
+            patch.object(
+                exercise,
+                "_validate_instance",
+                return_value=(False, None, None, None, None, "missing backup", _failure_kind().BACKUP_INVALID),
+            ),
+            patch.object(exercise, "_create_report", return_value=report) as mock_create_report,
+        ):
+            exercise.start()
+
+        mock_create_report.assert_called_once_with(selected_item["cluster"], selected_item["instance"])
+        report.mark.assert_called_once_with(
+            TaskStage.BACKUP_INVALID,
+            task_message=report.mark.call_args.kwargs["task_message"],
+        )
+        assert "missing backup" in report.mark.call_args.kwargs["task_message"]
+
+
+# ---------------------------------------------------------------------------
+# 6) SPECIFIED mode dispatch and discovery
 # ---------------------------------------------------------------------------
 
 
@@ -747,6 +841,34 @@ class TestGetSpecifiedInstancesDomainsFilter:
 
         assert [item["cluster"] for item in selected] == [in_biz]
         assert [cluster for cluster, _msg in skipped] == [out_biz]
+
+    def test_filters_domains_by_bk_cloud_ids(self):
+        """Domains outside bk_cloud_ids are skipped even when explicitly configured."""
+        in_cloud = _fake_cluster(1, bk_biz_id=10, bk_cloud_id=0, immute_domain="a.example.com")
+        out_cloud = _fake_cluster(2, bk_biz_id=10, bk_cloud_id=2000000, immute_domain="b.example.com")
+        domain_to_cluster = {"a.example.com": in_cloud, "b.example.com": out_cloud}
+
+        exercise = _make_exercise(
+            specified_domains=["a.example.com", "b.example.com"],
+            bk_cloud_ids=[0],
+        )
+
+        with (
+            patch(
+                f"{BASE_MODULE}.Cluster.objects.get",
+                side_effect=lambda immute_domain: domain_to_cluster[immute_domain],
+            ),
+            patch.object(
+                _exercise_cls(),
+                "_resolve_specified_cluster",
+                side_effect=lambda cluster: _fake_selection(cluster),
+            ),
+        ):
+            selected, skipped = exercise._get_specified_instances(num=10)
+
+        assert [item["cluster"] for item in selected] == [in_cloud]
+        assert [cluster for cluster, _msg in skipped] == [out_cloud]
+        assert "bk_cloud_id" in skipped[0][1]
 
     def test_no_bizs_keeps_legacy_behavior(self):
         """When specified_bizs is unset, every listed domain is selected (legacy)."""

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_base.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_base.py
@@ -322,7 +322,7 @@ class TestApplyExtraSkipCheck:
 
     _CLUSTER = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.Cluster"
 
-    def _make_task_with_override(self, base, hook):
+    def _make_task_with_override(self, base, hook, persist_hook=None):
         """Return a task whose ``extra_skip_check`` is the supplied hook.
 
         Bypasses ``__init__`` so we don't need a populated config; the
@@ -344,6 +344,9 @@ class TestApplyExtraSkipCheck:
 
             extra_skip_check = hook
 
+        if persist_hook is not None:
+            _Task.persist_extra_skip_report = persist_hook
+
         return _Task.__new__(_Task)
 
     def test_default_hook_returns_no_skip(self, base, fake_task_instance):
@@ -352,6 +355,7 @@ class TestApplyExtraSkipCheck:
         task = fake_task_instance()
         assert task._has_extra_skip_check() is False
         assert task.extra_skip_check(MagicMock()) == (False, "")
+        assert task.persist_extra_skip_report(MagicMock(), "reason") is None
 
     def test_no_override_short_circuits(self, base, fake_task_instance):
         # When the subclass doesn't override, we must not even hit the ORM.
@@ -386,6 +390,71 @@ class TestApplyExtraSkipCheck:
         assert skipped == {2, 3}
         assert "policy-skip-2" in caplog.text
         assert "policy-skip-3" in caplog.text
+
+    def test_override_persists_skipped_clusters(self, base):
+        calls = []
+
+        def persist(self, cluster, reason):
+            calls.append((cluster.id, reason))
+
+        task = self._make_task_with_override(
+            base,
+            lambda self, cluster: (cluster.id == 2, f"policy-skip-{cluster.id}"),
+            persist_hook=persist,
+        )
+        clusters = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = clusters
+            skipped = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1, 2],
+                page_busy_ids=set(),
+                has_extra_skip=True,
+            )
+
+        assert skipped == {2}
+        assert calls == [(2, "policy-skip-2")]
+
+    def test_override_does_not_persist_non_skipped_clusters(self, base):
+        persist = MagicMock()
+        task = self._make_task_with_override(
+            base,
+            lambda self, cluster: (False, ""),
+            persist_hook=persist,
+        )
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = [SimpleNamespace(id=1)]
+            skipped = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1],
+                page_busy_ids=set(),
+                has_extra_skip=True,
+            )
+
+        assert skipped == set()
+        persist.assert_not_called()
+
+    def test_persist_exception_keeps_cluster_skipped(self, base, caplog):
+        def persist(self, _cluster, _reason):
+            raise RuntimeError("report db down")
+
+        task = self._make_task_with_override(
+            base,
+            lambda self, cluster: (True, "policy-skip"),
+            persist_hook=persist,
+        )
+        with patch(self._CLUSTER) as cluster_cls:
+            cluster_cls.objects.filter.return_value = [SimpleNamespace(id=1)]
+            caplog.set_level("WARNING")
+            skipped = task._apply_extra_skip_check(
+                task_name="X",
+                page_ids=[1],
+                page_busy_ids=set(),
+                has_extra_skip=True,
+            )
+
+        assert skipped == {1}
+        assert "persist_extra_skip_report raised" in caplog.text
 
     def test_override_only_fetches_non_busy_ids(self, base):
         # Avoid wasting a Cluster.objects.filter on rows we already know
@@ -438,6 +507,84 @@ class TestApplyExtraSkipCheck:
                 has_extra_skip=True,
             )
         assert skipped == set()
+
+
+# ---------------------------------------------------------------------------
+# BaseRedisAgentCheckTask.get_clusters_to_check
+# ---------------------------------------------------------------------------
+class TestGetClustersToCheck:
+    _CLUSTER = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.Cluster"
+    _CLUSTER_OPERATE_RECORD = "backend.db_periodic_task.local_tasks.redis_tasks.agent_checks.base.ClusterOperateRecord"
+
+    @pytest.mark.django_db
+    def test_skip_reports_use_normal_window(self, base, fake_task_instance):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from backend.db_report.enums import ReportStateType
+        from backend.db_report.models import RedisCheckReport
+
+        task = fake_task_instance(
+            batch_size=10,
+            candidate_page_size=10,
+            max_candidate_scan=10,
+            normal_skip_days=30,
+            selection_strategy="sequential",
+        )
+
+        class _FakeClusterQuerySet:
+            def __init__(self, candidate_ids):
+                self.candidate_ids = candidate_ids
+                self.excluded_ids = set()
+
+            def exclude(self, **kwargs):
+                self.excluded_ids.update(kwargs.get("id__in", set()))
+                return self
+
+            def order_by(self, *_args):
+                return self
+
+            def values_list(self, *_args, **_kwargs):
+                return [cid for cid in self.candidate_ids if cid not in self.excluded_ids]
+
+        def _create_report(cluster_id, msg, created_at, state=ReportStateType.NORMAL.value):
+            report = RedisCheckReport.objects.create(
+                cluster_id=cluster_id,
+                subtype=task.subtype.value,
+                report_day=int(created_at.strftime("%Y%m%d")),
+                cluster=f"cluster-{cluster_id}.db",
+                cluster_type="TwemproxyRedisInstance",
+                bk_biz_id=1001,
+                bk_cloud_id=0,
+                shard="all",
+                instance="all",
+                status=True,
+                state=state,
+                msg=msg,
+                creator="",
+                updater="",
+            )
+            RedisCheckReport.objects.filter(id=report.id).update(create_at=created_at, update_at=created_at)
+
+        now = timezone.now()
+        _create_report(1, f"{base.SKIP_REPORT_MSG_PREFIX} maxmemory-policy=allkeys-lru enables eviction", now)
+        _create_report(
+            2,
+            f"{base.SKIP_REPORT_MSG_PREFIX} maxmemory-policy=volatile-lru enables eviction",
+            now - timedelta(hours=25),
+        )
+        _create_report(3, "agent reported no capacity growth risk", now - timedelta(hours=25))
+
+        fake_cluster_qs = _FakeClusterQuerySet(candidate_ids=[1, 2, 3, 4])
+        with (
+            patch(self._CLUSTER) as cluster_cls,
+            patch(self._CLUSTER_OPERATE_RECORD) as operate_record_cls,
+        ):
+            cluster_cls.objects.filter.return_value = fake_cluster_qs
+            operate_record_cls.objects.filter.return_value.filter.return_value.values_list.return_value = []
+
+            assert task.get_clusters_to_check() == [4]
 
 
 # ---------------------------------------------------------------------------

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_check_cluster_capacity_growth.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_tasks/agent_checks/test_check_cluster_capacity_growth.py
@@ -38,6 +38,7 @@ def fake_cluster():
     return SimpleNamespace(
         id=42,
         bk_biz_id=1001,
+        bk_cloud_id=0,
         immute_domain="cache.test.db",
         major_version="Redis-6",
         cluster_type="TwemproxyRedisInstance",
@@ -122,3 +123,41 @@ class TestExtraSkipCheckOverride:
         assert skipped is True
         assert policy in reason
         assert "eviction" in reason
+
+
+# ---------------------------------------------------------------------------
+# CheckClusterCapacityGrowthTask.persist_extra_skip_report
+# ---------------------------------------------------------------------------
+class TestPersistExtraSkipReport:
+    @pytest.mark.django_db
+    def test_creates_normal_skip_report(self, cap_growth, task, fake_cluster):
+        from backend.db_report.enums import ReportStateType
+        from backend.db_report.models import RedisCheckReport
+
+        reason = "maxmemory-policy=allkeys-lru enables eviction"
+        existing_report_ids = set(
+            RedisCheckReport.objects.filter(cluster_id=fake_cluster.id, subtype=task.subtype.value).values_list(
+                "id", flat=True
+            )
+        )
+        task.persist_extra_skip_report(fake_cluster, reason)
+
+        current_report_ids = set(
+            RedisCheckReport.objects.filter(cluster_id=fake_cluster.id, subtype=task.subtype.value).values_list(
+                "id", flat=True
+            )
+        )
+        report = RedisCheckReport.objects.get(
+            cluster_id=fake_cluster.id,
+            subtype=task.subtype.value,
+            id__in=current_report_ids - existing_report_ids,
+        )
+        assert report.cluster == fake_cluster.immute_domain
+        assert report.cluster_type == fake_cluster.cluster_type
+        assert report.bk_biz_id == fake_cluster.bk_biz_id
+        assert report.bk_cloud_id == fake_cluster.bk_cloud_id
+        assert report.shard == "all"
+        assert report.instance == "all"
+        assert report.status is True
+        assert report.state == ReportStateType.NORMAL.value
+        assert report.msg == f"{cap_growth.SKIP_REPORT_MSG_PREFIX} {reason}"

--- a/dbm-ui/backend/tests/db_report/views/redis/test_redis_recover_drill_view.py
+++ b/dbm-ui/backend/tests/db_report/views/redis/test_redis_recover_drill_view.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _make_report_row(bk_biz_id=100):
+    return SimpleNamespace(
+        bk_biz_id=bk_biz_id,
+        ticket_id=123,
+        ticket_flow_obj_id="ticket-root",
+        rollback_flow_obj_id="rollback-root",
+        delete_flow_obj_id="delete-root",
+    )
+
+
+def test_redis_rollback_exercise_flow_links_use_configured_biz():
+    from backend.db_report.views.redis import redis_recover_drill_view as view
+
+    serializer = view.RedisRecoverDrillTaskSerializer()
+    obj = _make_report_row(bk_biz_id=100)
+
+    with patch(
+        "backend.db_services.redis.rollback.config.RedisRollbackExerciseConfig.from_settings",
+        return_value=SimpleNamespace(bk_biz_id=200),
+    ) as mock_from_settings:
+        assert (
+            serializer.get_rollback_flow_link(obj)
+            == f"{view.BK_SAAS_HOST}/200/task-history/detail/rollback-root?from=taskHistoryList"
+        )
+        assert (
+            serializer.get_delete_flow_link(obj)
+            == f"{view.BK_SAAS_HOST}/200/task-history/detail/delete-root?from=taskHistoryList"
+        )
+
+    mock_from_settings.assert_called_once_with()
+
+
+def test_redis_rollback_exercise_flow_links_fallback_to_report_biz_when_config_unset():
+    from backend.db_report.views.redis import redis_recover_drill_view as view
+
+    serializer = view.RedisRecoverDrillTaskSerializer()
+    obj = _make_report_row(bk_biz_id=100)
+
+    with patch(
+        "backend.db_services.redis.rollback.config.RedisRollbackExerciseConfig.from_settings",
+        return_value=SimpleNamespace(bk_biz_id=0),
+    ):
+        assert (
+            serializer.get_rollback_flow_link(obj)
+            == f"{view.BK_SAAS_HOST}/100/task-history/detail/rollback-root?from=taskHistoryList"
+        )
+        assert (
+            serializer.get_delete_flow_link(obj)
+            == f"{view.BK_SAAS_HOST}/100/task-history/detail/delete-root?from=taskHistoryList"
+        )
+
+
+def test_redis_rollback_exercise_ticket_flow_link_uses_annotated_flow_obj_id():
+    from backend.db_report.views.redis import redis_recover_drill_view as view
+
+    serializer = view.RedisRecoverDrillTaskSerializer()
+    obj = _make_report_row(bk_biz_id=100)
+
+    with patch("backend.db_report.views.redis.redis_recover_drill_view.Flow") as flow:
+        assert (
+            serializer.get_ticket_flow_link(obj)
+            == f"{view.BK_SAAS_HOST}/100/task-history/detail/ticket-root?from=taskHistoryList"
+        )
+
+    flow.objects.filter.assert_not_called()
+
+
+def test_redis_rollback_exercise_ticket_flow_link_missing_annotation_returns_none():
+    from backend.db_report.views.redis import redis_recover_drill_view as view
+
+    serializer = view.RedisRecoverDrillTaskSerializer()
+    obj = _make_report_row(bk_biz_id=100)
+    obj.ticket_flow_obj_id = ""
+
+    assert serializer.get_ticket_flow_link(obj) is None

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
@@ -11,6 +11,7 @@ from backend.flow.engine.bamboo.scene.redis.revoke.redis_rollback_exercise_revok
 from backend.flow.engine.controller.redis import RedisController
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
     RedisExerciseBestEffortCleanupComponent,
+    RedisExerciseBestEffortCleanupService,
     RedisExerciseRevokeAppliedHostsComponent,
     RedisExerciseRevokeAppliedHostsService,
 )
@@ -94,13 +95,21 @@ def test_redis_rollback_revoke_flow_runs_best_effort_before_recycle_output():
 
     builder = FakeBuilder.instances[0]
     assert builder.root_id == "revoke-root"
-    assert builder.data["uid"] == 123
+    assert builder.data["uid"] == 999
+    assert builder.data["parent_ticket"] == 123
     assert [act["act_component_code"] for act in builder.acts] == [
         RedisExerciseBestEffortCleanupComponent.code,
         RedisExerciseRevokeAppliedHostsComponent.code,
     ]
     assert builder.acts[0]["extra"]["error_ignorable"] is True
     assert isinstance(builder.run_kwargs["init_trans_data_class"], RedisRollbackExerciseContext)
+
+
+def test_best_effort_cleanup_uses_parent_ticket_for_rollback_tasks():
+    service = RedisExerciseBestEffortCleanupService()
+
+    assert service._get_rollback_task_ticket_id({"uid": 999, "parent_ticket": 123}) == 123
+    assert service._get_rollback_task_ticket_id({"uid": 999}) == 999
 
 
 def test_revoke_applied_hosts_service_outputs_unique_redis_hosts():
@@ -116,7 +125,6 @@ def test_revoke_applied_hosts_service_outputs_unique_redis_hosts():
                                 "ip": "1.1.1.1",
                                 "bk_cloud_id": 0,
                                 "bk_host_id": 101,
-                                "city": "sz",
                             }
                         ]
                     },
@@ -127,11 +135,36 @@ def test_revoke_applied_hosts_service_outputs_unique_redis_hosts():
         }
     )
 
+    standardized_hosts = [
+        {
+            "ip": "1.1.1.1",
+            "bk_cloud_id": 0,
+            "bk_host_id": 101,
+            "city": "sz",
+            "sub_zone": "sz-a",
+            "rack_id": "rack-1",
+            "os_name": "linux",
+            "device_class": "S5",
+        }
+    ]
     with patch(
         "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.FlowOutputHandler"
-    ) as handler:
+    ) as handler, patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.ResourceHandler"
+    ) as resource_handler:
+        resource_handler.standardized_resource_host.return_value = standardized_hosts
         service._execute_inner_captured(data, parent_data=None)
 
+    resource_handler.standardized_resource_host.assert_called_once_with(
+        [
+            {
+                "ip": "1.1.1.1",
+                "bk_cloud_id": 0,
+                "bk_host_id": 101,
+                "remark": "Redis rollback exercise revoked",
+            }
+        ]
+    )
     handler.return_value.insert_data.assert_called_once()
     root_id, hosts = handler.return_value.insert_data.call_args.args
     assert root_id == "root-1"
@@ -141,8 +174,33 @@ def test_revoke_applied_hosts_service_outputs_unique_redis_hosts():
             "bk_cloud_id": 0,
             "bk_host_id": 101,
             "remark": "Redis rollback exercise revoked",
+            "city": "sz",
+            "sub_zone": "sz-a",
+            "rack_id": "rack-1",
+            "os_name": "linux",
+            "device_class": "S5",
         }
     ]
+
+
+def test_revoke_applied_hosts_service_warns_when_cmdb_drops_hosts(caplog):
+    caplog.set_level("WARNING")
+    recycle_hosts = [
+        {"ip": "1.1.1.1", "bk_cloud_id": 0, "bk_host_id": 101, "remark": "keep"},
+        {"ip": "2.2.2.2", "bk_cloud_id": 0, "bk_host_id": 102, "remark": "missing"},
+    ]
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.ResourceHandler"
+    ) as resource_handler:
+        resource_handler.standardized_resource_host.return_value = [
+            {"ip": "1.1.1.1", "bk_cloud_id": 0, "bk_host_id": 101}
+        ]
+
+        hosts = RedisExerciseRevokeAppliedHostsService._standardize_recycle_hosts(recycle_hosts)
+
+    assert hosts == [{"ip": "1.1.1.1", "bk_cloud_id": 0, "bk_host_id": 101, "remark": "keep"}]
+    assert "Recycle hosts dropped after CMDB normalization: [102]" in caplog.text
 
 
 def test_revoke_applied_hosts_service_outputs_empty_table_when_no_redis_hosts():

--- a/dbm-ui/backend/ticket/builders/mongodb/mongo_data_export.py
+++ b/dbm-ui/backend/ticket/builders/mongodb/mongo_data_export.py
@@ -59,6 +59,7 @@ class MongoDBDataExportDetailSerializer(BaseMongoDBOperateDetailSerializer):
 
 class MongoDBDataExportFlowParamBuilder(BaseMongoOperateFlowParamBuilder):
     controller = MongoDBController.mongo_data_export
+    ARCHIVE_SUFFIXES = (".tar.gz", ".tar")
 
     def format_ticket_data(self):
         def pop_if_empty(export_options: dict, key: str):
@@ -83,20 +84,27 @@ class MongoDBDataExportFlowParamBuilder(BaseMongoOperateFlowParamBuilder):
         if not flow or flow.status != TicketFlowStatus.SUCCEEDED:
             return
 
-        _, files = MediumHandler().storage.listdir(MONGODB_DATA_EXPORT_PATH.format(biz=self.ticket.bk_biz_id))
+        result_dir = MONGODB_DATA_EXPORT_PATH.format(biz=self.ticket.bk_biz_id)
+        _status, files = MediumHandler().storage.listdir(result_dir)
         file_name_size_map = {file["name"]: file["size"] for file in files}
         cluster_results = {}
         for info in flow.details["ticket_data"]["infos"]:
             cluster_id = info["cluster_id"]
-            result_file_path = "{}/{}.tar".format(
-                MONGODB_DATA_EXPORT_PATH.format(biz=self.ticket.bk_biz_id), info["filename"]
-            )
+            result_file_name = self._get_result_file_name(info["filename"], file_name_size_map)
+            result_file_path = "{}/{}".format(result_dir, result_file_name)
             cluster_results[cluster_id] = {
                 "file_path": result_file_path,
                 "file_name": info["filename"],
-                "size": file_name_size_map.get(f"{info['filename']}.tar"),
+                "size": file_name_size_map.get(result_file_name),
             }
         self.ticket.update_details(exported_files=cluster_results)
+
+    def _get_result_file_name(self, file_name: str, file_name_size_map: dict) -> str:
+        for suffix in self.ARCHIVE_SUFFIXES:
+            result_file_name = f"{file_name}{suffix}"
+            if result_file_name in file_name_size_map:
+                return result_file_name
+        return f"{file_name}{self.ARCHIVE_SUFFIXES[0]}"
 
 
 @builders.BuilderFactory.register(TicketType.MONGODB_DATA_EXPORT)


### PR DESCRIPTION
## 改动

- **回档演练单据revoke退回资源卡住**：`RedisRollbackExerciseRevokeFlow` 不再把 `uid` 覆盖为 `parent_ticket` → Bamboo 回调回到当前退回单据，使人工确认可继续流转
- **演练单据终止后清理语义**：cleanup 显式使用 `parent_ticket or uid` 查原回档任务 → 保留父单据清理能力，不污染 `FlowTree.uid`
- **待退回主机信息不足**：复用 `ResourceHandler.standardized_resource_host()` 补齐主机信息 → 回收输出和后续分池参数一致
- **回档演练噪音报告**：已有临时实例/互斥单据先拦截并静默跳过 → 避免忙碌集群刷出无意义 SKIPPED 报告
- **容量增长检查跳过可追溯**：`maxmemory-policy` 触发跳过时落 NORMAL 报告 → 后续调度可按跳过窗口去重
- **定位信息不准**：亲和性建议指出实际需迁移的主/副节点，演练报告链接按配置业务生成 → 排查路径更准确

## 测试 & 风险

- 单测已覆盖 revoke 编排、父单据清理 ID、主机标准化输出、容量增长跳过报告、亲和性建议、演练报告链接
- 影响范围集中在 Redis 回档演练、Redis agent check 报告和 Redis 亲和性检查；无对外 API breaking change