### PR TITLE
feat(db-resource): 暴露云梯 CVM 详情查询 API #17887

### DIFF
--- a/dbm-services/common/db-resource/internal/controller/manage/rs_import.go
+++ b/dbm-services/common/db-resource/internal/controller/manage/rs_import.go
@@ -240,6 +240,33 @@ func buildCvmMachList(hosts []*cc.Host) []string {
 	return machIpList
 }
 
+// QueryCvmDetailParam 查询云梯CVM详情请求参数
+type QueryCvmDetailParam struct {
+	Ips []string `json:"ips" binding:"required,gt=0,dive,ip"`
+}
+
+// QueryCvmDetail 按 IP 列表查询云梯 CVM 详情
+func (c *MachineResourceHandler) QueryCvmDetail(r *rf.Context) {
+	var input QueryCvmDetailParam
+	if err := c.Prepare(r, &input); err != nil {
+		logger.Error("Prepare Error %s", err.Error())
+		return
+	}
+	if !config.AppConfig.Yunti.IsNotEmpty() {
+		err := fmt.Errorf("yunti config is empty, cvm detail api is unavailable")
+		logger.Error(err.Error())
+		c.SendResponse(r, err, nil)
+		return
+	}
+	cvmInfoMap, err := getCvmMachDetailInfo(lo.Uniq(input.Ips))
+	if err != nil {
+		logger.Error("query cvm detail failed: %s", err.Error())
+		c.SendResponse(r, err, nil)
+		return
+	}
+	c.SendResponse(r, nil, cvmInfoMap)
+}
+
 // transHostInfoToDbModule 获取的到的主机信息赋值给db model
 func (p ImportMachParam) transHostInfoToDbModule(h *cc.Host, bkCloudId int, label []byte) model.TbRpDetail {
 	return buildTbRpItem(h, p.ForBiz, p.BkBizId, bkCloudId, p.RsType, label, p.Operator)

--- a/dbm-services/common/db-resource/internal/controller/manage/rs_manage.go
+++ b/dbm-services/common/db-resource/internal/controller/manage/rs_manage.go
@@ -63,6 +63,7 @@ func (c *MachineResourceHandler) RegisterRouter(engine *rf.Engine) {
 		r.POST("/spec/sum", c.SpecSum)
 		r.POST("/groupby/label/count", c.GroupByLabelCount)
 		r.POST("/refresh/disk/info", c.RefreshDiskInfo)
+		r.POST("/cvm/detail", c.QueryCvmDetail)
 	}
 }
 


### PR DESCRIPTION
## Summary

将 `db-resource` 内部 helper `getCvmMachDetailInfo` 封装为对外 HTTP API：`POST /resource/cvm/detail`，便于外部按 IP 列表查询云梯（yunti）的 CVM 详情（CPU、内存、数据盘等）。

- 路径：`POST /resource/cvm/detail`，挂在 `manage.MachineResourceHandler` 上（与 `Import` 同 handler）
- 请求体：`{"ips": ["127.0.0.1", "127.0.0.2"]}`，使用 `binding:"required,gt=0,dive,ip"` 做合法性校验
- 云梯未配置（`config.AppConfig.Yunti.IsNotEmpty() == false`）时直接返回错误，不再静默回退到空 map
- 复用 `BaseHandler.SendResponse`，正常 `code=0`
- 私有 helper `getCvmMachDetailInfo` 保留小写与原签名，不影响既有 3 处调用方（`DoImport` / `ImportMachineWithDiffInfo` / `getCvmInfoForBiz`）

## Changes

- `dbm-services/common/db-resource/internal/controller/manage/rs_import.go`：新增 `QueryCvmDetailParam` 结构体与 `(c *MachineResourceHandler) QueryCvmDetail` handler。
- `dbm-services/common/db-resource/internal/controller/manage/rs_manage.go`：在 `RegisterRouter` 的 `/resource` 分组追加 `r.POST("/cvm/detail", c.QueryCvmDetail)`。

## Test plan

- [x] `go build ./...` 通过
- [x] `go vet ./internal/controller/manage/...` 通过
- [ ] 部署后用 IP 列表验证 `POST /resource/cvm/detail` 返回的 `data` 与云梯返回字段一致
- [ ] 验证云梯未配置时返回明确错误而非空 map

Closes #17887
