### PR TITLE
fix(redis): split client retry semantics and harden dts online switch #17922

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/client.go
@@ -39,30 +39,15 @@ const (
 	redisConfigRewriteSaveFixVersion = "6.2.2"
 	newConnMaxRetryDuration          = 3 * time.Minute
 	newConnRetrySleep                = 10 * time.Second
+	newConnDefaultTimeout            = 1 * time.Minute
+	redisClientNoRetries             = -1
 )
 
-// NewRedisClient 建redis客户端
-func NewRedisClient(addr, passwd string, db int, dbType string) (conn *RedisClient, err error) {
-	// 统一不使用智能client,一个连接固定到某个实例上
-	// 智能client连接redis cluster,容易在执行命令时,漂移到cluster的不同实例上
-	dbType = consts.TendisTypeRedisInstance
-	conn = &RedisClient{
-		Addr:         addr,
-		Password:     passwd,
-		DB:           db,
-		MaxRetryTime: 60, // 默认重试60次
-		DbType:       dbType,
-		nodesMu:      &sync.Mutex{},
-	}
-	err = conn.newConn(1 * time.Minute)
-	if err != nil {
-		return nil, err
-	}
-	return
-}
-
-// NewRedisClientWithTimeout 建redis客户端,可指定超时时间
-func NewRedisClientWithTimeout(addr, passwd string, db int, dbType string, timeout time.Duration) (
+// NewRedisClient 建redis客户端,仅尝试一次连接,不重试.
+// timeout 可选,未传时默认为 newConnDefaultTimeout (1 分钟),一般用于确认进程killed.
+// 注意: timeout 会同时作为 DialTimeout/ReadTimeout/WriteTimeout, 并保留在 client 上,
+// 作为后续每条命令的超时时间(贯穿 client 整个生命周期), 而不仅是连接阶段.
+func NewRedisClient(addr, passwd string, db int, dbType string, timeout ...time.Duration) (
 	conn *RedisClient, err error) {
 	// 统一不使用智能client,一个连接固定到某个实例上
 	// 智能client连接redis cluster,容易在执行命令时,漂移到cluster的不同实例上
@@ -71,31 +56,68 @@ func NewRedisClientWithTimeout(addr, passwd string, db int, dbType string, timeo
 		Addr:         addr,
 		Password:     passwd,
 		DB:           db,
-		MaxRetryTime: int(timeout.Seconds()),
+		MaxRetryTime: redisClientNoRetries,
 		DbType:       dbType,
 		nodesMu:      &sync.Mutex{},
 	}
-	err = conn.newConn(timeout)
+	t := newConnDefaultTimeout
+	if len(timeout) > 0 {
+		t = timeout[0]
+	}
+	err = conn.ConnectNoRetry(t)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return
+}
+
+// NewRedisClientWithRetry 建redis客户端,在 newConnMaxRetryDuration 总预算内自动重试,
+// 用于需要等待 proxy/redis/tendis 进程就绪的场景.
+// timeout 为单次连接及后续每条命令的 Dial/Read/Write 超时, 同样贯穿 client 整个生命周期;
+// 重试总预算固定为 newConnMaxRetryDuration. 长耗时命令(如 reshape/backup)据此传入较大 timeout.
+func NewRedisClientWithRetry(addr, passwd string, db int, dbType string, timeout time.Duration) (
+	conn *RedisClient, err error) {
+	dbType = consts.TendisTypeRedisInstance
+	conn = &RedisClient{
+		Addr:         addr,
+		Password:     passwd,
+		DB:           db,
+		MaxRetryTime: redisClientNoRetries,
+		DbType:       dbType,
+		nodesMu:      &sync.Mutex{},
+	}
+	err = conn.ConnectWithRetry(timeout, newConnMaxRetryDuration)
 	if err != nil {
 		return nil, err
 	}
 	return
 }
 
-func (db *RedisClient) newConn(timeout time.Duration) (err error) {
+// ConnectNoRetry performs one bounded connection ping without go-redis or outer retries.
+func (db *RedisClient) ConnectNoRetry(timeout time.Duration) (err error) {
+	return db.connect(timeout, 0, 0)
+}
+
+// ConnectWithRetry connects with an explicit overall retry budget.
+func (db *RedisClient) ConnectWithRetry(timeout, retryBudget time.Duration) (err error) {
+	return db.connect(timeout, retryBudget, newConnRetrySleep)
+}
+
+func (db *RedisClient) connect(timeout time.Duration, retryBudget, retrySleep time.Duration) (err error) {
 	// 执行命令失败重连,确保重连后,databases正确
 	var redisConnHook = func(ctx context.Context, cn *redis.Conn) error {
 		pipe01 := cn.Pipeline()
-		_, err := pipe01.Select(context.TODO(), db.DB).Result()
+		_, err := pipe01.Select(ctx, db.DB).Result()
 		if err != nil {
 			err = fmt.Errorf("newConnct pipeline change db fail,err:%v", err)
-			mylog.Logger.Error(err.Error())
+			mylog.Logger.Error("%v", err)
 			return err
 		}
-		_, err = pipe01.Exec(context.TODO())
+		_, err = pipe01.Exec(ctx)
 		if err != nil {
 			err = fmt.Errorf("newConnct pipeline.exec db fail,err:%v", err)
-			mylog.Logger.Error(err.Error())
+			mylog.Logger.Error("%v", err)
 			return err
 		}
 		return nil
@@ -106,8 +128,8 @@ func (db *RedisClient) newConn(timeout time.Duration) (err error) {
 		DialTimeout:     timeout,
 		ReadTimeout:     timeout,
 		MaxConnAge:      24 * time.Hour,
-		MaxRetries:      db.MaxRetryTime, // 失败自动重试,重试次数
-		MinRetryBackoff: 1 * time.Second, // 重试间隔
+		MaxRetries:      redisClientNoRetries, // 统一由外层语义控制是否重试
+		MinRetryBackoff: 1 * time.Second,      // 重试间隔
 		MaxRetryBackoff: 1 * time.Second,
 		PoolSize:        10,
 		OnConnect:       redisConnHook,
@@ -117,8 +139,8 @@ func (db *RedisClient) newConn(timeout time.Duration) (err error) {
 		DialTimeout:     timeout,
 		ReadTimeout:     timeout,
 		MaxConnAge:      24 * time.Hour,
-		MaxRetries:      db.MaxRetryTime, // 失败自动重试,重试次数
-		MinRetryBackoff: 1 * time.Second, // 重试间隔
+		MaxRetries:      redisClientNoRetries, // 统一由外层语义控制是否重试
+		MinRetryBackoff: 1 * time.Second,      // 重试间隔
 		MaxRetryBackoff: 1 * time.Second,
 		PoolSize:        10,
 		OnConnect:       redisConnHook,
@@ -127,12 +149,12 @@ func (db *RedisClient) newConn(timeout time.Duration) (err error) {
 		redisOpt.Password = db.Password
 		clusterOpt.Password = db.Password
 	}
-	ctx := context.TODO()
-	deadline := time.Now().Add(newConnMaxRetryDuration)
+	deadline := time.Now().Add(retryBudget)
 	attempt := 0
 	var pingErr error
 	for {
 		attempt++
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		if db.DbType == consts.TendisTypeRedisCluster {
 			db.ClusterClient = redis.NewClusterClient(clusterOpt)
 			_, pingErr = db.ClusterClient.Ping(ctx).Result()
@@ -140,6 +162,7 @@ func (db *RedisClient) newConn(timeout time.Duration) (err error) {
 			db.InstanceClient = redis.NewClient(redisOpt)
 			_, pingErr = db.InstanceClient.Ping(ctx).Result()
 		}
+		cancel()
 
 		if pingErr != nil && strings.Contains(pingErr.Error(), "LOADING Redis is loading") {
 			mylog.Logger.Warn("redis:%s conn warn,err:%v", db.Addr, pingErr)
@@ -148,13 +171,16 @@ func (db *RedisClient) newConn(timeout time.Duration) (err error) {
 		if pingErr == nil {
 			return nil
 		}
-		// 即将再睡一轮就会越过总预算时, 直接放弃, 避免 sleep 完才发现超时
-		if time.Now().Add(newConnRetrySleep).After(deadline) {
+		if retryBudget <= 0 || retrySleep <= 0 {
 			break
 		}
-		mylog.Logger.Error(
+		// 即将再睡一轮就会越过总预算时, 直接放弃, 避免 sleep 完才发现超时
+		if time.Now().Add(retrySleep).After(deadline) {
+			break
+		}
+		mylog.Logger.Warn(
 			"redis new conn fail (attempt %d),sleep %s then retry.err:%v,addr:%s",
-			attempt, newConnRetrySleep, pingErr, db.Addr)
+			attempt, retrySleep, pingErr, db.Addr)
 		// 释放本轮失败的 client, 防止 goroutine / 连接泄漏
 		if db.ClusterClient != nil {
 			_ = db.ClusterClient.Close()
@@ -164,10 +190,10 @@ func (db *RedisClient) newConn(timeout time.Duration) (err error) {
 			_ = db.InstanceClient.Close()
 			db.InstanceClient = nil
 		}
-		time.Sleep(newConnRetrySleep)
+		time.Sleep(retrySleep)
 	}
 	return fmt.Errorf("redis new conn fail after %d attempts (within %s budget),err:%v addr:%s",
-		attempt, newConnMaxRetryDuration, pingErr, db.Addr)
+		attempt, retryBudget, pingErr, db.Addr)
 }
 
 // RedisClusterConfigSetOnlyMasters run 'config set ' on all redis cluster running masters

--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/client_test.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/client_test.go
@@ -1,9 +1,14 @@
 package myredis
 
 import (
+	"net"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"dbm-services/redis/db-tools/dbactuator/mylog"
+	"dbm-services/redis/db-tools/dbactuator/pkg/consts"
 
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -37,4 +42,59 @@ func TestFormatSaveConfigValue(t *testing.T) {
 		convey.So(formatSaveConfigValue("900 1 300 10"), convey.ShouldEqual, "900 1 300 10")
 		convey.So(formatSaveConfigValue(" 900 1 "), convey.ShouldEqual, "900 1")
 	})
+}
+
+func unusedLocalRedisAddr(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on random local port failed: %v", err)
+	}
+	addr := listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close random local listener failed: %v", err)
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+}
+
+func TestNewRedisClientReturnsQuicklyWithoutRetry(t *testing.T) {
+	mylog.UnitTestInitLog()
+	addr := unusedLocalRedisAddr(t)
+	start := time.Now()
+
+	cli, err := NewRedisClient(addr, "", 0, consts.TendisTypeRedisInstance, 200*time.Millisecond)
+	if cli != nil {
+		cli.Close()
+	}
+	if err == nil {
+		t.Fatalf("expected ping once to fail for unused addr:%s", addr)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("ping once took too long: %s", elapsed)
+	}
+}
+
+func TestConnectWithRetryUsesExplicitRetryBudget(t *testing.T) {
+	mylog.UnitTestInitLog()
+	addr := unusedLocalRedisAddr(t)
+	cli := &RedisClient{
+		Addr:    addr,
+		DB:      0,
+		DbType:  consts.TendisTypeRedisInstance,
+		nodesMu: &sync.Mutex{},
+	}
+	start := time.Now()
+	err := cli.connect(50*time.Millisecond, 180*time.Millisecond, 50*time.Millisecond)
+	cli.Close()
+	if err == nil {
+		t.Fatalf("expected retrying connect to fail for unused addr:%s", addr)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("retrying connect did not wait for retry budget, elapsed:%s", elapsed)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("retrying connect exceeded expected test budget, elapsed:%s", elapsed)
+	}
 }

--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/myredis.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/myredis.go
@@ -204,7 +204,7 @@ func LocalRedisConnectTest(ip string, ports []int, password string) (err error) 
 		wg.Add(1)
 		go func(test01 *connTestItem) {
 			defer wg.Done()
-			cli01, err := NewRedisClientWithTimeout(test01.addr(), test01.Password, 0,
+			cli01, err := NewRedisClientWithRetry(test01.addr(), test01.Password, 0,
 				consts.TendisTypeRedisInstance, 10*time.Second)
 			if err != nil {
 				test01.Err = err
@@ -245,7 +245,7 @@ func CheckMultiRedisConnected(addrs []string, password string) (err error) {
 		wg.Add(1)
 		go func(test01 *connTestItem) {
 			defer wg.Done()
-			cli01, err := NewRedisClientWithTimeout(test01.addr(), test01.Password, 0,
+			cli01, err := NewRedisClientWithRetry(test01.addr(), test01.Password, 0,
 				consts.TendisTypeRedisInstance, 10*time.Second)
 			if err != nil {
 				test01.Err = err

--- a/dbm-services/redis/db-tools/dbactuator/models/myredis/proxy_common.go
+++ b/dbm-services/redis/db-tools/dbactuator/models/myredis/proxy_common.go
@@ -128,7 +128,7 @@ type PredixyInfoServer struct {
 // GetPredixyInfoServersRaw 获取predixy info server原始内容 s
 func GetPredixyInfoServersRaw(ip string, port int, password string) (svrsinfo string, err error) {
 	predixyAddr := fmt.Sprintf("%s:%d", ip, port)
-	cli01, err := NewRedisClientWithTimeout(predixyAddr, password, 0,
+	cli01, err := NewRedisClient(predixyAddr, password, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return
@@ -219,7 +219,7 @@ func GetTwemproxyRunTimeVersion(ip string, port int) (version string, err error)
 // GetPredixyRunTimeVersion 获取predixy运行时版本
 func GetPredixyRunTimeVersion(ip string, port int, password string) (version string, err error) {
 	predixyAddr := fmt.Sprintf("%s:%d", ip, port)
-	cli01, err := NewRedisClientWithTimeout(predixyAddr, password, 0,
+	cli01, err := NewRedisClient(predixyAddr, password, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/predixy_add_modules_cmds.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/predixy_add_modules_cmds.go
@@ -208,7 +208,7 @@ func (job *PredixyAddModulesCmds) startProxy() (err error) {
 		return err
 	}
 	addr := fmt.Sprintf("%s:%d", job.params.IP, port)
-	cli, err := myredis.NewRedisClientWithTimeout(addr, job.proxyPassword, 0,
+	cli, err := myredis.NewRedisClientWithRetry(addr, job.proxyPassword, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/predixy_config_servers_rewrite.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/predixy_config_servers_rewrite.go
@@ -101,7 +101,7 @@ func (job *PredixyConfServersRewrite) Run() (err error) {
 	return
 }
 func (job *PredixyConfServersRewrite) newConn(password string) (err error) {
-	job.predixyConn, err = myredis.NewRedisClientWithTimeout(job.params.Addr(), password, 0,
+	job.predixyConn, err = myredis.NewRedisClient(job.params.Addr(), password, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/proxy_reuse.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/proxy_reuse.go
@@ -124,8 +124,13 @@ func (job *ProxyReUse) Run() (err error) {
 	if err = job.getRole(); err != nil {
 		return
 	}
-	if err = myredis.LocalRedisConnectTest(job.params.IP, []int{job.params.Port}, job.params.Password); err != nil {
+	addr := fmt.Sprintf("%s:%d", job.params.IP, job.params.Port)
+	cli, err := myredis.NewRedisClient(addr, job.params.Password, 0,
+		consts.TendisTypeRedisInstance, 5*time.Second)
+	if err != nil {
 		job.runtime.Logger.Warn("try connect 2 proxy %s:%d failed :%+v", job.params.IP, job.params.Port, err)
+	} else {
+		cli.Close()
 	}
 	// 关闭 dbmon,最后再拉起
 	if err = util.StopBkDbmon(); err != nil {
@@ -393,7 +398,7 @@ func (job *ProxyReUse) startProxy() (err error) {
 		return err
 	}
 	addr := fmt.Sprintf("%s:%d", job.params.IP, port)
-	cli, err := myredis.NewRedisClientWithTimeout(addr, job.params.Password, 0,
+	cli, err := myredis.NewRedisClientWithRetry(addr, job.params.Password, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/proxy_upgrade.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomproxy/proxy_upgrade.go
@@ -81,10 +81,13 @@ func (job *ProxyVersionUpgrade) Name() string {
 
 // Run Command Run
 func (job *ProxyVersionUpgrade) Run() (err error) {
-	err = myredis.LocalRedisConnectTest(job.params.IP, []int{job.params.Port}, job.params.Password)
+	addr := fmt.Sprintf("%s:%d", job.params.IP, job.params.Port)
+	cli, err := myredis.NewRedisClient(addr, job.params.Password, 0,
+		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return err
 	}
+	cli.Close()
 	err = job.getRole()
 	if err != nil {
 		return
@@ -341,7 +344,7 @@ func (job *ProxyVersionUpgrade) startProxy() (err error) {
 		return err
 	}
 	addr := fmt.Sprintf("%s:%d", job.params.IP, port)
-	cli, err := myredis.NewRedisClientWithTimeout(addr, job.params.Password, 0,
+	cli, err := myredis.NewRedisClientWithRetry(addr, job.params.Password, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/cluster_forget.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/cluster_forget.go
@@ -152,7 +152,7 @@ func (job *RedisClusterForget) tryGetClusterNodesInfo() (
 		var clusterConn *myredis.RedisClient
 		job.runtime.Logger.Info("try make connect use %s:%s", job.params.ClusterMeta.ImmuteDomain, nodeAddr)
 
-		clusterConn, err = myredis.NewRedisClientWithTimeout(nodeAddr,
+		clusterConn, err = myredis.NewRedisClientWithRetry(nodeAddr,
 			job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 		if err != nil {
 			job.runtime.Logger.Error("connect cluster node [%d]:%s failed:%+v", idx, nodeAddr, err)
@@ -176,7 +176,7 @@ func (job *RedisClusterForget) tryGetClusterNodesInfo() (
 // DisconnectSlaves 与自身的slave实例进行断连行为
 func (job *RedisClusterForget) DisconnectSlaves(fnode *myredis.ClusterNodeData) (
 	slaveNodes []*myredis.ClusterNodeData, err error) {
-	clusterConn, err := myredis.NewRedisClientWithTimeout(fnode.Addr,
+	clusterConn, err := myredis.NewRedisClientWithRetry(fnode.Addr,
 		job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		job.runtime.Logger.Warn("connect cluster node %s failed:%+v", fnode.Addr, err)
@@ -193,7 +193,7 @@ func (job *RedisClusterForget) DisconnectSlaves(fnode *myredis.ClusterNodeData) 
 		return
 	}
 	for _, slave := range slaveNodes {
-		slaveConn, err := myredis.NewRedisClientWithTimeout(slave.Addr,
+		slaveConn, err := myredis.NewRedisClientWithRetry(slave.Addr,
 			job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 		if err != nil {
 			job.runtime.Logger.Warn("connect cluster node %s failed:%+v", slave.Addr, err)
@@ -224,7 +224,7 @@ func (job *RedisClusterForget) clusterForgetNode(
 		}
 		x, _ := json.Marshal(node)
 		job.runtime.Logger.Info("exec {cluster forget %s:%s} from [%s]", fnode.Addr, fnode.NodeID, node.Addr)
-		nodeConn, err := myredis.NewRedisClientWithTimeout(node.Addr,
+		nodeConn, err := myredis.NewRedisClientWithRetry(node.Addr,
 			job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 		if err != nil {
 			job.runtime.Logger.Warn("connect node failed %s:%+v", x, err)

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/cluster_reset_flush_meet.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/cluster_reset_flush_meet.go
@@ -158,7 +158,7 @@ type clusterResetFlushMeetTask struct {
 
 // createResetConn 创建连接
 func (task *clusterResetFlushMeetTask) createResetConn() {
-	task.resetRedisConn, task.Err = myredis.NewRedisClientWithTimeout(task.ResetRedisAddr(), task.ResetRedisPassword, 0,
+	task.resetRedisConn, task.Err = myredis.NewRedisClientWithRetry(task.ResetRedisAddr(), task.ResetRedisPassword, 0,
 		consts.TendisTypeRedisInstance, 10*time.Hour)
 }
 

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/clustermeet_checkfinish.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/clustermeet_checkfinish.go
@@ -140,7 +140,8 @@ func (task *ClusterMeetCheckFinish) allInstsAbleToConnect() (err error) {
 		instsAddrs = append(instsAddrs, item.MasterAddr())
 	}
 	for _, addr01 := range instsAddrs {
-		cli, err := myredis.NewRedisClient(addr01, task.params.Password, 0, consts.TendisTypeTendisplusInsance)
+		cli, err := myredis.NewRedisClientWithRetry(addr01, task.params.Password, 0,
+			consts.TendisTypeTendisplusInsance, 1*time.Minute)
 		if err != nil {
 			return err
 		}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/clustermeet_slotsassign.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/clustermeet_slotsassign.go
@@ -163,7 +163,8 @@ func (job *ClusterMeetSlotsAssign) allInstsAbleToConnect() (err error) {
 		instsAddrs = append(instsAddrs, item.SlaveAddr())
 	}
 	for _, addr01 := range instsAddrs {
-		cli, err := myredis.NewRedisClient(addr01, job.params.Password, 0, consts.TendisTypeRedisInstance)
+		cli, err := myredis.NewRedisClientWithRetry(addr01, job.params.Password, 0,
+			consts.TendisTypeRedisInstance, 1*time.Minute)
 		if err != nil {
 			return err
 		}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_backup.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_backup.go
@@ -500,7 +500,7 @@ func (task *BackupTask) GoFullBakcup() {
 }
 
 func (task *BackupTask) newConnect() {
-	task.Cli, task.Err = myredis.NewRedisClientWithTimeout(task.Addr(), task.Password, 0, consts.TendisTypeRedisInstance,
+	task.Cli, task.Err = myredis.NewRedisClientWithRetry(task.Addr(), task.Password, 0, consts.TendisTypeRedisInstance,
 		2*time.Hour)
 	if task.Err != nil {
 		return

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_client_conns_kill.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_client_conns_kill.go
@@ -112,7 +112,7 @@ func (job *RedisClientConnsKill) GetExcludedIpMap() (err error) {
 	if err != nil {
 		return err
 	}
-	redisCli, err := myredis.NewRedisClientWithTimeout(firstAddr, password, 0,
+	redisCli, err := myredis.NewRedisClientWithRetry(firstAddr, password, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return err
@@ -156,7 +156,7 @@ func (job *RedisClientConnsKill) GetExcludedIpMap() (err error) {
 // ConnectAndRunClientKill 连接并执行client kill操作
 func (job *RedisClientConnsKill) ConnectAndRunClientKill(addr, password string) (err error) {
 	// 连接redis
-	redisCli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+	redisCli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_cluster_failover.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_cluster_failover.go
@@ -165,7 +165,7 @@ func (job *RedisClusterFailover) checkClusterStatus() (err error) {
 		firstMasterAddr = ms.Master.Addr()
 		break
 	}
-	rc, err := myredis.NewRedisClientWithTimeout(firstMasterAddr, job.params.RedisPassword, 0,
+	rc, err := myredis.NewRedisClientWithRetry(firstMasterAddr, job.params.RedisPassword, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return
@@ -191,7 +191,7 @@ func (job *RedisClusterFailover) checkAllRedisInCluster() (err error) {
 		firstSlaveAddr = ms.Slave.Addr()
 		break
 	}
-	rc, err := myredis.NewRedisClientWithTimeout(firstSlaveAddr, job.params.RedisPassword, 0,
+	rc, err := myredis.NewRedisClientWithRetry(firstSlaveAddr, job.params.RedisPassword, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return
@@ -224,7 +224,7 @@ func (job *RedisClusterFailover) allClusterMastersConfSetMasterauth() (err error
 		firstSlaveAddr = ms.Slave.Addr()
 		break
 	}
-	rc, err := myredis.NewRedisClientWithTimeout(firstSlaveAddr, job.params.RedisPassword, 0,
+	rc, err := myredis.NewRedisClientWithRetry(firstSlaveAddr, job.params.RedisPassword, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return
@@ -254,7 +254,7 @@ func (job *RedisClusterFailover) checkAllSlaveLinkStatus() (err error) {
 	var replMasterHost, replMasterPort, replMasterAddr, replLinkStatus string
 	var masterLastIOSecAgo int
 	for _, ms := range job.params.RedisMasterSlavePairs {
-		rc, err := myredis.NewRedisClientWithTimeout(ms.Slave.Addr(), job.params.RedisPassword, 0,
+		rc, err := myredis.NewRedisClientWithRetry(ms.Slave.Addr(), job.params.RedisPassword, 0,
 			consts.TendisTypeRedisInstance, 5*time.Second)
 		if err != nil {
 			return err
@@ -400,7 +400,7 @@ type redisFailOverTask struct {
 
 // newSlaveCli 新建slaveCli
 func (task *redisFailOverTask) newSlaveCli() {
-	task.slaveCli, task.Err = myredis.NewRedisClientWithTimeout(task.SlaveAddr, task.RedisPassword, 0,
+	task.slaveCli, task.Err = myredis.NewRedisClientWithRetry(task.SlaveAddr, task.RedisPassword, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 }
 
@@ -489,7 +489,7 @@ func (task *redisFailOverTask) WaitReplicateStateOK() {
 	defer task.slaveCli.Close()
 	var masterCli *myredis.RedisClient
 	var logTailNData string
-	masterCli, task.Err = myredis.NewRedisClientWithTimeout(task.MasterAddr, task.RedisPassword, 0,
+	masterCli, task.Err = myredis.NewRedisClientWithRetry(task.MasterAddr, task.RedisPassword, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if task.Err != nil {
 		return

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_config_set.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_config_set.go
@@ -146,7 +146,7 @@ func (job *RedisConfigSet) allInstsAbleToConnect() (err error) {
 		if err != nil {
 			return err
 		}
-		cli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+		cli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 			consts.TendisTypeRedisInstance, 5*time.Second)
 		if err != nil {
 			return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_data_recovery.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_data_recovery.go
@@ -160,7 +160,8 @@ func (task *RedisDataRecover) Run() (err error) {
 			// 获取回档类型
 			redisAddr := fmt.Sprintf("%s:%s", task.params.NeWTempIP, strconv.Itoa(task.params.NewTempPorts[0]))
 			// 验证节点是否可连接
-			redisCli, err := myredis.NewRedisClient(redisAddr, task.password, 0, consts.TendisTypeRedisInstance)
+			redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.password, 0,
+				consts.TendisTypeRedisInstance, 1*time.Minute)
 			if err != nil {
 				return err
 			}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_data_structure.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_data_structure.go
@@ -9,6 +9,7 @@ import (
 
 	"strconv"
 	"sync"
+	"time"
 
 	"dbm-services/redis/db-tools/dbactuator/models/myredis"
 	"dbm-services/redis/db-tools/dbactuator/pkg/consts"
@@ -142,7 +143,8 @@ func (task *RedisDataStructure) Run() (err error) {
 
 		redisAddr := fmt.Sprintf("%s:%s", task.params.NeWTempIP, strconv.Itoa(task.params.NewTempPorts[0]))
 		// 验证节点是否可连接
-		redisCli, err := myredis.NewRedisClient(redisAddr, task.password, 0, consts.TendisTypeRedisInstance)
+		redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.password, 0,
+			consts.TendisTypeRedisInstance, 1*time.Minute)
 		if err != nil {
 			return err
 		}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_datacheck.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_datacheck.go
@@ -195,7 +195,7 @@ func (job *RedisDtsDataCheck) TestConnectable() (err error) {
 	job.runtime.Logger.Info("redis_dts_datacheck TestConnectable success,ip:%s,ports:%+v", job.params.SrcRedisIP, ports)
 
 	// 目的redis可连接
-	cli01, err := myredis.NewRedisClientWithTimeout(job.params.DstClusterAddr, job.params.DstClusterPassword, 0,
+	cli01, err := myredis.NewRedisClientWithRetry(job.params.DstClusterAddr, job.params.DstClusterPassword, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return err
@@ -339,7 +339,7 @@ func (task *RedisInsDtsDataCheckAndRepairTask) getRepairHotKeysFile() string {
 
 func (task *RedisInsDtsDataCheckAndRepairTask) isClusterEnabled() (enabled bool) {
 	var cli01 *myredis.RedisClient
-	cli01, task.Err = myredis.NewRedisClientWithTimeout(task.getSrcRedisAddr(), task.keyPatternTask.Password, 0,
+	cli01, task.Err = myredis.NewRedisClientWithRetry(task.getSrcRedisAddr(), task.keyPatternTask.Password, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if task.Err != nil {
 		return false

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_online_switch.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_online_switch.go
@@ -19,6 +19,8 @@ import (
 	"dbm-services/redis/db-tools/dbactuator/pkg/util"
 )
 
+const dtsOnlineSwitchBackupTimestampLayout = "20060102150405.000000000"
+
 // RedisDtsOnlineSwitchParams 在线切换参数
 type RedisDtsOnlineSwitchParams struct {
 	DstProxyPkg           common.MediaPkg `json:"dst_proxy_pkg" validate:"required"`
@@ -59,7 +61,7 @@ func (job *RedisDtsOnlineSwitch) Init(m *jobruntime.JobGenericRuntime) error {
 	job.runtime = m
 	err := json.Unmarshal([]byte(job.runtime.PayloadDecoded), &job.params)
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("json.Unmarshal failed,err:%+v", err))
+		job.runtime.Logger.Error("json.Unmarshal failed,err:%+v", err)
 		return err
 	}
 	// 参数有效性检查
@@ -89,13 +91,13 @@ func (job *RedisDtsOnlineSwitch) Run() (err error) {
 	if !consts.IsTwemproxyClusterType(job.params.SrcClusterType) &&
 		!consts.IsPredixyClusterType(job.params.SrcClusterType) {
 		err = fmt.Errorf("src cluster type %s is not supported", job.params.SrcClusterType)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return err
 	}
 	if !consts.IsTwemproxyClusterType(job.params.DstClusterType) &&
 		!consts.IsPredixyClusterType(job.params.DstClusterType) {
 		err = fmt.Errorf("dst cluster type %s is not supported", job.params.DstClusterType)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return err
 	}
 	var sameType bool = false
@@ -115,6 +117,12 @@ func (job *RedisDtsOnlineSwitch) Run() (err error) {
 	if err != nil {
 		return err
 	}
+	// 切换全程关闭 dbmon, 避免 dbmon 在 stop proxy 后将其拉起, 导致 alive 检查竞态及切换不稳定;
+	// 仅在任务成功结束时再拉起 dbmon; 失败场景保持 dbmon 关闭, 由人工介入排查.
+	job.runtime.Logger.Info("StopBkDbmon before switch to avoid dbmon respawning proxy mid-task")
+	if err = util.StopBkDbmon(); err != nil {
+		return err
+	}
 	if sameType {
 		err = job.BackupSrcProxyConfFile()
 		if err != nil {
@@ -128,11 +136,11 @@ func (job *RedisDtsOnlineSwitch) Run() (err error) {
 		if err != nil {
 			return err
 		}
-		err = job.RestartDbMon()
+		err = job.UpdateDbMonConfig()
 		if err != nil {
 			return err
 		}
-		return nil
+		return job.StartBkDbmonAfterSwitch()
 	}
 	err = job.UntarDstProxyMedia()
 	if err != nil {
@@ -142,17 +150,22 @@ func (job *RedisDtsOnlineSwitch) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	// 先Stop dbmon，防止中途被拉起，导致端口冲突
-	err = util.StopBkDbmon()
-	if err != nil {
-		return err
-	}
 	err = job.RestartProxyAndCheckBackends()
 	if err != nil {
 		return err
 	}
-	err = job.RestartDbMon()
+	err = job.UpdateDbMonConfig()
 	if err != nil {
+		return err
+	}
+	return job.StartBkDbmonAfterSwitch()
+}
+
+// StartBkDbmonAfterSwitch 切换成功后拉起本地 dbmon.
+func (job *RedisDtsOnlineSwitch) StartBkDbmonAfterSwitch() error {
+	job.runtime.Logger.Info("StartBkDbmon after switch finished")
+	if err := util.StartBkDbmon(); err != nil {
+		job.runtime.Logger.Error("StartBkDbmon after switch failed,err:%v", err)
 		return err
 	}
 	return nil
@@ -212,6 +225,33 @@ func (job *RedisDtsOnlineSwitch) getProxyFile(clusterType string, proxyPort int)
 	return ""
 }
 
+func newDtsOnlineSwitchBackupTimestamp() string {
+	return time.Now().Format(dtsOnlineSwitchBackupTimestampLayout)
+}
+
+func (job *RedisDtsOnlineSwitch) buildSrcProxyConfBackupFile(timestamp string) string {
+	bakFile := fmt.Sprintf("dts_bak_config.billid_%d.%s_%d.%s.%s",
+		job.params.DtsBillID, job.params.SrcProxyIP, job.params.SrcProxyPort,
+		timestamp, job.getSrcConfigFileSuffix())
+	return filepath.Join(job.getSrcProxyConfigSaveDir(), bakFile)
+}
+
+func (job *RedisDtsOnlineSwitch) buildSrcProxyConfBackupDir(timestamp string) string {
+	cleanSrcProxyConfDir := strings.TrimRight(job.getSrcProxyConfigSaveDir(), string(filepath.Separator))
+	targetConfDir := fmt.Sprintf("dts_online_switch_bak.billid_%d.%d.%s",
+		job.params.DtsBillID, job.params.SrcProxyPort, timestamp)
+	return filepath.Join(filepath.Dir(cleanSrcProxyConfDir), targetConfDir)
+}
+
+func (job *RedisDtsOnlineSwitch) buildGeneratedProxyConfDirBackup(saveDir string, timestamp string) string {
+	cleanSaveDir := strings.TrimRight(saveDir, string(filepath.Separator))
+	parentDir := filepath.Dir(cleanSaveDir)
+	baseDir := filepath.Base(cleanSaveDir)
+	targetConfDir := fmt.Sprintf("%s.dts_online_switch_bak.billid_%d.%s",
+		baseDir, job.params.DtsBillID, timestamp)
+	return filepath.Join(parentDir, targetConfDir)
+}
+
 func (job *RedisDtsOnlineSwitch) getProxyBackends(clusterType, proxyIP string, proxyPort int,
 	proxyPassword string) (backends string, err error) {
 	if consts.IsTwemproxyClusterType(clusterType) {
@@ -226,23 +266,25 @@ func (job *RedisDtsOnlineSwitch) getProxyBackends(clusterType, proxyIP string, p
 func (job *RedisDtsOnlineSwitch) IsSrcProxyConnected() (err error) {
 	localip, err := util.GetLocalIP()
 	if err != nil {
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return err
 	}
 	ok, err := util.CheckIPBelongToLocalServer(job.params.SrcProxyIP)
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("CheckIPBelongToLocalServer failed,err:%+v", err))
+		job.runtime.Logger.Error("CheckIPBelongToLocalServer failed,err:%+v", err)
 		return err
 	}
 	if !ok {
-		job.runtime.Logger.Error(fmt.Sprintf("src proxy ip:%s not belong to local server(%s)",
-			job.params.SrcProxyIP, localip))
+		job.runtime.Logger.Error("src proxy ip:%s not belong to local server(%s)",
+			job.params.SrcProxyIP, localip)
 		return fmt.Errorf("src proxy ip:%s not belong to local server(%s)", job.params.SrcProxyIP, localip)
 	}
-	err = myredis.LocalRedisConnectTest(job.params.SrcProxyIP, []int{job.params.SrcProxyPort}, job.params.SrcProxyPassword)
+	client, err := myredis.NewRedisClient(job.getSrcProxyAddr(), job.params.SrcProxyPassword, 0,
+		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return err
 	}
+	client.Close()
 	return nil
 }
 
@@ -261,18 +303,18 @@ func (job *RedisDtsOnlineSwitch) IsSrcProxyConfigOK() (err error) {
 			job.params.SrcProxyPort)
 	} else {
 		err = fmt.Errorf("unknown src cluster type:%s", job.params.SrcClusterType)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("psCmd:%s", psCmd))
+	job.runtime.Logger.Info("psCmd: %s", psCmd)
 	job.srcProxyConfigFile, err = util.RunBashCmd(psCmd, "", nil, 30*time.Second)
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("psCmd(%s) fail,err:%+v", psCmd, err))
+		job.runtime.Logger.Error("psCmd(%s) fail,err:%+v", psCmd, err)
 		return
 	}
 	if !util.FileExists(job.srcProxyConfigFile) {
 		err = fmt.Errorf("src proxy config file(%s) not exists", job.srcProxyConfigFile)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	srcProxyBytes, err := os.ReadFile(job.srcProxyConfigFile)
@@ -283,12 +325,12 @@ func (job *RedisDtsOnlineSwitch) IsSrcProxyConfigOK() (err error) {
 	if !strings.Contains(srcProxyStr, job.getSrcProxyAddr()) {
 		err = fmt.Errorf("src proxy config file(%s) not contains src proxy addr(%s)", job.srcProxyConfigFile,
 			job.getSrcProxyAddr())
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	if !strings.Contains(srcProxyStr, job.params.SrcProxyPassword) {
 		err = fmt.Errorf("src proxy config file(%s) not contains correct password", job.srcProxyConfigFile)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	job.srcProxyConfigSaveDir = filepath.Dir(job.srcProxyConfigFile)
@@ -297,21 +339,15 @@ func (job *RedisDtsOnlineSwitch) IsSrcProxyConfigOK() (err error) {
 
 // BackupSrcProxyConfFile 备份源proxy配置文件
 func (job *RedisDtsOnlineSwitch) BackupSrcProxyConfFile() (err error) {
-	var msg string
-	bakFile := fmt.Sprintf("dts_bak_config.billid_%d.%s_%d.%s",
-		job.params.DtsBillID, job.params.SrcProxyIP, job.params.SrcProxyPort,
-		job.getSrcConfigFileSuffix())
-	bakFile = filepath.Join(job.getSrcProxyConfigSaveDir(), bakFile)
+	bakFile := job.buildSrcProxyConfBackupFile(newDtsOnlineSwitchBackupTimestamp())
 	if util.FileExists(bakFile) {
-		msg = fmt.Sprintf("bakFile(%s) already exists", bakFile)
-		job.runtime.Logger.Info(msg)
-		return
+		return fmt.Errorf("backup file(%s) already exists", bakFile)
 	}
 	cpCmd := fmt.Sprintf("cp %s %s", job.srcProxyConfigFile, bakFile)
-	job.runtime.Logger.Info(fmt.Sprintf("cpCmd:%s", cpCmd))
+	job.runtime.Logger.Info("cpCmd: %s", cpCmd)
 	_, err = util.RunBashCmd(cpCmd, "", nil, 30*time.Second)
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("cpCmd(%s) fail,err:%+v", cpCmd, err))
+		job.runtime.Logger.Error("cpCmd(%s) fail,err:%+v", cpCmd, err)
 		return
 	}
 	return nil
@@ -343,8 +379,8 @@ func (job *RedisDtsOnlineSwitch) getDstPredixyLogRootDir() string {
 func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForSameType() (err error) {
 	dstConfContent := job.params.DstProxyConfigContent
 	dstConfContent = strings.ReplaceAll(dstConfContent, job.getDstProxyAddr(), job.getSrcProxyAddr())
-	job.runtime.Logger.Info(fmt.Sprintf("replace dstConfContent dstProxyAddr:%s => srcProxyAddr:%s",
-		job.getDstProxyAddr(), job.getSrcProxyAddr()))
+	job.runtime.Logger.Info("replace dstConfContent dstProxyAddr:%s => srcProxyAddr:%s",
+		job.getDstProxyAddr(), job.getSrcProxyAddr())
 	// 增加上SrcProxyIP限制，避免出现类似backend seg 350000 被替换的情况
 	dstConfContent = strings.ReplaceAll(dstConfContent,
 		job.params.SrcProxyIP+":"+strconv.Itoa(job.params.DstProxyPort),
@@ -378,26 +414,26 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForSameType() (err error) {
 	err = os.WriteFile(newFile, []byte(dstConfContent), 0644)
 	if err != nil {
 		err = fmt.Errorf("write new proxy config file(%s) fail,err:%+v", newFile, err)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	newFileMd5, err := util.GetFileMd5(newFile)
 	if err != nil {
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	currentMd5, err := util.GetFileMd5(job.srcProxyConfigFile)
 	if err != nil {
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	if newFileMd5 == currentMd5 {
-		job.runtime.Logger.Info(fmt.Sprintf("newFile(%s) md5(%s) equals currentFile(%s) md5(%s),no need to update",
-			newFile, newFileMd5, job.srcProxyConfigFile, currentMd5))
+		job.runtime.Logger.Info("newFile(%s) md5(%s) equals currentFile(%s) md5(%s),no need to update",
+			newFile, newFileMd5, job.srcProxyConfigFile, currentMd5)
 		return nil
 	}
 	mvCmd := fmt.Sprintf("mv %s %s", newFile, job.srcProxyConfigFile)
-	job.runtime.Logger.Info(fmt.Sprintf("mvCmd:%s", mvCmd))
+	job.runtime.Logger.Info("mvCmd: %s", mvCmd)
 	_, err = util.RunBashCmd(mvCmd, "", nil, 30*time.Second)
 	if err != nil {
 		return
@@ -437,11 +473,11 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForDiffType() (err error) {
 
 	proxyFileForDstPort := job.getProxyFile(job.params.DstClusterType, job.params.DstProxyPort)
 	proxyFileForDstPort = filepath.Join(saveDirForDstPort, proxyFileForDstPort)
-	job.runtime.Logger.Info(fmt.Sprintf("proxyFileForDstPort:%s", proxyFileForDstPort))
+	job.runtime.Logger.Info("proxyFileForDstPort: %s", proxyFileForDstPort)
 	err = os.WriteFile(proxyFileForDstPort, []byte(dstConfContent), 0644)
 	if err != nil {
 		err = fmt.Errorf("write new proxy config file(%s) fail,err:%+v", proxyFileForDstPort, err)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	util.LocalDirChownMysql(saveDirForDstPort)
@@ -453,15 +489,15 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForDiffType() (err error) {
 	}
 
 	// 重启 proxy(此时端口还是 dstProxyPort)
-	job.runtime.Logger.Info(fmt.Sprintf("stop proxy(%s:%d) dst cluster_type:%s",
-		job.params.SrcProxyIP, job.params.DstProxyPort, job.params.DstClusterType))
+	job.runtime.Logger.Info("stop proxy(%s:%d) dst cluster_type:%s",
+		job.params.SrcProxyIP, job.params.DstProxyPort, job.params.DstClusterType)
 	err = job.StopProxy(job.params.SrcProxyIP, job.params.DstProxyPort,
 		job.params.SrcProxyPassword, job.params.DstClusterType)
 	if err != nil {
 		return
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("start proxy(%s:%d) dst cluster_type:%s",
-		job.params.SrcProxyIP, job.params.DstProxyPort, job.params.DstClusterType))
+	job.runtime.Logger.Info("start proxy(%s:%d) dst cluster_type:%s",
+		job.params.SrcProxyIP, job.params.DstProxyPort, job.params.DstClusterType)
 	err = job.StartProxy(job.params.SrcProxyIP, job.params.DstProxyPort,
 		job.params.SrcProxyPassword, job.params.DstClusterType)
 	if err != nil {
@@ -478,42 +514,42 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForDiffType() (err error) {
 	if !strings.Contains(proxyBackends, dstRedisAddr) {
 		err = fmt.Errorf("new proxy(%s:%d) backends(%s) not contains dst redis(%s)",
 			job.params.SrcProxyIP, job.params.DstProxyPort, proxyBackends, dstRedisAddr)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return err
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("new proxy(%s:%d) backends contains dst redis(%s)",
-		job.params.SrcProxyIP, job.params.DstProxyPort, dstRedisAddr))
+	job.runtime.Logger.Info("new proxy(%s:%d) backends contains dst redis(%s)",
+		job.params.SrcProxyIP, job.params.DstProxyPort, dstRedisAddr)
 
 	// 再次 stop proxy,修改端口
-	job.runtime.Logger.Info(fmt.Sprintf("stop proxy(%s:%d) dst cluster_type:%s",
-		job.params.SrcProxyIP, job.params.DstProxyPort, job.params.DstClusterType))
+	job.runtime.Logger.Info("stop proxy(%s:%d) dst cluster_type:%s",
+		job.params.SrcProxyIP, job.params.DstProxyPort, job.params.DstClusterType)
 	err = job.StopProxy(job.params.SrcProxyIP, job.params.DstProxyPort,
 		job.params.SrcProxyPassword, job.params.DstClusterType)
 	if err != nil {
 		return
 	}
 	// 修改端口
-	job.runtime.Logger.Info(fmt.Sprintf("replace dstConfContent %s -> %s",
+	job.runtime.Logger.Info("replace dstConfContent %s -> %s",
 		job.params.SrcProxyIP+":"+strconv.Itoa(job.params.DstProxyPort),
 		job.params.SrcProxyIP+":"+strconv.Itoa(job.params.SrcProxyPort),
-	))
+	)
 	dstConfContent = strings.ReplaceAll(dstConfContent,
 		job.params.SrcProxyIP+":"+strconv.Itoa(job.params.DstProxyPort),
 		job.params.SrcProxyIP+":"+strconv.Itoa(job.params.SrcProxyPort),
 	)
-	job.runtime.Logger.Info(fmt.Sprintf("replace dstConfContent %s -> %s",
+	job.runtime.Logger.Info("replace dstConfContent %s -> %s",
 		strconv.Itoa(job.params.DstProxyPort),
 		strconv.Itoa(job.params.SrcProxyPort),
-	))
+	)
 	dstConfContent = strings.ReplaceAll(dstConfContent,
 		strconv.Itoa(job.params.DstProxyPort),
 		strconv.Itoa(job.params.SrcProxyPort))
-	job.runtime.Logger.Info(fmt.Sprintf(" dstConfContent data:%s", dstConfContent))
+	job.runtime.Logger.Info(" dstConfContent data:%s", dstConfContent)
 	// 重新写文件
 	err = os.WriteFile(proxyFileForDstPort, []byte(dstConfContent), 0644)
 	if err != nil {
 		err = fmt.Errorf("write final proxy config file(%s) fail,err:%+v", proxyFileForDstPort, err)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	// 下面执行逻辑,例如:
@@ -521,23 +557,29 @@ func (job *RedisDtsOnlineSwitch) NewProxyConfigFileForDiffType() (err error) {
 	// cd /data/twemproxy-0.2.4/50000/ && mv nutcracker.50100.yml nutcracker.50000.yml
 	saveDirForSrcPort := job.getProxyConfigSaveDir(job.params.DstClusterType, job.params.SrcProxyPort)
 	if util.FileExists(saveDirForSrcPort) {
-		// 先删除
-		rmCmd := fmt.Sprintf("rm -rf %s", saveDirForSrcPort)
-		job.runtime.Logger.Info(rmCmd)
-		util.RunBashCmd(rmCmd, "", nil, 30*time.Second)
+		backupDir := job.buildGeneratedProxyConfDirBackup(saveDirForSrcPort, newDtsOnlineSwitchBackupTimestamp())
+		mvCmd := fmt.Sprintf("mv %s %s", saveDirForSrcPort, backupDir)
+		job.runtime.Logger.Info("mvCmd: %s", mvCmd)
+		_, err = util.RunBashCmd(mvCmd, "", nil, 30*time.Second)
+		if err != nil {
+			err = fmt.Errorf("backup existing proxy config dir(%s) to dir(%s) fail,err:%+v",
+				saveDirForSrcPort, backupDir, err)
+			job.runtime.Logger.Error("%v", err)
+			return
+		}
 	}
 	mvCmd := fmt.Sprintf("mv %s %s", saveDirForDstPort, saveDirForSrcPort)
-	job.runtime.Logger.Info(mvCmd)
+	job.runtime.Logger.Info("mvCmd: %s", mvCmd)
 	_, err = util.RunBashCmd(mvCmd, "", nil, 30*time.Second)
 	if err != nil {
 		err = fmt.Errorf("mv proxy config dir(%s) to dir(%s) fail,err:%+v", saveDirForDstPort, saveDirForSrcPort, err)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return
 	}
 	proxyFileForSrcPort := job.getProxyFile(job.params.DstClusterType, job.params.SrcProxyPort)
 	if filepath.Base(proxyFileForDstPort) != proxyFileForSrcPort {
 		mvCmd = fmt.Sprintf("cd %s && mv %s %s", saveDirForSrcPort, filepath.Base(proxyFileForDstPort), proxyFileForSrcPort)
-		job.runtime.Logger.Info(mvCmd)
+		job.runtime.Logger.Info("mvCmd: %s", mvCmd)
 		_, err = util.RunBashCmd(mvCmd, "", nil, 30*time.Second)
 		if err != nil {
 			return
@@ -557,7 +599,7 @@ func (job *RedisDtsOnlineSwitch) IsProxyAlive(proxyIP string, proxyPort int, pro
 		return alive
 	}
 	addr := fmt.Sprintf("%s:%d", proxyIP, proxyPort)
-	client, err := myredis.NewRedisClientWithTimeout(addr, proxyPassword, 0, consts.TendisTypeRedisInstance, 5*time.Second)
+	client, err := myredis.NewRedisClient(addr, proxyPassword, 0, consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		return false
 	}
@@ -569,7 +611,7 @@ func (job *RedisDtsOnlineSwitch) IsProxyAlive(proxyIP string, proxyPort int, pro
 func (job *RedisDtsOnlineSwitch) StartProxy(proxyIP string, proxyPort int,
 	proxyPassword string, clusterType string) (err error) {
 	if job.IsProxyAlive(proxyIP, proxyPort, proxyPassword) {
-		job.runtime.Logger.Info(fmt.Sprintf("proxy(%s:%d) already started,skip...", proxyIP, proxyPort))
+		job.runtime.Logger.Info("proxy(%s:%d) already started,skip...", proxyIP, proxyPort)
 		return nil
 	}
 	var cmd string
@@ -578,7 +620,7 @@ func (job *RedisDtsOnlineSwitch) StartProxy(proxyIP string, proxyPort int,
 	} else if consts.IsPredixyClusterType(clusterType) {
 		cmd = fmt.Sprintf("/usr/local/predixy/bin/start_predixy.sh %d", proxyPort)
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("start proxy(%s:%d) cmd:%s", proxyIP, proxyPort, cmd))
+	job.runtime.Logger.Info("start proxy(%s:%d) cmd:%s", proxyIP, proxyPort, cmd)
 	startCmd := []string{"su", consts.MysqlAaccount, "-c", cmd}
 	maxRetryTimes := 5
 	for maxRetryTimes >= 0 {
@@ -586,22 +628,22 @@ func (job *RedisDtsOnlineSwitch) StartProxy(proxyIP string, proxyPort int,
 		err = nil
 		_, err = util.RunLocalCmd(startCmd[0], startCmd[1:], "", nil, 30*time.Second)
 		if err != nil {
-			job.runtime.Logger.Warn(fmt.Sprintf("start proxy(%s:%d) fail,err:%+v,retry...", proxyIP, proxyPort, err))
+			job.runtime.Logger.Warn("start proxy(%s:%d) fail,err:%+v,retry...", proxyIP, proxyPort, err)
 			time.Sleep(5 * time.Second)
 			continue
 		}
 		if !job.IsProxyAlive(proxyIP, proxyPort, proxyPassword) {
-			job.runtime.Logger.Warn(fmt.Sprintf("start proxy(%s:%d) fail,proxy not alive,retry...", proxyIP, proxyPort))
+			job.runtime.Logger.Warn("start proxy(%s:%d) fail,proxy not alive,retry...", proxyIP, proxyPort)
 			time.Sleep(5 * time.Second)
 			continue
 		}
 		break
 	}
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("start proxy(%s:%d) fail,err:%+v, not retry", proxyIP, proxyPort, err))
+		job.runtime.Logger.Error("start proxy(%s:%d) fail,err:%+v, not retry", proxyIP, proxyPort, err)
 		return
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("start proxy(%s:%d) success", proxyIP, proxyPort))
+	job.runtime.Logger.Info("start proxy(%s:%d) success", proxyIP, proxyPort)
 	return nil
 }
 
@@ -610,7 +652,7 @@ func (job *RedisDtsOnlineSwitch) StopProxy(proxyIP string, proxyPort int,
 	proxyPassword string, clusterType string) error {
 	var err error
 	if !job.IsProxyAlive(proxyIP, proxyPort, proxyPassword) {
-		job.runtime.Logger.Info(fmt.Sprintf("proxy(%s:%d) already stopped,skip...", proxyIP, proxyPort))
+		job.runtime.Logger.Info("proxy(%s:%d) already stopped,skip...", proxyIP, proxyPort)
 		return nil
 	}
 	var cmd1, killCmd string
@@ -624,25 +666,25 @@ func (job *RedisDtsOnlineSwitch) StopProxy(proxyIP string, proxyPort int,
 		killCmd = fmt.Sprintf(`ps aux|grep 'predixy'|grep -Ev 'grep|exporter'|grep %d|awk '{print $2}'|xargs kill -9`,
 			proxyPort)
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("stop proxy(%s:%d) cmd1:%s,cmd2:%s", proxyIP, proxyPort, cmd1, killCmd))
+	job.runtime.Logger.Info("stop proxy(%s:%d) cmd1:%s,cmd2:%s", proxyIP, proxyPort, cmd1, killCmd)
 	stopCmd := []string{"su", consts.MysqlAaccount, "-c", cmd1}
 	util.RunLocalCmd(stopCmd[0], stopCmd[1:], "", nil, 30*time.Second)
 	if !job.IsProxyAlive(proxyIP, proxyPort, proxyPassword) {
-		job.runtime.Logger.Info(fmt.Sprintf("proxy(%s:%d) stop success", proxyIP, proxyPort))
+		job.runtime.Logger.Info("proxy(%s:%d) stop success", proxyIP, proxyPort)
 		return nil
 	}
 	time.Sleep(2 * time.Second)
 	_, err = util.RunBashCmd(killCmd, "", nil, 30*time.Second)
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("proxy(%s:%d) stop fail,err:%+v", proxyIP, proxyPort, err))
+		job.runtime.Logger.Error("proxy(%s:%d) stop fail,err:%+v", proxyIP, proxyPort, err)
 		return err
 	}
 	if job.IsProxyAlive(proxyIP, proxyPort, proxyPassword) {
 		err = fmt.Errorf("proxy(%s:%d) stop fail,proxy still alive", proxyIP, proxyPort)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return err
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("proxy(%s:%d) stop success", proxyIP, proxyPort))
+	job.runtime.Logger.Info("proxy(%s:%d) stop success", proxyIP, proxyPort)
 	return nil
 }
 
@@ -669,11 +711,11 @@ func (job *RedisDtsOnlineSwitch) RestartProxyAndCheckBackends() (err error) {
 	if !strings.Contains(proxyBackends, dstRedisAddr) {
 		err = fmt.Errorf("proxy(%s:%d) backends(%s) not contains dst redis(%s)",
 			job.params.SrcProxyIP, job.params.SrcProxyPort, proxyBackends, dstRedisAddr)
-		job.runtime.Logger.Error(err.Error())
+		job.runtime.Logger.Error("%v", err)
 		return err
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("proxy(%s:%d) backends contains dst redis(%s)",
-		job.params.SrcProxyIP, job.params.SrcProxyPort, dstRedisAddr))
+	job.runtime.Logger.Info("proxy(%s:%d) backends contains dst redis(%s)",
+		job.params.SrcProxyIP, job.params.SrcProxyPort, dstRedisAddr)
 	return nil
 }
 
@@ -686,15 +728,16 @@ func (job *RedisDtsOnlineSwitch) getProxyRoleByClusterType(clusterType string) s
 	return ""
 }
 
-// RestartDbMon 如果集群类型有变化,修复dbmon 配置,重启 dbmon
-func (job *RedisDtsOnlineSwitch) RestartDbMon() (err error) {
+// UpdateDbMonConfig 若集群类型发生变化, 修复 dbmon 配置及 exporter 配置.
+// dbmon 的 stop/start 由 Run() 的 defer 统一负责, 此函数不再触发 StartBkDbmon.
+func (job *RedisDtsOnlineSwitch) UpdateDbMonConfig() (err error) {
 	if job.params.SrcClusterType == job.params.DstClusterType {
-		job.runtime.Logger.Info("src cluster type equals dst cluster type,skip restart dbmon")
+		job.runtime.Logger.Info("src cluster type equals dst cluster type,skip dbmon config update")
 		return nil
 	}
 	sedCmd := fmt.Sprintf(`sed -i 's/cluster_type: %s/cluster_type: %s/g' %s`,
 		job.params.SrcClusterType, job.params.DstClusterType, consts.BkDbmonConfFile)
-	job.runtime.Logger.Info(sedCmd)
+	job.runtime.Logger.Info("sedCmd: %s", sedCmd)
 	_, err = util.RunBashCmd(sedCmd, "", nil, 30*time.Second)
 	if err != nil {
 		return
@@ -704,22 +747,12 @@ func (job *RedisDtsOnlineSwitch) RestartDbMon() (err error) {
 	if srcProxyRole != dstProxyRole {
 		sedCmd = fmt.Sprintf(`sed -i 's/meta_role: %s/meta_role: %s/g' %s`,
 			srcProxyRole, dstProxyRole, consts.BkDbmonConfFile)
-		job.runtime.Logger.Info(sedCmd)
+		job.runtime.Logger.Info("sedCmd: %s", sedCmd)
 		_, err = util.RunBashCmd(sedCmd, "", nil, 30*time.Second)
 		if err != nil {
 			return
 		}
 	}
-	// // 重启 dbmon
-	// err = util.StopBkDbmon()
-	// if err != nil {
-	// 	return err
-	// }
-	err = util.StartBkDbmon()
-	if err != nil {
-		return err
-	}
-	// 更新export配置文件
 	err = common.CreateLocalExporterConfigFile(job.params.SrcProxyIP, job.params.SrcProxyPort, dstProxyRole, "")
 	if err != nil {
 		return err
@@ -742,7 +775,7 @@ func (job *RedisDtsOnlineSwitch) UntarDstProxyMedia() (err error) {
 	}
 	err = job.params.DstProxyPkg.Check()
 	if err != nil {
-		job.runtime.Logger.Error(fmt.Sprintf("check dst proxy pkg fail,err:%+v", err))
+		job.runtime.Logger.Error("check dst proxy pkg fail,err:%+v", err)
 		return err
 	}
 	pkgBaseName := job.params.DstProxyPkg.GePkgBaseName()
@@ -752,7 +785,7 @@ func (job *RedisDtsOnlineSwitch) UntarDstProxyMedia() (err error) {
 		// 如果包不存在,则解压到 /usr/local 下
 		pkgAbsPath := job.params.DstProxyPkg.GetAbsolutePath()
 		tarCmd := fmt.Sprintf("tar -zxf %s -C %s", pkgAbsPath, consts.UsrLocal)
-		job.runtime.Logger.Info(tarCmd)
+		job.runtime.Logger.Info("tarCmd: %s", tarCmd)
 		_, err = util.RunBashCmd(tarCmd, "", nil, 10*time.Second)
 		if err != nil {
 			return
@@ -775,14 +808,14 @@ func (job *RedisDtsOnlineSwitch) UntarDstProxyMedia() (err error) {
 		// 如果软连接存在,则判断是否指向了正确的目录
 		softLinkTarget, err = os.Readlink(proxySoftLink)
 		if err != nil {
-			job.runtime.Logger.Error(fmt.Sprintf("read soft link(%s) fail,err:%+v", proxySoftLink, err))
+			job.runtime.Logger.Error("read soft link(%s) fail,err:%+v", proxySoftLink, err)
 			return err
 		}
 		if softLinkTarget != dstProxyBinDir {
 			// 如果软连接指向的目录不正确,则删除软连接,重新创建
 			createSoftLink = true
 			rmSoftLinkCmd := fmt.Sprintf("rm -f %s", proxySoftLink)
-			job.runtime.Logger.Info(rmSoftLinkCmd)
+			job.runtime.Logger.Info("rmSoftLinkCmd: %s", rmSoftLinkCmd)
 			_, err = util.RunBashCmd(rmSoftLinkCmd, "", nil, 10*time.Second)
 			if err != nil {
 				return err
@@ -792,21 +825,21 @@ func (job *RedisDtsOnlineSwitch) UntarDstProxyMedia() (err error) {
 	if createSoftLink {
 		// 创建软连接
 		softLinkCmd := fmt.Sprintf("ln -s %s %s", dstProxyBinDir, proxySoftLink)
-		job.runtime.Logger.Info(softLinkCmd)
+		job.runtime.Logger.Info("softLinkCmd: %s", softLinkCmd)
 		_, err = util.RunBashCmd(softLinkCmd, "", nil, 10*time.Second)
 		if err != nil {
 			return
 		}
-		job.runtime.Logger.Info(fmt.Sprintf("create soft link(%s) success", proxySoftLink))
+		job.runtime.Logger.Info("create soft link(%s) success", proxySoftLink)
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("soft link(%s) => %s", proxySoftLink, dstProxyBinDir))
+	job.runtime.Logger.Info("soft link(%s) => %s", proxySoftLink, dstProxyBinDir)
 	util.LocalDirChownMysql(proxySoftLink + string(filepath.Separator))
 
 	if consts.IsPredixyClusterType(job.params.DstClusterType) {
 		// 替换 start_predixy.sh 中的 /data
 		sedCmd := fmt.Sprintf("sed -i 's#/data\"#%s\"#g' %s", consts.GetRedisDataDir(),
 			filepath.Join(proxySoftLink, "bin", "start_predixy.sh"))
-		job.runtime.Logger.Info(sedCmd)
+		job.runtime.Logger.Info("sedCmd: %s", sedCmd)
 		_, err = util.RunBashCmd(sedCmd, "", nil, 30*time.Second)
 		if err != nil {
 			return
@@ -818,23 +851,18 @@ func (job *RedisDtsOnlineSwitch) UntarDstProxyMedia() (err error) {
 // MvSrcProxyCfgDirForDiffType move源 proxy 配置文件目录(如果源集群、目标集群类型不一致)
 func (job *RedisDtsOnlineSwitch) MvSrcProxyCfgDirForDiffType() (err error) {
 	srcProxyConfDir := job.getSrcProxyConfigSaveDir()
-	parentDir := filepath.Dir(srcProxyConfDir)
-
-	targetConfDir := fmt.Sprintf("dts_online_switch_bak.billid_%d.%d", job.params.DtsBillID, job.params.SrcProxyPort)
-	targetConfDir = filepath.Join(parentDir, targetConfDir)
+	targetConfDir := job.buildSrcProxyConfBackupDir(newDtsOnlineSwitchBackupTimestamp())
 	_, err = os.Stat(targetConfDir)
 	if err == nil {
-		// 如果目标目录已经存在,则直接返回
-		job.runtime.Logger.Info(fmt.Sprintf("target conf dir(%s) already exist,skip mv", targetConfDir))
-		return nil
+		return fmt.Errorf("target conf dir(%s) already exists", targetConfDir)
 	}
 	mvCmd := fmt.Sprintf("mv %s %s", srcProxyConfDir, targetConfDir)
-	job.runtime.Logger.Info(mvCmd)
+	job.runtime.Logger.Info("mvCmd: %s", mvCmd)
 	_, err = util.RunBashCmd(mvCmd, "", nil, 10*time.Second)
 	if err != nil {
 		return
 	}
-	job.runtime.Logger.Info(fmt.Sprintf("mv src proxy conf dir(%s) to target dir(%s) success",
-		srcProxyConfDir, targetConfDir))
+	job.runtime.Logger.Info("mv src proxy conf dir(%s) to target dir(%s) success",
+		srcProxyConfDir, targetConfDir)
 	return nil
 }

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_online_switch_test.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_dts_online_switch_test.go
@@ -1,0 +1,71 @@
+package atomredis
+
+import (
+	"net"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"dbm-services/redis/db-tools/dbactuator/pkg/consts"
+)
+
+func unusedLocalPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on random local port failed: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close random local listener failed: %v", err)
+	}
+	return port
+}
+
+func TestDtsOnlineSwitchBackupNamesIncludeTimestamp(t *testing.T) {
+	timestamp := "20260528111617.123456789"
+	job := &RedisDtsOnlineSwitch{
+		params: RedisDtsOnlineSwitchParams{
+			DtsBillID:      123,
+			SrcProxyIP:     "1.1.1.1",
+			SrcProxyPort:   50048,
+			SrcClusterType: consts.TendisTypeTwemproxyRedisInstance,
+		},
+	}
+
+	backupFile := filepath.Base(job.buildSrcProxyConfBackupFile(timestamp))
+	wantFile := "dts_bak_config.billid_123.1.1.1.1_50048.20260528111617.123456789.yml"
+	if backupFile != wantFile {
+		t.Fatalf("unexpected backup file name, got:%s want:%s", backupFile, wantFile)
+	}
+
+	backupDir := job.buildGeneratedProxyConfDirBackup("/data/predixy/50048/", timestamp)
+	wantDir := "/data/predixy/50048.dts_online_switch_bak.billid_123.20260528111617.123456789"
+	if backupDir != wantDir {
+		t.Fatalf("unexpected backup dir name, got:%s want:%s", backupDir, wantDir)
+	}
+}
+
+func TestDtsOnlineSwitchBackupTimestampFormat(t *testing.T) {
+	timestamp := newDtsOnlineSwitchBackupTimestamp()
+	matched := regexp.MustCompile(`^\d{14}\.\d{9}$`).MatchString(timestamp)
+	if !matched {
+		t.Fatalf("unexpected backup timestamp format:%s", timestamp)
+	}
+}
+
+func TestIsProxyAliveReturnsQuicklyForClosedPort(t *testing.T) {
+	port := unusedLocalPort(t)
+	job := &RedisDtsOnlineSwitch{}
+	start := time.Now()
+
+	alive := job.IsProxyAlive("127.0.0.1", port, "")
+	if alive {
+		t.Fatalf("expected proxy on closed port %s to be dead", strconv.Itoa(port))
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("closed-port proxy check took too long:%s", elapsed)
+	}
+}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_install.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_install.go
@@ -396,7 +396,7 @@ func (job *RedisInstall) IsRedisInstalled(port int) (installed bool, err error) 
 	}
 	// 端口已被使用
 	redisAddr := job.params.IP + ":" + strconv.Itoa(port)
-	redisCli, err := myredis.NewRedisClientWithTimeout(redisAddr, job.params.Password, 0,
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, job.params.Password, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		err = fmt.Errorf("%d is in used by other process", port)

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_load_modules.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_load_modules.go
@@ -191,7 +191,7 @@ func (job *RedisLoadModules) allInstsAbleToConnect() (err error) {
 		if err != nil {
 			return err
 		}
-		cli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+		cli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 			consts.TendisTypeRedisInstance, 5*time.Second)
 		if err != nil {
 			return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_local_redo_dr.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_local_redo_dr.go
@@ -145,7 +145,7 @@ func (r *RedisLocalDoDR) startAndWetLinkUp(addr, pass string, idx int, instance 
 		return fmt.Errorf("r:%s:e:%+v", rst, err)
 	}
 
-	rConn, err := myredis.NewRedisClientWithTimeout(addr, pass, 0, r.params.ClusterType, time.Second*10)
+	rConn, err := myredis.NewRedisClientWithRetry(addr, pass, 0, r.params.ClusterType, time.Second*10)
 	if err != nil {
 		r.runtime.Logger.Warn("connect instance failed %d:%s:%+v", idx, addr, err)
 		return err
@@ -272,7 +272,7 @@ func (r *RedisLocalDoDR) tryBackupData(src, dst, addr string) error {
 // tryLoginAndShutdown 登陆检查
 // do bgsave [redis-cluster 理论上不会用到这个流程]
 func (r *RedisLocalDoDR) tryLoginAndShutdown(addr string, password string, idx int, instance ReplicaItem) error {
-	rConn, err := myredis.NewRedisClientWithTimeout(addr, password, 0, r.params.ClusterType, time.Second*10)
+	rConn, err := myredis.NewRedisClientWithRetry(addr, password, 0, r.params.ClusterType, time.Second*10)
 	if err != nil {
 		r.runtime.Logger.Warn("connect instance failed %d:%s:%+v , mabye restarted machine.", idx, addr, err)
 	} else {

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_maxmemory_dynamically_set.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_maxmemory_dynamically_set.go
@@ -150,7 +150,7 @@ func (job *RedisMaxMemoryDynamicallySet) GetRedisUsedMemory() (err error) {
 		wg.Add(1)
 		go func(memItem *RedisUsedMemItem) {
 			defer wg.Done()
-			memItem.redisCli, memItem.Err = myredis.NewRedisClientWithTimeout(memItem.Addr(), memItem.Password,
+			memItem.redisCli, memItem.Err = myredis.NewRedisClientWithRetry(memItem.Addr(), memItem.Password,
 				0, consts.TendisTypeRedisInstance, 5*time.Second)
 			if memItem.Err != nil {
 				return
@@ -284,7 +284,7 @@ func (job *RedisMaxMemoryDynamicallySet) ConcurrentlyConfigSetMaxmemory() error 
 				func(tmpItem *myredis.InfoReplSlave, password string, maxmemory int64) {
 					var err error
 					// 连接slave 并设置maxmemory
-					slaveCli, err := myredis.NewRedisClientWithTimeout(tmpItem.Addr(), password, 0, consts.TendisTypeRedisInstance,
+					slaveCli, err := myredis.NewRedisClientWithRetry(tmpItem.Addr(), password, 0, consts.TendisTypeRedisInstance,
 						10*time.Second)
 					if err != nil {
 						return

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_replicaof.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_replicaof.go
@@ -156,13 +156,13 @@ func (task *ReplicaTask) InfoReplMasterAddr() string {
 
 func (task *ReplicaTask) newConnects() {
 	task.runtime.Logger.Info("begin to connect master:%s", task.MasterAddr())
-	task.MasterCli, task.Err = myredis.NewRedisClientWithTimeout(task.MasterAddr(), task.MasterAuth,
+	task.MasterCli, task.Err = myredis.NewRedisClientWithRetry(task.MasterAddr(), task.MasterAuth,
 		0, consts.TendisTypeRedisInstance, 5*time.Second)
 	if task.Err != nil {
 		return
 	}
 	task.runtime.Logger.Info("begin to connect slave:%s", task.SlaveAddr())
-	task.SlaveCli, task.Err = myredis.NewRedisClientWithTimeout(task.SlaveAddr(), task.SlavePassword,
+	task.SlaveCli, task.Err = myredis.NewRedisClientWithRetry(task.SlaveAddr(), task.SlavePassword,
 		0, consts.TendisTypeRedisInstance, 5*time.Second)
 	if task.Err != nil {
 		return

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_replicas_force_resync.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_replicas_force_resync.go
@@ -202,7 +202,7 @@ func (job *ReplicasForceResync) slaveInstsAbleToConnect() (err error) {
 		if err != nil {
 			return err
 		}
-		cli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+		cli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 			consts.TendisTypeRedisInstance, 5*time.Second)
 		if err != nil {
 			return err

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_reshape.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_reshape.go
@@ -104,7 +104,7 @@ func (job *RedisReshape) allInstCconnect() (err error) {
 		wg.Add(1)
 		go func(task *reshapeTaskItem) {
 			defer wg.Done()
-			task.redisConn, task.Err = myredis.NewRedisClientWithTimeout(task.Addr(), task.Password, 0,
+			task.redisConn, task.Err = myredis.NewRedisClientWithRetry(task.Addr(), task.Password, 0,
 				consts.TendisTypeRedisInstance, 10*time.Hour)
 		}(task)
 	}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_scene_kill_conn.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_scene_kill_conn.go
@@ -87,7 +87,7 @@ func (job *RedisKillDeadConn) Run() (err error) {
 			}
 			return err
 		}
-		rconn, err := myredis.NewRedisClientWithTimeout(addr, pwd, 0, job.params.ClusterType, time.Second*10)
+		rconn, err := myredis.NewRedisClientWithRetry(addr, pwd, 0, job.params.ClusterType, time.Second*10)
 		if err != nil {
 			job.runtime.Logger.Error("conn redis failed,err %s:%v", addr, err)
 			return nil

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_scene_param_sync.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_scene_param_sync.go
@@ -78,14 +78,14 @@ func (job *RedisPramsSync) Run() (err error) {
 			job.runtime.Logger.Error("get redis pass from local failed,err %s:%v", addr1, err)
 			return err
 		}
-		rc1, err := myredis.NewRedisClientWithTimeout(addr1, pwd, 0, job.params.ClusterType, time.Second*10)
+		rc1, err := myredis.NewRedisClientWithRetry(addr1, pwd, 0, job.params.ClusterType, time.Second*10)
 		if err != nil {
 			return fmt.Errorf("conn redis %s failed:%+v", addr1, err)
 		}
 		defer rc1.Close()
 
 		addr2 := fmt.Sprintf("%s:%d", pair.SlaveInfo.IP, pair.SlaveInfo.Port)
-		rc2, err := myredis.NewRedisClientWithTimeout(addr2, pwd, 0, job.params.ClusterType, time.Second*10)
+		rc2, err := myredis.NewRedisClientWithRetry(addr2, pwd, 0, job.params.ClusterType, time.Second*10)
 		if err != nil {
 			return fmt.Errorf("conn redis %s failed:%+v", addr2, err)
 		}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_scene_sync_check.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_scene_sync_check.go
@@ -114,7 +114,7 @@ func (job *RedisSyncCheck) checkReplication(ins InstanceParam) error {
 		job.runtime.Logger.Error("get redis pass from local failed,err %s:%v", addr, err)
 		return err
 	}
-	rc1, err := myredis.NewRedisClientWithTimeout(addr, pwd, 0, job.params.ClusterType, time.Second*10)
+	rc1, err := myredis.NewRedisClientWithRetry(addr, pwd, 0, job.params.ClusterType, time.Second*10)
 	if err != nil {
 		return fmt.Errorf("conn redis %s failed:%+v", addr, err)
 	}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_switch.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_switch.go
@@ -308,7 +308,7 @@ func (job *RedisSwitch) Run() (err error) {
 
 func (job *RedisSwitch) enableWrite4Slave(ip string, port int, pass string) error {
 	newMasterAddr := fmt.Sprintf("%s:%d", ip, port)
-	newMasterConn, err := myredis.NewRedisClientWithTimeout(newMasterAddr,
+	newMasterConn, err := myredis.NewRedisClientWithRetry(newMasterAddr,
 		pass, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		return err
@@ -331,7 +331,7 @@ func (job *RedisSwitch) doSlaveOfNoOne4NewMaster(ip string, port int, pass strin
 	newMasterAddr := fmt.Sprintf("%s:%d", ip, port)
 	job.runtime.Logger.Info("[%s] before exec SLAVEOF NO ONE wait 3 seconds chessing master", newMasterAddr)
 	time.Sleep(3 * time.Second)
-	newMasterConn, err := myredis.NewRedisClientWithTimeout(newMasterAddr,
+	newMasterConn, err := myredis.NewRedisClientWithRetry(newMasterAddr,
 		pass, 1, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		return fmt.Errorf("[%s] conn new master failed :%+v", newMasterAddr, err)
@@ -357,7 +357,7 @@ func (job *RedisSwitch) doSlaveOfNoOne4NewMaster(ip string, port int, pass strin
 // tryShutdownMasterInstance 尝试去关掉master实例，使得长链接断开，重连到新的master实例上去
 func (job *RedisSwitch) tryShutdownMasterInstance(ip string, port int, pass string) {
 	oldMasterAddr := fmt.Sprintf("%s:%d", ip, port)
-	oldMasterConn, err := myredis.NewRedisClientWithTimeout(oldMasterAddr,
+	oldMasterConn, err := myredis.NewRedisClientWithRetry(oldMasterAddr,
 		pass, 1, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		job.runtime.Logger.Warn("[%s] conn old master failed:%+v", oldMasterAddr, err)
@@ -373,7 +373,7 @@ func (job *RedisSwitch) tryShutdownMasterInstance(ip string, port int, pass stri
 // doTendisStorageSwitch4Cluster rediscluster 类型架构切换姿势 http://redis.cn/commands/cluster-failover.html
 func (job *RedisSwitch) doTendisStorageSwitch4Cluster(storagePair InstanceSwitchParam) error {
 	newMasterAddr := fmt.Sprintf("%s:%d", storagePair.SlaveInfo.IP, storagePair.SlaveInfo.Port)
-	newMasterConn, err := myredis.NewRedisClientWithTimeout(newMasterAddr,
+	newMasterConn, err := myredis.NewRedisClientWithRetry(newMasterAddr,
 		job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		return err
@@ -443,7 +443,7 @@ func (job *RedisSwitch) doTendisStorageSwitch4Cluster(storagePair InstanceSwitch
 // cluster模式下，执行互切，尝试给新slave（OldMaster）设置密码
 func (job *RedisSwitch) trySetMasterAuth(sp InstanceSwitchParam) {
 	oldAddr := fmt.Sprintf("%s:%d", sp.MasterInfo.IP, sp.MasterInfo.Port)
-	conn, err := myredis.NewRedisClientWithTimeout(oldAddr,
+	conn, err := myredis.NewRedisClientWithRetry(oldAddr,
 		job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		job.runtime.Logger.Warn("try conn old master :%s:%d failed:%+v", sp.MasterInfo.IP, sp.MasterInfo.Port, err)
@@ -686,7 +686,7 @@ func (job *RedisSwitchPreCheck) GetClusterRuntimeMasters() (map[string]string, e
 		}
 		// gossip cluster模式
 	} else if consts.IsPredixyClusterType(job.params.ClusterMeta.ClusterType) {
-		rconn, err := myredis.NewRedisClientWithTimeout(addr,
+		rconn, err := myredis.NewRedisClientWithRetry(addr,
 			job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 		if err != nil {
 			return runtimeMasters, fmt.Errorf("conn redis failed:%s;%+v", job.params.ClusterMeta.ImmuteDomain, err)
@@ -798,7 +798,7 @@ func (job *RedisSwitchPreCheck) precheckStorageSync() error {
 			defer wg.Done()
 			// oldMasterAddr := fmt.Sprintf("%s:%d", storagePair.MasterInfo.IP, storagePair.MasterInfo.Port)
 			newMasterAddr := fmt.Sprintf("%s:%d", storagePair.SlaveInfo.IP, storagePair.SlaveInfo.Port)
-			newMasterConn, err := myredis.NewRedisClientWithTimeout(newMasterAddr,
+			newMasterConn, err := myredis.NewRedisClientWithRetry(newMasterAddr,
 				job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 			if err != nil {
 				job.errChan <- fmt.Errorf("[%s]new master node, err:%+v", newMasterAddr, err)
@@ -871,7 +871,7 @@ func (job *RedisSwitchPreCheck) checkReplicationDetail(
 		job.runtime.Logger.Info("[%s:%d] storage really had running confied master %s:%s in [ms] mode ! ok~",
 			storagePair.SlaveInfo.IP, storagePair.SlaveInfo.Port, realIP, realPort)
 	} else if job.params.SyncCondition.InstanceSyncType == "msms" {
-		oldSlaveConn, err := myredis.NewRedisClientWithTimeout(fmt.Sprintf("%s:%s", realIP, realPort),
+		oldSlaveConn, err := myredis.NewRedisClientWithRetry(fmt.Sprintf("%s:%s", realIP, realPort),
 			job.params.ClusterMeta.StoragePassword, 1, job.params.ClusterMeta.ClusterType, time.Second*10)
 		if err != nil {
 			return fmt.Errorf("[%s:%d] conn addr:%s:%s,err:%+v",
@@ -982,7 +982,7 @@ func (job *RedisSwitchPreCheck) checkReplicationSync(newMasterConn *myredis.Redi
 // setHeartBeatWhenDbmonStoped # here we just set on the master heartbeat:
 func (job *RedisSwitchPreCheck) trySetHeartBeatWhenDbmonStoped(storagePair InstanceSwitchParam) error {
 	oldMasterAddr := fmt.Sprintf("%s:%d", storagePair.MasterInfo.IP, storagePair.MasterInfo.Port)
-	oldMasterConn, err := myredis.NewRedisClientWithTimeout(oldMasterAddr,
+	oldMasterConn, err := myredis.NewRedisClientWithRetry(oldMasterAddr,
 		job.params.ClusterMeta.StoragePassword, 0, job.params.ClusterMeta.ClusterType, time.Second*10)
 	if err != nil {
 		job.runtime.Logger.Warn("[%s] conntect 2 old master failed :%+v", oldMasterAddr, err)
@@ -1057,7 +1057,7 @@ func (job *RedisSwitchPreCheck) precheckProxyLogin() error {
 
 // precheckLogin 检查 proxy/redis 可以登录
 func (job *RedisSwitchPreCheck) precheckLogin(addr, pass, clusterType string) error {
-	rconn, err := myredis.NewRedisClientWithTimeout(addr, pass, 0, clusterType, time.Second*10)
+	rconn, err := myredis.NewRedisClientWithRetry(addr, pass, 0, clusterType, time.Second*10)
 	if err != nil {
 		return fmt.Errorf("conn redis %s failed:%+v", addr, err)
 	}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_version_update.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_version_update.go
@@ -324,7 +324,7 @@ func (job *RedisVersionUpdate) allInstsAbleToConnect() (err error) {
 		if err != nil {
 			return err
 		}
-		cli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+		cli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 			consts.TendisTypeRedisInstance, 5*time.Second)
 		if err != nil {
 			return err
@@ -518,7 +518,7 @@ func (job *RedisVersionUpdate) flushDataAfterStart(port int) error {
 	if err != nil {
 		return fmt.Errorf("flush after upgrade: get pwd from conf failed,addr:%s,err:%v", addr, err)
 	}
-	cli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+	cli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return fmt.Errorf("flush after upgrade: connect %s failed,err:%v", addr, err)
@@ -721,7 +721,7 @@ func (job *RedisVersionUpdate) startRedis(port int) (err error) {
 		return err
 	}
 	addr := fmt.Sprintf("%s:%d", job.params.IP, port)
-	cli, err := myredis.NewRedisClientWithTimeout(addr, password, 0,
+	cli, err := myredis.NewRedisClientWithRetry(addr, password, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil && strings.Contains(err.Error(), "LOADING Redis is loading") {
 		job.runtime.Logger.Warn(fmt.Sprintf("redis:%s conn warn,err:%v", addr, err))

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/tendisssd_dr_restore.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/tendisssd_dr_restore.go
@@ -271,14 +271,14 @@ func (task *TendisssdDrRestoreTask) Run() {
 }
 func (task *TendisssdDrRestoreTask) newConnect() {
 	task.runtime.Logger.Info("start connect master(%s)", task.MasterAddr())
-	task.MasterCli, task.Err = myredis.NewRedisClient(task.MasterAddr(), task.MasterAuth, 0,
-		consts.TendisTypeRedisInstance)
+	task.MasterCli, task.Err = myredis.NewRedisClientWithRetry(task.MasterAddr(), task.MasterAuth, 0,
+		consts.TendisTypeRedisInstance, 1*time.Minute)
 	if task.Err != nil {
 		return
 	}
 	task.runtime.Logger.Info("start connect slave(%s)", task.SlaveAddr())
-	task.SlaveCli, task.Err = myredis.NewRedisClient(task.SlaveAddr(), task.SlavePassword, 0,
-		consts.TendisTypeRedisInstance)
+	task.SlaveCli, task.Err = myredis.NewRedisClientWithRetry(task.SlaveAddr(), task.SlavePassword, 0,
+		consts.TendisTypeRedisInstance, 1*time.Minute)
 	if task.Err != nil {
 		return
 	}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomsys/change_password.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomsys/change_password.go
@@ -271,7 +271,7 @@ func (job *ChangePwd) changeRedisPwd(port int, oldPwd string, newPwd string) err
 	}
 	job.runtime.Logger.Info("rewrite config (%s:%d) success", job.params.IP, port)
 
-	cli, err := myredis.NewRedisClientWithTimeout(insAddr, newPwd, 0,
+	cli, err := myredis.NewRedisClientWithRetry(insAddr, newPwd, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return err
@@ -285,7 +285,7 @@ func (job *ChangePwd) changeRedisPwd(port int, oldPwd string, newPwd string) err
 // checkConn 检查用新密码是否能正常连接
 func (job *ChangePwd) checkConn(port int, pwd string) error {
 	addr := fmt.Sprintf("%s:%d", job.params.IP, port)
-	cli, err := myredis.NewRedisClientWithTimeout(addr, pwd, 0,
+	cli, err := myredis.NewRedisClientWithRetry(addr, pwd, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	defer cli.Close()
 

--- a/dbm-services/redis/db-tools/dbactuator/pkg/backupsys/fullback.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/backupsys/fullback.go
@@ -1091,7 +1091,8 @@ func (full *TplusFullBackPull) RestoreBackup(dstTplusIP string, dstTplusPort int
 	msg := fmt.Sprintf("master:%s开始导入全备", redisAddr)
 	mylog.Logger.Info(msg)
 	//再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, dstTplusPasswd, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, dstTplusPasswd, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1263,7 +1264,8 @@ func (full *TplusFullBackPull) RecoverTredisFromRocksdb(dstTplusIP string,
 	msg := fmt.Sprintf("master:%s开始导入全备", redisAddr)
 	mylog.Logger.Info(msg)
 	//再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, dstTplusPasswd, 0, consts.TendisTypeTendisSSDInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, dstTplusPasswd, 0,
+		consts.TendisTypeTendisSSDInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1381,7 +1383,8 @@ func (full *TplusFullBackPull) RecoverTredisFromRocksdb(dstTplusIP string,
 	time.Sleep(2 * time.Second)
 
 	//再次探测tendisplus连接性->拉起是否成功
-	redisCli, err = myredis.NewRedisClient(redisAddr, dstTplusPasswd, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err = myredis.NewRedisClientWithRetry(redisAddr, dstTplusPasswd, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1425,7 +1428,8 @@ func (full *TplusFullBackPull) RecoverCacheRedisFromBackupFile(sourceIP string,
 		"redis:%s from redis:%s aof or rdb ... ", newRedisAddr, oldnewRedisAddr)
 	mylog.Logger.Info(msg)
 	//再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(newRedisAddr, dstTplusPasswd, 0, consts.TendisTypeRedisInstance)
+	redisCli, err := myredis.NewRedisClientWithRetry(newRedisAddr, dstTplusPasswd, 0,
+		consts.TendisTypeRedisInstance, time.Minute)
 	if err != nil {
 		mylog.Logger.Error(err.Error())
 		full.Err = err
@@ -1588,7 +1592,8 @@ func (full *TplusFullBackPull) RecoverCacheRedisFromBackupFile(sourceIP string,
 	}
 
 	//再次探测tendisplus连接性->拉起是否成功
-	redisCli, err = myredis.NewRedisClient(newRedisAddr, dstTplusPasswd, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err = myredis.NewRedisClientWithRetry(newRedisAddr, dstTplusPasswd, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		mylog.Logger.Error("NewRedisClient failed :%v", err)
 		full.Err = err
@@ -1627,7 +1632,8 @@ func (full *TplusFullBackPull) WaitForStartRedis(dstTplusIP string, dstTplusPort
 			break
 		}
 		// NewRedisClient 这里也会去ping
-		_, err = myredis.NewRedisClient(newRedisAddr, dstTplusPasswd, 0, consts.TendisTypeRedisInstance)
+		_, err = myredis.NewRedisClientWithRetry(newRedisAddr, dstTplusPasswd, 0,
+			consts.TendisTypeRedisInstance, time.Minute)
 		if err != nil {
 			if retryTimeLimit > 0 {
 				mylog.Logger.Warn("WaitForStartRedis info:%v", err)

--- a/dbm-services/redis/db-tools/dbactuator/pkg/backupsys/rollback.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/backupsys/rollback.go
@@ -70,7 +70,8 @@ func (task *RedisInsRecoverTask) GetRedisCli() error {
 	redisAddr := fmt.Sprintf("%s:%s", task.NeWTempIP, strconv.Itoa(task.NewTmpPort))
 	msg := fmt.Sprintf("开始获取master:%s的连接...", redisAddr)
 	task.runtime.Logger.Info(msg)
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		err = fmt.Errorf("获取连接失败:%v", err)
 		task.runtime.Logger.Error(err.Error())
@@ -416,7 +417,8 @@ func (task *RedisInsRecoverTask) StopSlave() error {
 		task.runtime.Logger.Info(msg)
 
 		// 断开同步关系
-		newCli01, err := myredis.NewRedisClient(slaveNode01.Addr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+		newCli01, err := myredis.NewRedisClientWithRetry(slaveNode01.Addr, task.NewTmpPassword, 0,
+			consts.TendisTypeTendisplusInsance, time.Minute)
 		if err != nil {
 			return err
 		}
@@ -510,7 +512,8 @@ func (task *RedisInsRecoverTask) CheckDecompressedDirIsOK() (isExists, isCompele
 	msg = fmt.Sprintf("开始检查全备(已解压)目录是否存在,是否完整")
 	task.runtime.Logger.Info(msg)
 	// 测试tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return false, false, msg
 	}
@@ -739,7 +742,8 @@ func (task *RedisInsRecoverTask) RecoverSlave() error {
 	for _, slaveNode01 := range slaveNodes {
 		slaveNodeItem := slaveNode01
 		slaveAddr := slaveNodeItem.Addr
-		slaveCli02, err := myredis.NewRedisClient(slaveAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+		slaveCli02, err := myredis.NewRedisClientWithRetry(slaveAddr, task.NewTmpPassword, 0,
+			consts.TendisTypeTendisplusInsance, time.Minute)
 		if err != nil {
 			return err
 		}
@@ -957,7 +961,8 @@ func (task *RedisInsRecoverTask) RestoreFullbackup() error {
 	msg := fmt.Sprintf("master:%s开始导入全备", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1059,7 +1064,8 @@ func (task *RedisInsRecoverTask) ImportIncrBackup() error {
 	msg := fmt.Sprintf("master:%s开始导入增备(binlog)", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		task.Err = err
 		return task.Err
@@ -1089,7 +1095,8 @@ func (task *RedisInsRecoverTask) CheckRollbackResult() error {
 	msg := fmt.Sprintf("CheckRollbackResult: master:%s开始检查回档结果是否正确", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取redis连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		task.Err = err
 		return task.Err
@@ -1210,7 +1217,8 @@ func (task *RedisInsRecoverTask) SSDRestoreFullbackup() error {
 	msg := fmt.Sprintf("master:%s start recover_tredis_from_rocksdb ...", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取tendis ssd连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisSSDInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisSSDInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1234,7 +1242,8 @@ func (task *RedisInsRecoverTask) SSDImportIncrBackup() error {
 	msg := fmt.Sprintf("master:%s开始导入增备(binlog)", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisSSDInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisSSDInsance, time.Minute)
 	if err != nil {
 		task.Err = err
 		return task.Err
@@ -1257,7 +1266,8 @@ func (task *RedisInsRecoverTask) CacheRestoreFullbackup() error {
 	msg := fmt.Sprintf("master:%s start recover redis from aof/rdb ...", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取tendis ssd连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeRedisInstance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeRedisInstance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1286,7 +1296,8 @@ func (task *RedisInsRecoverTask) getNeWTempIPClusterNodes() error {
 		return err
 	}
 	// 验证节点是否可连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, password, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, password, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}

--- a/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/fullback.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/fullback.go
@@ -1157,7 +1157,8 @@ func (full *TendisFullBackPull) RestoreBackup(dstTendisIP string, dstTendisPort 
 	msg := fmt.Sprintf("master:%s开始导入全备", redisAddr)
 	mylog.Logger.Info(msg)
 	//再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, dstTendisPasswd, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, dstTendisPasswd, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1334,7 +1335,8 @@ func (full *TendisFullBackPull) RecoverTredisFromRocksdb(dstTendisIP string,
 	msg := fmt.Sprintf("master:%s开始导入全备", redisAddr)
 	mylog.Logger.Info(msg)
 	//再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, dstTendisPasswd, 0, consts.TendisTypeTendisSSDInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, dstTendisPasswd, 0,
+		consts.TendisTypeTendisSSDInsance, time.Minute)
 	if err != nil {
 		full.Err = err
 		return
@@ -1457,7 +1459,8 @@ func (full *TendisFullBackPull) RecoverTredisFromRocksdb(dstTendisIP string,
 	//再次探测tendisplus连接性->拉起是否成功
 	// 实例比较大时，可能拉起的比较慢，需要多次探测。 如果10分钟都还没拉起，那就认为失败了
 	for i := 1; i < 20; i++ {
-		redisCli, err = myredis.NewRedisClient(redisAddr, dstTendisPasswd, 0, consts.TendisTypeTendisplusInsance)
+		redisCli, err = myredis.NewRedisClientWithRetry(redisAddr, dstTendisPasswd, 0,
+			consts.TendisTypeTendisplusInsance, time.Minute)
 		if err != nil {
 			mylog.Logger.Warn("第%d/20探测%d实例是否存活失败...sleep 30s后进行下一次探测", i, dstTendisPort)
 			time.Sleep(30 * time.Second)
@@ -1508,7 +1511,8 @@ func (full *TendisFullBackPull) RecoverCacheRedisFromBackupFile(sourceIP string,
 		"redis:%s from redis:%s aof or rdb ... ", newRedisAddr, oldnewRedisAddr)
 	mylog.Logger.Info(msg)
 	//再次探测tendis连接性
-	redisCli, err := myredis.NewRedisClient(newRedisAddr, dstTendisPasswd, 0, consts.TendisTypeRedisInstance)
+	redisCli, err := myredis.NewRedisClientWithRetry(newRedisAddr, dstTendisPasswd, 0,
+		consts.TendisTypeRedisInstance, time.Minute)
 	if err != nil {
 		mylog.Logger.Error(err.Error())
 		full.Err = err
@@ -1675,7 +1679,8 @@ func (full *TendisFullBackPull) RecoverCacheRedisFromBackupFile(sourceIP string,
 	}
 
 	//再次探测tendis连接性->拉起是否成功
-	redisCli, err = myredis.NewRedisClient(newRedisAddr, dstTendisPasswd, 0, consts.TendisTypeRedisInstance)
+	redisCli, err = myredis.NewRedisClientWithRetry(newRedisAddr, dstTendisPasswd, 0,
+		consts.TendisTypeRedisInstance, time.Minute)
 	if err != nil {
 		mylog.Logger.Error("NewRedisClient failed :%v", err)
 		full.Err = err
@@ -1714,7 +1719,8 @@ func (full *TendisFullBackPull) WaitForStartRedis(dstTendisIP string, dstTendisP
 			break
 		}
 		// NewRedisClient 这里也会去ping
-		_, err = myredis.NewRedisClient(newRedisAddr, dstTendisPasswd, 0, consts.TendisTypeRedisInstance)
+		_, err = myredis.NewRedisClientWithRetry(newRedisAddr, dstTendisPasswd, 0,
+			consts.TendisTypeRedisInstance, time.Minute)
 		if err != nil {
 			if retryTimeLimit > 0 {
 				mylog.Logger.Warn("WaitForStartRedis info:%v", err)

--- a/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/rollback.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/datastructure/rollback.go
@@ -86,7 +86,8 @@ func (task *TendisInsRecoverTask) GetRedisCli() error {
 	redisAddr := fmt.Sprintf("%s:%s", task.NeWTempIP, strconv.Itoa(task.NewTmpPort))
 	msg := fmt.Sprintf("开始获取master:%s的连接...", redisAddr)
 	task.runtime.Logger.Info(msg)
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		err = fmt.Errorf("获取连接失败:%v", err)
 		task.runtime.Logger.Error(err.Error())
@@ -231,7 +232,8 @@ func (task *TendisInsRecoverTask) StopSlave() error {
 		task.runtime.Logger.Info(msg)
 
 		// 断开同步关系
-		newCli01, err := myredis.NewRedisClient(slaveNode01.Addr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+		newCli01, err := myredis.NewRedisClientWithRetry(slaveNode01.Addr, task.NewTmpPassword, 0,
+			consts.TendisTypeTendisplusInsance, time.Minute)
 		if err != nil {
 			return err
 		}
@@ -325,7 +327,8 @@ func (task *TendisInsRecoverTask) CheckDecompressedDirIsOK() (isExists, isCompel
 	msg = fmt.Sprintf("开始检查全备(已解压)目录是否存在,是否完整")
 	task.runtime.Logger.Info(msg)
 	// 测试tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return false, false, msg
 	}
@@ -554,7 +557,8 @@ func (task *TendisInsRecoverTask) RecoverSlave() error {
 	for _, slaveNode01 := range slaveNodes {
 		slaveNodeItem := slaveNode01
 		slaveAddr := slaveNodeItem.Addr
-		slaveCli02, err := myredis.NewRedisClient(slaveAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+		slaveCli02, err := myredis.NewRedisClientWithRetry(slaveAddr, task.NewTmpPassword, 0,
+			consts.TendisTypeTendisplusInsance, time.Minute)
 		if err != nil {
 			return err
 		}
@@ -773,7 +777,8 @@ func (task *TendisInsRecoverTask) RestoreFullbackup() error {
 	msg := fmt.Sprintf("master:%s开始导入全备", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -874,7 +879,8 @@ func (task *TendisInsRecoverTask) ImportIncrBackup() error {
 	msg := fmt.Sprintf("master:%s开始导入增备(binlog)", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		task.Err = err
 		return task.Err
@@ -904,7 +910,8 @@ func (task *TendisInsRecoverTask) CheckRollbackResult() error {
 	msg := fmt.Sprintf("CheckRollbackResult: master:%s开始检查回档结果是否正确", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取redis连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		task.Err = err
 		return task.Err
@@ -988,7 +995,7 @@ func (task *TendisInsRecoverTask) CheckTendisRollbackResult() error {
 	msg := fmt.Sprintf("CheckTendisRollbackResult: master:%s开始检查回档结果是否正确", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取redis连接
-	redisCli, err := myredis.NewRedisClientWithTimeout(redisAddr, task.NewTmpPassword, 0,
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
 		consts.TendisTypeRedisInstance, 5*time.Second)
 	if err != nil {
 		task.Err = err
@@ -1114,7 +1121,8 @@ func (task *TendisInsRecoverTask) SSDRestoreFullbackup() error {
 	msg := fmt.Sprintf("master:%s start recover_tredis_from_rocksdb ...", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取tendis ssd连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisSSDInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisSSDInsance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1138,7 +1146,8 @@ func (task *TendisInsRecoverTask) SSDImportIncrBackup() error {
 	msg := fmt.Sprintf("master:%s开始导入增备(binlog)", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 再次探测tendisplus连接性
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeTendisSSDInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeTendisSSDInsance, time.Minute)
 	if err != nil {
 		task.Err = err
 		return task.Err
@@ -1161,7 +1170,8 @@ func (task *TendisInsRecoverTask) CacheRestoreFullbackup() error {
 	msg := fmt.Sprintf("master:%s start recover redis from aof/rdb ...", redisAddr)
 	task.runtime.Logger.Info(msg)
 	// 获取tendis 连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, task.NewTmpPassword, 0, consts.TendisTypeRedisInstance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, task.NewTmpPassword, 0,
+		consts.TendisTypeRedisInstance, time.Minute)
 	if err != nil {
 		return err
 	}
@@ -1190,7 +1200,8 @@ func (task *TendisInsRecoverTask) getNeWTempIPClusterNodes() error {
 		return err
 	}
 	// 验证节点是否可连接
-	redisCli, err := myredis.NewRedisClient(redisAddr, password, 0, consts.TendisTypeTendisplusInsance)
+	redisCli, err := myredis.NewRedisClientWithRetry(redisAddr, password, 0,
+		consts.TendisTypeTendisplusInsance, time.Minute)
 	if err != nil {
 		return err
 	}

--- a/dbm-services/redis/db-tools/dbactuator/tests/redistest/redis_dts_datacheck.go
+++ b/dbm-services/redis/db-tools/dbactuator/tests/redistest/redis_dts_datacheck.go
@@ -170,14 +170,14 @@ func genSomeDiffKeys(srcAddr, srcPassword, dstAddr, dtsPassword string) {
 	var err error
 	var masterCli, slaveCli *myredis.RedisClient
 	var member *redis.Z
-	masterCli, err = myredis.NewRedisClientWithTimeout(srcAddr, srcPassword, 0,
+	masterCli, err = myredis.NewRedisClientWithRetry(srcAddr, srcPassword, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return
 	}
 	defer masterCli.Close()
 
-	slaveCli, err = myredis.NewRedisClientWithTimeout(dstAddr, dtsPassword, 0,
+	slaveCli, err = myredis.NewRedisClientWithRetry(dstAddr, dtsPassword, 0,
 		consts.TendisTypeRedisInstance, 10*time.Second)
 	if err != nil {
 		return

--- a/dbm-ui/backend/db_report/views/redis/redis_recover_drill_view.py
+++ b/dbm-ui/backend/db_report/views/redis/redis_recover_drill_view.py
@@ -12,7 +12,6 @@ specific language governing permissions and limitations under the License.
 import logging
 from functools import cached_property
 
-from django.db.models import OuterRef, Subquery
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
@@ -24,8 +23,6 @@ from backend.db_report.serializers import ReportCommonFieldSerializerMixin
 from backend.db_report.views.revover_drill_report_view import RecoverDrillTaskViewSet
 from backend.db_services.redis.rollback.config import RedisRollbackExerciseConfig
 from backend.env import BK_SAAS_HOST
-from backend.ticket.constants import FlowType
-from backend.ticket.models import Flow
 
 logger = logging.getLogger("root")
 
@@ -37,7 +34,7 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
     recover_duration = serializers.SerializerMethodField(help_text=_("恢复花费时间(分钟)"))
     rollback_flow_link = serializers.SerializerMethodField(help_text=_("构造流程链接"))
     delete_flow_link = serializers.SerializerMethodField(help_text=_("销毁流程链接"))
-    ticket_flow_link = serializers.SerializerMethodField(help_text=_("单据流程链接"))
+    ticket_link = serializers.SerializerMethodField(help_text=_("单据链接"))
 
     def get_instance(self, obj):
         """Combine ip:port as instance"""
@@ -75,14 +72,11 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
             return None
         return f"{BK_SAAS_HOST}/{bk_biz_id}/task-history/detail/{obj.delete_flow_obj_id}?from=taskHistoryList"
 
-    def get_ticket_flow_link(self, obj):
-        """Generate ticket flow link"""
+    def get_ticket_link(self, obj):
+        """Generate ticket link"""
         if not obj.ticket_id or not obj.bk_biz_id:
             return None
-        flow_obj_id = getattr(obj, "ticket_flow_obj_id", "")
-        if not flow_obj_id:
-            return None
-        return f"{BK_SAAS_HOST}/{obj.bk_biz_id}/task-history/detail/{flow_obj_id}?from=taskHistoryList"
+        return f"{BK_SAAS_HOST}/ticket/{obj.ticket_id}"
 
     class Meta:
         model = RedisRollbackExerciseReport
@@ -96,7 +90,7 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
             "recover_start_time",
             "recover_duration",
             "state",
-            "ticket_flow_link",
+            "ticket_link",
             "rollback_flow_link",
             "delete_flow_link",
             "task_message",
@@ -108,24 +102,17 @@ class RedisRecoverDrillTaskSerializer(serializers.ModelSerializer, ReportCommonF
 class RedisRecoverDrillTaskViewSet(RecoverDrillTaskViewSet):
     """Redis recover drill task viewset"""
 
-    ticket_flow_obj_id_subquery = Flow.objects.filter(
-        ticket_id=OuterRef("ticket_id"), flow_type=FlowType.INNER_FLOW
-    ).values("flow_obj_id")[:1]
-    queryset = (
-        RedisRollbackExerciseReport.objects.filter(
-            task_stage__in=[
-                RedisRollbackExerciseTaskStage.DONE,
-                RedisRollbackExerciseTaskStage.TICKET_GEN_FAILED,
-                RedisRollbackExerciseTaskStage.RESOURCE_APPLI_FAILED,
-                RedisRollbackExerciseTaskStage.ROLLBACK_FAILED,
-                RedisRollbackExerciseTaskStage.CLEANUP_FAILED,
-                RedisRollbackExerciseTaskStage.SKIPPED,
-                RedisRollbackExerciseTaskStage.BACKUP_INVALID,
-            ]
-        )
-        .annotate(ticket_flow_obj_id=Subquery(ticket_flow_obj_id_subquery))
-        .order_by("-update_at")
-    )
+    queryset = RedisRollbackExerciseReport.objects.filter(
+        task_stage__in=[
+            RedisRollbackExerciseTaskStage.DONE,
+            RedisRollbackExerciseTaskStage.TICKET_GEN_FAILED,
+            RedisRollbackExerciseTaskStage.RESOURCE_APPLI_FAILED,
+            RedisRollbackExerciseTaskStage.ROLLBACK_FAILED,
+            RedisRollbackExerciseTaskStage.CLEANUP_FAILED,
+            RedisRollbackExerciseTaskStage.SKIPPED,
+            RedisRollbackExerciseTaskStage.BACKUP_INVALID,
+        ]
+    ).order_by("-update_at")
     serializer_class = RedisRecoverDrillTaskSerializer
 
     filter_fields = {
@@ -190,8 +177,8 @@ class RedisRecoverDrillTaskViewSet(RecoverDrillTaskViewSet):
             "format": ReportFieldFormat.STATUS.value,
         },
         {
-            "name": "ticket_flow_link",
-            "display_name": _("单据流程链接"),
+            "name": "ticket_link",
+            "display_name": _("单据链接"),
             "format": ReportFieldFormat.LINK.value,
         },
         {

--- a/dbm-ui/backend/tests/db_report/views/redis/test_redis_recover_drill_view.py
+++ b/dbm-ui/backend/tests/db_report/views/redis/test_redis_recover_drill_view.py
@@ -7,7 +7,6 @@ def _make_report_row(bk_biz_id=100):
     return SimpleNamespace(
         bk_biz_id=bk_biz_id,
         ticket_id=123,
-        ticket_flow_obj_id="ticket-root",
         rollback_flow_obj_id="rollback-root",
         delete_flow_obj_id="delete-root",
     )
@@ -55,26 +54,20 @@ def test_redis_rollback_exercise_flow_links_fallback_to_report_biz_when_config_u
         )
 
 
-def test_redis_rollback_exercise_ticket_flow_link_uses_annotated_flow_obj_id():
+def test_redis_rollback_exercise_ticket_link():
     from backend.db_report.views.redis import redis_recover_drill_view as view
 
     serializer = view.RedisRecoverDrillTaskSerializer()
     obj = _make_report_row(bk_biz_id=100)
 
-    with patch("backend.db_report.views.redis.redis_recover_drill_view.Flow") as flow:
-        assert (
-            serializer.get_ticket_flow_link(obj)
-            == f"{view.BK_SAAS_HOST}/100/task-history/detail/ticket-root?from=taskHistoryList"
-        )
-
-    flow.objects.filter.assert_not_called()
+    assert serializer.get_ticket_link(obj) == f"{view.BK_SAAS_HOST}/ticket/123"
 
 
-def test_redis_rollback_exercise_ticket_flow_link_missing_annotation_returns_none():
+def test_redis_rollback_exercise_ticket_link_missing_ticket_id_returns_none():
     from backend.db_report.views.redis import redis_recover_drill_view as view
 
     serializer = view.RedisRecoverDrillTaskSerializer()
     obj = _make_report_row(bk_biz_id=100)
-    obj.ticket_flow_obj_id = ""
+    obj.ticket_id = 0
 
-    assert serializer.get_ticket_flow_link(obj) is None
+    assert serializer.get_ticket_link(obj) is None


### PR DESCRIPTION
## 解决什么

- redis client 连接重试语义混用，导致在线切换/proxy 升级因隐式长重试拉长停机并误判进程状态，而部分恢复/集群组建链路又因默认值翻转误失重试；同时演练报表「单据链接」跳错目标

## 具体改动

- **重试语义两套混用**：`NewRedisClient` 收敛为单次连接（不重试，用于探活/确认进程已停），`NewRedisClientWithTimeout` 更名 `NewRedisClientWithRetry` 并持有显式总预算；go-redis `MaxRetries` 统一 `-1`，重试只走外层循环 → 语义清晰、调用方按需选择
- **探活被长重试拖慢/误判**：`IsProxyAlive`/`IsSrcProxyConnected` 及 predixy info/version 改单次探测，`connection refused` 即时返回 → 不再把 dbmon 重启窗口误判为 proxy 仍在，缩短切换停机
- **切换中途竞态与备份覆盖**：`RedisDtsOnlineSwitch` 入口对所有分支先 `StopBkDbmon`、成功收尾才 `StartBkDbmon`；proxy 配置文件/目录备份加纳秒级时间戳、已存在即报错 → 杜绝 dbmon 把旧 proxy 拉回、避免多次切换互相覆盖
- **进程刚启动探活被打回**：`proxy_upgrade`/`proxy_reuse`/`predixy_add_modules` 的 startProxy 探活改回 `NewRedisClientWithRetry` → 吸收 `start_predixy.sh` 返回到端口 bind 间的瞬时 refused
- **恢复/组建链路误失重试**：cluster-meet 连通性门、回档/全备恢复、DR restore 等连「正在拉起实例」的调用恢复 `NewRedisClientWithRetry`（已起实例的稳态操作、自带轮询循环的保持单次）
- **演练报表跳错链接**：`ticket_flow_link` 改为 `ticket_link` 直跳单据详情，移除多余的 `INNER_FLOW` `Subquery` annotate

## 测试 & 风险

- 新增 `client_test.go`（NoRetry 快速失败 / WithRetry 显式预算两条路径）与 `redis_dts_online_switch_test.go`（时间戳备份命名、端口关闭时 `IsProxyAlive` 即时返回）；`test_redis_recover_drill_view.py` 同步调整
- 跨 ~70 处调用按「探活/稳态→单次，等待拉起→重试」重新归类；中途重试日志由 Error 降级为 Warn（预算耗尽终态仍 Error）
- DTS 切换失败后 dbmon 不自动拉起，需人工介入；报表 `ticket_flow_link` 字段更名为 `ticket_link`（前端取数字段变更）