### PR TITLE
refactor(mongodb): mongodb-flow 优化与 upgrade 两阶段守卫 #17908

### DIFF
--- a/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/instance_op.go
+++ b/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/instance_op.go
@@ -30,6 +30,11 @@ type instOpParams struct {
 	GracefulStop   *bool  `json:"gracefulStop,omitempty"`
 	SetName        string `json:"set_name,omitempty"`
 	CurrentVersion string `json:"currentVersion,omitempty"`
+	// 滚动升级两阶段守卫字段（仅升级流程下传）：
+	// UpgradePhase=secondary|primary，DestVersion 用于决策文件归属校验，InstanceType 用于识别 mongos（无主从、不守卫）。
+	UpgradePhase string `json:"upgradePhase,omitempty"`
+	DestVersion  string `json:"destVersion,omitempty"`
+	InstanceType string `json:"instanceType,omitempty"`
 	// OldFullVersion mongodb-x.y.z (upgrade hop source); used by backup_mongodata directory name.
 	OldFullVersion   string `json:"oldFullVersion,omitempty"`
 	GrantRolesToUser struct {
@@ -64,6 +69,29 @@ func (s *instOpJob) Name() string {
 func (s *instOpJob) Run() error {
 	var op = s.GetInstanceOp()
 	s.runtime.Logger.Info("do op %s", s.ConfParams.Op)
+	// 这一段是升级操作特有逻辑，非升级操作时，UpgradePhase为空，直接跳过，不进入下方主 switch。
+	// 滚动升级两阶段守卫：shield_dbmon 是决策点，mongod 在线时一次性判定并持久化跳过决策；
+	// 升级序列其余步骤复用该决策文件。被判定跳过时直接成功返回(no-op)，不进入下方主 switch。
+	if s.ConfParams.UpgradePhase != "" {
+		var (
+			skip bool
+			err  error
+		)
+		switch s.ConfParams.Op {
+		case "shield_dbmon":
+			skip, err = s.decideAndCheckUpgradePhase()
+		case "stop", "start", "backup_mongodata", "service_status_check", "unblock_dbmon":
+			skip, err = upgradePhaseShouldSkip(s.ConfParams.Port, s.ConfParams.UpgradePhase, s.ConfParams.DestVersion)
+		}
+		if err != nil {
+			return err
+		}
+		if skip {
+			s.runtime.Logger.Info("upgrade phase %s: skip op %s for %s:%d",
+				s.ConfParams.UpgradePhase, s.ConfParams.Op, s.ConfParams.IP, s.ConfParams.Port)
+			return nil
+		}
+	}
 	switch s.ConfParams.Op {
 	case "rs_remove_other_node":
 		// remove me from the replica set
@@ -117,7 +145,24 @@ func (s *instOpJob) Run() error {
 		return op.DoFlushRouterConfig()
 	case "service_status_check":
 		// 检查服务状态
-		return op.DoServiceStatusCheck(s.runtime.Logger)
+		if err := op.DoServiceStatusCheck(s.runtime.Logger); err != nil {
+			return err
+		}
+		// 升级链最后一步成功后清理决策文件（best-effort）：本成员本阶段升级真实完成。
+		// 跳过分支不在此清理：旧标签靠 (phase, destVersion) 自然失效，下一阶段 / 下一 hop 的 shield 会覆盖。
+		// 失败仅记 warn，不阻断已成功的升级路径。
+		if s.ConfParams.UpgradePhase != "" {
+			path := upgradePhaseDecisionFile(s.ConfParams.Port)
+			if rmErr := os.Remove(path); rmErr != nil {
+				if !os.IsNotExist(rmErr) {
+					s.runtime.Logger.Warn("cleanup upgrade phase decision file failed (ignored): %s", rmErr)
+				}
+			} else {
+				s.runtime.Logger.Info("removed upgrade phase decision file: %s:%d path=%s",
+					s.ConfParams.IP, s.ConfParams.Port, path)
+			}
+		}
+		return nil
 	case "backup_mongodata":
 		return s.doBackupMongodata()
 	case "precheck_upgrade":
@@ -267,6 +312,97 @@ func (s *instOpJob) doStopDbmon() error {
 		return errors.Wrap(err, "stop dbmon failed")
 	}
 	return nil
+}
+
+// decideAndCheckUpgradePhase 仅在升级序列首个步骤(shield_dbmon)被调用：此时 mongod 仍在线，
+// 一次性判定本成员在本阶段是否需要跳过，并把决策持久化供后续步骤读取。返回值为本步骤是否跳过。
+func (s *instOpJob) decideAndCheckUpgradePhase() (bool, error) {
+	phase := strings.TrimSpace(s.ConfParams.UpgradePhase)
+	if phase == "" {
+		return false, nil
+	}
+	// mongos 无主从概念，不做角色守卫，恒执行。
+	if strings.EqualFold(s.ConfParams.InstanceType, "mongos") {
+		if err := writeUpgradePhaseDecision(s.ConfParams.Port, phase, s.ConfParams.DestVersion, false); err != nil {
+			return false, errors.Wrap(err, "writeUpgradePhaseDecision(mongos)")
+		}
+		s.runtime.Logger.Info("wrote upgrade phase decision file (mongos): %s:%d phase=%s destVersion=%s skip=false path=%s",
+			s.ConfParams.IP, s.ConfParams.Port, phase, s.ConfParams.DestVersion, upgradePhaseDecisionFile(s.ConfParams.Port))
+		return false, nil
+	}
+	// 是否已是目标版本（运行期实测）：阶段2据此判定，避免“角色被改写后误跳过未升级节点”。
+	runningMM, err := s.getRunningVersionMajorMinor()
+	if err != nil {
+		return false, errors.Wrap(err, "get running version for upgrade phase decide")
+	}
+	destMM := versionMajorMinor(s.ConfParams.DestVersion)
+	alreadyTarget := runningMM != "" && runningMM == destMM
+
+	var skip bool
+	switch phase {
+	case UpgradePhaseSecondary:
+		// 升 secondary 阶段：已是目标版本则跳过（幂等重试）；否则运行期为 PRIMARY 的节点本阶段跳过（留到阶段2最后升）。
+		if alreadyTarget {
+			skip = true
+		} else {
+			isMaster, merr := s.GetInstanceOp().IsMasterDirect()
+			if merr != nil {
+				return false, errors.Wrap(merr, "IsMasterDirect for upgrade phase decide")
+			}
+			skip = isMaster.IsMaster
+		}
+	case UpgradePhasePrimary:
+		// 升 primary 阶段：以“是否已是目标版本”判定，而非角色。仍为旧版本的节点（正常即旧 primary）才真正执行，
+		// 其 stop 由 stepDownIfPrimary 决定是否 stepDown（整 hop 至多一次）；已是目标版本的节点跳过(no-op)。
+		// 这样即使阶段间发生选主导致角色翻转，未升级的节点也不会被误跳过。
+		skip = alreadyTarget
+	default:
+		return false, fmt.Errorf("unknown upgradePhase %q", phase)
+	}
+	if err := writeUpgradePhaseDecision(s.ConfParams.Port, phase, s.ConfParams.DestVersion, skip); err != nil {
+		return false, errors.Wrap(err, "writeUpgradePhaseDecision")
+	}
+	s.runtime.Logger.Info("wrote upgrade phase decision file: %s:%d phase=%s destVersion=%s skip=%v path=%s",
+		s.ConfParams.IP, s.ConfParams.Port, phase, s.ConfParams.DestVersion, skip,
+		upgradePhaseDecisionFile(s.ConfParams.Port))
+	s.runtime.Logger.Info("upgrade phase %s decided for %s:%d runningMM=%s destMM=%s alreadyTarget=%v skip=%v",
+		phase, s.ConfParams.IP, s.ConfParams.Port, runningMM, destMM, alreadyTarget, skip)
+	return skip, nil
+}
+
+// getRunningVersionMajorMinor 通过 buildInfo 读取在线 mongod 的运行版本并归一化为 "M.m"，
+// 供升级阶段守卫判定该成员是否“已是目标版本”。复用 doPrecheckUpgrade 的查询方式。
+// 滚动升级期间整集群可能发生选主/瞬时连接失败，因此重试 3 次（间隔 2s）后再判失败，
+// 避免单次抖动让 alreadyTarget 判错而误跳过未升级节点。
+func (s *instOpJob) getRunningVersionMajorMinor() (string, error) {
+	mongoBin := filepath.Join(consts.GetMongoBinDir(), "mongodb", "bin", "mongo")
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		ret, err := mycmd.New(
+			mongoBin,
+			"-u", s.ConfParams.AdminUsername,
+			"-p", mycmd.Password(s.ConfParams.AdminPassword),
+			"--host", s.ConfParams.IP,
+			"--port", strconv.Itoa(s.ConfParams.Port),
+			"--authenticationDatabase=admin",
+			"--quiet",
+			"--eval", "db.adminCommand({buildInfo:1}).version",
+			"admin",
+		).Run(60 * time.Second)
+		if err == nil {
+			return versionMajorMinor(strings.TrimSpace(ret.GetStdout())), nil
+		}
+		lastErr = fmt.Errorf(
+			"get buildInfo version failed (attempt %d/%d): cmd=%q exitCode=%d err=%v stdout=%q stderr=%q",
+			attempt, maxAttempts, ret.Cmdline, ret.ExitCode, err, ret.GetStdout(), ret.GetStderr(),
+		)
+		s.runtime.Logger.Warn("%s", lastErr.Error())
+		if attempt < maxAttempts {
+			time.Sleep(2 * time.Second)
+		}
+	}
+	return "", lastErr
 }
 
 func (s *instOpJob) doShieldDbmon() error {

--- a/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/replace_package.go
+++ b/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/replace_package.go
@@ -22,6 +22,8 @@ type ReplacePackageConfParams struct {
 	CurrentVersion  string `json:"currentVersion" validate:"required"` // 当前版本
 	DestVersion     string `json:"destVersion" validate:"required"`    // 目标版本
 	InstanceType    string `json:"instanceType" validate:"required"`   // mongos mongod
+	// UpgradePhase 滚动升级两阶段守卫（仅升级流程下传，secondary|primary）：本成员本阶段被判定跳过时直接返回(no-op)。
+	UpgradePhase string `json:"upgradePhase,omitempty"`
 }
 
 // ReplacePackage 安装包替换
@@ -54,6 +56,19 @@ func (r *ReplacePackage) Name() string {
 // 2. 解压安装包并修改属主，重建软链接
 // 3. 检测当前db版本，如果当前版本不是目标版本，则返回错误
 func (r *ReplacePackage) Run() error {
+	// 滚动升级两阶段守卫：读取 shield 阶段持久化的决策，本成员本阶段被判定跳过时直接返回(no-op)。
+	// 注意：此处使用未去前缀的原始 DestVersion，与决策文件写入时保持一致。
+	if r.ConfParams.UpgradePhase != "" {
+		skip, err := upgradePhaseShouldSkip(r.ConfParams.Port, r.ConfParams.UpgradePhase, r.ConfParams.DestVersion)
+		if err != nil {
+			return err
+		}
+		if skip {
+			r.runtime.Logger.Info("upgrade phase %s: skip replace_package for %s:%d",
+				r.ConfParams.UpgradePhase, r.ConfParams.IP, r.ConfParams.Port)
+			return nil
+		}
+	}
 	// fetch File Lock
 	fileLock, err := common.NewFileLock(r.LockFilePath)
 	if err != nil {

--- a/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/upgrade_phase_guard.go
+++ b/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/upgrade_phase_guard.go
@@ -1,0 +1,79 @@
+package atommongodb
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"dbm-services/mongodb/db-tools/dbactuator/pkg/consts"
+)
+
+// 滚动升级两阶段守卫：
+// 每个 hop 内先升 secondary、最后升 primary，使整个 hop 只发生一次 stepDown。
+// 由于一个成员的升级要跨越 shield/stop/backup/replace/start/unblock/check 多个原子步骤，
+// 且过程中 mongod 会被停掉、节点角色/版本会发生变化（primary 经自身 stop+stepDown 后变为 secondary），
+// 因此不能在每个步骤各自实时判定角色。
+// 解决方式：在第一个步骤（shield_dbmon，此时 mongod 仍在线）一次性判定并把"是否跳过"持久化到决策文件，
+// 后续所有步骤（含以 root 运行的 replace_package）只读取该决策文件，保证整段升级动作语义一致。
+
+const (
+	// UpgradePhaseSecondary 升 secondary 阶段：运行期为 PRIMARY 的节点跳过。
+	UpgradePhaseSecondary = "secondary"
+	// UpgradePhasePrimary 升 primary 阶段：已是目标版本的节点跳过（基于版本而非角色判定，避免阶段间选主导致未升级节点被误跳过）；
+	// 仍为旧版本的节点（正常即旧 primary）真正执行，其 stop 触发整 hop 唯一一次 stepDown。
+	UpgradePhasePrimary = "primary"
+)
+
+type upgradePhaseDecision struct {
+	Phase       string `json:"phase"`
+	DestVersion string `json:"destVersion"`
+	Skip        bool   `json:"skip"`
+}
+
+// upgradePhaseDecisionFile 决策文件路径，落在实例数据目录下（mysql 属主可写、root 可读）。
+func upgradePhaseDecisionFile(port int) string {
+	return filepath.Join(consts.GetMongoDataDir(), "mongodata", strconv.Itoa(port), ".dbm_upgrade_phase.json")
+}
+
+// writeUpgradePhaseDecision 在 mongod 在线时持久化本成员在本阶段的跳过决策，供后续步骤读取。
+// 采用 write-to-temp + rename 模式：rename(2) 在同文件系统上是原子的，
+// 进程被 kill 时读侧永远只会看到旧文件、新文件或文件不存在，不会读到半截/空 JSON。
+// 这是必要前提——upgradePhaseShouldSkip 在 unmarshal 失败时 fail-open（按"执行"处理），
+// 若读到坏文件会让本该跳过的 PRIMARY 重新走 stop+stepDown，违反"每 hop 仅一次 stepDown"。
+func writeUpgradePhaseDecision(port int, phase, destVersion string, skip bool) error {
+	d := upgradePhaseDecision{Phase: phase, DestVersion: destVersion, Skip: skip}
+	b, err := json.Marshal(&d)
+	if err != nil {
+		return err
+	}
+	path := upgradePhaseDecisionFile(port)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// upgradePhaseShouldSkip 读取已持久化的阶段决策；缺失或与当前 (phase,destVersion) 不匹配时返回 false（兜底为执行，不误跳过升级）。
+func upgradePhaseShouldSkip(port int, phase, destVersion string) (bool, error) {
+	if strings.TrimSpace(phase) == "" {
+		return false, nil
+	}
+	b, err := os.ReadFile(upgradePhaseDecisionFile(port))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	var d upgradePhaseDecision
+	if err := json.Unmarshal(b, &d); err != nil {
+		return false, nil
+	}
+	if d.Phase != phase || d.DestVersion != destVersion {
+		return false, nil
+	}
+	return d.Skip, nil
+}

--- a/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/upgrade_phase_guard_test.go
+++ b/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/upgrade_phase_guard_test.go
@@ -1,0 +1,141 @@
+package atommongodb
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// setupGuardTestDir 把决策文件根目录指向独立 temp dir，并预创建 mongodata/<port>/。
+// upgradePhaseDecisionFile 通过 consts.GetMongoDataDir() → MONGO_DATA_DIR 环境变量定位文件，
+// 这里用 t.Setenv 隔离避免污染实际 /data1。
+func setupGuardTestDir(t *testing.T, port int) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("MONGO_DATA_DIR", root)
+	if err := os.MkdirAll(filepath.Join(root, "mongodata", strconv.Itoa(port)), 0755); err != nil {
+		t.Fatalf("mkdir mongodata/%d failed: %v", port, err)
+	}
+}
+
+func TestUpgradePhase_WriteAndReadRoundTrip(t *testing.T) {
+	const port = 27001
+	setupGuardTestDir(t, port)
+
+	if err := writeUpgradePhaseDecision(port, UpgradePhaseSecondary, "mongodb-3.6.23", true); err != nil {
+		t.Fatalf("write skip=true failed: %v", err)
+	}
+	skip, err := upgradePhaseShouldSkip(port, UpgradePhaseSecondary, "mongodb-3.6.23")
+	if err != nil {
+		t.Fatalf("read after write skip=true err: %v", err)
+	}
+	if !skip {
+		t.Fatalf("expect skip=true, got false")
+	}
+
+	// 覆盖写：skip=false 应被原样读出。
+	if err := writeUpgradePhaseDecision(port, UpgradePhaseSecondary, "mongodb-3.6.23", false); err != nil {
+		t.Fatalf("overwrite skip=false failed: %v", err)
+	}
+	skip, err = upgradePhaseShouldSkip(port, UpgradePhaseSecondary, "mongodb-3.6.23")
+	if err != nil {
+		t.Fatalf("read after overwrite err: %v", err)
+	}
+	if skip {
+		t.Fatalf("expect skip=false after overwrite, got true")
+	}
+}
+
+func TestUpgradePhase_FileNotExist(t *testing.T) {
+	const port = 27002
+	setupGuardTestDir(t, port)
+	// 不写入，文件不存在。
+	skip, err := upgradePhaseShouldSkip(port, UpgradePhaseSecondary, "mongodb-3.6.23")
+	if err != nil {
+		t.Fatalf("missing file should not error, got: %v", err)
+	}
+	if skip {
+		t.Fatalf("missing file must fail-open (skip=false), got true")
+	}
+}
+
+func TestUpgradePhase_CorruptedJSON(t *testing.T) {
+	const port = 27003
+	setupGuardTestDir(t, port)
+	// 写入坏字节模拟进程被 kill 残留半截文件（虽然修复后此场景不该出现，仍要兜底为不跳过）。
+	if err := os.WriteFile(upgradePhaseDecisionFile(port), []byte("{not-json"), 0644); err != nil {
+		t.Fatalf("seed corrupted file failed: %v", err)
+	}
+	skip, err := upgradePhaseShouldSkip(port, UpgradePhaseSecondary, "mongodb-3.6.23")
+	if err != nil {
+		t.Fatalf("corrupted file should not error, got: %v", err)
+	}
+	if skip {
+		t.Fatalf("corrupted file must fail-open (skip=false), got true")
+	}
+}
+
+func TestUpgradePhase_PhaseMismatch(t *testing.T) {
+	const port = 27004
+	setupGuardTestDir(t, port)
+	if err := writeUpgradePhaseDecision(port, UpgradePhaseSecondary, "mongodb-3.6.23", true); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	// 同 destVersion，不同 phase：旧标签应被忽略。
+	skip, err := upgradePhaseShouldSkip(port, UpgradePhasePrimary, "mongodb-3.6.23")
+	if err != nil {
+		t.Fatalf("phase mismatch read err: %v", err)
+	}
+	if skip {
+		t.Fatalf("phase mismatch must return skip=false, got true")
+	}
+}
+
+func TestUpgradePhase_DestVersionMismatch(t *testing.T) {
+	const port = 27005
+	setupGuardTestDir(t, port)
+	if err := writeUpgradePhaseDecision(port, UpgradePhaseSecondary, "mongodb-3.6.23", true); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	// 同 phase，不同 destVersion：跨 hop 残留旧标签应被忽略，避免下一阶段误跳过。
+	skip, err := upgradePhaseShouldSkip(port, UpgradePhaseSecondary, "mongodb-4.0.26")
+	if err != nil {
+		t.Fatalf("destVersion mismatch read err: %v", err)
+	}
+	if skip {
+		t.Fatalf("destVersion mismatch must return skip=false, got true")
+	}
+}
+
+func TestUpgradePhase_EmptyPhaseShortCircuit(t *testing.T) {
+	const port = 27006
+	setupGuardTestDir(t, port)
+	// 即使文件存在 skip=true，调用方传入空 phase 也必须立刻返回 false（非升级链路不启用守卫）。
+	if err := writeUpgradePhaseDecision(port, UpgradePhaseSecondary, "mongodb-3.6.23", true); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	skip, err := upgradePhaseShouldSkip(port, "", "mongodb-3.6.23")
+	if err != nil {
+		t.Fatalf("empty phase read err: %v", err)
+	}
+	if skip {
+		t.Fatalf("empty phase must short-circuit to skip=false, got true")
+	}
+}
+
+func TestUpgradePhase_AtomicWriteNoTmpLeak(t *testing.T) {
+	const port = 27007
+	setupGuardTestDir(t, port)
+	if err := writeUpgradePhaseDecision(port, UpgradePhaseSecondary, "mongodb-3.6.23", true); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	tmp := upgradePhaseDecisionFile(port) + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Fatalf(".tmp must be renamed away after successful write, stat err=%v", err)
+	}
+	final := upgradePhaseDecisionFile(port)
+	if _, err := os.Stat(final); err != nil {
+		t.Fatalf("final file must exist after write, err=%v", err)
+	}
+}

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/mongodb_install_dbmon.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/mongodb_install_dbmon.py
@@ -19,7 +19,7 @@ from backend import env
 from backend.configuration.constants import DBType
 from backend.db_package.models import Package
 from backend.flow.consts import MediumEnum
-from backend.flow.engine.bamboo.scene.common.builder import Builder
+from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.mongodb.base_flow import MongoBaseFlow
 from backend.flow.engine.bamboo.scene.mongodb.sub_task.install_dbmon_sub import (
     InstallDBMonSubTask,
@@ -101,12 +101,15 @@ def add_install_dbmon(root_id, flow_data, pipeline, iplist, bk_cloud_id, allow_e
         if not sub_bk_host_list:
             raise Exception("sub_bk_host_list is None")
         bk_host_list.extend(sub_bk_host_list)
-        sub_pipelines.append(sub_pl.build_sub_process(_("dbmon-{}").format(ip)))
+        sub_pipelines.append(sub_pl.build_sub_process(_("安装dbmon-{}").format(ip)))
+
+    # 将安装dbmon相关的动作封装为一个独立子流程，使其在外层流程中作为一个整体节点
+    dbmon_pipeline = SubBuilder(root_id=root_id, data=flow_data)
 
     # 介质下发，包括actuator+dbmon+dbtools
-    pipeline.add_act(
+    dbmon_pipeline.add_act(
         **SendMedia.act(
-            act_name=_("CpFile: actuator+dbmon+dbtools+toolkit"),
+            act_name=_("下发介质(actuator/dbmon/dbtools/toolkit)"),
             file_list=file_list,
             bk_host_list=bk_host_list,
             file_target_path=actuator_workdir,
@@ -114,7 +117,7 @@ def add_install_dbmon(root_id, flow_data, pipeline, iplist, bk_cloud_id, allow_e
     )
 
     # 安装流程中，由prepare_instance_info来填充servers信息. 数据写在global_data -> 'ip' -> instances 中
-    pipeline.add_act(
+    dbmon_pipeline.add_act(
         **PrepareInstanceInfo.process_iplist(
             bk_cloud_id=bk_cloud_id,
             iplist=iplist,
@@ -125,7 +128,9 @@ def add_install_dbmon(root_id, flow_data, pipeline, iplist, bk_cloud_id, allow_e
     )
 
     # 并行执行actuator
-    pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
+    dbmon_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
+
+    pipeline.add_sub_pipeline(sub_flow=dbmon_pipeline.build_sub_process(sub_name=_("安装dbmon")))
 
 
 class MongoInstallDBMonFlow(MongoBaseFlow):

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/mongodb_upgrade_version.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/mongodb_upgrade_version.py
@@ -259,12 +259,16 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
         def rs_members(rs: ReplicaSet) -> List[MongoNode]:
             return [n for n in [rs.get_backup_node(), *rs.get_not_backup_nodes()] if n]
 
+        def rs_group(name: str, rs: ReplicaSet) -> Dict:
+            # not_backup 为数据承载成员（其中运行期恰有一个 primary），用于升级阶段2只升 primary。
+            return {"name": name, "members": rs_members(rs), "not_backup": list(rs.get_not_backup_nodes())}
+
         groups = {"replicasets": [], "mongos": []}
         if cluster.cluster_type == ClusterType.MongoReplicaSet:
-            groups["replicasets"].append({"name": cluster.name, "members": rs_members(cluster.get_shards()[0])})
+            groups["replicasets"].append(rs_group(cluster.name, cluster.get_shards()[0]))
         elif cluster.cluster_type == ClusterType.MongoShardedCluster:
             for shard in cluster.get_shards(with_config=True, sort_by_set_name=True):
-                groups["replicasets"].append({"name": shard.set_name, "members": rs_members(shard)})
+                groups["replicasets"].append(rs_group(shard.set_name, shard))
             groups["mongos"] = sorted(cluster.get_mongos(), key=lambda n: (n.ip, n.port))
         else:
             raise Exception(_("unsupported cluster type {}".format(cluster.cluster_type)))
@@ -397,6 +401,9 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
             cluster_sb.add_parallel_acts(acts_list=precheck_acts)
 
         # --- upgrade_cluster: parallel replicaset upgrades ---
+        # 每个 RS 顺序两阶段，使每个 hop 仅发生一次 stepDown：
+        #   阶段1(phase=secondary)：顺序升级全部成员，运行期为 PRIMARY 的节点由 actuator 守卫自动跳过（升 backup/secondary）。
+        #   阶段2(phase=primary)：顺序升级数据承载成员，运行期非 PRIMARY 的节点自动跳过，仅旧 primary 真正执行（唯一一次 stepDown）。
         rs_parallel_pipes = []
         for rs_group in exec_groups["replicasets"]:
             rs_sb = SubBuilder(root_id=self.root_id, data=self.payload)
@@ -410,6 +417,20 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
                         dest_version=dest_version,
                         target_pkg=target_pkg,
                         include_backup=include_backup,
+                        upgrade_phase="secondary",
+                    )
+                )
+            for node in rs_group.get("not_backup", []):
+                rs_sb.add_sub_pipeline(
+                    sub_flow=self._build_member_sub_flow(
+                        node=node,
+                        file_path=file_path,
+                        instance_type="mongod",
+                        current_version=current_version,
+                        dest_version=dest_version,
+                        target_pkg=target_pkg,
+                        include_backup=include_backup,
+                        upgrade_phase="primary",
                     )
                 )
             rs_parallel_pipes.append(rs_sb.build_sub_process(_("replicaset-{}".format(rs_group["name"]))))
@@ -437,11 +458,8 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
         )
         if postcheck_act:
             cluster_sb.add_act(**postcheck_act)
-        persist_version_act = self._build_persist_meta_version_act(
-            cluster=cluster,
-            target_version=self._resolve_persist_version(target_pkg=target_pkg, dest_version=dest_version),
-        )
-        cluster_sb.add_act(**persist_version_act)
+        # 注意：版本元数据回写不在此处，统一挪到 hop barrier 之后（_build_hop_stage_sub_flow），
+        # 确保 barrier 验证全部成员就位再持久化，避免 barrier 失败但元数据已被改动。
 
         process_name = sub_process_name if sub_process_name else _("mongo_upgrade_cluster_{}".format(cluster.name))
         return cluster_sb.build_sub_process(process_name)
@@ -478,6 +496,19 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
         barrier_sf = self._build_hop_barrier_stage_sub_flow(hop=hop, file_path=file_path)
         if barrier_sf:
             hop_sb.add_sub_pipeline(sub_flow=barrier_sf)
+        # barrier 通过后再回写版本元数据，避免成员漏升时元数据被提前更新到目标版本。
+        persist_acts = [
+            self._build_persist_meta_version_act(
+                cluster=item["cluster"],
+                target_version=self._resolve_persist_version(
+                    target_pkg=item["hop_plan_map"][hop]["target_pkg"],
+                    dest_version=item["hop_plan_map"][hop]["dest_version"],
+                ),
+            )
+            for item in self.cluster_infos
+        ]
+        if persist_acts:
+            hop_sb.add_parallel_acts(acts_list=persist_acts)
         return hop_sb.build_sub_process(_("mongo_upgrade_hop_{}->{}".format(from_mm, to_mm)))
 
     def _build_member_sub_flow(
@@ -490,6 +521,7 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
         target_pkg: Package,
         *,
         include_backup: bool = True,
+        upgrade_phase: Optional[str] = None,
     ):
         member_sb = SubBuilder(root_id=self.root_id, data=self.payload)
         self._append_node_upgrade_acts(
@@ -501,8 +533,14 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
             dest_version=dest_version,
             target_pkg=target_pkg,
             include_backup=include_backup,
+            upgrade_phase=upgrade_phase,
         )
-        return member_sb.build_sub_process(_("member-{}:{}".format(node.ip, node.port)))
+        phase_label = {"secondary": _("升从"), "primary": _("升主")}.get(upgrade_phase, "")
+        if phase_label:
+            name = _("member-{}-{}:{}").format(phase_label, node.ip, node.port)
+        else:
+            name = _("member-{}:{}").format(node.ip, node.port)
+        return member_sb.build_sub_process(name)
 
     def _build_mongos_stage_sub_flow(
         self,
@@ -593,15 +631,32 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
         target_pkg: Package,
         *,
         include_backup: bool = True,
+        upgrade_phase: Optional[str] = None,
     ):
-        sb.add_act(**MongoUpgradeVersionSubTask.shield_dbmon_act(file_path=file_path, exec_node=node))
-        sb.add_act(**MongoUpgradeVersionSubTask.stop_act(file_path=file_path, exec_node=node))
+        # upgrade_phase 透传给所有原子步骤：shield_dbmon 在 mongod 在线时判定并持久化跳过决策，
+        # 其余步骤据该决策 no-op；upgrade_phase 为空（如 mongos）时不启用守卫。
+        sb.add_act(
+            **MongoUpgradeVersionSubTask.shield_dbmon_act(
+                file_path=file_path,
+                exec_node=node,
+                upgrade_phase=upgrade_phase,
+                dest_version=dest_version,
+                instance_type=instance_type,
+            )
+        )
+        sb.add_act(
+            **MongoUpgradeVersionSubTask.stop_act(
+                file_path=file_path, exec_node=node, upgrade_phase=upgrade_phase, dest_version=dest_version
+            )
+        )
         if include_backup:
             sb.add_act(
                 **MongoUpgradeVersionSubTask.backup_data_act(
                     file_path=file_path,
                     exec_node=node,
                     old_full_version=normalize_mongodb_full_version(current_version),
+                    upgrade_phase=upgrade_phase,
+                    dest_version=dest_version,
                 )
             )
         sb.add_act(
@@ -613,8 +668,21 @@ class MongoUpgradeVersionFlow(MongoBaseFlow):
                 instance_type=instance_type,
                 pkg=os.path.basename(target_pkg.path),
                 pkg_md5=target_pkg.md5,
+                upgrade_phase=upgrade_phase,
             )
         )
-        sb.add_act(**MongoUpgradeVersionSubTask.start_act(file_path=file_path, exec_node=node))
-        sb.add_act(**MongoUpgradeVersionSubTask.unblock_dbmon_act(file_path=file_path, exec_node=node))
-        sb.add_act(**MongoUpgradeVersionSubTask.service_check_act(file_path=file_path, exec_node=node))
+        sb.add_act(
+            **MongoUpgradeVersionSubTask.start_act(
+                file_path=file_path, exec_node=node, upgrade_phase=upgrade_phase, dest_version=dest_version
+            )
+        )
+        sb.add_act(
+            **MongoUpgradeVersionSubTask.unblock_dbmon_act(
+                file_path=file_path, exec_node=node, upgrade_phase=upgrade_phase, dest_version=dest_version
+            )
+        )
+        sb.add_act(
+            **MongoUpgradeVersionSubTask.service_check_act(
+                file_path=file_path, exec_node=node, upgrade_phase=upgrade_phase, dest_version=dest_version
+            )
+        )

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/sub_task/install_dbmon_sub.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/sub_task/install_dbmon_sub.py
@@ -101,7 +101,7 @@ class InstallDBMonSubTask(BaseSubTask):
         sub_pipeline = SubBuilder(root_id=root_id, data=flow_data)
         kwargs = cls.make_kwargs(ip, bk_cloud_id, nodes, file_path, pkg_info, bk_monitor_beat_config)
         act = {
-            "act_name": _("node-{}".format(kwargs["exec_ip"])),
+            "act_name": _("安装dbmon"),
             "act_component_code": ExecJobComponent2.code,
             "kwargs": kwargs,
         }
@@ -165,7 +165,7 @@ class PrepareInstanceInfo(BaseSubTask):
             bk_monitor_beat_config=bk_monitor_beat_config,
         )
         return {
-            "act_name": _("prepare_instance_info:{} ip".format(len(iplist))),
+            "act_name": _("准备实例信息(共{}个IP)").format(len(iplist)),
             "act_component_code": ExecPrepareInstanceInfoOperationComponent.code,
             "kwargs": kwargs,
         }

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/sub_task/instance_op.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/sub_task/instance_op.py
@@ -31,7 +31,15 @@ class InstanceOpSubTask(BaseSubTask):
 
     @classmethod
     def make_kwargs(
-        cls, file_path, exec_node: MongoNode, op: str, username: str = None, graceful_stop: Optional[bool] = None
+        cls,
+        file_path,
+        exec_node: MongoNode,
+        op: str,
+        username: str = None,
+        graceful_stop: Optional[bool] = None,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+        instance_type: Optional[str] = None,
     ) -> dict:
         if username is None:
             username = MongoDBManagerUser.DbaUser.value
@@ -45,6 +53,13 @@ class InstanceOpSubTask(BaseSubTask):
         }
         if graceful_stop is not None:
             payload["gracefulStop"] = graceful_stop
+        # 滚动升级两阶段守卫字段：仅升级流程下传，其余流程不带（actuator 侧据此判断是否启用守卫）
+        if upgrade_phase:
+            payload["upgradePhase"] = upgrade_phase
+        if dest_version:
+            payload["destVersion"] = dest_version
+        if instance_type:
+            payload["instanceType"] = instance_type
         return {
             "set_trans_data_dataclass": CommonContext.__name__,
             "get_trans_data_ip_var": None,
@@ -69,7 +84,22 @@ class InstanceOpSubTask(BaseSubTask):
         instance_type: str,
         pkg: str,
         pkg_md5: str,
+        upgrade_phase: Optional[str] = None,
     ) -> dict:
+        payload = {
+            "mediapkg": {
+                "pkg": pkg,
+                "pkg_md5": pkg_md5,
+            },
+            "ip": exec_node.ip,
+            "port": int(exec_node.port),
+            "currentVersion": current_version,
+            "destVersion": dest_version,
+            "instanceType": instance_type,
+        }
+        # 滚动升级两阶段守卫字段：仅升级流程下传
+        if upgrade_phase:
+            payload["upgradePhase"] = upgrade_phase
         return {
             "set_trans_data_dataclass": CommonContext.__name__,
             "get_trans_data_ip_var": None,
@@ -80,17 +110,7 @@ class InstanceOpSubTask(BaseSubTask):
                 "file_path": file_path,
                 "exec_account": "root",
                 "sudo_account": "root",
-                "payload": {
-                    "mediapkg": {
-                        "pkg": pkg,
-                        "pkg_md5": pkg_md5,
-                    },
-                    "ip": exec_node.ip,
-                    "port": int(exec_node.port),
-                    "currentVersion": current_version,
-                    "destVersion": dest_version,
-                    "instanceType": instance_type,
-                },
+                "payload": payload,
             },
         }
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/sub_task/upgrade_version.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mongodb/sub_task/upgrade_version.py
@@ -24,32 +24,83 @@ class MongoUpgradeVersionSubTask:
     """MongoDB version-upgrade atom actions for one node."""
 
     @classmethod
-    def shield_dbmon_act(cls, file_path: str, exec_node: MongoNode) -> dict:
+    def shield_dbmon_act(
+        cls,
+        file_path: str,
+        exec_node: MongoNode,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+        instance_type: Optional[str] = None,
+    ) -> dict:
         return {
             "act_name": _("MongoDB-屏蔽dbmon-{}:{}".format(exec_node.ip, exec_node.port)),
             "act_component_code": ExecJobComponent2.code,
-            "kwargs": InstanceOpSubTask.make_kwargs(file_path=file_path, exec_node=exec_node, op="shield_dbmon"),
+            "kwargs": InstanceOpSubTask.make_kwargs(
+                file_path=file_path,
+                exec_node=exec_node,
+                op="shield_dbmon",
+                upgrade_phase=upgrade_phase,
+                dest_version=dest_version,
+                instance_type=instance_type,
+            ),
         }
 
     @classmethod
-    def unblock_dbmon_act(cls, file_path: str, exec_node: MongoNode) -> dict:
+    def unblock_dbmon_act(
+        cls,
+        file_path: str,
+        exec_node: MongoNode,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+    ) -> dict:
         return {
             "act_name": _("MongoDB-解除屏蔽dbmon-{}:{}".format(exec_node.ip, exec_node.port)),
             "act_component_code": ExecJobComponent2.code,
-            "kwargs": InstanceOpSubTask.make_kwargs(file_path=file_path, exec_node=exec_node, op="unblock_dbmon"),
+            "kwargs": InstanceOpSubTask.make_kwargs(
+                file_path=file_path,
+                exec_node=exec_node,
+                op="unblock_dbmon",
+                upgrade_phase=upgrade_phase,
+                dest_version=dest_version,
+            ),
         }
 
     @classmethod
-    def stop_act(cls, file_path: str, exec_node: MongoNode) -> dict:
+    def stop_act(
+        cls,
+        file_path: str,
+        exec_node: MongoNode,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+    ) -> dict:
         return {
             "act_name": _("MongoDB-停实例-{}:{}".format(exec_node.ip, exec_node.port)),
             "act_component_code": ExecJobComponent2.code,
-            "kwargs": InstanceOpSubTask.make_kwargs(file_path=file_path, exec_node=exec_node, op="stop"),
+            "kwargs": InstanceOpSubTask.make_kwargs(
+                file_path=file_path,
+                exec_node=exec_node,
+                op="stop",
+                upgrade_phase=upgrade_phase,
+                dest_version=dest_version,
+            ),
         }
 
     @classmethod
-    def backup_data_act(cls, file_path: str, exec_node: MongoNode, old_full_version: str) -> dict:
-        kwargs = InstanceOpSubTask.make_kwargs(file_path=file_path, exec_node=exec_node, op="backup_mongodata")
+    def backup_data_act(
+        cls,
+        file_path: str,
+        exec_node: MongoNode,
+        old_full_version: str,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+    ) -> dict:
+        kwargs = InstanceOpSubTask.make_kwargs(
+            file_path=file_path,
+            exec_node=exec_node,
+            op="backup_mongodata",
+            upgrade_phase=upgrade_phase,
+            dest_version=dest_version,
+        )
         kwargs["db_act_template"]["payload"]["oldFullVersion"] = old_full_version
         return {
             "act_name": _("MongoDB-备份数据目录-{}:{}".format(exec_node.ip, exec_node.port)),
@@ -67,6 +118,7 @@ class MongoUpgradeVersionSubTask:
         instance_type: str,
         pkg: str,
         pkg_md5: str,
+        upgrade_phase: Optional[str] = None,
     ) -> dict:
         return {
             "act_name": _("MongoDB-升级二进制-{}:{}".format(exec_node.ip, exec_node.port)),
@@ -79,24 +131,47 @@ class MongoUpgradeVersionSubTask:
                 instance_type=instance_type,
                 pkg=pkg,
                 pkg_md5=pkg_md5,
+                upgrade_phase=upgrade_phase,
             ),
         }
 
     @classmethod
-    def start_act(cls, file_path: str, exec_node: MongoNode) -> dict:
+    def start_act(
+        cls,
+        file_path: str,
+        exec_node: MongoNode,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+    ) -> dict:
         return {
             "act_name": _("MongoDB-启实例-{}:{}".format(exec_node.ip, exec_node.port)),
             "act_component_code": ExecJobComponent2.code,
-            "kwargs": InstanceOpSubTask.make_kwargs(file_path=file_path, exec_node=exec_node, op="start"),
+            "kwargs": InstanceOpSubTask.make_kwargs(
+                file_path=file_path,
+                exec_node=exec_node,
+                op="start",
+                upgrade_phase=upgrade_phase,
+                dest_version=dest_version,
+            ),
         }
 
     @classmethod
-    def service_check_act(cls, file_path: str, exec_node: MongoNode) -> dict:
+    def service_check_act(
+        cls,
+        file_path: str,
+        exec_node: MongoNode,
+        upgrade_phase: Optional[str] = None,
+        dest_version: Optional[str] = None,
+    ) -> dict:
         return {
             "act_name": _("MongoDB-服务检查-{}:{}".format(exec_node.ip, exec_node.port)),
             "act_component_code": ExecJobComponent2.code,
             "kwargs": InstanceOpSubTask.make_kwargs(
-                file_path=file_path, exec_node=exec_node, op="service_status_check"
+                file_path=file_path,
+                exec_node=exec_node,
+                op="service_status_check",
+                upgrade_phase=upgrade_phase,
+                dest_version=dest_version,
             ),
         }
 

--- a/dbm-ui/backend/flow/plugins/components/collections/mongodb/fast_exec_script.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mongodb/fast_exec_script.py
@@ -53,7 +53,8 @@ class _ExecBkJobService(BkJobService):
         trans_data = data.get_one_of_inputs("trans_data")
 
         self.log_info("_execute trans_data {} global_data {} kwargs {}".format(trans_data, global_data, kwargs))
-        if trans_data is None or trans_data == "${trans_data}":
+        # 兜底处理 trans_data 不是合法上下文实例（None / 占位符 / dict 等）的场景，避免后续 trans_data.set(...) 报 AttributeError
+        if trans_data is None or trans_data == "${trans_data}" or not hasattr(trans_data, "set"):
             trans_data = getattr(flow_context, kwargs["set_trans_data_dataclass"])()
             self.log_info("now init trans_data {}".format(trans_data))
 


### PR DESCRIPTION
- fix: MongoFastExecScript 当 trans_data 为 dict 等非上下文对象时, 增加 not hasattr(trans_data, "set") 兜底, 避免 trans_data.set() 抛 AttributeError
- refactor: 将安装 dbmon 流程(下发介质+准备实例信息+并行安装)封装为独立子流程节点
- style: 优化安装 dbmon 流程节点名并修正 gettext 先 format 再翻译的用法
- refactor: upgrade 增加两阶段守卫决策文件 (.dbm_upgrade_phase.json), shield_dbmon 在 mongod 在线时一次性判定并持久化跳过决策, 升级序列其余步骤据该决策 no-op; 升级链最后一步 (service_status_check) 成功后清理决策文件
- refactor: 升级 hop 内的版本元数据回写从 cluster_subflow 末尾挪到 hop barrier 之后, 避免 barrier 失败时 db_meta 已被改到目标版本