### PR TITLE
refactor(redis): harden replace flow and rollback-exercise cleanup #18070

### DIFF
--- a/dbm-ui/backend/db_services/redis/redis_modules/util.py
+++ b/dbm-ui/backend/db_services/redis/redis_modules/util.py
@@ -19,10 +19,12 @@ from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
 from .models import TbRedisModuleSupport
 
 
-def get_redis_moudles_detail(major_version: str, module_names: list = []) -> list:
+def get_redis_modules_detail(major_version: str, module_names: list = None) -> list:
     """
     根据major_version获取redis module详情信息
     """
+    if module_names is None:
+        module_names = []
     if not major_version:
         return []
     if not module_names:
@@ -65,10 +67,10 @@ def get_cluster_redis_module_names(cluster_id: int) -> list:
     return modules_name
 
 
-def get_cluster_redis_modules_detial(cluster_id: int) -> list:
+def get_cluster_redis_modules_detail(cluster_id: int) -> list:
     """
     获取集群的redis module详情信息
     """
     cluster = Cluster.objects.get(id=cluster_id)
     modules_name = get_cluster_redis_module_names(cluster_id)
-    return get_redis_moudles_detail(cluster.major_version, modules_name)
+    return get_redis_modules_detail(cluster.major_version, modules_name)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/proxy_install.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/proxy_install.py
@@ -10,7 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 import logging.config
 from dataclasses import asdict
-from typing import Dict
+from typing import Dict, List, Optional
 
 from django.utils.translation import gettext as _
 
@@ -18,7 +18,7 @@ from backend.configuration.constants import DBType
 from backend.db_meta.enums.cluster_type import ClusterType
 from backend.db_meta.enums.machine_type import MachineType
 from backend.db_meta.models import AppCache, Cluster
-from backend.db_services.redis.redis_modules.util import get_cluster_redis_modules_detial
+from backend.db_services.redis.redis_modules.util import get_cluster_redis_modules_detail
 from backend.flow.consts import DEPENDENCIES_PLUGINS
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
@@ -41,7 +41,12 @@ logger = logging.getLogger("flow")
 
 
 def ProxyBatchInstallAtomJob(
-    root_id, ticket_data, act_kwargs: ActKwargs, param: Dict, to_install_dbmon: bool = True, load_modules: list = []
+    root_id,
+    ticket_data,
+    act_kwargs: ActKwargs,
+    param: Dict,
+    to_install_dbmon: bool = True,
+    load_modules: Optional[List] = None,
 ) -> SubBuilder:
     """
     ### SubBuilder: Proxy安装原子任务
@@ -120,15 +125,16 @@ def ProxyBatchInstallAtomJob(
     sub_pipeline.add_parallel_acts(acts_list=acts_list)
 
     # proxy扩容/替换/自愈，config从参数传过来
+    resolved_load_modules = load_modules
     if "conf_configs" in param:
         act_kwargs.cluster["conf_configs"] = param["conf_configs"]
         act_kwargs.cluster["dbconfig"] = param["conf_configs"]
-        # 从dbconfig中获取load_modules
-        cluster = Cluster.objects.get(immute_domain=act_kwargs.cluster["immute_domain"])
-        load_modules = []
-        module_rows = get_cluster_redis_modules_detial(cluster_id=cluster.id)
-        for module_row in module_rows:
-            load_modules.append(module_row["module_name"])
+        if resolved_load_modules is None:
+            cluster = Cluster.objects.get(immute_domain=act_kwargs.cluster["immute_domain"])
+            module_rows = get_cluster_redis_modules_detail(cluster_id=cluster.id)
+            resolved_load_modules = [module_row["module_name"] for module_row in module_rows]
+    if resolved_load_modules is None:
+        resolved_load_modules = []
 
     # 安装proxy实例
     if act_kwargs.cluster["cluster_type"] in [
@@ -144,7 +150,7 @@ def ProxyBatchInstallAtomJob(
         act_kwargs.cluster["predixyadminpasswd"] = param["proxy_admin_pwd"]
         act_kwargs.cluster["port"] = param["proxy_port"]
         act_kwargs.cluster["servers"] = param["servers"]
-        act_kwargs.cluster["load_modules"] = load_modules
+        act_kwargs.cluster["load_modules"] = resolved_load_modules
         act_kwargs.cluster["databases"] = str(param.get("databases", ""))  # PredixyTendisplusInstance
         act_kwargs.get_redis_payload_func = RedisActPayload.get_install_predixy_payload.__name__
     else:
@@ -155,7 +161,7 @@ def ProxyBatchInstallAtomJob(
         act_kwargs.cluster["password"] = param["proxy_pwd"]
         act_kwargs.cluster["port"] = param["proxy_port"]
         act_kwargs.cluster["servers"] = param["servers"]
-        act_kwargs.cluster["load_modules"] = load_modules
+        act_kwargs.cluster["load_modules"] = resolved_load_modules
         act_kwargs.get_redis_payload_func = RedisActPayload.get_install_twemproxy_payload.__name__
     sub_pipeline.add_act(
         act_name=_("Proxy-003-{}-安装实例").format(exec_ip),

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_master_rep.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_master_rep.py
@@ -115,6 +115,7 @@ def TwemproxyClusterMasterReplaceJob(
     twemproxy_server_shards = get_twemproxy_cluster_server_shards(
         act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"], new_instances_to_master
     )
+    cache_backup_mode = get_cache_backup_mode(act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"])
 
     # ## 部署实例 #############################################################################
     sub_pipelines = []
@@ -132,9 +133,7 @@ def TwemproxyClusterMasterReplaceJob(
             "spec_id": master_replace_info["master_spec"].get("id", 0),
             "spec_config": master_replace_info["master_spec"],
             "server_shards": twemproxy_server_shards.get(new_host_master, {}),
-            "cache_backup_mode": get_cache_backup_mode(
-                act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"]
-            ),
+            "cache_backup_mode": cache_backup_mode,
         }
         if act_kwargs.cluster["cluster_type"] == ClusterType.TendisRedisInstance.value:
             params["start_port"] = min(act_kwargs.cluster["master_ports"][old_master])
@@ -224,9 +223,7 @@ def TwemproxyClusterMasterReplaceJob(
                     "sync_dst1": rep_link.new_master_port,
                     "sync_dst2": rep_link.new_slave_port,
                     "server_shards": twemproxy_server_shards.get(rep_link.new_master_ip, {}),
-                    "cache_backup_mode": get_cache_backup_mode(
-                        act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"]
-                    ),
+                    "cache_backup_mode": cache_backup_mode,
                 }
             )
         sync_relations.append(sync_params)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_slave_rep.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_cluster_slave_rep.py
@@ -126,7 +126,13 @@ def _collect_replace_info(slave_replace_detail, act_kwargs):
 
 
 def _deploy_new_instances(
-    root_id, ticket_data, act_kwargs, slave_replace_detail, slave_replace_info, twemproxy_server_shards
+    root_id,
+    ticket_data,
+    act_kwargs,
+    slave_replace_detail,
+    slave_replace_info,
+    twemproxy_server_shards,
+    cache_backup_mode,
 ):
     """部署新实例"""
     sub_pipelines = []
@@ -142,9 +148,7 @@ def _deploy_new_instances(
             "spec_id": slave_replace_info["slave_spec"].get("id", 0),
             "spec_config": slave_replace_info["slave_spec"],
             "server_shards": twemproxy_server_shards.get(new_slave, {}),
-            "cache_backup_mode": get_cache_backup_mode(
-                act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"]
-            ),
+            "cache_backup_mode": cache_backup_mode,
         }
         if act_kwargs.cluster["cluster_type"] == ClusterType.TendisRedisInstance.value:
             params["start_port"] = min(act_kwargs.cluster["slave_ports"][old_slave])
@@ -154,7 +158,13 @@ def _deploy_new_instances(
 
 
 def _setup_sync_relations(
-    root_id, ticket_data, act_kwargs, slave_replace_detail, replace_link_info, twemproxy_server_shards
+    root_id,
+    ticket_data,
+    act_kwargs,
+    slave_replace_detail,
+    replace_link_info,
+    twemproxy_server_shards,
+    cache_backup_mode,
 ):
     """建立同步关系"""
     sub_pipelines = []
@@ -168,9 +178,7 @@ def _setup_sync_relations(
             "sync_dst1": new_slave,
             "ins_link": [],
             "server_shards": twemproxy_server_shards.get(new_slave, {}),
-            "cache_backup_mode": get_cache_backup_mode(
-                act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"]
-            ),
+            "cache_backup_mode": cache_backup_mode,
         }
         for slave_port in act_kwargs.cluster["slave_ports"][old_slave]:
             old_ins = "{}{}{}".format(old_slave, IP_PORT_DIVIDER, slave_port)
@@ -381,16 +389,29 @@ def RedisClusterSlaveReplaceJob(root_id, ticket_data, sub_kwargs: ActKwargs, sla
     twemproxy_server_shards = get_twemproxy_cluster_server_shards(
         act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"], newslave_to_master
     )
+    cache_backup_mode = get_cache_backup_mode(act_kwargs.cluster["bk_biz_id"], act_kwargs.cluster["cluster_id"])
 
     # 部署新实例
     deploy_sub_pipelines = _deploy_new_instances(
-        root_id, ticket_data, act_kwargs, slave_replace_detail, slave_replace_info, twemproxy_server_shards
+        root_id,
+        ticket_data,
+        act_kwargs,
+        slave_replace_detail,
+        slave_replace_info,
+        twemproxy_server_shards,
+        cache_backup_mode,
     )
     redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=deploy_sub_pipelines)
 
     # 建立同步关系
     sync_sub_pipelines = _setup_sync_relations(
-        root_id, ticket_data, act_kwargs, slave_replace_detail, replace_link_info, twemproxy_server_shards
+        root_id,
+        ticket_data,
+        act_kwargs,
+        slave_replace_detail,
+        replace_link_info,
+        twemproxy_server_shards,
+        cache_backup_mode,
     )
     redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=sync_sub_pipelines)
 

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_load_module.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/atom_jobs/redis_load_module.py
@@ -18,7 +18,7 @@ from django.utils.translation import gettext as _
 from backend.configuration.constants import DBType
 from backend.db_meta.enums import InstanceStatus
 from backend.db_meta.models import Cluster
-from backend.db_services.redis.redis_modules.util import get_redis_moudles_detail
+from backend.db_services.redis.redis_modules.util import get_redis_modules_detail
 from backend.db_services.redis.util import is_predixy_proxy_type
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
@@ -74,7 +74,7 @@ def ClusterLoadModulesAtomJob(root_id, ticket_data, sub_kwargs: ActKwargs, param
         act_kwargs.exec_ip = ip
         act_kwargs.cluster["ip"] = ip
         act_kwargs.cluster["ports"] = ports
-        act_kwargs.cluster["load_modules_detail"] = get_redis_moudles_detail(
+        act_kwargs.cluster["load_modules_detail"] = get_redis_modules_detail(
             cluster.major_version, param["load_modules"]
         )
         act_kwargs.get_redis_payload_func = RedisActPayload.redis_load_modules.__name__
@@ -90,7 +90,7 @@ def ClusterLoadModulesAtomJob(root_id, ticket_data, sub_kwargs: ActKwargs, param
         act_kwargs.exec_ip = ip
         act_kwargs.cluster["ip"] = ip
         act_kwargs.cluster["ports"] = ports
-        act_kwargs.cluster["load_modules_detail"] = get_redis_moudles_detail(
+        act_kwargs.cluster["load_modules_detail"] = get_redis_modules_detail(
             cluster.major_version, param["load_modules"]
         )
         act_kwargs.get_redis_payload_func = RedisActPayload.redis_load_modules.__name__

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_load_modules.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_load_modules.py
@@ -16,7 +16,7 @@ from django.utils.translation import gettext as _
 
 from backend.configuration.constants import DBType
 from backend.db_meta.models import Cluster
-from backend.db_services.redis.redis_modules.util import get_redis_moudles_detail
+from backend.db_services.redis.redis_modules.util import get_redis_modules_detail
 from backend.flow.engine.bamboo.scene.common.builder import Builder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
 from backend.flow.engine.bamboo.scene.redis.atom_jobs import ClusterLoadModulesAtomJob
@@ -56,7 +56,7 @@ class RedisClusterLoadModulesSceneFlow(object):
         cluster = Cluster.objects.get(id=cluster_id)
         major_version = cluster.major_version
         for load_module in load_modules:
-            module_row = get_redis_moudles_detail(major_version=major_version, module_names=[load_module])
+            module_row = get_redis_modules_detail(major_version=major_version, module_names=[load_module])
             if not module_row:
                 raise Exception(
                     _("cluster:{} major_version:{}  redis module {}").format(

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_cluster_scene_cmr.py
@@ -22,6 +22,7 @@ from backend.configuration.constants import DBType
 from backend.db_meta import api
 from backend.db_meta.enums import ClusterEntryType, ClusterType, InstanceRole
 from backend.db_meta.models import Cluster
+from backend.db_services.redis.redis_modules.util import get_cluster_redis_modules_detail
 from backend.db_services.redis.util import is_twemproxy_proxy_type
 from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigFileEnum, ConfigTypeEnum, DnsOpType, SyncType
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
@@ -320,6 +321,8 @@ class RedisClusterCMRSceneFlow(object):
             act_kwargs.cluster["immute_domain"],
             proxy_version,
         )
+        module_rows = get_cluster_redis_modules_detail(cluster_id=act_kwargs.cluster["cluster_id"])
+        load_modules = [module_row["module_name"] for module_row in module_rows]
 
         for proxy_ip in new_proxies:
             replace_kwargs = copy.deepcopy(act_kwargs)
@@ -334,7 +337,9 @@ class RedisClusterCMRSceneFlow(object):
                 "spec_id": proxy_replace_info["proxy_spec"].get("id", 0),
                 "spec_config": proxy_replace_info["proxy_spec"],
             }
-            sub_builder = ProxyBatchInstallAtomJob(self.root_id, self.data, replace_kwargs, params)
+            sub_builder = ProxyBatchInstallAtomJob(
+                self.root_id, self.data, replace_kwargs, params, load_modules=load_modules
+            )
             sub_pipelines.append(sub_builder)
         sub_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
 
@@ -414,19 +419,23 @@ class RedisClusterCMRSceneFlow(object):
                     ).get(id=cluster_id, bk_biz_id=self.data["bk_biz_id"])
                 except Cluster.DoesNotExist as e:
                     raise Exception("redis cluster does not exist,{}", e)
+                existing_proxy_ips = {p.machine.ip for p in cluster.proxyinstance_set.all()}
+                existing_slave_ips = set()
+                existing_master_ips = set()
+                for inst in cluster.storageinstance_set.all():
+                    if inst.instance_role == InstanceRole.REDIS_SLAVE.value:
+                        existing_slave_ips.add(inst.machine.ip)
+                    elif inst.instance_role == InstanceRole.REDIS_MASTER.value:
+                        existing_master_ips.add(inst.machine.ip)
                 # check proxy
                 for proxy in cluster_replacement.get("proxy", []):
-                    if not cluster.proxyinstance_set.filter(machine__ip=proxy["ip"]):
+                    if proxy["ip"] not in existing_proxy_ips:
                         raise Exception("proxy {} does not exist in cluster {}", proxy["ip"], cluster.immute_domain)
                 # check slave
                 for slave in cluster_replacement.get("redis_slave", []):
-                    if not cluster.storageinstance_set.filter(
-                        machine__ip=slave["ip"], instance_role=InstanceRole.REDIS_SLAVE.value
-                    ):
+                    if slave["ip"] not in existing_slave_ips:
                         raise Exception("slave {} does not exist in cluster {}", slave["ip"], cluster.immute_domain)
                 # check master
                 for master in cluster_replacement.get("redis_master", []):
-                    if not cluster.storageinstance_set.filter(
-                        machine__ip=master["ip"], instance_role=InstanceRole.REDIS_MASTER.value
-                    ):
+                    if master["ip"] not in existing_master_ips:
                         raise Exception("master {} does not exist in cluster {}", master["ip"], cluster.immute_domain)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
@@ -19,6 +19,7 @@ from backend.constants import IP_PORT_DIVIDER
 from backend.db_meta.models import Cluster
 from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
+from backend.flow.consts import DEFAULT_REDIS_START_PORT
 from backend.flow.engine.bamboo.scene.common.builder import Builder, Conditions, SubBuilder
 from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
@@ -72,10 +73,31 @@ class RedisRollbackExerciseFlow(object):
 
         logger.info("ticket_data: %s", self.ticket_data)
 
+    @staticmethod
+    def _enrich_drill_prod_temp_instance_pairs(info: dict) -> None:
+        """Persist drill prod/temp pairs on ticket info for best-effort cleanup when task row is missing."""
+        if info.get("drill_prod_temp_instance_pairs"):
+            return
+        resource_applied = info.get("redis") or []
+        instance_ip = info.get("instance_ip")
+        instance_port = info.get("instance_port")
+        if not resource_applied or instance_ip is None or instance_port is None:
+            return
+        temp_host_ip = resource_applied[0]["ip"]
+        info["drill_prod_temp_instance_pairs"] = [
+            [
+                "{}{}{}".format(instance_ip, IP_PORT_DIVIDER, instance_port),
+                "{}{}{}".format(temp_host_ip, IP_PORT_DIVIDER, DEFAULT_REDIS_START_PORT),
+            ]
+        ]
+
     def rollback_exercise_flow(self):
         """
         Composes data-structure + cleanup steps directly instead of spawning inner pipelines and polling.
         """
+        for info in self.ticket_data["infos"]:
+            self._enrich_drill_prod_temp_instance_pairs(info)
+
         pipeline = Builder(root_id=self.root_id, data=copy.deepcopy(self.ticket_data))
 
         sub_flows = []

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -21,13 +21,14 @@ from pipeline.core.flow.activity import StaticIntervalGenerator
 
 from backend import env
 from backend.components import JobApi
+from backend.constants import IP_PORT_DIVIDER
 from backend.db_meta.api.cluster.nosqlcomm.decommission import decommission_instances
 from backend.db_meta.models import Cluster, StorageInstance
 from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.db_services.dbresource.handlers import ResourceHandler
 from backend.db_services.redis.rollback.models import TbTendisRollbackTasks
-from backend.flow.consts import StateType
+from backend.flow.consts import DEFAULT_REDIS_START_PORT, StateType
 from backend.flow.engine.bamboo.engine import BambooEngine
 from backend.flow.engine.bamboo.scene.common.machine_os_init import RecycleOutputContext
 from backend.flow.engine.bamboo.scene.redis.redis_data_structure import RedisDataStructureFlow
@@ -505,6 +506,45 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
                 temp_addrs.add(temp_addr)
         return prod_addrs, temp_addrs
 
+    def _extract_allowlisted_temp_ports(
+        self,
+        temp_host_ip: str,
+        prod_temp_instance_pairs: list,
+        temp_instance_range: Optional[list] = None,
+        prod_instance_range: Optional[list] = None,
+        task_id: Optional[int] = None,
+    ) -> list:
+        task_temp_addrs = self._parse_instance_set(temp_instance_range)
+        task_prod_addrs = self._parse_instance_set(prod_instance_range)
+        pair_prod_addrs, pair_temp_addrs = self._parse_prod_temp_pairs(prod_temp_instance_pairs)
+        if not pair_temp_addrs:
+            if task_id is not None:
+                self.log_warning(
+                    _("Rollback task {} has no prod/temp instance pairs, skipping work-dir cleanup").format(task_id)
+                )
+            return []
+
+        if task_temp_addrs:
+            allowed_temp_addrs = task_temp_addrs & pair_temp_addrs
+        else:
+            allowed_temp_addrs = set(pair_temp_addrs)
+
+        unsafe_addrs = allowed_temp_addrs & (task_prod_addrs | pair_prod_addrs)
+        if unsafe_addrs:
+            label = _("Rollback task {}").format(task_id) if task_id is not None else _("Drill fallback")
+            self.log_warning(
+                _("{} temp addresses overlap source/prod addresses {}, skipping them").format(
+                    label, sorted("{}:{}".format(ip, port) for ip, port in unsafe_addrs)
+                )
+            )
+            allowed_temp_addrs -= unsafe_addrs
+
+        ports = set()
+        for ip, port in allowed_temp_addrs:
+            if ip == temp_host_ip:
+                ports.add(port)
+        return sorted(ports)
+
     def _get_task_temp_ports(self, ticket_id, bk_biz_id, cluster_id, temp_host_ip: str) -> list:
         if not ticket_id or not bk_biz_id or not cluster_id:
             return []
@@ -515,29 +555,39 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
         )
         ports = set()
         for task in tasks:
-            task_temp_addrs = self._parse_instance_set(task.temp_instance_range)
-            task_prod_addrs = self._parse_instance_set(task.prod_instance_range)
-            pair_prod_addrs, pair_temp_addrs = self._parse_prod_temp_pairs(task.prod_temp_instance_pairs)
-            if not pair_temp_addrs:
-                self.log_warning(
-                    _("Rollback task {} has no prod/temp instance pairs, skipping work-dir cleanup").format(task.id)
-                )
-                continue
-
-            allowed_temp_addrs = task_temp_addrs & pair_temp_addrs
-            unsafe_addrs = allowed_temp_addrs & (task_prod_addrs | pair_prod_addrs)
-            if unsafe_addrs:
-                self.log_warning(
-                    _("Rollback task {} temp addresses overlap source/prod addresses {}, skipping them").format(
-                        task.id, sorted("{}:{}".format(ip, port) for ip, port in unsafe_addrs)
-                    )
-                )
-                allowed_temp_addrs -= unsafe_addrs
-
-            for ip, port in allowed_temp_addrs:
-                if ip == temp_host_ip:
-                    ports.add(port)
+            for port in self._extract_allowlisted_temp_ports(
+                temp_host_ip,
+                task.prod_temp_instance_pairs,
+                temp_instance_range=task.temp_instance_range,
+                prod_instance_range=task.prod_instance_range,
+                task_id=task.id,
+            ):
+                ports.add(port)
         return sorted(ports)
+
+    @classmethod
+    def _get_drill_prod_temp_instance_pairs(cls, info: dict):
+        pairs = info.get("drill_prod_temp_instance_pairs")
+        if pairs:
+            return pairs
+        resource_applied = info.get("redis") or []
+        instance_ip = info.get("instance_ip")
+        instance_port = info.get("instance_port")
+        if not resource_applied or instance_ip is None or instance_port is None:
+            return None
+        temp_host_ip = resource_applied[0]["ip"]
+        return [
+            [
+                "{}{}{}".format(instance_ip, IP_PORT_DIVIDER, instance_port),
+                "{}{}{}".format(temp_host_ip, IP_PORT_DIVIDER, DEFAULT_REDIS_START_PORT),
+            ]
+        ]
+
+    def _get_drill_fallback_temp_ports(self, info: dict, temp_host_ip: str) -> list:
+        pairs = self._get_drill_prod_temp_instance_pairs(info)
+        if not pairs:
+            return []
+        return self._extract_allowlisted_temp_ports(temp_host_ip, pairs)
 
     @staticmethod
     def _get_rollback_task_ticket_id(global_data: dict):
@@ -580,6 +630,12 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
                 continue
 
             ports = self._get_task_temp_ports(ticket_id, ticket_bk_biz_id, cluster.id, temp_host_ip)
+            if not ports:
+                ports = self._get_drill_fallback_temp_ports(info, temp_host_ip)
+                if ports:
+                    self.log_info(
+                        _("Using drill ticket pairs fallback for {} (no TbTendisRollbackTasks)").format(temp_host_ip)
+                    )
             source_instance = self._parse_ip_port("{}:{}".format(info.get("instance_ip"), info.get("instance_port")))
             if source_instance and source_instance[0] == temp_host_ip and source_instance[1] in ports:
                 self.log_warning(

--- a/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_act_playload.py
@@ -37,7 +37,7 @@ from backend.db_services.redis.maxmemory_set.util import (
 )
 from backend.db_services.redis.redis_dts.models.tb_tendis_dts_switch_backup import TbTendisDtsSwitchBackup
 from backend.db_services.redis.redis_modules.models.redis_module_support import ClusterRedisModuleAssociate
-from backend.db_services.redis.redis_modules.util import get_cluster_redis_modules_detial, get_redis_moudles_detail
+from backend.db_services.redis.redis_modules.util import get_cluster_redis_modules_detail, get_redis_modules_detail
 from backend.db_services.redis.util import (
     is_predixy_proxy_type,
     is_redis_instance_type,
@@ -828,7 +828,7 @@ class RedisActPayload(object):
             servers = redis_master_set + redis_slave_set
 
         # 从dbconfig中获取load_modules
-        module_rows = get_cluster_redis_modules_detial(cluster_id=cluster.id)
+        module_rows = get_cluster_redis_modules_detail(cluster_id=cluster.id)
         load_modules = [module_row["module_name"] for module_row in module_rows]
 
         payload.update(
@@ -1608,7 +1608,7 @@ class RedisActPayload(object):
             "inst_num": int(params["inst_num"]),
             "start_port": int(params["start_port"]),
             "redis_conf_configs": redis_conf,
-            "load_modules_detail": get_cluster_redis_modules_detial(cluster_id=cluster.id),
+            "load_modules_detail": get_cluster_redis_modules_detail(cluster_id=cluster.id),
         }
         # tendisplus cluster 模式暂时不需要特别指定这两个参数
         if is_twemproxy_proxy_type(self.namespace):
@@ -1653,7 +1653,7 @@ class RedisActPayload(object):
                 "ip": params["exec_ip"],
                 # "inst_num": params["inst_num"],
                 # "start_port": int(params["start_port"]),
-                "load_modules_detail": get_redis_moudles_detail(
+                "load_modules_detail": get_redis_modules_detail(
                     major_version=params["db_version"], module_names=params.get("load_modules", [])
                 ),
             },

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
@@ -376,6 +376,20 @@ def test_execute_without_report_id_skips_report_update():
 
 # ==================== Best-effort cleanup guards ====================
 
+PROD_INSTANCE_IP = "1.1.1.4"
+TEMP_INSTANCE_IP = "1.1.1.3"
+
+
+def _assert_cleanup_never_touches_prod(cleanup_hosts):
+    prod_hosts = [host for host in cleanup_hosts if host["ip"] == PROD_INSTANCE_IP]
+    assert not prod_hosts, f"cleanup must not target prod host {PROD_INSTANCE_IP!r}, got {cleanup_hosts}"
+
+
+def _collect_cleanup_hosts_checked(service, global_data):
+    cleanup_hosts = service._collect_cleanup_hosts(global_data)
+    _assert_cleanup_never_touches_prod(cleanup_hosts)
+    return cleanup_hosts
+
 
 def _cleanup_service():
     service = RedisExerciseBestEffortCleanupService()
@@ -391,9 +405,9 @@ def _cleanup_global_data():
         "infos": [
             {
                 "cluster_id": 101,
-                "instance_ip": "1.1.1.4",
+                "instance_ip": PROD_INSTANCE_IP,
                 "instance_port": 30000,
-                "redis": [{"ip": "1.1.1.3"}],
+                "redis": [{"ip": TEMP_INSTANCE_IP}],
             }
         ],
     }
@@ -407,9 +421,11 @@ def _storage_instance(port, cluster_ids=None):
 def _rollback_task(temp_range=None, prod_range=None, pairs=None):
     return SimpleNamespace(
         id=1,
-        temp_instance_range=temp_range if temp_range is not None else ["1.1.1.3:30000"],
-        prod_instance_range=prod_range if prod_range is not None else ["1.1.1.4:30000"],
-        prod_temp_instance_pairs=pairs if pairs is not None else [["1.1.1.4:30000", "1.1.1.3:30000"]],
+        temp_instance_range=temp_range if temp_range is not None else [f"{TEMP_INSTANCE_IP}:30000"],
+        prod_instance_range=prod_range if prod_range is not None else [f"{PROD_INSTANCE_IP}:30000"],
+        prod_temp_instance_pairs=pairs
+        if pairs is not None
+        else [[f"{PROD_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30000"]],
     )
 
 
@@ -425,19 +441,19 @@ def test_cleanup_targets_use_rollback_task_ports_not_all_storage_ports(
     mock_storage_filter.return_value = [_storage_instance(30000), _storage_instance(39999)]
     mock_task_filter.return_value = [
         _rollback_task(
-            temp_range=["1.1.1.3:30001", "2.2.2.2:30000", "1.1.1.3:30000"],
-            prod_range=["1.1.1.4:30000", "1.1.1.4:30001"],
+            temp_range=[f"{TEMP_INSTANCE_IP}:30001", "2.2.2.2:30000", f"{TEMP_INSTANCE_IP}:30000"],
+            prod_range=[f"{PROD_INSTANCE_IP}:30000", f"{PROD_INSTANCE_IP}:30001"],
             pairs=[
-                ["1.1.1.4:30000", "1.1.1.3:30000"],
-                ["1.1.1.4:30001", "1.1.1.3:30001"],
-                ["1.1.1.4:30002", "2.2.2.2:30000"],
+                [f"{PROD_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30000"],
+                [f"{PROD_INSTANCE_IP}:30001", f"{TEMP_INSTANCE_IP}:30001"],
+                [f"{PROD_INSTANCE_IP}:30002", "2.2.2.2:30000"],
             ],
         )
     ]
 
-    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), _cleanup_global_data())
 
-    assert cleanup_hosts == [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000, 30001]}]
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000, 30001]}]
     mock_task_filter.assert_called_once_with(related_rollback_bill_id=123, bk_biz_id=3, prod_cluster_id=101)
 
 
@@ -453,9 +469,9 @@ def test_cleanup_targets_allow_expected_source_cluster_binding(
     mock_storage_filter.return_value = [_storage_instance(30000, cluster_ids=[101])]
     mock_task_filter.return_value = [_rollback_task()]
 
-    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), _cleanup_global_data())
 
-    assert cleanup_hosts == [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000]}]
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000]}]
 
 
 @patch(
@@ -470,7 +486,7 @@ def test_cleanup_targets_skip_unexpected_cluster_bound_storage(
     mock_storage_filter.return_value = [_storage_instance(30000, cluster_ids=[202])]
     mock_task_filter.return_value = [_rollback_task()]
 
-    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), _cleanup_global_data())
 
     assert cleanup_hosts == []
     mock_task_filter.assert_not_called()
@@ -485,12 +501,15 @@ def test_cleanup_targets_skip_when_no_matching_rollback_task(mock_cluster_get, m
     mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
     mock_storage_filter.return_value = []
     mock_task_filter.return_value = [
-        _rollback_task(temp_range=["2.2.2.2:30000"], pairs=[["1.1.1.4:30000", "2.2.2.2:30000"]])
+        _rollback_task(
+            temp_range=["2.2.2.2:30000"],
+            pairs=[[f"{PROD_INSTANCE_IP}:30000", "2.2.2.2:30000"]],
+        )
     ]
 
-    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), _cleanup_global_data())
 
-    assert cleanup_hosts == []
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000]}]
 
 
 @patch(
@@ -503,18 +522,18 @@ def test_cleanup_targets_exclude_source_prod_addresses(mock_cluster_get, mock_st
     mock_storage_filter.return_value = []
     mock_task_filter.return_value = [
         _rollback_task(
-            temp_range=["1.1.1.3:30000", "1.1.1.3:30001"],
-            prod_range=["1.1.1.4:30000", "1.1.1.3:30001"],
+            temp_range=[f"{TEMP_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30001"],
+            prod_range=[f"{PROD_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30001"],
             pairs=[
-                ["1.1.1.4:30000", "1.1.1.3:30000"],
-                ["1.1.1.3:30001", "1.1.1.3:30001"],
+                [f"{PROD_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30000"],
+                [f"{TEMP_INSTANCE_IP}:30001", f"{TEMP_INSTANCE_IP}:30001"],
             ],
         )
     ]
 
-    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), _cleanup_global_data())
 
-    assert cleanup_hosts == [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000]}]
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000]}]
 
 
 @patch(
@@ -527,16 +546,115 @@ def test_cleanup_targets_require_prod_temp_pairs(mock_cluster_get, mock_storage_
     mock_storage_filter.return_value = []
     mock_task_filter.return_value = [_rollback_task(pairs=[])]
 
-    cleanup_hosts = _cleanup_service()._collect_cleanup_hosts(_cleanup_global_data())
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), _cleanup_global_data())
+
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000]}]
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_drill_fallback_when_no_rollback_task(mock_cluster_get, mock_storage_filter, mock_task_filter):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = [_storage_instance(30000, cluster_ids=[101])]
+    mock_task_filter.return_value = []
+
+    global_data = _cleanup_global_data()
+    global_data["infos"][0]["drill_prod_temp_instance_pairs"] = [
+        [f"{PROD_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30000"]
+    ]
+
+    service = _cleanup_service()
+    cleanup_hosts = _collect_cleanup_hosts_checked(service, global_data)
+
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000]}]
+    service.log_info.assert_any_call(
+        f"Using drill ticket pairs fallback for {TEMP_INSTANCE_IP} (no TbTendisRollbackTasks)"
+    )
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_drill_fallback_from_ticket_instance_fields(
+    mock_cluster_get, mock_storage_filter, mock_task_filter
+):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = []
+    mock_task_filter.return_value = []
+
+    service = _cleanup_service()
+    cleanup_hosts = _collect_cleanup_hosts_checked(service, _cleanup_global_data())
+
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000]}]
+    service.log_info.assert_any_call(
+        f"Using drill ticket pairs fallback for {TEMP_INSTANCE_IP} (no TbTendisRollbackTasks)"
+    )
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_task_record_wins_over_drill_fallback(mock_cluster_get, mock_storage_filter, mock_task_filter):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = []
+    mock_task_filter.return_value = [
+        _rollback_task(
+            temp_range=[f"{TEMP_INSTANCE_IP}:30001"],
+            prod_range=[f"{PROD_INSTANCE_IP}:30001"],
+            pairs=[[f"{PROD_INSTANCE_IP}:30001", f"{TEMP_INSTANCE_IP}:30001"]],
+        )
+    ]
+
+    global_data = _cleanup_global_data()
+    global_data["infos"][0]["drill_prod_temp_instance_pairs"] = [
+        [f"{PROD_INSTANCE_IP}:30000", f"{TEMP_INSTANCE_IP}:30000"]
+    ]
+
+    service = _cleanup_service()
+    cleanup_hosts = _collect_cleanup_hosts_checked(service, global_data)
+
+    assert cleanup_hosts == [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30001]}]
+    fallback_calls = [
+        str(call) for call in service.log_info.call_args_list if "drill ticket pairs fallback" in str(call)
+    ]
+    assert fallback_calls == []
+
+
+@patch(
+    "backend.flow.plugins.components.collections.redis.redis_rollback_exercise.TbTendisRollbackTasks.objects.filter"
+)
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.StorageInstance.objects.filter")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.get")
+def test_cleanup_targets_skip_when_no_task_and_no_drill_pairs(mock_cluster_get, mock_storage_filter, mock_task_filter):
+    mock_cluster_get.return_value = SimpleNamespace(id=101, bk_cloud_id=0)
+    mock_storage_filter.return_value = []
+    mock_task_filter.return_value = []
+
+    global_data = {
+        "uid": 123,
+        "bk_biz_id": 3,
+        "infos": [{"cluster_id": 101, "redis": [{"ip": TEMP_INSTANCE_IP}]}],
+    }
+
+    cleanup_hosts = _collect_cleanup_hosts_checked(_cleanup_service(), global_data)
 
     assert cleanup_hosts == []
 
 
 def test_cleanup_script_removes_only_allowlisted_work_dirs():
-    script = RedisExerciseBestEffortCleanupService._build_cleanup_script(
-        [{"ip": "1.1.1.3", "bk_cloud_id": 0, "ports": [30000, 30001]}]
-    )
+    cleanup_hosts = [{"ip": TEMP_INSTANCE_IP, "bk_cloud_id": 0, "ports": [30000, 30001]}]
+    _assert_cleanup_never_touches_prod(cleanup_hosts)
+    script = RedisExerciseBestEffortCleanupService._build_cleanup_script(cleanup_hosts)
 
+    assert TEMP_INSTANCE_IP in script
+    assert PROD_INSTANCE_IP not in script
     assert "30000 30001" in script
     assert "39999" not in script
     assert "/data/redis/*" not in script

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
@@ -112,6 +112,16 @@ def test_best_effort_cleanup_uses_parent_ticket_for_rollback_tasks():
     assert service._get_rollback_task_ticket_id({"uid": 999}) == 999
 
 
+def test_enrich_drill_prod_temp_instance_pairs_sets_expected_mapping():
+    info = {
+        "instance_ip": "1.1.1.4",
+        "instance_port": 30000,
+        "redis": [{"ip": "1.1.1.3"}],
+    }
+    RedisRollbackExerciseFlow._enrich_drill_prod_temp_instance_pairs(info)
+    assert info["drill_prod_temp_instance_pairs"] == [["1.1.1.4:30000", "1.1.1.3:30000"]]
+
+
 def test_revoke_applied_hosts_service_outputs_unique_redis_hosts():
     service = RedisExerciseRevokeAppliedHostsService()
     data = FakeData(


### PR DESCRIPTION
## 具体改动

- **函数名拼写错误**：`get_redis_moudles_detail`、`get_cluster_redis_modules_detial` 重命名为正确拼写，并同步全部调用点（已确认无残留旧名）
- **整机替换 proxy module 注入**：CMR 场景预取一次 module 列表并显式传入 `ProxyBatchInstallAtomJob`；`load_modules` 默认值从可变 `[]` 改为 `None`，避免可变默认参数 + 每次重复查 dbconfig
- **precheck N+1 查询**：整机替换存在性校验改为基于 prefetch 的内存集合判断，proxy/slave/master 校验从「每 IP 一次 `.filter()`」降为 0 次额外查询
- **cache_backup_mode 重复调用**：主从替换原子任务将 `get_cache_backup_mode` 提到循环外只取一次，并透传到部署新实例 / 建同步子流程
- **回档演练缺 task 行时漏清理**：抽出 `_extract_allowlisted_temp_ports` 复用，新增 drill 兜底——无 `TbTendisRollbackTasks` 时用 ticket 上 prod/temp 配对推导临时端口，仍保留 prod 地址重叠保护

## 测试 & 风险

- 单测已覆盖 drill 配对推导、回档清理兜底分支、prod IP 永不被清理（runner 全量加守卫）
- 仅影响 Redis 替换 / 回档演练链路；无对外接口变更；函数重命名已同步所有调用点