### PR TITLE
fix(redis): correct data structure backup download and disk check #18196

### DIFF
--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
@@ -73,6 +73,7 @@ from backend.flow.utils.redis.redis_act_playload import RedisActPayload
 from backend.flow.utils.redis.redis_cluster_nodes import convert_slot_to_str
 from backend.flow.utils.redis.redis_context_dataclass import ActKwargs, RedisDataStructureContext
 from backend.flow.utils.redis.redis_db_meta import RedisDBMeta
+from backend.utils.string import format_size
 from backend.utils.time import str2datetime
 
 logger = logging.getLogger("flow")
@@ -350,24 +351,20 @@ class RedisDataStructureFlow(object):
 
         # ### 检查新机器磁盘空间和内存是否够##############################################
         acts_list_disk_check = self.generate_acts_list_disk_check(
-            info["redis"], acts_list, cluster_type, first_act_kwargs
+            info["redis"], acts_list, tendis_type, first_act_kwargs
         )
         redis_pipeline.add_parallel_acts(acts_list=acts_list_disk_check)
 
-        # 并发下载 节点维度的备份文件
-        sub_pipelines = []
+        # Part2: 备份下载 || (redis 安装 -> CC 模块 -> cluster meet -> proxy -> payload json)
+        sub_pipelines_download = []
         for act in acts_list:
             data_params = act["kwargs"]["cluster"]
-            # source_ports = data_params["source_ports"]
-            # for source_port in source_ports:
-            # 这里可以一次下载，不用按端口分批下载
             sub_builder = redis_backupfile_download(
                 self.root_id,
                 cluster_ticket_data,
                 info,
                 {
                     "source_ip": data_params["source_ip"],
-                    # "source_port": source_port,
                     "new_temp_ip": data_params["new_temp_ip"],
                     "full_file_list": data_params["full_file_list"],
                     "binlog_file_list": data_params["binlog_file_list"],
@@ -375,42 +372,45 @@ class RedisDataStructureFlow(object):
                     "tendis_type": data_params["tendis_type"],
                 },
             )
-            sub_pipelines.append(sub_builder)
-            # 并发下载
-        redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
+            sub_pipelines_download.append(sub_builder)
 
-        # 检查备份信息存在，机器磁盘是否够，然后下载到临时机器，这里最后再部署redis 节点，免得做无用步骤
-        redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines_install)
+        install_setup_pipeline = SubBuilder(root_id=self.root_id, data=cluster_ticket_data)
+        install_setup_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines_install)
 
-        # # ###cc 转移机器模块 ################################################################
         cluster_kwargs.cluster["meta_func_name"] = RedisDBMeta.redis_rollback_host_transfer.__name__
         cluster_kwargs.cluster["tendiss"] = []
         for instance in cluster_dst_instance:
             ip, port = instance.split(":")
             cluster_kwargs.cluster["tendiss"].append({"receiver": {"ip": ip, "port": int(port)}})
-        redis_pipeline.add_act(
+        install_setup_pipeline.add_act(
             act_name=_("Redis-临时节点加入源集群cc模块"),
             act_component_code=RedisDBMetaComponent.code,
             kwargs=asdict(cluster_kwargs),
         )
-        # # ### cc 转移机器模块完成 ############################################################
 
-        # 人工确认文件下发完成的节点
+        if is_redis_cluster_protocal(cluster_type) and not is_drill:
+            self._setup_cluster_meet(cluster_type, act_kwargs, cluster_dst_instance, info, install_setup_pipeline)
+
+        self._deploy_proxy_instance(
+            cluster_type,
+            act_kwargs,
+            info,
+            redis_instance_set,
+            node_pairs,
+            cluster_dst_instance,
+            install_setup_pipeline,
+        )
+        if acts_list_push_json:
+            install_setup_pipeline.add_parallel_acts(acts_list=acts_list_push_json)
+
+        part2_parallel_branches = sub_pipelines_download + [
+            install_setup_pipeline.build_sub_process(sub_name=_("Redis实例部署及环境准备"))
+        ]
+        redis_pipeline.add_parallel_sub_pipeline(sub_flow_list=part2_parallel_branches)
+
         if not cluster_ticket_data.get("skip_mannual_confirm", False):
             redis_pipeline.add_act(act_name=_("人工确认"), act_component_code=PauseComponent.code, kwargs={})
 
-        # ### 如果是tendisplus,需要构建tendis cluster关系 ############################################################
-        if is_redis_cluster_protocal(cluster_type) and not is_drill:
-            self._setup_cluster_meet(cluster_type, act_kwargs, cluster_dst_instance, info, redis_pipeline)
-        # ### 构建tendisplus集群关系结束 #############################################################################
-
-        # ### 部署proxy实例 #############################################################################
-        self._deploy_proxy_instance(
-            cluster_type, act_kwargs, info, redis_instance_set, node_pairs, cluster_dst_instance, redis_pipeline
-        )
-        # ### 数据构造payload json下发 #########################################################################
-        redis_pipeline.add_parallel_acts(acts_list=acts_list_push_json)
-        # ### 数据构造下发actuator #############################################################################
         redis_pipeline.add_parallel_acts(acts_list=acts_list)
 
         # # ###  # ### 如果是tendisplus,需要重新构建 cluster关系,因为tendisplus数据构造需要reset集群关系  ##############
@@ -455,31 +455,35 @@ class RedisDataStructureFlow(object):
 
     @staticmethod
     def generate_acts_list_disk_check(
-        redis_hosts: List[Dict], acts_list: List[Dict], cluster_type: str, first_act_kwargs: ActKwargs
+        redis_hosts: List[Dict], acts_list: List[Dict], tendis_type: str, first_act_kwargs: ActKwargs
     ) -> List:
         acts_list_disk_check = []
+        include_binlog = tendis_type in [
+            ClusterType.TendisplusInstance.value,
+            ClusterType.TendisSSDInstance.value,
+        ]
         for index, new_master in enumerate([host["ip"] for host in redis_hosts]):
             # 计算待下载的备份文件大小和获取对应机器磁盘大小,这里是单个任务的时候，还有多个任务的时候
             multi_total_size = 0
+            host_full_count = 0
+            host_binlog_count = 0
             for act in acts_list:
                 data_params = act["kwargs"]["cluster"]
-                logger.info(_("generate_acts_list_disk_check_data_params: {}".format(data_params)))
-                full_size = 0
+                full_size = sum(int(full["size"]) for full in data_params["full_file_list"])
                 all_binlog_size = 0
-                for full in data_params["full_file_list"]:
-                    logger.info(_("generate_acts_list_disk_check full: {}".format(full)))
-                    full_size += int(full["size"])
-                # ssd和tendisplus才有binlog文件
-                if cluster_type in [
-                    ClusterType.TendisTwemproxyRedisInstance.value,
-                    ClusterType.TwemproxyTendisSSDInstance.value,
-                ]:
-                    for binlog in data_params["binlog_file_list"]:
-                        logger.info(_("generate_acts_list_disk_check binlog: {}".format(binlog)))
-                        all_binlog_size += int(binlog["size"])
+                if include_binlog:
+                    all_binlog_size = sum(int(binlog["size"]) for binlog in data_params["binlog_file_list"])
                 total_size = full_size + all_binlog_size
                 if data_params["new_temp_ip"] == new_master:
                     multi_total_size += total_size
+                    host_full_count += len(data_params["full_file_list"])
+                    if include_binlog:
+                        host_binlog_count += len(data_params["binlog_file_list"])
+            logger.debug(
+                _("generate_acts_list_disk_check host={} full_files={} binlog_files={} total_size={}").format(
+                    new_master, host_full_count, host_binlog_count, format_size(multi_total_size)
+                )
+            )
             first_act_kwargs.cluster["multi_total_size"] = multi_total_size
             first_act_kwargs.exec_ip = new_master
             acts_list_disk_check.append(

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_sub.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_sub.py
@@ -37,49 +37,47 @@ def redis_backupfile_download(root_id: str, ticket_data: dict, cluster_info: dic
 
     sub_pipeline = SubBuilder(root_id=root_id, data=copy.deepcopy(ticket_data))
     redis_os_account = PayloadHandler.redis_get_os_account()
-    logger.info("+==redis_backupfile_download download_kwargs redis_os_account:{} +++ ".format(redis_os_account))
 
-    # 全备份文件下载
-    task_ids = [file_info["task_id"] for file_info in param["full_file_list"]]
+    full_file_list = param["full_file_list"]
+    binlog_file_list = param.get("binlog_file_list") or []
+
+    # cache类型的情况，只有全备份文件,ssd和tendisplus 必须有binlog文件
+    if param["tendis_type"] in [ClusterType.TendisplusInstance.value, ClusterType.TendisSSDInstance.value]:
+        if len(binlog_file_list) == 0:
+            raise TendisGetBinlogFailedException(
+                message=_("集群类型为:{},但是下载的binlog备份信息为0，不符合预期，最少有2个binlog".format(param["tendis_type"]))
+            )
+
+    all_files = full_file_list + binlog_file_list
+    task_ids = [file_info["task_id"] for file_info in all_files]
+    total_bytes = sum(int(file_info["size"]) for file_info in all_files)
+
     download_kwargs = DownloadBackupFileKwargs(
         bk_cloud_id=cluster_info["bk_cloud_id"],
         task_ids=task_ids,
         dest_ip=param["new_temp_ip"],
         dest_dir=param["dest_dir"],
-        reason="redis data structure full backup file download",
+        reason="redis data structure backup download",
         login_user=redis_os_account["os_user"],
         login_passwd=redis_os_account["os_password"],
+        source_ip=param["source_ip"],
+        full_count=len(full_file_list),
+        binlog_count=len(binlog_file_list),
+        total_bytes=total_bytes,
     )
-    logger.info("+==redis_backupfile_download download_kwargs download_kwargs:{} +++ ".format(download_kwargs))
+    logger.info(
+        "redis_backupfile_download source={} dest={} full={} binlog={} total_bytes={}".format(
+            param["source_ip"],
+            param["new_temp_ip"],
+            len(full_file_list),
+            len(binlog_file_list),
+            total_bytes,
+        )
+    )
     sub_pipeline.add_act(
-        act_name=_("下载{}全备文件到{}").format(param["source_ip"], param["new_temp_ip"]),
+        act_name=_("下载{}备份到{}").format(param["source_ip"], param["new_temp_ip"]),
         act_component_code=RedisDownloadBackupfileComponent.code,
         kwargs=asdict(download_kwargs),
     )
-
-    # cache类型的情况，只有全备份文件,ssd和tendisplus 必须有binlog文件
-    if param["tendis_type"] in [ClusterType.TendisplusInstance.value, ClusterType.TendisSSDInstance.value]:
-
-        if len(param["binlog_file_list"]) == 0:
-            raise TendisGetBinlogFailedException(
-                message=_("集群类型为:{},但是下载的binlog备份信息为0，不符合预期，最少有2个binlog".format(param["tendis_type"]))
-            )
-        # binlog文件下载
-        task_ids = [file_info["task_id"] for file_info in param["binlog_file_list"]]
-        download_kwargs = DownloadBackupFileKwargs(
-            bk_cloud_id=cluster_info["bk_cloud_id"],
-            task_ids=task_ids,
-            dest_ip=param["new_temp_ip"],
-            dest_dir=param["dest_dir"],
-            reason="redis data structure binlog backup file download",
-            login_user=redis_os_account["os_user"],
-            login_passwd=redis_os_account["os_password"],
-        )
-        logger.info("+==redis_backupfile_download download_kwargs download_kwargs:{} +++ ".format(download_kwargs))
-        sub_pipeline.add_act(
-            act_name=_("下载{}binlog文件到{}").format(param["source_ip"], param["new_temp_ip"]),
-            act_component_code=RedisDownloadBackupfileComponent.code,
-            kwargs=asdict(download_kwargs),
-        )
 
     return sub_pipeline.build_sub_process(sub_name=_("下载备份文件到{}".format(param["new_temp_ip"])))

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/exec_shell_script.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/exec_shell_script.py
@@ -24,7 +24,7 @@ from backend.flow.models import FlowNode
 from backend.flow.plugins.components.collections.common.base_service import BaseService, BkJobService
 from backend.flow.utils.redis.redis_context_dataclass import RedisDataStructureContext
 from backend.flow.utils.redis.redis_script_template import redis_fast_execute_script_common_kwargs
-from backend.utils.string import base64_encode
+from backend.utils.string import base64_encode, format_size
 
 logger = logging.getLogger("json")
 
@@ -154,10 +154,6 @@ class RedisDataStructurePrecheckService(BaseService):
             # 表示没有加载上下文内容，则在此添加
             trans_data = getattr(flow_context, kwargs["set_trans_data_dataclass"])()
 
-        # 打印信息
-        self.log_info(" RedisDataStructurePrecheckService start")
-        self.log_info("kwargs: {}".format(kwargs))
-
         try:
             # 临时机器磁盘空间是否足够
             if not self.check_src_redis_host_disk(trans_data, kwargs):
@@ -188,21 +184,50 @@ class RedisDataStructurePrecheckService(BaseService):
         ret["mount_on"] = l01[5]
         return ret
 
-    def log_disk_error(self, exec_ip, disk_info):
-        error_message = _("源Redis服务器：{} {} 磁盘使用率：{}% > 85%").format(
-            exec_ip["ip"], disk_info["filesystem"], disk_info["used_ratio"]
-        )
-        self.log_error(error_message)
-        return False
-
-    def check_disk_usage(self, disk_info, exec_ip, data_size):
-        if disk_info["used_ratio"] > 85:
-            return self.log_disk_error(exec_ip, disk_info)
-        if (disk_info["used"] + data_size) / disk_info["total"] > 0.9:
-            error_message = _("源Redis服务器：{} 磁盘使用情况：{}+Redis数据大小：{} 将会 >=90%").format(
-                exec_ip, disk_info["used"], data_size
+    def log_disk_usage_summary(self, exec_ip, dir_label, disk_info, data_size):
+        self.log_info(
+            _("临时机 {} [{}] {}: 需要 {} / 可用 {} (已用 {}%, 总量 {})").format(
+                exec_ip,
+                dir_label,
+                disk_info["mount_on"],
+                format_size(data_size),
+                format_size(disk_info["avail"]),
+                disk_info["used_ratio"],
+                format_size(disk_info["total"]),
             )
-            self.log_error(error_message)
+        )
+
+    def check_disk_usage(self, exec_ip, dir_label, disk_info, data_size):
+        self.log_disk_usage_summary(exec_ip, dir_label, disk_info, data_size)
+        if disk_info["used_ratio"] > 85:
+            self.log_error(
+                _("临时机 {} [{}] {} 磁盘使用率 {}% > 85%").format(
+                    exec_ip, dir_label, disk_info["mount_on"], disk_info["used_ratio"]
+                )
+            )
+            return False
+        if data_size > disk_info["avail"]:
+            self.log_error(
+                _("临时机 {} [{}] {} 空间不足: 需要 {} > 可用 {}").format(
+                    exec_ip,
+                    dir_label,
+                    disk_info["mount_on"],
+                    format_size(data_size),
+                    format_size(disk_info["avail"]),
+                )
+            )
+            return False
+        if (disk_info["used"] + data_size) / disk_info["total"] > 0.9:
+            self.log_error(
+                _("临时机 {} [{}] {} 预计占用达 90%: 已用 {} + 需要 {} / 总量 {}").format(
+                    exec_ip,
+                    dir_label,
+                    disk_info["mount_on"],
+                    format_size(disk_info["used"]),
+                    format_size(data_size),
+                    format_size(disk_info["total"]),
+                )
+            )
             return False
         return True
 
@@ -221,25 +246,26 @@ class RedisDataStructurePrecheckService(BaseService):
 
         # # 当所有机器的备份目录一样时，对backup_dir赋值
         trans_data.backup_dir = backup_dir
-        self.log_info(_("检查源Redis服务器磁盘使用情况：{}").format(disk_used))
-        self.log_info("check_src_redis_host_disk  disk_used:{}".format(disk_used))
 
         exec_ip = kwargs["exec_ip"]
         cluster = kwargs["cluster"]
+        needed_size = cluster["multi_total_size"]
+        self.log_info(_("临时机 {} 待下载备份总量: {}").format(exec_ip, format_size(needed_size)))
+
         # 检查备份目录
         redis_backup_dir_data = disk_used.get(exec_ip)["redis_backup_dir_data"]
         cluster["backup_dir"] = disk_used.get(exec_ip)["backup_dir"]
         disk_info = self.decode_slave_host_disk_info(redis_backup_dir_data)
-        if not self.check_disk_usage(disk_info, exec_ip, cluster["multi_total_size"]):
+        if not self.check_disk_usage(exec_ip, _("备份"), disk_info, needed_size):
             return False
 
         # 检查数据目录
         redis_data_dir_data = disk_used.get(exec_ip)["redis_data_dir_data"]
         data_disk_info = self.decode_slave_host_disk_info(redis_data_dir_data)
-        if not self.check_disk_usage(data_disk_info, exec_ip, cluster["multi_total_size"]):
+        if not self.check_disk_usage(exec_ip, _("数据"), data_disk_info, needed_size):
             return False
 
-        self.log_info(_("redis 临时机器:{} 磁盘空间检查通过").format(kwargs["exec_ip"]))
+        self.log_info(_("临时机 {} 磁盘空间检查通过").format(exec_ip))
         return True
 
     @staticmethod

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_download_backup_files.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_download_backup_files.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import logging.config
+import time
 
 from django.utils.translation import gettext as _
 from pipeline.component_framework.component import Component
@@ -19,8 +20,11 @@ import backend.flow.utils.redis.redis_context_dataclass as flow_context
 from backend.components.mysql_backup.client import RedisBackupApi
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils.redis.redis_context_dataclass import RedisDataStructureContext
+from backend.utils.string import format_size
 
 logger = logging.getLogger("flow")
+
+_PROGRESS_LOG_INTERVAL_SEC = 60
 
 
 class RedisDownloadBackupfile(BaseService):
@@ -29,7 +33,7 @@ class RedisDownloadBackupfile(BaseService):
     """
 
     __need_schedule__ = True
-    interval = StaticIntervalGenerator(3)  # poll every 3 sec
+    interval = StaticIntervalGenerator(15)
 
     def _execute(self, data, parent_data) -> bool:
         kwargs = data.get_one_of_inputs("kwargs")
@@ -47,44 +51,70 @@ class RedisDownloadBackupfile(BaseService):
             "dest_dir": dest_dir,
             "reason": kwargs["reason"],
         }
-        logger.info("+==RedisDownloadBackupfile params :{} +++ ".format(params))
+        self.log_debug({k: v for k, v in params.items() if k != "login_passwd"})
 
-        self.log_debug(params)
         response = RedisBackupApi.download(params=params)
         backup_bill_id = response.get("bill_id", -1)
         if backup_bill_id > 0:
-            self.log_debug(_("调起下载 {}").format(backup_bill_id))
+            file_count = len(kwargs["task_ids"])
+            total_bytes = kwargs.get("total_bytes")
+            total_size = format_size(total_bytes) if total_bytes is not None else _("未知")
+            self.log_info(
+                _(
+                    "下载备份到 {dest_ip}: source={source_ip}, full={full_count}, binlog={binlog_count}, "
+                    "files={file_count}, size={total_size}, bill={bill_id}"
+                ).format(
+                    dest_ip=kwargs["dest_ip"],
+                    source_ip=kwargs.get("source_ip") or "-",
+                    full_count=kwargs.get("full_count") if kwargs.get("full_count") is not None else "-",
+                    binlog_count=kwargs.get("binlog_count") if kwargs.get("binlog_count") is not None else "-",
+                    file_count=file_count,
+                    total_size=total_size,
+                    bill_id=backup_bill_id,
+                )
+            )
             data.outputs.backup_bill_id = backup_bill_id
             return True
         else:
             return False
 
     def _schedule(self, data, parent_data, callback_data=None):
-        # 定义异步扫描
         backup_bill_id = data.get_one_of_outputs("backup_bill_id")
-        self.log_info(_("下载单据ID {}").format(backup_bill_id))
+        self.log_debug(_("轮询下载单据 {}").format(backup_bill_id))
         result_response = RedisBackupApi.download_result({"bill_id": backup_bill_id})
-        # 如何判断
         if result_response is not None and "total" in result_response:
-            if (
-                result_response["total"]["todo"] == 0
-                and result_response["total"]["doing"] == 0
-                and result_response["total"]["fail"] == 0
-            ):
+            total = result_response["total"]
+            if total["todo"] == 0 and total["doing"] == 0 and total["fail"] == 0:
                 self.log_info(_("{} 下载成功").format(backup_bill_id))
                 self.finish_schedule()
                 return True
-            elif result_response["total"]["fail"] > 0:
+            elif total["fail"] > 0:
                 self.log_error(_("{} 下载失败").format(backup_bill_id))
                 self.log_debug(str(result_response))
                 self.finish_schedule()
                 return False
             else:
-                self.log_debug(_("{} 下载中: todo {}").format(backup_bill_id, result_response["total"]["todo"]))
+                self._log_download_progress(data, backup_bill_id, total)
         else:
             self.log_debug("result response fail")
             self.finish_schedule()
             return False
+
+    def _log_download_progress(self, data, backup_bill_id, total):
+        todo = total["todo"]
+        doing = total["doing"]
+        last_todo = data.get_one_of_outputs("last_todo")
+        last_doing = data.get_one_of_outputs("last_doing")
+        last_log_ts = data.get_one_of_outputs("last_progress_log_ts") or 0
+        now = time.time()
+        progress_changed = todo != last_todo or doing != last_doing
+        if progress_changed or (now - last_log_ts) >= _PROGRESS_LOG_INTERVAL_SEC:
+            self.log_info(_("{} 下载中: todo={} doing={}").format(backup_bill_id, todo, doing))
+            data.outputs.last_todo = todo
+            data.outputs.last_doing = doing
+            data.outputs.last_progress_log_ts = now
+        else:
+            self.log_debug(_("{} 下载中: todo={} doing={}").format(backup_bill_id, todo, doing))
 
 
 class RedisDownloadBackupfileComponent(Component):

--- a/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
@@ -212,6 +212,10 @@ class DownloadBackupFileKwargs:
     login_passwd: str
     cluster: dict = None
     tendis_backup_info: list = None  # 占位：执行备份后的信息
+    source_ip: str = None
+    full_count: int = None
+    binlog_count: int = None
+    total_bytes: int = None
 
 
 @dataclass()

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_data_structure.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_data_structure.py
@@ -11,6 +11,50 @@ from backend.flow.plugins.components.collections.common.disable_alarm_shield imp
 from backend.flow.utils.redis.redis_context_dataclass import ActKwargs
 
 
+def _make_disk_check_act(new_temp_ip, full_size, binlog_size=0, binlog_count=0):
+    return {
+        "kwargs": {
+            "cluster": {
+                "new_temp_ip": new_temp_ip,
+                "full_file_list": [{"size": full_size, "task_id": "full-1"}],
+                "binlog_file_list": [{"size": binlog_size, "task_id": f"binlog-{i}"} for i in range(binlog_count)],
+            }
+        }
+    }
+
+
+def test_generate_acts_list_disk_check_includes_binlog_for_tendisplus():
+    acts_list = [_make_disk_check_act("1.1.1.3", full_size=100, binlog_size=50, binlog_count=2)]
+    act_kwargs = ActKwargs()
+    act_kwargs.cluster = {}
+
+    result = RedisDataStructureFlow.generate_acts_list_disk_check(
+        [{"ip": "1.1.1.3"}],
+        acts_list,
+        ClusterType.TendisplusInstance.value,
+        act_kwargs,
+    )
+
+    assert len(result) == 1
+    assert result[0]["kwargs"]["cluster"]["multi_total_size"] == 200  # 100 full + 2 * 50 binlog
+
+
+def test_generate_acts_list_disk_check_excludes_binlog_for_cache():
+    acts_list = [_make_disk_check_act("1.1.1.3", full_size=100, binlog_size=50, binlog_count=2)]
+    act_kwargs = ActKwargs()
+    act_kwargs.cluster = {}
+
+    result = RedisDataStructureFlow.generate_acts_list_disk_check(
+        [{"ip": "1.1.1.3"}],
+        acts_list,
+        ClusterType.RedisInstance.value,
+        act_kwargs,
+    )
+
+    assert len(result) == 1
+    assert result[0]["kwargs"]["cluster"]["multi_total_size"] == 100
+
+
 def test_parse_shard_value_ranges_accepts_multiple_slot_ranges():
     shard_value = "1365-1637 10651-10923\n13382-13654 15020-15292 16111-16383"
 
@@ -201,7 +245,31 @@ def test_build_cluster_data_structure_installs_dbmon_only_when_not_drill(
     ), patch.object(
         RedisDataStructureFlow,
         "get_prod_temp_instance_pairs",
-        return_value=([], []),
+        return_value=(
+            [
+                {
+                    "act_name": "data-structure-act",
+                    "act_component_code": "redis_data_structure_actuator_execute",
+                    "kwargs": {
+                        "cluster": {
+                            "source_ip": "1.1.1.2",
+                            "new_temp_ip": "1.1.1.3",
+                            "full_file_list": [{"size": 100, "task_id": "full-1"}],
+                            "binlog_file_list": [],
+                            "dest_dir": "",
+                            "tendis_type": ClusterType.RedisInstance.value,
+                        }
+                    },
+                }
+            ],
+            [
+                {
+                    "act_name": "push-json",
+                    "act_component_code": "push_data_structure_json_script",
+                    "kwargs": {"cluster": {"new_temp_ip": "1.1.1.3"}},
+                }
+            ],
+        ),
     ):
         flow.build_cluster_data_structure(info)
 
@@ -210,10 +278,19 @@ def test_build_cluster_data_structure_installs_dbmon_only_when_not_drill(
     for call in mock_install_atom.call_args_list:
         assert call.args[1] is cluster_global_data
         assert call.args[1]["cluster_type"] == ClusterType.TendisTwemproxyRedisInstance.value
+        assert call.kwargs.get("to_trans_files", True) is True
         assert call.kwargs["to_install_dbmon"] is expected_install_dbmon, (
             f"to_install_dbmon must be {expected_install_dbmon} when is_drill={is_drill}, "
             f"got {call.kwargs.get('to_install_dbmon')!r}"
         )
+
+    part2_calls = [
+        call.kwargs["sub_flow_list"]
+        for call in pipeline.add_parallel_sub_pipeline.call_args_list
+        if mock_backup_download.return_value in call.kwargs["sub_flow_list"]
+    ]
+    assert part2_calls, "backup download should be in Part2 parallel branches"
+    assert len(part2_calls[0]) >= 2, "Part2 should include backup download and install-setup sub-process"
     component_codes = [call.kwargs.get("act_component_code") for call in pipeline.add_act.call_args_list]
     assert (AddAlarmShieldComponent.code in component_codes) is (not is_drill)
     assert (DisableAlarmShieldComponent.code in component_codes) is (not is_drill)


### PR DESCRIPTION
- Redis 数据构造流程中备份下载与磁盘预检不准、日志无效信息、安装与下载串行的问题

## 具体改动

- **binlog 未计入磁盘预检**：`generate_acts_list_disk_check` 按 `tendis_type`（Tendisplus/SSD）纳入 binlog 体积，Cache 类型不计入 → 临时机空间不足可在预检阶段提前失败
- **全备/binlog 重复下载**：`redis_backupfile_download` 合并为单次 `RedisDownloadBackupfile` 调用，统一 `task_ids` 与 `total_bytes` → 减少子流程节点、下载单据更易追踪
- **下载与安装串行耗时**：Part2 将「备份下载」与「Redis 安装 → CC 模块 → cluster meet → proxy → payload json」改为并行分支 → 缩短数据构造主流程等待时间
- **重复下发介质**：主流程已初始化机器后，`to_trans_files=False` 跳过安装阶段重复传包 → 避免冗余介质下发
- **下载进度日志刷屏**：轮询间隔 3s→15s，进度 `log_info` 仅在状态变化或 60s 心跳时输出 → 流水线日志可读性提升
- **磁盘预检信息不足**：`RedisDataStructurePrecheckService` 输出待下载总量、挂载点、需要/可用/已用空间（`format_size`）→ 空间不足时可定位到备份/数据目录

## 测试 & 风险

- 单测已覆盖 Tendisplus/Cache 的 `multi_total_size` 计算、Part2 并行分支编排（下载 + 安装部署子流程）、`to_trans_files=False` 与演练场景 `dbmon` 开关
- 仅影响 Redis 数据构造链路；无对外 API 变更；Part2 并行后安装与下载同时进行，人工确认仍在执行 actuator 之前