### PR TITLE
fix(backend): 修复query_cap函数返回值不一致导致MongoShardedCluster容量查询解包失败 #18238

### DIFF
--- a/dbm-ui/backend/db_monitor/tasks.py
+++ b/dbm-ui/backend/db_monitor/tasks.py
@@ -171,7 +171,7 @@ def query_cap(bk_biz_id, cluster_type, cap_key="used", immute_domains=None):
     query_template = QUERY_TEMPLATE.get(cluster_type)
     if not query_template:
         logger.error("No query template for cluster type: %s", cluster_type)
-        return {}
+        return {}, {}
 
     # now-5/15m ~ now
     end_time = datetime.datetime.now(timezone.utc)

--- a/dbm-ui/backend/db_monitor/views/shield.py
+++ b/dbm-ui/backend/db_monitor/views/shield.py
@@ -18,7 +18,7 @@ from backend.bk_web.viewsets import SystemViewSet
 from backend.components import BKMonitorV3Api
 from backend.db_monitor import serializers
 from backend.db_monitor.constants import SWAGGER_TAG
-from backend.db_monitor.utils import deformat_shield_description, format_shield_description
+from backend.db_monitor.utils import deformat_shield_description, format_shield_description, parse_shield_description_biz
 from backend.iam_app.dataclass import ActionEnum, ResourceEnum
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.monitor import AlertShieldPermission
@@ -59,27 +59,65 @@ class AlarmShieldView(SystemViewSet):
     )
     def list(self, request):
         params = self.validated_data
+        bk_biz_id = params["bk_biz_id"]
         page_size = int(request.query_params.get("limit", 10))
         page = int(int(request.query_params.get("offset", 0)) / page_size) + 1
         if params.get("category"):
             params["categories"] = [params["category"]]
-        conditions = params.get("conditions", [])
-        conditions.append({"key": "description", "value": format_shield_description(params["bk_biz_id"])})
-        params.update(
+        base_conditions = params.get("conditions", [])
+
+        # 查询1：DBM 通过接口创建的屏蔽（description 含 [dbm:appid=xxx] 前缀）
+        dbm_conditions = list(base_conditions)
+        dbm_conditions.append({"key": "description", "value": format_shield_description(bk_biz_id)})
+        dbm_params = dict(params)
+        dbm_params.update(
             {
                 "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
                 "bk_biz_ids": [env.DBA_APP_BK_BIZ_ID],
-                "page": page,
-                "page_size": page_size,
-                "conditions": conditions,
+                "page": 1,
+                "page_size": 500,
+                "conditions": dbm_conditions,
             }
         )
-        data = BKMonitorV3Api.list_shield(params)
-        for index, shield in enumerate(data["shield_list"]):
-            data["shield_list"][index]["description"] = deformat_shield_description(
-                params["bk_biz_id"], shield["description"]
-            )
-        return Response(data)
+        dbm_data = BKMonitorV3Api.list_shield(dbm_params)
+
+        # 查询2：手机端直接在目标业务下创建的屏蔽（bk_biz_ids 包含目标业务 appid）
+        app_conditions = list(base_conditions)
+        app_params = dict(params)
+        app_params.update(
+            {
+                "bk_biz_id": bk_biz_id,
+                "bk_biz_ids": [bk_biz_id],
+                "page": 1,
+                "page_size": 500,
+                "conditions": app_conditions,
+            }
+        )
+        app_data = BKMonitorV3Api.list_shield(app_params)
+
+        # 合并去重（以 shield id 为唯一键），DBM 创建的优先（description 会被格式化）
+        seen_ids = set()
+        merged_shields = []
+
+        for shield in dbm_data.get("shield_list", []):
+            if shield["id"] not in seen_ids:
+                seen_ids.add(shield["id"])
+                shield["description"] = deformat_shield_description(bk_biz_id, shield["description"])
+                merged_shields.append(shield)
+
+        for shield in app_data.get("shield_list", []):
+            if shield["id"] not in seen_ids:
+                # 手机端创建的屏蔽，description 无 DBM 前缀，直接保留
+                seen_ids.add(shield["id"])
+                merged_shields.append(shield)
+
+        # 对合并结果做分页
+        total = len(merged_shields)
+        start = (page - 1) * page_size
+        end = start + page_size
+        paged_shields = merged_shields[start:end]
+
+        return Response({"count": total, "shield_list": paged_shields})
 
     @common_swagger_auto_schema(
         operation_summary=_("告警屏蔽详情"),

--- a/dbm-ui/backend/db_monitor/views/shield.py
+++ b/dbm-ui/backend/db_monitor/views/shield.py
@@ -18,7 +18,7 @@ from backend.bk_web.viewsets import SystemViewSet
 from backend.components import BKMonitorV3Api
 from backend.db_monitor import serializers
 from backend.db_monitor.constants import SWAGGER_TAG
-from backend.db_monitor.utils import deformat_shield_description, format_shield_description, parse_shield_description_biz
+from backend.db_monitor.utils import deformat_shield_description, format_shield_description
 from backend.iam_app.dataclass import ActionEnum, ResourceEnum
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.monitor import AlertShieldPermission
@@ -59,65 +59,27 @@ class AlarmShieldView(SystemViewSet):
     )
     def list(self, request):
         params = self.validated_data
-        bk_biz_id = params["bk_biz_id"]
         page_size = int(request.query_params.get("limit", 10))
         page = int(int(request.query_params.get("offset", 0)) / page_size) + 1
         if params.get("category"):
             params["categories"] = [params["category"]]
-        base_conditions = params.get("conditions", [])
-
-        # 查询1：DBM 通过接口创建的屏蔽（description 含 [dbm:appid=xxx] 前缀）
-        dbm_conditions = list(base_conditions)
-        dbm_conditions.append({"key": "description", "value": format_shield_description(bk_biz_id)})
-        dbm_params = dict(params)
-        dbm_params.update(
+        conditions = params.get("conditions", [])
+        conditions.append({"key": "description", "value": format_shield_description(params["bk_biz_id"])})
+        params.update(
             {
                 "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
                 "bk_biz_ids": [env.DBA_APP_BK_BIZ_ID],
-                "page": 1,
-                "page_size": 500,
-                "conditions": dbm_conditions,
+                "page": page,
+                "page_size": page_size,
+                "conditions": conditions,
             }
         )
-        dbm_data = BKMonitorV3Api.list_shield(dbm_params)
-
-        # 查询2：手机端直接在目标业务下创建的屏蔽（bk_biz_ids 包含目标业务 appid）
-        app_conditions = list(base_conditions)
-        app_params = dict(params)
-        app_params.update(
-            {
-                "bk_biz_id": bk_biz_id,
-                "bk_biz_ids": [bk_biz_id],
-                "page": 1,
-                "page_size": 500,
-                "conditions": app_conditions,
-            }
-        )
-        app_data = BKMonitorV3Api.list_shield(app_params)
-
-        # 合并去重（以 shield id 为唯一键），DBM 创建的优先（description 会被格式化）
-        seen_ids = set()
-        merged_shields = []
-
-        for shield in dbm_data.get("shield_list", []):
-            if shield["id"] not in seen_ids:
-                seen_ids.add(shield["id"])
-                shield["description"] = deformat_shield_description(bk_biz_id, shield["description"])
-                merged_shields.append(shield)
-
-        for shield in app_data.get("shield_list", []):
-            if shield["id"] not in seen_ids:
-                # 手机端创建的屏蔽，description 无 DBM 前缀，直接保留
-                seen_ids.add(shield["id"])
-                merged_shields.append(shield)
-
-        # 对合并结果做分页
-        total = len(merged_shields)
-        start = (page - 1) * page_size
-        end = start + page_size
-        paged_shields = merged_shields[start:end]
-
-        return Response({"count": total, "shield_list": paged_shields})
+        data = BKMonitorV3Api.list_shield(params)
+        for index, shield in enumerate(data["shield_list"]):
+            data["shield_list"][index]["description"] = deformat_shield_description(
+                params["bk_biz_id"], shield["description"]
+            )
+        return Response(data)
 
     @common_swagger_auto_schema(
         operation_summary=_("告警屏蔽详情"),


### PR DESCRIPTION
close #18238

## 问题描述
`sync_cluster_stat_by_cluster_type` celery定时任务在查询 MongoShardedCluster 类型集群容量时，`query_cap` 函数因找不到对应的 QUERY_TEMPLATE，返回了单个空 dict `{}`，但调用方使用 `used_data, _ = query_cap(...)` 做 tuple 解包，导致 `ValueError: not enough values to unpack (expected 2, got 0)`。

该错误在每个调度周期（约3分钟）持续触发，每次产生13条错误日志。

## 修复内容
将 `query_cap` 函数在无匹配模板时的返回值从 `return {}` 改为 `return {}, {}`，与正常返回值签名 `(cluster_bytes, extra_info)` 保持一致。

## 测试
- [x] 修改后 `query_cap` 在无模板场景返回 `({}, {})`，调用方解包正常
- [x] `query_cluster_capacity` 对无模板集群类型返回空 dict，不影响其他类型
