### PR TITLE
fix(redis): 修复异步调用的问题 #18274

### DIFF
--- a/dbm-ui/backend/flow/utils/redis/redis_proxy_util.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_proxy_util.py
@@ -1014,28 +1014,17 @@ def get_cluster_info_by_cluster_id(cluster_id):
 
 def async_get_multi_cluster_info_by_cluster_ids(cluster_ids: List[int]) -> Dict[int, Any]:
     """
-    根据集群id批量获取集群信息
+    根据集群id批量获取集群信息（使用多线程并发，避免在已有事件循环的上下文中调用 asyncio.run）
     """
-
-    async def async_hanlder(cluster_ids: List[int]) -> Dict[int, Any]:
-        loop = asyncio.get_running_loop()
-
-        # 自定义线程池
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            # 将所有的任务提交到线程池
-            tasks = [
-                loop.run_in_executor(executor, get_cluster_info_by_cluster_id, cluster_id)
-                for cluster_id in cluster_ids
-            ]
-            # 等待所有任务完成并收集结果
-            results = await asyncio.gather(*tasks)
-
-        ret_dict = {}
-        for result in results:
+    ret_dict = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_id = {
+            executor.submit(get_cluster_info_by_cluster_id, cluster_id): cluster_id for cluster_id in cluster_ids
+        }
+        for future in concurrent.futures.as_completed(future_to_id):
+            result = future.result()
             ret_dict[result["cluster_id"]] = result
-        return ret_dict
-
-    return asyncio.run(async_hanlder(cluster_ids))
+    return ret_dict
 
 
 def get_cluster_info_by_ip(ip: str) -> Dict[str, Any]:


### PR DESCRIPTION
两层问题叠加：

asyncio.run() 不能在已有事件循环的上下文中调用：Django 的某些中间件（如 bk_dataview/prometheus/handlers.py 中的装饰器）已经建立了异步上下文，此时再调用 asyncio.run() 会抛出 RuntimeError: This event loop is already running。

Django ORM 在 async 上下文的线程中被调用：即使绕过第一个问题，run_in_executor 提交的线程仍然被 Django 检测到处于异步上下文中，Django 的 SynchronousOnlyOperation 保护机制会阻止同步 ORM 调用。

修复方案
将 async_get_multi_cluster_info_by_cluster_ids 改为纯同步多线程实现，直接使用 concurrent.futures.ThreadPoolExecutor 并发执行，完全移除 asyncio：