### PR TITLE
feat(redis): apply rollback exercise resources in inner flow #18263

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/__init__.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/__init__.py
@@ -8,6 +8,16 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .task import init_redis_rollback_candidates, redis_rollback_exercise, repair_stuck_redis_rollback_exercise
+from .task import (
+    init_redis_rollback_candidates,
+    redis_rollback_exercise,
+    repair_missing_redis_rollback_exercise_recycle,
+    repair_stuck_redis_rollback_exercise,
+)
 
-__all__ = ["init_redis_rollback_candidates", "redis_rollback_exercise", "repair_stuck_redis_rollback_exercise"]
+__all__ = [
+    "init_redis_rollback_candidates",
+    "redis_rollback_exercise",
+    "repair_missing_redis_rollback_exercise_recycle",
+    "repair_stuck_redis_rollback_exercise",
+]

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/base.py
@@ -38,7 +38,7 @@ from backend.db_services.redis.util import (
 )
 from backend.exceptions import AppBaseException
 from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
-from backend.ticket.builders.common.base import ClusterType, IpSource
+from backend.ticket.builders.common.base import ClusterType
 from backend.ticket.constants import TicketType
 from backend.ticket.models import ClusterOperateRecord, Ticket
 from backend.utils.redis import RedisConn
@@ -97,9 +97,9 @@ class RedisRollbackExercise:
         3. Create a REDIS_ROLLBACK_EXERCISE drill ticket with selected instances
 
         The drill ticket will:
-        - Apply resources
+        - Apply resources inside the inner flow
         - Create `redis_data_structure` flow to rollback each instance
-        - Each rollback flow requires 1 machine with spec equal to instance selected
+        - Each rollback flow requires 1 redis-pool machine with disk/mem >= source instance
         - Monitor rollback flow states
         - Destroy temp instances via `redis_data_structure_task_delete` flow
         - Return the resources
@@ -420,12 +420,6 @@ class RedisRollbackExercise:
                 "instance_port": instance.port,
                 "recovery_time_point": datetime2str(recovery_time_point),
                 "report_id": report.id,  # Link to report record for status updates
-                "resource_spec": {
-                    "redis": {
-                        "count": 1,
-                        "spec_id": instance.machine.spec_id,
-                    }
-                },
             }
             infos.append(instance_info)
 
@@ -442,7 +436,6 @@ class RedisRollbackExercise:
                         "polling_timeout": self.config.polling_timeout,
                         "error_ignorable": self.config.error_ignorable,
                     },
-                    "ip_source": IpSource.RESOURCE_POOL.value,
                 },
                 auto_execute=True,
             )

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/task.py
@@ -21,10 +21,102 @@ from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.flow.consts import StateType
 from backend.flow.models import FlowTree
 from backend.flow.signal.redis_rollback_exercise_handler import wakeup_redis_rollback_runner_by_child
+from backend.ticket.constants import FlowType, TicketStatus, TicketType
+from backend.ticket.models import Flow, Ticket
 
 from .base import RedisRollbackExercise
 
 logger = logging.getLogger("root")
+
+RECYCLE_TICKET_TYPES = (TicketType.RECYCLE_APPLY_HOST, TicketType.RECYCLE_OLD_HOST)
+TERMINAL_TICKET_STATUSES = (
+    TicketStatus.SUCCEEDED,
+    TicketStatus.FAILED,
+    TicketStatus.TERMINATED,
+    TicketStatus.REVOKED,
+)
+RECENT_TICKET_LOOKBACK_DAYS = 2
+
+
+def ticket_has_applied_hosts(ticket: Ticket) -> bool:
+    """Return True when rollback exercise ticket details contain applied resource hosts."""
+    recycle_hosts = ticket.details.get("recycle_hosts") or []
+    if recycle_hosts:
+        return True
+
+    for info in ticket.details.get("infos") or []:
+        if info.get("redis"):
+            return True
+    return False
+
+
+def ticket_has_recycle_ticket(ticket_id: int) -> bool:
+    """Return True when the parent drill ticket already has a linked recycle ticket.
+
+    ``Ticket.create_recycle_ticket`` registers a DELIVERY flow on the parent with
+    ``details.related_ticket`` pointing to the recycle ticket. Query by indexed
+    ``Flow.ticket_id`` instead of JSON ``details.parent_ticket`` on Ticket.
+    """
+    related_ticket_ids = []
+    for flow in Flow.objects.filter(
+        ticket_id=ticket_id,
+        flow_type=FlowType.DELIVERY.value,
+    ).only("details"):
+        related_id = (flow.details or {}).get("related_ticket")
+        if related_id:
+            related_ticket_ids.append(related_id)
+
+    if not related_ticket_ids:
+        return False
+
+    return Ticket.objects.filter(
+        id__in=related_ticket_ids,
+        ticket_type__in=RECYCLE_TICKET_TYPES,
+    ).exists()
+
+
+def resolve_missing_recycle_request(ticket: Ticket) -> tuple[TicketType, list]:
+    """Choose recycle ticket type/hosts for a drill ticket missing recycle linkage."""
+    recycle_hosts = ticket.details.get("recycle_hosts") or []
+    if ticket.status == TicketStatus.TERMINATED:
+        return TicketType.RECYCLE_APPLY_HOST, []
+    return TicketType.RECYCLE_OLD_HOST, recycle_hosts
+
+
+def repair_missing_redis_rollback_recycle_tickets(polling_timeout: int) -> int:
+    """
+    Best-effort safety net for drill tickets that applied hosts but missed recycle creation.
+    """
+    now = django_timezone.now()
+    grace_cutoff = now - timedelta(seconds=polling_timeout)
+    recent_cutoff = now - timedelta(days=RECENT_TICKET_LOOKBACK_DAYS)
+
+    tickets = Ticket.objects.filter(
+        ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE,
+        status__in=TERMINAL_TICKET_STATUSES,
+        update_at__lt=grace_cutoff,
+        create_at__gte=recent_cutoff,
+    ).only("id", "status", "details")
+
+    repaired = 0
+    for ticket in tickets:
+        if not ticket_has_applied_hosts(ticket):
+            continue
+        if ticket_has_recycle_ticket(ticket.id):
+            continue
+
+        recycle_type, recycle_hosts = resolve_missing_recycle_request(ticket)
+        logger.warning(
+            _("Redis rollback exercise ticket {} is {} with applied hosts but no recycle ticket; creating {}").format(
+                ticket.id, ticket.status, recycle_type
+            )
+        )
+        Ticket.create_recycle_ticket(ticket.id, recycle_hosts, recycle_type)
+        repaired += 1
+
+    if repaired:
+        logger.info(_("Created {} missing redis rollback recycle ticket(s)").format(repaired))
+    return repaired
 
 
 @register_periodic_task(run_every=crontab(day_of_week="0", hour="12", minute="0"))
@@ -85,3 +177,12 @@ def repair_stuck_redis_rollback_exercise():
 
     if recovered:
         logger.info(_("Recovered {} stuck redis rollback runner(s)").format(recovered))
+
+
+@register_periodic_task(run_every=crontab(hour="3", minute="0"))
+def repair_missing_redis_rollback_exercise_recycle():
+    """
+    Daily safety net for drill tickets that applied hosts but missed recycle creation.
+    """
+    polling_timeout = RedisRollbackExercise().config.polling_timeout
+    repair_missing_redis_rollback_recycle_tickets(polling_timeout)

--- a/dbm-ui/backend/db_report/models/redis_rollback_exercise_report.py
+++ b/dbm-ui/backend/db_report/models/redis_rollback_exercise_report.py
@@ -184,7 +184,9 @@ class RedisRollbackExerciseReport(BaseReportABS):
 
         if task_message:
             update_fields.append("task_message")
-            self.task_message = task_message
+            self.task_message = "".join(
+                ch for ch in task_message if ord(ch) <= 0xFFFF
+            )  # For MySQL utf8mb3 compatibility
 
         for field_name, value in kwargs.items():
             setattr(self, field_name, value)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
@@ -26,9 +26,11 @@ from backend.flow.plugins.components.collections.redis.redis_rollback_exercise i
     RedisExerciseBestEffortCleanupComponent,
     RedisExerciseFlowRunnerComponent,
     RedisExerciseReportUpdateComponent,
+    RedisExerciseResourceApplyComponent,
     RedisRollbackExerciseAlarmShieldComponent,
 )
 from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
+from backend.flow.utils.redis.redis_rollback_exercise_resource import build_drill_resource_spec, get_instance_machine
 
 logger = logging.getLogger("flow")
 
@@ -93,24 +95,29 @@ class RedisRollbackExerciseFlow(object):
 
     def rollback_exercise_flow(self):
         """
-        Composes data-structure + cleanup steps directly instead of spawning inner pipelines and polling.
+        Composes resource apply, per-cluster exercise sub-flows, and best-effort cleanup.
         """
-        for info in self.ticket_data["infos"]:
-            self._enrich_drill_prod_temp_instance_pairs(info)
+        flow_data = copy.deepcopy(self.ticket_data)
 
-        pipeline = Builder(root_id=self.root_id, data=copy.deepcopy(self.ticket_data))
+        pipeline = Builder(root_id=self.root_id, data=flow_data)
+
+        pipeline.add_act(
+            act_name=_("申请演练资源"),
+            act_component_code=RedisExerciseResourceApplyComponent.code,
+            kwargs={
+                "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
+            },
+            error_ignorable=True,
+        )
 
         sub_flows = []
-        for info in self.ticket_data["infos"]:
-            sf = self._build_exercise_sub_flow(info)
+        for info_index, info in enumerate(flow_data["infos"]):
+            sf = self._build_exercise_sub_flow(info, info_index, flow_data)
             if sf is not None:
                 sub_flows.append(sf)
 
-        if not sub_flows:
-            logger.warning("No valid sub-flows to run")
-            return
-
-        pipeline.add_parallel_sub_pipeline(sub_flows)
+        if sub_flows:
+            pipeline.add_parallel_sub_pipeline(sub_flows)
 
         pipeline.add_act(
             act_name=_("最佳尝试清理"),
@@ -122,11 +129,57 @@ class RedisRollbackExerciseFlow(object):
 
         pipeline.run_pipeline(init_trans_data_class=RedisRollbackExerciseContext())
 
+    @staticmethod
+    def build_ds_flow_data(global_data: dict, info: dict, cluster: Cluster) -> dict:
+        resource_applied = info.get("redis") or []
+        instance_ip = info.get("instance_ip")
+        instance_port = info.get("instance_port")
+        master_instances = [f"{instance_ip}{IP_PORT_DIVIDER}{instance_port}"]
+        resource_spec = info.get("resource_spec") or {}
+        if not resource_spec.get("redis"):
+            machine = get_instance_machine(info, cluster)
+            if machine is not None:
+                resource_spec = build_drill_resource_spec(machine, host_count=len(resource_applied) or 1)
+        return {
+            "bk_biz_id": global_data["bk_biz_id"],
+            "uid": global_data.get("uid", global_data.get("job_root_id")),
+            "created_by": global_data.get("created_by", "system"),
+            "ticket_type": "REDIS_DATA_STRUCTURE",
+            "infos": [
+                {
+                    "cluster_id": cluster.id,
+                    "bk_cloud_id": cluster.bk_cloud_id,
+                    "master_instances": master_instances,
+                    "redis": resource_applied,
+                    "resource_spec": resource_spec,
+                    "recovery_time_point": info.get("recovery_time_point"),
+                }
+            ],
+            "skip_mannual_confirm": True,
+            "is_rollback_drill": True,
+        }
+
+    @staticmethod
+    def build_delete_flow_data(global_data: dict, cluster: Cluster) -> dict:
+        del_info = {
+            "related_rollback_bill_id": global_data.get("uid", global_data.get("job_root_id")),
+            "prod_cluster": cluster.immute_domain,
+        }
+        return {
+            "bk_biz_id": global_data["bk_biz_id"],
+            "uid": global_data.get("uid", global_data.get("job_root_id")),
+            "created_by": global_data.get("created_by", "system"),
+            "ticket_type": "REDIS_DATA_STRUCTURE_TASK_DELETE",
+            "skip_connections_check": True,
+            "is_rollback_drill": True,
+            "infos": [del_info],
+        }
+
     # -------------------------------------------------------------------------
     # New flow: sub-flow builder
     # -------------------------------------------------------------------------
 
-    def _build_exercise_sub_flow(self, info: dict):
+    def _build_exercise_sub_flow(self, info: dict, info_index: int, flow_data: dict):
         """Build a single-cluster exercise sub-flow.
 
         The data-structure step is wrapped in a polling runner act with
@@ -141,9 +194,7 @@ class RedisRollbackExerciseFlow(object):
         instance_ip = info["instance_ip"]
         instance_port = info["instance_port"]
         report_id = info["report_id"]
-        resource_applied = info.get("redis", [])
-        recovery_time_point = info.get("recovery_time_point")
-        config = self.ticket_data.get("drill_config", {})
+        config = flow_data.get("drill_config", {})
         polling_timeout = config.get("polling_timeout", 3600)
         polling_interval = config.get("polling_interval", 10)
         error_ignorable = config.get("error_ignorable", True)
@@ -157,29 +208,20 @@ class RedisRollbackExerciseFlow(object):
             report.mark(TaskStage.SKIPPED, task_message=task_message)
             return None
 
-        if not resource_applied or len(resource_applied) != 1:
-            logger.warning(_("Resource applied is abnormal: {}").format(resource_applied or "None"))
-            report.mark(TaskStage.RESOURCE_APPLI_FAILED, task_message=_("资源申请异常"))
-            return None
-        report.mark(TaskStage.RESOURCE_APPLI_SUCCEEDED)
-
-        temp_host_ip = resource_applied[0]["ip"]
-        master_instances = [f"{instance_ip}{IP_PORT_DIVIDER}{instance_port}"]
-
-        sub_flow = SubBuilder(root_id=self.root_id, data=copy.deepcopy(self.ticket_data))
+        sub_flow = SubBuilder(root_id=self.root_id, data=flow_data)
 
         # ---- Alarm shield ----
         shield_duration_seconds = polling_timeout + settings.DISABLE_ALARM_SHIELD_DELAY
         sub_flow.add_act(
-            act_name=_("屏蔽主机 {} 告警(超时 {:.1f} mins)").format(temp_host_ip, shield_duration_seconds / 60),
+            act_name=_("屏蔽演练主机告警(超时 {:.1f} mins)").format(shield_duration_seconds / 60),
             act_component_code=RedisRollbackExerciseAlarmShieldComponent.code,
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
+                "info_index": info_index,
                 "duration_seconds": polling_timeout,
-                "description": _("主机 {} Redis回档演练操作").format(temp_host_ip),
+                "description": _("Redis回档演练操作"),
                 "dimensions": [
                     {"name": "appid", "values": [str(cluster.bk_biz_id)]},
-                    {"name": "bk_target_ip", "values": [temp_host_ip]},
                 ],
             },
         )
@@ -191,54 +233,21 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "report_id": report_id,
+                "info_index": info_index,
                 "stage": TaskStage.ROLLBACK_STARTED,
             },
         )
 
         # ================================================================
-        # Data-structure & delete flow data
+        # Data-structure & delete flow data resolved at runner runtime
         # ================================================================
-        ds_data = {
-            "bk_biz_id": self.ticket_data["bk_biz_id"],
-            "uid": self.ticket_data.get("uid", self.root_id),
-            "created_by": self.ticket_data.get("created_by", "system"),
-            "ticket_type": "REDIS_DATA_STRUCTURE",
-            "infos": [
-                {
-                    "cluster_id": cluster_id,
-                    "bk_cloud_id": cluster.bk_cloud_id,
-                    "master_instances": master_instances,
-                    "redis": resource_applied,
-                    "resource_spec": info.get("resource_spec", {}),
-                    "recovery_time_point": recovery_time_point,
-                }
-            ],
-            "skip_mannual_confirm": True,
-            "is_rollback_drill": True,
-        }
-
-        del_info = {
-            "related_rollback_bill_id": self.ticket_data.get("uid", self.root_id),
-            "prod_cluster": cluster.immute_domain,
-        }
-        del_data = {
-            "bk_biz_id": self.ticket_data["bk_biz_id"],
-            "uid": self.ticket_data.get("uid", self.root_id),
-            "created_by": self.ticket_data.get("created_by", "system"),
-            "ticket_type": "REDIS_DATA_STRUCTURE_TASK_DELETE",
-            "skip_connections_check": True,
-            "is_rollback_drill": True,
-            "infos": [del_info],
-        }
-
         self._build_runner_flow(
             sub_flow,
-            ds_data,
-            del_data,
+            info_index,
             report_id,
+            cluster_id,
             polling_timeout,
             polling_interval,
-            temp_host_ip,
             error_ignorable,
         )
 
@@ -249,12 +258,11 @@ class RedisRollbackExerciseFlow(object):
     def _build_runner_flow(
         self,
         sub_flow,
-        ds_data,
-        del_data,
+        info_index,
         report_id,
+        cluster_id,
         polling_timeout,
         polling_interval,
-        temp_host_ip,
         error_ignorable,
     ):
         """Build runner acts with conditional branching on outcomes.
@@ -277,7 +285,9 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "flow_identifier": "redis_data_structure",
-                "flow_data": ds_data,
+                "info_index": info_index,
+                "cluster_id": cluster_id,
+                "build_flow_data_from_global": True,
                 "report_id": report_id,
                 "flow_id_field": "rollback_flow_obj_id",
                 "polling_timeout": polling_timeout,
@@ -289,7 +299,7 @@ class RedisRollbackExerciseFlow(object):
         )
 
         # ---- Success branch: report_succeeded -> delete runner -> conditional ----
-        success_branch = SubBuilder(root_id=self.root_id, data=copy.deepcopy(self.ticket_data))
+        success_branch = SubBuilder(root_id=self.root_id, data=sub_flow.data)
 
         success_branch.add_act(
             act_name=_("标记回档成功"),
@@ -297,6 +307,7 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "report_id": report_id,
+                "info_index": info_index,
                 "stage": TaskStage.ROLLBACK_SUCCEEDED,
             },
         )
@@ -307,7 +318,9 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "flow_identifier": "redis_data_structure_task_delete",
-                "flow_data": del_data,
+                "info_index": info_index,
+                "cluster_id": cluster_id,
+                "build_delete_flow_data_from_global": True,
                 "report_id": report_id,
                 "flow_id_field": "delete_flow_obj_id",
                 "polling_timeout": polling_timeout,
@@ -324,6 +337,7 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "report_id": report_id,
+                "info_index": info_index,
                 "stage": TaskStage.DONE,
             },
             extend=False,
@@ -335,6 +349,7 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "report_id": report_id,
+                "info_index": info_index,
                 "stage": TaskStage.CLEANUP_FAILED,
             },
             extend=False,
@@ -359,6 +374,7 @@ class RedisRollbackExerciseFlow(object):
             kwargs={
                 "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
                 "report_id": report_id,
+                "info_index": info_index,
                 "stage": TaskStage.ROLLBACK_FAILED,
             },
             extend=False,
@@ -377,7 +393,7 @@ class RedisRollbackExerciseFlow(object):
 
         # ---- Disable alarm shield (always runs after conditional converge) ----
         sub_flow.add_act(
-            act_name=_("15 分钟后解除主机 {} 告警屏蔽").format(temp_host_ip),
+            act_name=_("15 分钟后解除演练主机告警屏蔽"),
             act_component_code=DisableAlarmShieldComponent.code,
             kwargs={},
             error_ignorable=True,  # Don't let bkmonitor affect the task flow

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import copy
 import logging
 import shlex
+from collections import defaultdict
 from datetime import datetime
 from typing import Optional
 
@@ -22,6 +23,7 @@ from pipeline.core.flow.activity import StaticIntervalGenerator
 from backend import env
 from backend.components import JobApi
 from backend.constants import IP_PORT_DIVIDER
+from backend.core.notify.constants import MsgType
 from backend.db_meta.api.cluster.nosqlcomm.decommission import decommission_instances
 from backend.db_meta.models import Cluster, StorageInstance
 from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
@@ -39,7 +41,15 @@ from backend.flow.plugins.components.collections.common.base_service import Base
 from backend.flow.utils.base.flow_output import FlowOutputHandler
 from backend.flow.utils.redis import redis_context_dataclass as flow_context
 from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
+from backend.flow.utils.redis.redis_rollback_exercise_resource import (
+    all_infos_have_redis,
+    apply_exercise_resources,
+    get_effective_drill_infos,
+    info_has_applied_redis,
+)
 from backend.flow.utils.redis.redis_script_template import redis_fast_execute_script_common_kwargs
+from backend.ticket.constants import TicketStatus
+from backend.ticket.models import Ticket
 from backend.utils.basic import generate_root_id
 from backend.utils.string import base64_encode
 
@@ -98,6 +108,21 @@ class RedisLogCapturingService(BaseService):
         super().log_debug(msg)
         self._append_to_task_info(msg, "debug")
 
+    @staticmethod
+    def _get_effective_infos(data) -> list:
+        global_data = data.get_one_of_inputs("global_data") or {}
+        trans_data = data.get_one_of_inputs("trans_data")
+        return get_effective_drill_infos(global_data, trans_data)
+
+    @classmethod
+    def _get_effective_info(cls, data, info_index: Optional[int]):
+        if info_index is None:
+            return None
+        infos = cls._get_effective_infos(data)
+        if info_index >= len(infos):
+            return None
+        return infos[info_index]
+
     def _execute(self, data, parent_data) -> bool:
         self.init_trans_data(data)
         data.inputs.trans_data = self.trans_data
@@ -127,6 +152,24 @@ class RedisRollbackExerciseAlarmShieldService(RedisLogCapturingService, AddAlarm
     """
 
     def _execute_inner_captured(self, data, parent_data) -> bool:
+        kwargs = data.get_one_of_inputs("kwargs") or {}
+        info_index = kwargs.get("info_index")
+        if info_index is not None:
+            info = self._get_effective_info(data, info_index)
+            if info is None:
+                self.log_warning(_("info_index {} out of range, skip alarm shield").format(info_index))
+                return True
+            redis_hosts = info.get("redis") or []
+            if len(redis_hosts) == 1:
+                temp_host_ip = redis_hosts[0]["ip"]
+                dimensions = list(kwargs.get("dimensions") or [])
+                dimensions.append({"name": "bk_target_ip", "values": [temp_host_ip]})
+                kwargs["dimensions"] = dimensions
+                kwargs["description"] = _("主机 {} Redis回档演练操作").format(temp_host_ip)
+                data.inputs.kwargs = kwargs
+            else:
+                self.log_info(_("演练资源未申请，跳过告警屏蔽"))
+                return True
         return AddAlarmShieldService._execute(self, data, parent_data)
 
 
@@ -143,12 +186,28 @@ class RedisExerciseReportUpdateService(RedisLogCapturingService):
     """
 
     TERMINAL_STAGES = {TaskStage.DONE, TaskStage.ROLLBACK_FAILED, TaskStage.CLEANUP_FAILED}
+    RESOURCE_DEPENDENT_STAGES = {
+        TaskStage.ROLLBACK_STARTED,
+        TaskStage.ROLLBACK_SUCCEEDED,
+        TaskStage.ROLLBACK_FAILED,
+        TaskStage.DONE,
+        TaskStage.CLEANUP_FAILED,
+    }
 
     def _execute_inner_captured(self, data, parent_data) -> bool:
         kwargs = data.get_one_of_inputs("kwargs")
         report_id = kwargs.get("report_id")
         stage = kwargs.get("stage")
         task_message = kwargs.get("task_message")
+        info_index = kwargs.get("info_index")
+
+        if (
+            stage in self.RESOURCE_DEPENDENT_STAGES
+            and info_index is not None
+            and not info_has_applied_redis(self._get_effective_info(data, info_index))
+        ):
+            self.log_info(_("演练资源未申请，跳过标记 {}").format(stage))
+            return True
 
         if stage in self.TERMINAL_STAGES and not task_message and self.trans_data and self.trans_data.task_msg:
             task_message = "\n".join(self.trans_data.task_msg)
@@ -248,13 +307,56 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
         self.interval = StaticIntervalGenerator(polling_interval)
 
         flow_identifier = kwargs["flow_identifier"]
-        flow_data = kwargs["flow_data"]
         report_id = kwargs.get("report_id")
         flow_id_field = kwargs.get("flow_id_field")
         polling_timeout = kwargs.get("polling_timeout", 3600)
         output_var = kwargs.get("output_var", "rollback_code")
 
         data.outputs.output_var = output_var
+
+        if kwargs.get("build_flow_data_from_global") or kwargs.get("build_delete_flow_data_from_global"):
+            global_data = data.get_one_of_inputs("global_data") or {}
+            info_index = kwargs.get("info_index")
+            cluster_id = kwargs.get("cluster_id")
+            infos = self._get_effective_infos(data)
+            if info_index is None or info_index >= len(infos):
+                self.log_warning(_("info_index invalid, skip child flow"))
+                self._set_result(data, 1)
+                self.finish_schedule()
+                return True
+            info = infos[info_index]
+            redis_hosts = info.get("redis") or []
+            if len(redis_hosts) != 1:
+                self.log_info(_("演练资源未申请，跳过子流程"))
+                self._set_result(data, 1)
+                self.finish_schedule()
+                return True
+            try:
+                cluster = Cluster.objects.get(id=cluster_id or info["cluster_id"])
+            except Cluster.DoesNotExist:
+                self.log_error(_("集群 {} 不存在").format(cluster_id or info.get("cluster_id")))
+                self._set_result(data, 1)
+                self.finish_schedule()
+                return True
+
+            from backend.flow.engine.bamboo.scene.redis.redis_rollback_exercise import RedisRollbackExerciseFlow
+
+            if kwargs.get("build_delete_flow_data_from_global"):
+                flow_data = RedisRollbackExerciseFlow.build_delete_flow_data(global_data, cluster)
+            else:
+                flow_data = RedisRollbackExerciseFlow.build_ds_flow_data(global_data, info, cluster)
+                if not info.get("drill_prod_temp_instance_pairs"):
+                    instance_ip = info.get("instance_ip")
+                    instance_port = info.get("instance_port")
+                    temp_host_ip = redis_hosts[0]["ip"]
+                    info["drill_prod_temp_instance_pairs"] = [
+                        [
+                            "{}{}{}".format(instance_ip, IP_PORT_DIVIDER, instance_port),
+                            "{}{}{}".format(temp_host_ip, IP_PORT_DIVIDER, DEFAULT_REDIS_START_PORT),
+                        ]
+                    ]
+        else:
+            flow_data = kwargs["flow_data"]
 
         registry_entry = FLOW_REGISTRY.get(flow_identifier)
         if not registry_entry:
@@ -434,6 +536,211 @@ class RedisExerciseRevokeAppliedHostsComponent(Component):
     bound_service = RedisExerciseRevokeAppliedHostsService
 
 
+class RedisExerciseResourceApplyService(RedisLogCapturingService):
+    """Batch-apply redis drill hosts via DBResourceApi and inject ticket recycle metadata."""
+
+    @staticmethod
+    def _instance_addr(info: dict) -> str:
+        return "{}{}{}".format(info.get("instance_ip"), IP_PORT_DIVIDER, info.get("instance_port"))
+
+    @classmethod
+    def _resolve_cluster_domains(cls, infos: list) -> dict:
+        missing_cluster_ids = {
+            info["cluster_id"] for info in infos if info.get("cluster_id") and not info.get("cluster_domain")
+        }
+        if not missing_cluster_ids:
+            return {}
+        return dict(Cluster.objects.filter(id__in=missing_cluster_ids).values_list("id", "immute_domain"))
+
+    @classmethod
+    def _build_resource_apply_log_summary(
+        cls,
+        infos: list,
+        *,
+        header: str,
+        include_applied_ip: bool = True,
+        pending_suffix: str = "",
+    ) -> str:
+        cluster_domain_map = cls._resolve_cluster_domains(infos)
+        clusters = defaultdict(lambda: {"domain": "", "instance_groups": defaultdict(list)})
+
+        for info in infos:
+            cluster_id = info.get("cluster_id")
+            if cluster_id is None:
+                continue
+            cluster_domain = info.get("cluster_domain") or cluster_domain_map.get(cluster_id) or ""
+            clusters[cluster_id]["domain"] = cluster_domain or clusters[cluster_id]["domain"]
+
+            instance_addr = cls._instance_addr(info)
+            redis_hosts = info.get("redis") or []
+            if include_applied_ip and redis_hosts:
+                applied_ip = redis_hosts[0].get("ip") or ""
+                clusters[cluster_id]["instance_groups"][applied_ip].append(instance_addr)
+            else:
+                clusters[cluster_id]["instance_groups"][""].append(instance_addr)
+
+        lines = [header]
+        for cluster_id in sorted(clusters):
+            cluster_data = clusters[cluster_id]
+            cluster_label = (
+                "{}:{}".format(cluster_id, cluster_data["domain"]) if cluster_data["domain"] else str(cluster_id)
+            )
+            lines.append(cluster_label)
+            for applied_ip in sorted(cluster_data["instance_groups"]):
+                instances = sorted(cluster_data["instance_groups"][applied_ip])
+                instances_label = ",".join(instances)
+                if include_applied_ip and applied_ip:
+                    lines.append("    {}: {}".format(instances_label, applied_ip))
+                elif pending_suffix:
+                    lines.append("    {}{}".format(instances_label, pending_suffix))
+                else:
+                    lines.append("    {}".format(instances_label))
+
+        return "\n".join(lines)
+
+    def _log_applied_resources(self, infos: list, request_id: str = ""):
+        host_count = sum(1 for info in infos if info.get("redis"))
+        if not host_count:
+            return
+
+        header = _("演练资源申请完成，共 {} 台主机").format(host_count)
+        if request_id:
+            header = "{} request_id={}".format(header, request_id)
+        self.log_info(self._build_resource_apply_log_summary(infos, header=header))
+
+    def _log_resource_apply_failure(self, infos: list, error_message: str):
+        header = _("演练资源申请失败: {}").format(error_message)
+        self.log_error(
+            self._build_resource_apply_log_summary(
+                infos,
+                header=header,
+                include_applied_ip=False,
+                pending_suffix=_(" (no resource)"),
+            )
+        )
+
+    def _inject_ticket_details(
+        self,
+        ticket_id: int,
+        applied_hosts: list,
+        node_infos: dict,
+        resource_request_id: str,
+        summary: list,
+    ):
+        standardized = ResourceHandler.standardized_resource_host(applied_hosts)
+        ticket = Ticket.objects.get(id=ticket_id)
+        ticket.details["recycle_hosts"] = standardized
+        ticket.details["nodes"] = node_infos
+        ticket.details["resource_request_id"] = resource_request_id
+        ticket.details["resource_apply_summary"] = summary
+        ticket.details["immediate_recycle"] = True
+        ticket.details["send_msg_config"] = {
+            status: {MsgType.RTX: True} if status == TicketStatus.FAILED else {}
+            for status in TicketStatus.get_values()
+        }
+        ticket.save(update_fields=["details"])
+
+    def _persist_applied_infos(self, infos: list):
+        if self.trans_data is None:
+            return
+        self.trans_data.applied_infos = copy.deepcopy(infos)
+
+    def _execute_inner_captured(self, data, parent_data) -> bool:
+        global_data = data.get_one_of_inputs("global_data") or {}
+        infos = global_data.get("infos") or []
+        ticket_id = global_data.get("uid")
+
+        if all_infos_have_redis(infos):
+            self.log_info(_("演练资源已申请，跳过重复申请"))
+            self._persist_applied_infos(infos)
+            self._log_applied_resources(infos)
+            return True
+
+        result = apply_exercise_resources(global_data, global_data.get("job_root_id") or self.root_id)
+
+        if result.skipped_idempotent:
+            self.log_info(_("演练资源已申请，跳过重复申请"))
+            self._persist_applied_infos(infos)
+            self._log_applied_resources(infos)
+            return True
+
+        if not result.success:
+            warn_msg = _("WARN: no available resources")
+            fail_msg = result.error_message or warn_msg
+            self._persist_applied_infos(infos)
+            self._log_resource_apply_failure(infos, fail_msg)
+            if result.node_infos and ticket_id:
+                partial_hosts = [
+                    {
+                        "bk_host_id": host["bk_host_id"],
+                        "ip": host["ip"],
+                        "bk_cloud_id": host["bk_cloud_id"],
+                    }
+                    for hosts in result.node_infos.values()
+                    for host in hosts
+                ]
+                if partial_hosts:
+                    self._inject_ticket_details(
+                        ticket_id,
+                        partial_hosts,
+                        result.node_infos,
+                        result.resource_request_id,
+                        result.resource_apply_summary,
+                    )
+            for info in infos:
+                report_id = info.get("report_id")
+                if not report_id:
+                    continue
+                try:
+                    report = Report.objects.get(id=report_id)
+                    report.mark(TaskStage.SKIPPED, task_message=fail_msg)
+                except Report.DoesNotExist:
+                    self.log_warning(_("Report {} not found when marking resource skip").format(report_id))
+            return True
+
+        applied_hosts = []
+        for hosts in result.node_infos.values():
+            for host in hosts:
+                applied_hosts.append(
+                    {
+                        "bk_host_id": host["bk_host_id"],
+                        "ip": host["ip"],
+                        "bk_cloud_id": host["bk_cloud_id"],
+                    }
+                )
+
+        if applied_hosts and ticket_id:
+            self._inject_ticket_details(
+                ticket_id,
+                applied_hosts,
+                result.node_infos,
+                result.resource_request_id,
+                result.resource_apply_summary,
+            )
+
+        self._persist_applied_infos(infos)
+        self._log_applied_resources(infos, result.resource_request_id)
+
+        for info in infos:
+            report_id = info.get("report_id")
+            if not report_id:
+                continue
+            try:
+                report = Report.objects.get(id=report_id)
+                if info.get("redis"):
+                    report.mark(TaskStage.RESOURCE_APPLI_SUCCEEDED)
+            except Report.DoesNotExist:
+                self.log_warning(_("Report {} not found when marking resource success").format(report_id))
+
+        return True
+
+
+class RedisExerciseResourceApplyComponent(Component):
+    name = __name__
+    code = "redis_exercise_resource_apply"
+    bound_service = RedisExerciseResourceApplyService
+
+
 class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobService):
     """Best-effort cleanup for exercise failures.
 
@@ -597,8 +904,9 @@ class RedisExerciseBestEffortCleanupService(RedisLogCapturingService, BkJobServi
         ticket_id = self._get_rollback_task_ticket_id(global_data)
         ticket_bk_biz_id = global_data.get("bk_biz_id")
         cleanup_hosts = []
+        infos = get_effective_drill_infos(global_data, self.trans_data)
 
-        for info in global_data.get("infos", []):
+        for info in infos:
             resource_applied = info.get("redis", [])
             if not resource_applied:
                 continue
@@ -844,7 +1152,7 @@ done
             except Exception as e:
                 self.log_error(_("Failed to clean TbTendisRollbackTasks: {}").format(e))
 
-        infos = global_data.get("infos", [])
+        infos = get_effective_drill_infos(global_data, self.trans_data)
         for info in infos:
             report_id = info.get("report_id")
             try:
@@ -868,6 +1176,7 @@ done
 
         terminal_stages = {
             TaskStage.DONE,
+            TaskStage.SKIPPED,
             TaskStage.RESOURCE_APPLI_FAILED,
             TaskStage.ROLLBACK_FAILED,
             TaskStage.CLEANUP_FAILED,

--- a/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
@@ -195,6 +195,7 @@ class RedisRollbackExerciseContext:
 
     alarm_shield_id: int = None  # 告警屏蔽ID
     task_msg: list = field(default_factory=list)  # 执行情况
+    applied_infos: list = field(default_factory=list)  # resource-apply result, visible to sub-processes
 
 
 @dataclass()

--- a/dbm-ui/backend/flow/utils/redis/redis_rollback_exercise_resource.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_rollback_exercise_resource.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from django.utils.translation import gettext as _
+
+from backend.components.dbresource.client import DBResourceApi
+from backend.configuration.constants import AffinityEnum
+from backend.constants import INT_MAX
+from backend.db_dirty.constants import MachineEventType
+from backend.db_dirty.models import MachineEvent
+from backend.db_meta.models import AppCache, Cluster, Machine, Spec, StorageInstance, Tag
+from backend.ticket.builders.common.base import fetch_apply_hosts
+from backend.ticket.constants import ResourceApplyErrCode
+
+logger = logging.getLogger("flow")
+
+DEFAULT_SPEC = {
+    "id": 0,
+    "name": "",
+    "cpu": "",
+    "mem": "",
+    "qps": "",
+    "device_class": "",
+    "storage_spec": "",
+}
+
+
+@dataclass
+class ApplyExerciseResourcesResult:
+    success: bool
+    skipped_idempotent: bool = False
+    resource_request_id: str = ""
+    node_infos: Dict[str, List] = field(default_factory=dict)
+    resource_apply_summary: List[Dict] = field(default_factory=list)
+    error_message: str = ""
+
+
+def all_infos_have_redis(infos: List[dict]) -> bool:
+    return bool(infos) and all(info.get("redis") for info in infos)
+
+
+def info_has_applied_redis(info: Optional[dict]) -> bool:
+    if not info:
+        return False
+    redis_hosts = info.get("redis") or []
+    return len(redis_hosts) == 1
+
+
+def get_effective_drill_infos(global_data: dict, trans_data=None) -> List[dict]:
+    """Return drill infos with applied hosts.
+
+    Sub-processes receive a build-time snapshot of ``global_data`` that does not
+    include hosts assigned by the resource-apply act. Prefer ``trans_data.applied_infos``
+    when present.
+    """
+    if trans_data is not None:
+        applied_infos = getattr(trans_data, "applied_infos", None)
+        if applied_infos:
+            return applied_infos
+    return global_data.get("infos") or []
+
+
+def get_instance_machine(info: dict, cluster: Cluster) -> Optional[Machine]:
+    instance = (
+        StorageInstance.objects.filter(
+            cluster=cluster,
+            machine__ip=info["instance_ip"],
+            port=info["instance_port"],
+        )
+        .select_related("machine")
+        .first()
+    )
+    if instance:
+        return instance.machine
+    return Machine.objects.filter(ip=info["instance_ip"], bk_cloud_id=cluster.bk_cloud_id).first()
+
+
+def _resolve_mem_min_gb(machine: Machine) -> int:
+    """Return minimum memory (GB) from machine spec_config with Spec fallback.
+
+    ``spec_config.mem`` / ``Spec.mem`` use GB, consistent with
+    ``Spec._get_apply_params_detail`` (GB -> MB via ``* 1024`` for resource pool).
+    """
+    spec_config = machine.spec_config or {}
+    mem_info = spec_config.get("mem") or {}
+    mem_min_gb = int(mem_info.get("min") or 0)
+
+    if not mem_min_gb and machine.spec_id:
+        try:
+            spec = Spec.objects.get(spec_id=machine.spec_id)
+            mem_min_gb = int(spec.mem.get("min") or 1)
+        except Spec.DoesNotExist:
+            pass
+
+    if not mem_min_gb and getattr(machine, "mem", 0):
+        mem_min_gb = int(machine.mem)
+
+    return max(mem_min_gb, 1)
+
+
+def _build_storage_spec(machine: Machine) -> List[dict]:
+    storage_spec = []
+    for mount_point, disk in (machine.storage_device or {}).items():
+        size = disk.get("size")
+        if size is None:
+            continue
+        storage_spec.append(
+            {
+                "mount_point": mount_point,
+                "disk_type": "",
+                "min": int(size),
+                "max": INT_MAX,
+            }
+        )
+
+    if storage_spec:
+        return storage_spec
+
+    spec_config = machine.spec_config or {}
+    for item in spec_config.get("storage_spec") or []:
+        mount_point = item.get("mount_point")
+        spec_item = {
+            "disk_type": "",
+            "min": int(item.get("min") or 0),
+            "max": INT_MAX,
+        }
+        if mount_point:
+            spec_item["mount_point"] = mount_point
+        storage_spec.append(spec_item)
+
+    if storage_spec:
+        return storage_spec
+
+    return [{"disk_type": "", "min": 1, "max": INT_MAX}]
+
+
+def _build_location_spec(region: str) -> dict:
+    """Random region ('default') means no city filter, aligned with Spec._get_apply_params_detail."""
+    city = region or ""
+    if city == "default":
+        city = ""
+    return {"city": city, "sub_zone_ids": []}
+
+
+def build_apply_detail_from_machine(index: int, cluster: Cluster, machine: Machine) -> dict:
+    mem_min_gb = _resolve_mem_min_gb(machine)
+    return {
+        "group_mark": f"{index}_redis",
+        "bk_cloud_id": cluster.bk_cloud_id,
+        "count": 1,
+        "affinity": AffinityEnum.NONE.value,
+        "location_spec": _build_location_spec(cluster.region),
+        "spec": {
+            # Drill only constrains memory; CPU is unconstrained (0/0 = empty spec in db-resource).
+            "cpu": {"min": 0, "max": 0},
+            "ram": {"min": int(mem_min_gb * 1024), "max": INT_MAX},
+        },
+        "storage_spec": _build_storage_spec(machine),
+    }
+
+
+def format_resource_hosts(hosts, biz_name_map, label_name_map) -> List[dict]:
+    return [
+        {
+            "bk_biz_id": host.get("bk_biz_id", 0),
+            "ip": host["ip"],
+            "bk_cloud_id": host["bk_cloud_id"],
+            "host_id": host["bk_host_id"],
+            "bk_host_id": host["bk_host_id"],
+            "bk_idc_id": host.get("idc_id"),
+            "bk_cpu": host["cpu_num"],
+            "bk_disk": host["total_storage_cap"],
+            "bk_mem": host["dram_cap"],
+            "os_name": host["os_name"],
+            "os_type": host["os_type"],
+            "storage_device": host["storage_device"],
+            "city": host.get("city"),
+            "sub_zone": host.get("sub_zone"),
+            "sub_zone_id": host.get("sub_zone_id"),
+            "rack_id": host.get("rack_id"),
+            "device_class": host.get("device_class"),
+            "for_biz": host["dedicated_biz"],
+            "labels": host["labels"],
+            "for_biz_info": {
+                "bk_biz_id": host["dedicated_biz"],
+                "bk_biz_name": biz_name_map.get(host["dedicated_biz"]),
+            },
+            "label_info": [
+                {"id": int(label_id), "name": label_name_map.get(int(label_id), "")} for label_id in host["labels"]
+            ],
+            "resource_type": host["rs_type"],
+            "spec": DEFAULT_SPEC,
+        }
+        for host in hosts
+    ]
+
+
+def build_drill_resource_spec(machine: Machine, host_count: int = 1) -> dict:
+    """Build the resource_spec block expected by RedisDataStructureFlow."""
+    redis_spec = dict(machine.spec_config or {})
+    if machine.spec_id:
+        redis_spec["id"] = machine.spec_id
+    redis_spec.setdefault("id", 0)
+    redis_spec["count"] = host_count
+    return {"redis": redis_spec}
+
+
+def build_resource_apply_summary(info: dict, cluster: Cluster, host: dict) -> dict:
+    return {
+        "cluster_id": cluster.id,
+        "cluster_domain": cluster.immute_domain,
+        "instance_ip": info.get("instance_ip"),
+        "instance_port": info.get("instance_port"),
+        "applied_ip": host.get("ip"),
+        "applied_bk_host_id": host.get("bk_host_id"),
+        "region": host.get("city") or cluster.region,
+        "sub_zone": host.get("sub_zone"),
+        "cpu": host.get("bk_cpu"),
+        "mem_mb": host.get("bk_mem"),
+        "storage_device": host.get("storage_device"),
+        "device_class": host.get("device_class"),
+    }
+
+
+def apply_exercise_resources(ticket_data: dict, root_id: str) -> ApplyExerciseResourcesResult:
+    infos = ticket_data.get("infos") or []
+    if all_infos_have_redis(infos):
+        return ApplyExerciseResourcesResult(success=True, skipped_idempotent=True)
+
+    apply_details = []
+    cluster_map = {}
+    for index, info in enumerate(infos):
+        try:
+            cluster = Cluster.objects.get(id=info["cluster_id"])
+        except Cluster.DoesNotExist:
+            return ApplyExerciseResourcesResult(
+                success=False,
+                error_message=_("集群 {} 不存在").format(info["cluster_id"]),
+            )
+        cluster_map[index] = cluster
+        machine = get_instance_machine(info, cluster)
+        if machine is None:
+            return ApplyExerciseResourcesResult(
+                success=False,
+                error_message=_("实例 {}:{} 机器不存在").format(info.get("instance_ip"), info.get("instance_port")),
+            )
+        apply_details.append(build_apply_detail_from_machine(index, cluster, machine))
+
+    if not apply_details:
+        return ApplyExerciseResourcesResult(success=False, error_message=_("无有效资源申请项"))
+
+    apply_params = {
+        "for_biz_id": ticket_data["bk_biz_id"],
+        "resource_type": "redis",
+        "bill_id": str(ticket_data.get("uid", root_id)),
+        "bill_type": ticket_data.get("ticket_type", ""),
+        "task_id": root_id,
+        "operator": ticket_data.get("created_by", "system"),
+        "details": apply_details,
+    }
+
+    resp = DBResourceApi.resource_apply(params=apply_params, raw=True)
+    if resp.get("code") != 0:
+        err_code = resp.get("code")
+        if err_code in ResourceApplyErrCode.get_values():
+            err_label = ResourceApplyErrCode.get_choice_label(err_code)
+            message = _("资源池服务错误 [{}]: {}").format(err_label, resp.get("message", ""))
+        else:
+            message = _("资源申请失败 [{}]: {}").format(err_code, resp.get("message", ""))
+        return ApplyExerciseResourcesResult(success=False, error_message=message)
+
+    resource_request_id = resp.get("request_id", "")
+    apply_data = resp.get("data") or []
+    for_biz_ids = [item["dedicated_biz"] for info in apply_data for item in info["data"]]
+    biz_name_map = AppCache.batch_get_app_attr(bk_biz_ids=for_biz_ids, attr_name="bk_biz_name")
+    label_ids = [int(label) for info in apply_data for item in info["data"] for label in item["labels"]]
+    label_name_map = {tag.id: tag.value for tag in Tag.objects.filter(id__in=label_ids)}
+
+    node_infos: Dict[str, List] = defaultdict(list)
+    resource_apply_summary: List[dict] = []
+    for info in apply_data:
+        role = info["item"]
+        host_infos = format_resource_hosts(info["data"], biz_name_map, label_name_map)
+        node_infos[role].extend(host_infos)
+
+    for index, info in enumerate(infos):
+        hosts = node_infos.get(f"{index}_redis") or []
+        if len(hosts) != 1:
+            return ApplyExerciseResourcesResult(
+                success=False,
+                resource_request_id=resource_request_id,
+                node_infos=dict(node_infos),
+                error_message=_("资源申请结果异常: index={}, hosts={}").format(index, hosts),
+            )
+        info["redis"] = hosts
+        cluster = cluster_map[index]
+        resource_apply_summary.append(build_resource_apply_summary(info, cluster, hosts[0]))
+
+    applied_host_infos = fetch_apply_hosts({"nodes": node_infos})
+    ticket = None
+    ticket_id = ticket_data.get("uid")
+    if ticket_id:
+        from backend.ticket.models import Ticket
+
+        ticket = Ticket.objects.filter(id=ticket_id).first()
+
+    MachineEvent.host_event_trigger(
+        ticket_data["bk_biz_id"],
+        applied_host_infos,
+        event=MachineEventType.ApplyResource,
+        operator=ticket_data.get("created_by", "system"),
+        ticket=ticket,
+    )
+
+    return ApplyExerciseResourcesResult(
+        success=True,
+        resource_request_id=resource_request_id,
+        node_infos=dict(node_infos),
+        resource_apply_summary=resource_apply_summary,
+    )

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise_repair.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise_repair.py
@@ -19,7 +19,8 @@ from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
 from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.flow.consts import StateType
 from backend.flow.models import FlowTree
-from backend.ticket.constants import TicketType
+from backend.ticket.constants import FlowType, TicketFlowStatus, TicketStatus, TicketType
+from backend.ticket.models import Flow, Ticket
 
 pytestmark = pytest.mark.django_db
 
@@ -290,3 +291,212 @@ def test_periodic_repair_running_child_under_3_timeout_no_warning():
     mock_warning.assert_not_called()
     report.delete()
     flow_tree.delete()
+
+
+# ==================== Missing recycle ticket repair ====================
+
+
+def _make_drill_ticket(status: TicketStatus, details: dict, hours_ago: int = 2) -> Ticket:
+    ticket = Ticket.objects.create(
+        bk_biz_id=1,
+        ticket_type=TicketType.REDIS_ROLLBACK_EXERCISE,
+        status=status,
+        creator="tester",
+        updater="tester",
+        remark="drill ticket",
+        details=details,
+        group="redis",
+    )
+    Ticket.objects.filter(id=ticket.id).update(
+        update_at=timezone.now() - timedelta(hours=hours_ago),
+        create_at=timezone.now() - timedelta(days=1),
+    )
+    ticket.refresh_from_db()
+    return ticket
+
+
+def _import_recycle_repair():
+    from backend.db_periodic_task.local_tasks.redis_backup_rollback.task import (
+        repair_missing_redis_rollback_recycle_tickets,
+        resolve_missing_recycle_request,
+        ticket_has_applied_hosts,
+        ticket_has_recycle_ticket,
+    )
+
+    return (
+        repair_missing_redis_rollback_recycle_tickets,
+        resolve_missing_recycle_request,
+        ticket_has_applied_hosts,
+        ticket_has_recycle_ticket,
+    )
+
+
+def test_ticket_has_applied_hosts_from_recycle_hosts():
+    ticket = _make_drill_ticket(TicketStatus.SUCCEEDED, {"recycle_hosts": [{"bk_host_id": 1, "ip": "1.1.1.1"}]})
+    _, _, ticket_has_applied_hosts, _ = _import_recycle_repair()
+
+    assert ticket_has_applied_hosts(ticket) is True
+    ticket.delete()
+
+
+def test_ticket_has_applied_hosts_from_infos_redis():
+    ticket = _make_drill_ticket(
+        TicketStatus.FAILED,
+        {"infos": [{"redis": [{"bk_host_id": 2, "ip": "2.2.2.2", "bk_cloud_id": 0}]}]},
+    )
+    _, _, ticket_has_applied_hosts, _ = _import_recycle_repair()
+
+    assert ticket_has_applied_hosts(ticket) is True
+    ticket.delete()
+
+
+def test_ticket_has_recycle_ticket_ignores_parent_ticket_without_delivery_flow():
+    parent = _make_drill_ticket(TicketStatus.SUCCEEDED, {"recycle_hosts": [{"bk_host_id": 1}]})
+    recycle = Ticket.objects.create(
+        bk_biz_id=1,
+        ticket_type=TicketType.RECYCLE_OLD_HOST,
+        status=TicketStatus.PENDING,
+        creator="tester",
+        updater="tester",
+        remark="recycle",
+        details={"parent_ticket": parent.id},
+        group="common",
+    )
+    _, _, _, ticket_has_recycle_ticket = _import_recycle_repair()
+
+    assert ticket_has_recycle_ticket(parent.id) is False
+    recycle.delete()
+    parent.delete()
+
+
+def test_ticket_has_recycle_ticket_by_delivery_flow():
+    parent = _make_drill_ticket(TicketStatus.SUCCEEDED, {"recycle_hosts": [{"bk_host_id": 1}]})
+    recycle = Ticket.objects.create(
+        bk_biz_id=1,
+        ticket_type=TicketType.RECYCLE_OLD_HOST,
+        status=TicketStatus.PENDING,
+        creator="tester",
+        updater="tester",
+        remark="recycle",
+        details={"parent_ticket": parent.id},
+        group="common",
+    )
+    Flow.objects.create(
+        ticket=parent,
+        flow_type=FlowType.DELIVERY.value,
+        status=TicketFlowStatus.SUCCEEDED,
+        details={"related_ticket": recycle.id},
+        flow_alias="recycle",
+    )
+    _, _, _, ticket_has_recycle_ticket = _import_recycle_repair()
+
+    assert ticket_has_recycle_ticket(parent.id) is True
+    recycle.delete()
+    parent.delete()
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_type"),
+    [
+        (TicketStatus.SUCCEEDED, TicketType.RECYCLE_OLD_HOST),
+        (TicketStatus.FAILED, TicketType.RECYCLE_OLD_HOST),
+        (TicketStatus.TERMINATED, TicketType.RECYCLE_APPLY_HOST),
+        (TicketStatus.REVOKED, TicketType.RECYCLE_OLD_HOST),
+    ],
+)
+def test_resolve_missing_recycle_request(status, expected_type):
+    ticket = _make_drill_ticket(
+        status,
+        {"recycle_hosts": [{"bk_host_id": 1, "ip": "1.1.1.1", "bk_cloud_id": 0}]},
+    )
+    _, resolve_missing_recycle_request, _, _ = _import_recycle_repair()
+
+    recycle_type, recycle_hosts = resolve_missing_recycle_request(ticket)
+    assert recycle_type == expected_type
+    if expected_type == TicketType.RECYCLE_APPLY_HOST:
+        assert recycle_hosts == []
+    else:
+        assert recycle_hosts == ticket.details["recycle_hosts"]
+    ticket.delete()
+
+
+def test_repair_missing_recycle_creates_ticket_for_terminal_drill():
+    ticket = _make_drill_ticket(
+        TicketStatus.FAILED,
+        {"recycle_hosts": [{"bk_host_id": 1, "ip": "1.1.1.1", "bk_cloud_id": 0}]},
+    )
+    repair_missing_redis_rollback_recycle_tickets, _, _, _ = _import_recycle_repair()
+
+    with patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.Ticket.create_recycle_ticket"
+    ) as mock_create:
+        repaired = repair_missing_redis_rollback_recycle_tickets(10)
+
+    assert repaired == 1
+    mock_create.assert_called_once_with(ticket.id, ticket.details["recycle_hosts"], TicketType.RECYCLE_OLD_HOST)
+    ticket.delete()
+
+
+def test_repair_missing_recycle_skips_when_recycle_exists():
+    ticket = _make_drill_ticket(
+        TicketStatus.SUCCEEDED,
+        {"recycle_hosts": [{"bk_host_id": 1, "ip": "1.1.1.1", "bk_cloud_id": 0}]},
+    )
+    recycle = Ticket.objects.create(
+        bk_biz_id=1,
+        ticket_type=TicketType.RECYCLE_OLD_HOST,
+        status=TicketStatus.PENDING,
+        creator="tester",
+        updater="tester",
+        remark="recycle",
+        details={"parent_ticket": ticket.id},
+        group="common",
+    )
+    Flow.objects.create(
+        ticket=ticket,
+        flow_type=FlowType.DELIVERY.value,
+        status=TicketFlowStatus.SUCCEEDED,
+        details={"related_ticket": recycle.id},
+        flow_alias="recycle",
+    )
+    repair_missing_redis_rollback_recycle_tickets, _, _, _ = _import_recycle_repair()
+
+    with patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.Ticket.create_recycle_ticket"
+    ) as mock_create:
+        repaired = repair_missing_redis_rollback_recycle_tickets(10)
+
+    assert repaired == 0
+    mock_create.assert_not_called()
+    recycle.delete()
+    ticket.delete()
+
+
+def test_repair_missing_recycle_skips_running_ticket():
+    ticket = _make_drill_ticket(
+        TicketStatus.RUNNING,
+        {"recycle_hosts": [{"bk_host_id": 1, "ip": "1.1.1.1", "bk_cloud_id": 0}]},
+    )
+    repair_missing_redis_rollback_recycle_tickets, _, _, _ = _import_recycle_repair()
+
+    with patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.Ticket.create_recycle_ticket"
+    ) as mock_create:
+        repaired = repair_missing_redis_rollback_recycle_tickets(10)
+
+    assert repaired == 0
+    mock_create.assert_not_called()
+    ticket.delete()
+
+
+def test_daily_recycle_repair_invokes_missing_recycle_repair():
+    from backend.db_periodic_task.local_tasks.redis_backup_rollback.task import (
+        repair_missing_redis_rollback_exercise_recycle,
+    )
+
+    with _PATCH_EXERCISE_CFG, patch(
+        "backend.db_periodic_task.local_tasks.redis_backup_rollback.task.repair_missing_redis_rollback_recycle_tickets"
+    ) as mock_repair:
+        repair_missing_redis_rollback_exercise_recycle()
+
+    mock_repair.assert_called_once_with(10)

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
@@ -12,6 +12,8 @@ from backend.flow.engine.controller.redis import RedisController
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
     RedisExerciseBestEffortCleanupComponent,
     RedisExerciseBestEffortCleanupService,
+    RedisExerciseResourceApplyComponent,
+    RedisExerciseResourceApplyService,
     RedisExerciseRevokeAppliedHostsComponent,
     RedisExerciseRevokeAppliedHostsService,
 )
@@ -46,6 +48,9 @@ class FakeBuilder:
             }
         )
 
+    def add_parallel_sub_pipeline(self, sub_flow_list):
+        self.sub_flows = sub_flow_list
+
     def run_pipeline(self, **kwargs):
         self.run_kwargs = kwargs
 
@@ -63,12 +68,10 @@ def test_build_exercise_sub_flow_missing_cluster_marks_report_skipped(mock_clust
         "report_id": 456,
         "redis": [{"ip": "2.2.2.2"}],
     }
-    flow = RedisRollbackExerciseFlow(
-        root_id="root-id",
-        data={"infos": [info], "drill_config": {}, "bk_biz_id": 100, "created_by": "system"},
-    )
+    ticket_data = {"infos": [info], "drill_config": {}, "bk_biz_id": 100, "created_by": "system"}
+    flow = RedisRollbackExerciseFlow(root_id="root-id", data=ticket_data)
 
-    result = flow._build_exercise_sub_flow(info)
+    result = flow._build_exercise_sub_flow(info, 0, ticket_data)
 
     assert result is None
     mock_report_get.assert_called_once_with(id=456)
@@ -223,3 +226,216 @@ def test_revoke_applied_hosts_service_outputs_empty_table_when_no_redis_hosts():
         service._execute_inner_captured(data, parent_data=None)
 
     handler.return_value.insert_data.assert_called_once_with("root-1", [])
+
+
+@patch("backend.flow.engine.bamboo.scene.redis.redis_rollback_exercise.Builder", FakeBuilder)
+def test_rollback_exercise_flow_starts_with_resource_apply_act():
+    FakeBuilder.instances = []
+    info = {
+        "cluster_id": 1,
+        "instance_ip": "1.1.1.1",
+        "instance_port": 30000,
+        "report_id": 1,
+        "redis": [{"ip": "2.2.2.2"}],
+    }
+    flow = RedisRollbackExerciseFlow(
+        root_id="root-id",
+        data={"infos": [info], "drill_config": {}, "bk_biz_id": 100, "created_by": "system"},
+    )
+
+    with patch.object(flow, "_build_exercise_sub_flow", return_value=None):
+        flow.rollback_exercise_flow()
+
+    builder = FakeBuilder.instances[0]
+    assert builder.acts[0]["act_component_code"] == RedisExerciseResourceApplyComponent.code
+    assert builder.acts[-1]["act_component_code"] == RedisExerciseBestEffortCleanupComponent.code
+
+
+def test_resource_apply_service_logs_applied_host_summary():
+    service = RedisExerciseResourceApplyService()
+    infos = [
+        {
+            "cluster_id": 10,
+            "cluster_domain": "cache.example.db",
+            "instance_ip": "1.1.1.1",
+            "instance_port": 30000,
+            "redis": [
+                {
+                    "ip": "2.2.2.2",
+                    "bk_host_id": 101,
+                    "bk_cloud_id": 0,
+                }
+            ],
+        }
+    ]
+
+    with patch.object(service, "log_info") as mock_log_info:
+        service._log_applied_resources(infos, "req-123")
+
+    assert mock_log_info.call_count == 1
+    summary_log = mock_log_info.call_args_list[0].args[0]
+    assert "演练资源申请完成，共 1 台主机 request_id=req-123" in summary_log
+    assert "10:cache.example.db" in summary_log
+    assert "    1.1.1.1:30000: 2.2.2.2" in summary_log
+
+
+def test_resource_apply_service_log_summary_groups_instances_by_applied_ip():
+    service = RedisExerciseResourceApplyService()
+    infos = [
+        {
+            "cluster_id": 10,
+            "cluster_domain": "cache.example.db",
+            "instance_ip": "1.1.1.1",
+            "instance_port": 30000,
+            "redis": [{"ip": "2.2.2.2"}],
+        },
+        {
+            "cluster_id": 10,
+            "cluster_domain": "cache.example.db",
+            "instance_ip": "1.1.1.1",
+            "instance_port": 30001,
+            "redis": [{"ip": "2.2.2.2"}],
+        },
+        {
+            "cluster_id": 11,
+            "cluster_domain": "cache.other.db",
+            "instance_ip": "3.3.3.3",
+            "instance_port": 30000,
+            "redis": [{"ip": "4.4.4.4"}],
+        },
+    ]
+
+    summary = service._build_resource_apply_log_summary(infos, header="applied")
+
+    assert summary == "\n".join(
+        [
+            "applied",
+            "10:cache.example.db",
+            "    1.1.1.1:30000,1.1.1.1:30001: 2.2.2.2",
+            "11:cache.other.db",
+            "    3.3.3.3:30000: 4.4.4.4",
+        ]
+    )
+
+
+def test_get_effective_drill_infos_prefers_trans_data_applied_infos():
+    from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
+    from backend.flow.utils.redis.redis_rollback_exercise_resource import get_effective_drill_infos
+
+    global_data = {"infos": [{"cluster_id": 1, "instance_ip": "1.1.1.1", "instance_port": 30000}]}
+    trans_data = RedisRollbackExerciseContext(
+        applied_infos=[
+            {"cluster_id": 1, "instance_ip": "1.1.1.1", "instance_port": 30000, "redis": [{"ip": "2.2.2.2"}]}
+        ]
+    )
+
+    infos = get_effective_drill_infos(global_data, trans_data)
+
+    assert infos[0]["redis"][0]["ip"] == "2.2.2.2"
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Report.objects.get")
+def test_report_update_skips_rollback_started_without_applied_resource(mock_report_get):
+    from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
+    from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
+        RedisExerciseReportUpdateService,
+    )
+    from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
+
+    service = RedisExerciseReportUpdateService()
+    service.trans_data = RedisRollbackExerciseContext(
+        applied_infos=[{"cluster_id": 1, "instance_ip": "1.1.1.1", "instance_port": 30000, "report_id": 8}]
+    )
+    data = FakeData(
+        inputs={
+            "kwargs": {
+                "report_id": 8,
+                "info_index": 0,
+                "stage": TaskStage.ROLLBACK_STARTED,
+            },
+            "global_data": {"infos": [{"cluster_id": 1, "instance_ip": "1.1.1.1", "instance_port": 30000}]},
+            "trans_data": service.trans_data,
+        }
+    )
+
+    assert service._execute_inner_captured(data, {}) is True
+    mock_report_get.assert_not_called()
+
+
+def test_flow_runner_reads_applied_infos_from_trans_data():
+    from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
+        RedisExerciseFlowRunnerService,
+    )
+    from backend.flow.utils.redis.redis_rollback_exercise_resource import info_has_applied_redis
+
+    service = RedisExerciseFlowRunnerService()
+    data = FakeData(
+        inputs={
+            "global_data": {
+                "infos": [{"cluster_id": 24, "instance_ip": "1.1.1.1", "instance_port": 30000}],
+            },
+            "trans_data": RedisRollbackExerciseContext(
+                applied_infos=[
+                    {
+                        "cluster_id": 24,
+                        "instance_ip": "1.1.1.1",
+                        "instance_port": 30000,
+                        "redis": [{"ip": "2.2.2.2"}],
+                    }
+                ]
+            ),
+        }
+    )
+
+    info = service._get_effective_info(data, 0)
+
+    assert info_has_applied_redis(info)
+    assert info["redis"][0]["ip"] == "2.2.2.2"
+
+
+@patch("backend.flow.engine.bamboo.scene.redis.redis_rollback_exercise.get_instance_machine")
+def test_build_ds_flow_data_fills_resource_spec_from_source_machine(mock_get_machine):
+    machine = MagicMock()
+    machine.spec_id = 42
+    machine.spec_config = {"cpu": {"min": 4, "max": 8}}
+    mock_get_machine.return_value = machine
+
+    cluster = MagicMock()
+    cluster.id = 24
+    cluster.bk_cloud_id = 0
+
+    flow_data = RedisRollbackExerciseFlow.build_ds_flow_data(
+        global_data={"bk_biz_id": 1, "uid": 99, "created_by": "system"},
+        info={
+            "instance_ip": "1.1.1.1",
+            "instance_port": 30000,
+            "recovery_time_point": "2026-06-15 00:00:00",
+            "redis": [{"ip": "2.2.2.2", "bk_host_id": 1, "bk_cloud_id": 0}],
+        },
+        cluster=cluster,
+    )
+
+    redis_spec = flow_data["infos"][0]["resource_spec"]["redis"]
+    assert redis_spec["id"] == 42
+    assert redis_spec["count"] == 1
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Report")
+def test_reconcile_report_sanitizes_captured_logs_with_emoji(mock_report_model):
+    from backend.db_report.models import RedisRollbackExerciseReport as Report
+
+    report = Report()
+    report.task_message = ""
+    report.task_stage = TaskStage.ROLLBACK_FAILED
+    report.save = MagicMock()
+    mock_report_model.objects.get.return_value = report
+
+    service = RedisExerciseBestEffortCleanupService()
+    service.trans_data = RedisRollbackExerciseContext()
+    service.trans_data.task_msg = ["[2026-06-15 16:50:46] [INFO]: [node] 任务正在执行🤔"]
+
+    service._reconcile_report(15)
+
+    assert "🤔" not in report.task_message
+    assert "任务正在执行" in report.task_message
+    report.save.assert_called_once()

--- a/dbm-ui/backend/tests/flow/utils/redis/test_redis_rollback_exercise_resource.py
+++ b/dbm-ui/backend/tests/flow/utils/redis/test_redis_rollback_exercise_resource.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.flow.utils.redis.redis_rollback_exercise_resource import (
+    all_infos_have_redis,
+    build_apply_detail_from_machine,
+)
+
+
+@pytest.mark.django_db
+def test_build_apply_detail_from_machine_uses_disk_mem_not_spec_id():
+    cluster = MagicMock()
+    cluster.bk_cloud_id = 0
+    cluster.region = "sz"
+
+    machine = MagicMock()
+    machine.spec_config = {"cpu": {"min": 4, "max": 8}, "mem": {"min": 16, "max": 32}}
+    machine.storage_device = {"/data": {"size": 200, "disk_type": "SSD"}}
+    machine.spec_id = 999
+
+    detail = build_apply_detail_from_machine(0, cluster, machine)
+
+    assert detail["group_mark"] == "0_redis"
+    assert detail["bk_cloud_id"] == 0
+    assert detail["spec"]["cpu"] == {"min": 0, "max": 0}
+    assert detail["spec"]["ram"]["min"] == 16 * 1024
+    assert detail["storage_spec"][0]["min"] == 200
+    assert "spec_id" not in detail
+    assert detail["location_spec"] == {"city": "sz", "sub_zone_ids": []}
+
+
+@pytest.mark.django_db
+def test_build_apply_detail_from_machine_random_region_no_city_filter():
+    cluster = MagicMock()
+    cluster.bk_cloud_id = 0
+    cluster.region = "default"
+
+    machine = MagicMock()
+    machine.spec_config = {"cpu": {"min": 2}, "mem": {"min": 3}}
+    machine.storage_device = {"/data": {"size": 50}}
+    machine.spec_id = 0
+
+    detail = build_apply_detail_from_machine(0, cluster, machine)
+
+    assert detail["location_spec"] == {"city": "", "sub_zone_ids": []}
+
+
+def test_all_infos_have_redis():
+    assert all_infos_have_redis([{"redis": [{"ip": "1.1.1.1"}]}]) is True
+    assert all_infos_have_redis([{"redis": []}]) is False
+    assert all_infos_have_redis([]) is False
+
+
+@patch("backend.flow.utils.redis.redis_rollback_exercise_resource.DBResourceApi.resource_apply")
+@patch("backend.flow.utils.redis.redis_rollback_exercise_resource.MachineEvent.host_event_trigger")
+@patch("backend.flow.utils.redis.redis_rollback_exercise_resource.get_instance_machine")
+@patch("backend.flow.utils.redis.redis_rollback_exercise_resource.Cluster.objects.get")
+def test_apply_exercise_resources_marks_failure_on_api_error(
+    mock_cluster_get, mock_get_machine, mock_event, mock_apply
+):
+    from backend.flow.utils.redis.redis_rollback_exercise_resource import apply_exercise_resources
+
+    cluster = MagicMock()
+    cluster.id = 1
+    cluster.bk_cloud_id = 0
+    cluster.region = "sz"
+    mock_cluster_get.return_value = cluster
+    mock_get_machine.return_value = MagicMock(
+        spec_config={"cpu": {"min": 1}, "mem": {"min": 1}},
+        storage_device={"/data": {"size": 100}},
+        spec_id=0,
+    )
+    mock_apply.return_value = {"code": 1, "message": "lake"}
+
+    ticket_data = {
+        "bk_biz_id": 100,
+        "uid": 1,
+        "ticket_type": "REDIS_ROLLBACK_EXERCISE",
+        "created_by": "system",
+        "infos": [
+            {
+                "cluster_id": 1,
+                "instance_ip": "1.1.1.1",
+                "instance_port": 30000,
+                "report_id": 10,
+            }
+        ],
+    }
+
+    result = apply_exercise_resources(ticket_data, "root-id")
+
+    assert result.success is False
+    mock_event.assert_not_called()
+    assert mock_apply.call_args.kwargs["params"]["resource_type"] == "redis"

--- a/dbm-ui/backend/ticket/builders/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/ticket/builders/redis/redis_rollback_exercise.py
@@ -11,13 +11,10 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
-from backend.core.notify.constants import MsgType
-from backend.db_services.dbresource.handlers import ResourceHandler
 from backend.flow.engine.controller.redis import RedisController
 from backend.ticket import builders
-from backend.ticket.builders.common.base import AffinityEnum, BaseOperateResourceParamBuilder, IpSource
-from backend.ticket.builders.redis.base import BaseRedisTicketFlowBuilder, Cluster, RedisOpsBaseDetailSerializer
-from backend.ticket.constants import TicketStatus, TicketType
+from backend.ticket.builders.redis.base import BaseRedisTicketFlowBuilder, RedisOpsBaseDetailSerializer
+from backend.ticket.constants import TicketType
 
 
 class RedisRollbackExerciseDetailSerializer(RedisOpsBaseDetailSerializer):
@@ -28,16 +25,10 @@ class RedisRollbackExerciseDetailSerializer(RedisOpsBaseDetailSerializer):
         instance_ip = serializers.CharField(help_text=_("实例IP"))
         instance_port = serializers.IntegerField(help_text=_("实例端口"))
         recovery_time_point = serializers.CharField(help_text=_("恢复时间点"))
-        task_id = serializers.IntegerField(help_text=_("任务记录ID"))
-        resource_spec = serializers.JSONField(help_text=_("资源规格"))
+        report_id = serializers.IntegerField(help_text=_("任务记录ID"))
 
     infos = serializers.ListSerializer(help_text=_("回滚演练信息"), child=RollbackExerciseInfoSerializer())
     drill_config = serializers.JSONField(help_text=_("演练设置"), required=True)
-    ip_source = serializers.ChoiceField(
-        help_text=_("主机来源"),
-        choices=IpSource.get_choices(),
-        default=IpSource.RESOURCE_POOL,
-    )
 
 
 class RedisRollbackExerciseParamBuilder(builders.FlowParamBuilder):
@@ -47,56 +38,18 @@ class RedisRollbackExerciseParamBuilder(builders.FlowParamBuilder):
         super().format_ticket_data()
 
 
-class RedisRollbackExerciseResourceParamBuilder(BaseOperateResourceParamBuilder):
-    def format(self):
-        infos = self.ticket_data["infos"]
-        cluster_ids = [info["cluster_id"] for info in infos]
-        id__cluster = {cluster.id: cluster for cluster in Cluster.objects.filter(id__in=cluster_ids)}
-        for info in infos:
-            cluster: Cluster = id__cluster[info["cluster_id"]]
-            info["resource_spec"]["redis"].update(
-                affinity=AffinityEnum.NONE.value, location_spec={"city": cluster.region, "sub_zone_ids": []}
-            )
-            info.update(bk_cloud_id=cluster.bk_cloud_id, bk_biz_id=self.ticket.bk_biz_id)
-
-    def post_callback(self):
-        """
-        Set recycle_hosts after resource application but before inner flow starts.
-        This ensures recycle_hosts is available when ticket_status_trigger is called with SUCCEEDED.
-        """
-        applied_hosts = []
-        nodes = self.ticket_data.get("nodes", {})
-
-        for hosts in nodes.values():
-            for host in hosts:
-                applied_hosts.append(
-                    {
-                        "bk_host_id": host["bk_host_id"],
-                        "ip": host["ip"],
-                        "bk_cloud_id": host["bk_cloud_id"],
-                    }
-                )
-
-        if applied_hosts:
-            self.ticket.details["recycle_hosts"] = ResourceHandler.standardized_resource_host(applied_hosts)
-            self.ticket.details["immediate_recycle"] = True
-            # Only send notification when recycle ticket fails, explicitly disable all other statuses
-            self.ticket.details["send_msg_config"] = {
-                status: {MsgType.RTX: True} if status == TicketStatus.FAILED else {}
-                for status in TicketStatus.get_values()
-            }
-            self.ticket.save(update_fields=["details"])
-
-
 @builders.BuilderFactory.register(
     TicketType.REDIS_ROLLBACK_EXERCISE,
-    is_apply=True,
+    is_apply=False,
     is_recycle=True,
 )
 class RedisRollbackExerciseFlowBuilder(BaseRedisTicketFlowBuilder):
     serializer = RedisRollbackExerciseDetailSerializer
     inner_flow_builder = RedisRollbackExerciseParamBuilder
-    resource_batch_apply_builder = RedisRollbackExerciseResourceParamBuilder
     inner_flow_name = _("Redis 回档演练")
     default_need_itsm = False
     default_need_manual_confirm = False
+
+    @property
+    def need_resource_pool(self):
+        return False


### PR DESCRIPTION
## 具体改动

- **资源申请内置**：`need_resource_pool=False`，`ticket` 不再预填 `resource_spec`/`ip_source` → 资源改在 inner flow 首节点批量申请，以支持按 `MEM` 和 `DISK` 下限申请
- **按源实例规格申请主机**：新增 `redis_rollback_exercise_resource`，按源机 disk/mem/region 构造 `DBResourceApi.resource_apply`，不再绑定 `spec_id` → 资源池可匹配容量而非固定机型
- **漏建回收单兜底**：新增定时任务 `repair_missing_redis_rollback_exercise_recycle`，对已申请主机但无回收单的终态演练单补建 `RECYCLE_APPLY_HOST`/`RECYCLE_OLD_HOST`

## 测试 & 风险

- 单测已覆盖资源申请参数构造、inner flow 资源节点编排、`applied_infos` 透传、revoke 回收输出、缺失回收单 repair
- 仅影响 Redis 回档演练链路；无对外 API breaking change；演练单据资源申请走内部flow，行为变化属预期