### PR TITLE
feat(redis): add affinity check config and exercise resource spec logs #18342

### DIFF
--- a/dbm-ui/backend/configuration/constants.py
+++ b/dbm-ui/backend/configuration/constants.py
@@ -180,6 +180,7 @@ class SystemSettingsEnum(StrStructuredEnum):
     # Redis 巡检相关配置
     REDIS_ROLE_CHECK = EnumField("REDIS_ROLE_CHECK", _("Redis实例角色校验配置"))
     REDIS_ENTRY_CHECK = EnumField("REDIS_ENTRY_CHECK", _("Redis访问入口一致性校验配置"))
+    REDIS_AFFINITY_CHECK = EnumField("REDIS_AFFINITY_CHECK", _("Redis亲和性校验配置"))
     REDIS_CLUSTER_CAPACITY_GROWTH_CHECK = EnumField("REDIS_CLUSTER_CAPACITY_GROWTH_CHECK", _("Redis集群容量增长检查配置"))
     REDIS_BACKEND_LOAD_SKEW_CHECK = EnumField("REDIS_BACKEND_LOAD_SKEW_CHECK", _("Redis后端负载倾斜检查配置"))
     REDIS_BACKEND_DATA_SKEW_CHECK = EnumField("REDIS_BACKEND_DATA_SKEW_CHECK", _("Redis后端数据倾斜检查配置"))

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
@@ -11,13 +11,13 @@ specific language governing permissions and limitations under the License.
 
 import logging
 from collections import defaultdict
+from dataclasses import asdict, dataclass, field, fields
 from math import floor
 from typing import Dict, List, Optional, Tuple, Union
 
-from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from backend.configuration.constants import AffinityEnum, DBType
+from backend.configuration.constants import AffinityEnum, DBType, SystemSettingsEnum
 from backend.configuration.models import DBAdministrator
 from backend.db_meta.enums import ClusterPhase, ClusterType, InstanceRole, MachineType
 from backend.db_meta.models import Cluster, StorageInstance
@@ -29,16 +29,85 @@ from backend.flow.utils.redis.redis_report_utils import (
     is_cluster_labeled_with,
 )
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
+from backend.ticket.models import SystemSettings
 from backend.ticket.models.ticket import ClusterOperateRecord
 
 logger = logging.getLogger("root")
+
+
+DEFAULT_CLUSTER_TYPES = [
+    ClusterType.TendisTwemproxyRedisInstance.value,  # TendisCache 集群
+    ClusterType.TwemproxyTendisSSDInstance.value,  # TendisSSD 集群
+    ClusterType.TendisPredixyRedisCluster.value,  # RedisCluster 集群
+    ClusterType.TendisPredixyTendisplusCluster.value,  # Tendisplus 集群
+    ClusterType.TendisRedisInstance.value,  # Redis 主从
+]
+
+
+@dataclass
+class RedisAffinityCheckConfig:
+    """
+    Configuration for Redis affinity check task
+    """
+
+    enabled: bool = True
+    cluster_types: Optional[List[str]] = field(default_factory=lambda: list(DEFAULT_CLUSTER_TYPES))
+    bizs_ignored: Optional[List[int]] = field(default_factory=list)
+    clusters_ignored: Optional[List[int]] = field(default_factory=list)
+    # Empty list means all cloud areas; when set (e.g. [0]), only check matching bk_cloud_id.
+    bk_cloud_ids: Optional[List[int]] = field(default_factory=list)
+
+    @classmethod
+    def from_settings(cls) -> "RedisAffinityCheckConfig":
+        """Load config from SystemSettings with dataclass defaults for missing keys."""
+        raw = SystemSettings.get_setting_value(SystemSettingsEnum.REDIS_AFFINITY_CHECK.value, default={})
+        if not isinstance(raw, dict):
+            if raw:
+                logger.warning("RedisAffinityCheckConfig: expected dict, got %s", type(raw).__name__)
+            return cls()
+
+        valid_keys = {f.name for f in fields(cls)}
+        return cls(**{key: value for key, value in raw.items() if key in valid_keys})
+
+    def save_to_settings(self, user: str = "admin") -> None:
+        """Persist this config to SystemSettings for shell_plus maintenance."""
+        SystemSettings.insert_setting_value(
+            key=SystemSettingsEnum.REDIS_AFFINITY_CHECK.value,
+            value=asdict(self),
+            value_type="dict",
+            user=user,
+        )
+
+
+def _get_candidate_clusters(config: RedisAffinityCheckConfig):
+    """
+    Get candidate clusters for affinity check based on configuration
+    """
+    query = Cluster.objects.filter(cluster_type__in=config.cluster_types)
+
+    if config.bizs_ignored:
+        query = query.exclude(bk_biz_id__in=config.bizs_ignored)
+
+    if config.clusters_ignored:
+        query = query.exclude(id__in=config.clusters_ignored)
+
+    if config.bk_cloud_ids:
+        query = query.filter(bk_cloud_id__in=config.bk_cloud_ids)
+
+    return query
 
 
 def check_redis_affinity():
     """
     检查集群中的主从机器是否满足集群亲和性要求
     """
-    RedisAffinityChecker().check_all_clusters()
+    config = RedisAffinityCheckConfig.from_settings()
+
+    if not config.enabled:
+        logger.info(_("Redis affinity check is disabled, exiting"))
+        return
+
+    RedisAffinityChecker(config).check_all_clusters()
 
 
 class RedisAffinityChecker:
@@ -93,17 +162,11 @@ class RedisAffinityChecker:
     SKIP_PROXY_CHECK_LABEL = {"directmode": "true"}
     _subzone_map_cache: Dict[int, str] = {}
 
-    def __init__(self):
+    def __init__(self, config: Optional[RedisAffinityCheckConfig] = None):
         """Initialize the affinity checker"""
+        self._config = config or RedisAffinityCheckConfig.from_settings()
         self._writer = RedisReportWriter()
-        # ClusterTypes that need to check
-        self._supported_cluster_types = [
-            ClusterType.TendisTwemproxyRedisInstance.value,  # TendisCache 集群
-            ClusterType.TwemproxyTendisSSDInstance.value,  # TendisSSD 集群
-            ClusterType.TendisPredixyRedisCluster.value,  # RedisCluster 集群
-            ClusterType.TendisPredixyTendisplusCluster.value,  # Tendisplus 集群
-            ClusterType.TendisRedisInstance.value,  # Redis 主从
-        ]
+        self._supported_cluster_types = list(self._config.cluster_types)
         # Ignore cluster if it has machines changing
         self._ignore_tickets = [
             TicketType.REDIS_PROXY_CLOSE.value,
@@ -140,7 +203,7 @@ class RedisAffinityChecker:
             self._supported_cluster_types,
             self._writer.retention_days,
         )
-        for cluster in Cluster.objects.filter(Q(cluster_type__in=self._supported_cluster_types)):
+        for cluster in _get_candidate_clusters(self._config):
             try:
                 self._check_cluster_affinity(cluster)
             except Exception as e:

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -45,6 +45,7 @@ from backend.flow.utils.redis.redis_rollback_exercise_resource import (
     all_infos_have_redis,
     apply_exercise_resources,
     get_effective_drill_infos,
+    get_instance_machine,
     info_has_applied_redis,
 )
 from backend.flow.utils.redis.redis_script_template import redis_fast_execute_script_common_kwargs
@@ -54,6 +55,25 @@ from backend.utils.basic import generate_root_id
 from backend.utils.string import base64_encode
 
 logger = logging.getLogger("json")
+
+
+def merge_task_message(*messages: str) -> str:
+    """Merge report task logs into one ordered, de-duplicated block.
+
+    Node logs accumulate in ``trans_data.task_msg`` (append-only), so the same
+    lines are re-submitted repeatedly -- e.g. a terminal-stage snapshot and the
+    later cleanup pass both carry the full history up to that point. Merging per
+    line preserves order and any explicit notes already on the report while
+    dropping lines that were already persisted.
+    """
+    merged, seen = [], set()
+    for message in messages:
+        for line in (message or "").splitlines():
+            if line in seen:
+                continue
+            seen.add(line)
+            merged.append(line)
+    return "\n".join(merged).strip()
 
 
 class RedisLogCapturingService(BaseService):
@@ -107,6 +127,16 @@ class RedisLogCapturingService(BaseService):
         """Override to auto-capture debug logs"""
         super().log_debug(msg)
         self._append_to_task_info(msg, "debug")
+
+    def render_report_message(self, existing_msg: str = "") -> str:
+        """Build a report ``task_message`` from the captured node logs.
+
+        ``existing_msg`` (the message already stored on the report) is kept first
+        so explicit notes -- e.g. a build-time skip reason -- survive, then the
+        append-only ``trans_data.task_msg`` is merged on top with duplicates removed.
+        """
+        captured = self.trans_data.task_msg if self.trans_data else None
+        return merge_task_message(existing_msg, "\n".join(captured or []))
 
     @staticmethod
     def _get_effective_infos(data) -> list:
@@ -209,15 +239,21 @@ class RedisExerciseReportUpdateService(RedisLogCapturingService):
             self.log_info(_("演练资源未申请，跳过标记 {}").format(stage))
             return True
 
-        if stage in self.TERMINAL_STAGES and not task_message and self.trans_data and self.trans_data.task_msg:
-            task_message = "\n".join(self.trans_data.task_msg)
-
         try:
             report = Report.objects.get(id=report_id)
-            report.mark(stage, task_message=task_message)
-            self.log_info(_("Report {} marked as {}").format(report_id, stage))
         except Report.DoesNotExist:
             self.log_error(_("Report {} not found").format(report_id))
+            return True
+        except Exception as e:
+            self.log_error(_("Failed to update report {}: {}").format(report_id, str(e)))
+            return True
+
+        if stage in self.TERMINAL_STAGES and not task_message and self.trans_data and self.trans_data.task_msg:
+            task_message = self.render_report_message(report.task_message)
+
+        try:
+            report.mark(stage, task_message=task_message)
+            self.log_info(_("Report {} marked as {}").format(report_id, stage))
         except Exception as e:
             self.log_error(_("Failed to update report {}: {}").format(report_id, str(e)))
 
@@ -553,16 +589,167 @@ class RedisExerciseResourceApplyService(RedisLogCapturingService):
         return dict(Cluster.objects.filter(id__in=missing_cluster_ids).values_list("id", "immute_domain"))
 
     @classmethod
+    def _format_disk_gb(cls, redis_host: dict) -> Optional[int]:
+        disk_gb = redis_host.get("bk_disk")
+        if disk_gb not in (None, ""):
+            try:
+                disk_value = int(disk_gb)
+                if disk_value > 0:
+                    return disk_value
+            except (TypeError, ValueError):
+                pass
+
+        storage_device = redis_host.get("storage_device") or {}
+        total = 0
+        for item in storage_device.values():
+            if not isinstance(item, dict):
+                continue
+            try:
+                total += int(item.get("size") or 0)
+            except (TypeError, ValueError):
+                continue
+        return total or None
+
+    @classmethod
+    def _format_mem_gb(cls, mem_mb) -> str:
+        """Render ``bk_mem`` (stored in MB across db_meta / resource pool) as GB.
+
+        Whole values collapse to ints (16GB) and fractional ones keep one
+        decimal (3.5GB), so 3619MB no longer prints as the bogus "3619GB".
+        """
+        if mem_mb in (None, ""):
+            return ""
+        try:
+            gb = int(mem_mb) / 1024
+        except (TypeError, ValueError):
+            return ""
+        if gb <= 0:
+            return ""
+        return "{:g}GB".format(round(gb, 1))
+
+    @classmethod
+    def _format_spec_details(cls, redis_host: dict) -> str:
+        cpu = redis_host.get("bk_cpu")
+        mem_label = cls._format_mem_gb(redis_host.get("bk_mem"))
+        disk_gb = cls._format_disk_gb(redis_host)
+
+        parts = []
+        if cpu not in (None, ""):
+            parts.append("{} cores".format(cpu))
+        if mem_label:
+            parts.append("{} RAM".format(mem_label))
+        if disk_gb:
+            parts.append("{}GB disk".format(disk_gb))
+        return " ".join(parts)
+
+    @classmethod
+    def _resolve_bk_svr_device_cls_name(cls, redis_host: dict) -> str:
+        for key in ("bk_svr_device_cls_name", "device_class"):
+            value = redis_host.get(key)
+            if value:
+                return str(value)
+        return ""
+
+    @classmethod
+    def _machine_to_spec_host_dict(cls, machine) -> dict:
+        spec_config = machine.spec_config or {}
+        cpu_info = spec_config.get("cpu") or {}
+        mem_info = spec_config.get("mem") or {}
+        cpu = cpu_info.get("min") or cpu_info.get("max") or ""
+        # spec_config.mem is GB; normalize to MB so bk_mem stays consistent with the resource pool.
+        mem_gb = mem_info.get("min") or mem_info.get("max") or 0
+        try:
+            mem_mb = int(mem_gb) * 1024 or ""
+        except (TypeError, ValueError):
+            mem_mb = ""
+        return {
+            "bk_cpu": cpu,
+            "bk_mem": mem_mb,
+            "storage_device": machine.storage_device or {},
+            "bk_svr_device_cls_name": machine.bk_svr_device_cls_name or "",
+            "device_class": machine.bk_svr_device_cls_name or "",
+        }
+
+    @classmethod
+    def _resolve_source_machine_spec(cls, info: dict, cluster, machine_cache: dict) -> str:
+        cache_key = (info.get("cluster_id"), info.get("instance_ip"), info.get("instance_port"))
+        if cache_key in machine_cache:
+            return machine_cache[cache_key]
+
+        machine = get_instance_machine(info, cluster) if cluster else None
+        spec_label = cls._format_spec_details(cls._machine_to_spec_host_dict(machine)) if machine else ""
+        machine_cache[cache_key] = spec_label
+        return spec_label
+
+    @classmethod
+    def _format_applied_host_spec(cls, redis_host: dict) -> str:
+        spec_details = cls._format_spec_details(redis_host)
+        device_cls_name = cls._resolve_bk_svr_device_cls_name(redis_host)
+        if spec_details and device_cls_name:
+            return "{} {}".format(spec_details, device_cls_name)
+        return spec_details or device_cls_name
+
+    @classmethod
+    def _append_original_instance_lines(
+        cls,
+        lines: list,
+        entries: list,
+        cluster,
+        machine_cache: dict,
+        *,
+        spec_in_parens: bool = False,
+    ):
+        for entry in sorted(entries, key=lambda item: cls._instance_addr(item["info"])):
+            info = entry["info"]
+            instance_addr = cls._instance_addr(info)
+            orig_spec = cls._resolve_source_machine_spec(info, cluster, machine_cache)
+            if orig_spec and spec_in_parens:
+                lines.append("        {} ({})".format(instance_addr, orig_spec))
+            elif orig_spec:
+                lines.append("        {} {}".format(instance_addr, orig_spec))
+            else:
+                lines.append("        {}".format(instance_addr))
+
+    @classmethod
+    def _append_pending_instance_lines(
+        cls,
+        lines: list,
+        pending_infos: list,
+        cluster,
+        machine_cache: dict,
+        *,
+        no_resource_label: str = "",
+        spec_in_parens: bool = False,
+    ):
+        if not pending_infos:
+            return
+        if no_resource_label:
+            lines.append("    {}".format(no_resource_label))
+        for info in sorted(pending_infos, key=cls._instance_addr):
+            instance_addr = cls._instance_addr(info)
+            orig_spec = cls._resolve_source_machine_spec(info, cluster, machine_cache)
+            indent = "        " if no_resource_label else "    "
+            if orig_spec and spec_in_parens:
+                lines.append("{}{} ({})".format(indent, instance_addr, orig_spec))
+            elif orig_spec:
+                lines.append("{}{} {}".format(indent, instance_addr, orig_spec))
+            else:
+                lines.append("{}{}".format(indent, instance_addr))
+
+    @classmethod
     def _build_resource_apply_log_summary(
         cls,
         infos: list,
         *,
         header: str,
         include_applied_ip: bool = True,
-        pending_suffix: str = "",
+        no_resource_label: str = "",
     ) -> str:
         cluster_domain_map = cls._resolve_cluster_domains(infos)
-        clusters = defaultdict(lambda: {"domain": "", "instance_groups": defaultdict(list)})
+        cluster_ids = {info["cluster_id"] for info in infos if info.get("cluster_id")}
+        cluster_objects = {cluster.id: cluster for cluster in Cluster.objects.filter(id__in=cluster_ids)}
+
+        clusters = defaultdict(lambda: {"domain": "", "applied_hosts": defaultdict(list), "pending": []})
 
         for info in infos:
             cluster_id = info.get("cluster_id")
@@ -571,34 +758,45 @@ class RedisExerciseResourceApplyService(RedisLogCapturingService):
             cluster_domain = info.get("cluster_domain") or cluster_domain_map.get(cluster_id) or ""
             clusters[cluster_id]["domain"] = cluster_domain or clusters[cluster_id]["domain"]
 
-            instance_addr = cls._instance_addr(info)
             redis_hosts = info.get("redis") or []
             if include_applied_ip and redis_hosts:
                 applied_ip = redis_hosts[0].get("ip") or ""
-                clusters[cluster_id]["instance_groups"][applied_ip].append(instance_addr)
+                clusters[cluster_id]["applied_hosts"][applied_ip].append({"info": info, "redis_host": redis_hosts[0]})
             else:
-                clusters[cluster_id]["instance_groups"][""].append(instance_addr)
+                clusters[cluster_id]["pending"].append(info)
 
-        lines = [header]
+        lines = [header] if header else []
+        machine_cache = {}
         for cluster_id in sorted(clusters):
             cluster_data = clusters[cluster_id]
-            cluster_label = (
-                "{}:{}".format(cluster_id, cluster_data["domain"]) if cluster_data["domain"] else str(cluster_id)
-            )
+            cluster = cluster_objects.get(cluster_id)
+            cluster_label = cluster_data["domain"] or str(cluster_id)
             lines.append(cluster_label)
-            for applied_ip in sorted(cluster_data["instance_groups"]):
-                instances = sorted(cluster_data["instance_groups"][applied_ip])
-                instances_label = ",".join(instances)
-                if include_applied_ip and applied_ip:
-                    lines.append("    {}: {}".format(instances_label, applied_ip))
-                elif pending_suffix:
-                    lines.append("    {}{}".format(instances_label, pending_suffix))
+
+            for applied_ip in sorted(cluster_data["applied_hosts"]):
+                entries = cluster_data["applied_hosts"][applied_ip]
+                spec_label = cls._format_spec_details(entries[0]["redis_host"])
+                if spec_label:
+                    lines.append("    {} ({})".format(applied_ip, spec_label))
                 else:
-                    lines.append("    {}".format(instances_label))
+                    lines.append("    {}".format(applied_ip))
+                cls._append_original_instance_lines(lines, entries, cluster, machine_cache)
+
+            cls._append_pending_instance_lines(
+                lines,
+                cluster_data["pending"],
+                cluster,
+                machine_cache,
+                no_resource_label=no_resource_label,
+                spec_in_parens=bool(no_resource_label),
+            )
 
         return "\n".join(lines)
 
     def _log_applied_resources(self, infos: list, request_id: str = ""):
+        if self.trans_data and getattr(self.trans_data, "resource_apply_logged", False):
+            return
+
         host_count = sum(1 for info in infos if info.get("redis"))
         if not host_count:
             return
@@ -607,6 +805,8 @@ class RedisExerciseResourceApplyService(RedisLogCapturingService):
         if request_id:
             header = "{} request_id={}".format(header, request_id)
         self.log_info(self._build_resource_apply_log_summary(infos, header=header))
+        if self.trans_data:
+            self.trans_data.resource_apply_logged = True
 
     def _log_resource_apply_failure(self, infos: list, error_message: str):
         header = _("演练资源申请失败: {}").format(error_message)
@@ -615,7 +815,7 @@ class RedisExerciseResourceApplyService(RedisLogCapturingService):
                 infos,
                 header=header,
                 include_applied_ip=False,
-                pending_suffix=_(" (no resource)"),
+                no_resource_label=_("(no resource)"),
             )
         )
 
@@ -1171,8 +1371,7 @@ done
         except Report.DoesNotExist:
             return
 
-        cleanup_msg = "\n".join(self.trans_data.task_msg) if self.trans_data and self.trans_data.task_msg else ""
-        merged_msg = self._merge_task_message(report.task_message, cleanup_msg)
+        merged_msg = self.render_report_message(report.task_message)
 
         terminal_stages = {
             TaskStage.DONE,
@@ -1187,27 +1386,6 @@ done
             return
         report.mark(TaskStage.CLEANUP_FAILED, task_message=merged_msg)
         self.log_info(_("Report {} marked CLEANUP_FAILED by best-effort cleanup").format(report_id))
-
-    @staticmethod
-    def _merge_task_message(existing_msg: str, appended_msg: str) -> str:
-        """
-        Merge report task logs without clobbering historical content.
-
-        Rules:
-        1. Keep existing logs first.
-        2. Append new block only when non-empty.
-        3. Deduplicate when the existing message already ends with the same block.
-        """
-        existing = (existing_msg or "").strip()
-        appended = (appended_msg or "").strip()
-
-        if not existing:
-            return appended
-        if not appended:
-            return existing
-        if existing.endswith(appended):
-            return existing
-        return "{}\n{}".format(existing, appended)
 
 
 class RedisExerciseBestEffortCleanupComponent(Component):

--- a/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
@@ -196,6 +196,7 @@ class RedisRollbackExerciseContext:
     alarm_shield_id: int = None  # 告警屏蔽ID
     task_msg: list = field(default_factory=list)  # 执行情况
     applied_infos: list = field(default_factory=list)  # resource-apply result, visible to sub-processes
+    resource_apply_logged: bool = False  # guard duplicate resource summary in task_msg
 
 
 @dataclass()

--- a/dbm-ui/backend/flow/utils/redis/redis_rollback_exercise_resource.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_rollback_exercise_resource.py
@@ -191,6 +191,7 @@ def format_resource_hosts(hosts, biz_name_map, label_name_map) -> List[dict]:
             "sub_zone_id": host.get("sub_zone_id"),
             "rack_id": host.get("rack_id"),
             "device_class": host.get("device_class"),
+            "bk_svr_device_cls_name": host.get("bk_svr_device_cls_name") or host.get("device_class") or "",
             "for_biz": host["dedicated_biz"],
             "labels": host["labels"],
             "for_biz_info": {

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import importlib
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -43,3 +44,40 @@ def test_same_subzone_cross_switch_suggests_moving_master_when_slave_is_in_expec
 
     assert "请将主节点机器 1.1.1.2 替换或迁移到 园区(test-subzone-a) 且不同机架" in msg
     assert "副节点机器 1.1.1.1 替换" not in msg
+
+
+def test_check_redis_affinity_exits_when_disabled(redis_affinity_module):
+    config = redis_affinity_module.RedisAffinityCheckConfig(enabled=False)
+
+    with patch.object(redis_affinity_module.RedisAffinityCheckConfig, "from_settings", return_value=config):
+        with patch.object(redis_affinity_module, "RedisAffinityChecker") as checker_cls:
+            redis_affinity_module.check_redis_affinity()
+
+    checker_cls.assert_not_called()
+
+
+def test_get_candidate_clusters_filters_by_bk_cloud_ids(redis_affinity_module):
+    config = redis_affinity_module.RedisAffinityCheckConfig(
+        cluster_types=["RedisInstance"],
+        bk_cloud_ids=[0],
+    )
+    query = MagicMock()
+    query.exclude.return_value = query
+    query.filter.return_value = query
+
+    with patch.object(redis_affinity_module.Cluster.objects, "filter", return_value=query) as cluster_filter:
+        redis_affinity_module._get_candidate_clusters(config)
+
+    cluster_filter.assert_called_once_with(cluster_type__in=["RedisInstance"])
+    query.filter.assert_called_once_with(bk_cloud_id__in=[0])
+
+
+def test_get_candidate_clusters_checks_all_clouds_when_bk_cloud_ids_empty(redis_affinity_module):
+    config = redis_affinity_module.RedisAffinityCheckConfig(cluster_types=["RedisInstance"])
+    query = MagicMock()
+    query.exclude.return_value = query
+
+    with patch.object(redis_affinity_module.Cluster.objects, "filter", return_value=query):
+        redis_affinity_module._get_candidate_clusters(config)
+
+    query.filter.assert_not_called()

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
@@ -16,6 +16,7 @@ from backend.flow.plugins.components.collections.redis.redis_rollback_exercise i
     RedisExerciseResourceApplyService,
     RedisExerciseRevokeAppliedHostsComponent,
     RedisExerciseRevokeAppliedHostsService,
+    merge_task_message,
 )
 from backend.flow.utils.redis.redis_context_dataclass import RedisRollbackExerciseContext
 
@@ -251,7 +252,46 @@ def test_rollback_exercise_flow_starts_with_resource_apply_act():
     assert builder.acts[-1]["act_component_code"] == RedisExerciseBestEffortCleanupComponent.code
 
 
-def test_resource_apply_service_logs_applied_host_summary():
+def test_merge_task_message_deduplicates_prefix_snapshot():
+    early = "\n".join(
+        [
+            "[2026-06-17 13:00:18] [INFO]: resource apply summary",
+            "21000560:cache.example.db",
+            "    1.1.1.1:30000: 2.2.2.2",
+            "[2026-06-17 13:00:18] [INFO]: [apply act] success",
+        ]
+    )
+    full = early + "\n[2026-06-17 13:06:47] [INFO]: cleanup finished"
+
+    assert merge_task_message(early, full) == full
+    assert merge_task_message(full, early) == full
+
+
+def test_resource_apply_service_logs_applied_resources_only_once():
+    service = RedisExerciseResourceApplyService()
+    service.trans_data = RedisRollbackExerciseContext(resource_apply_logged=True)
+    infos = [{"cluster_id": 10, "redis": [{"ip": "2.2.2.2"}]}]
+
+    with patch.object(service, "log_info") as mock_log_info:
+        service._log_applied_resources(infos, "req-123")
+
+    mock_log_info.assert_not_called()
+
+
+def _mock_source_machine(cpu, mem, disk, device_cls):
+    return SimpleNamespace(
+        spec_config={"cpu": {"min": cpu}, "mem": {"min": mem}},
+        storage_device={"/data": {"size": disk}},
+        bk_svr_device_cls_name=device_cls,
+    )
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.get_instance_machine")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.filter")
+def test_resource_apply_service_logs_applied_host_summary(mock_cluster_filter, mock_get_instance_machine):
+    mock_cluster_filter.return_value = [SimpleNamespace(id=10, immute_domain="cache.example.db")]
+    mock_get_instance_machine.return_value = _mock_source_machine(4, 32, 500, "S5.4XLARGE16")
+
     service = RedisExerciseResourceApplyService()
     infos = [
         {
@@ -259,11 +299,16 @@ def test_resource_apply_service_logs_applied_host_summary():
             "cluster_domain": "cache.example.db",
             "instance_ip": "1.1.1.1",
             "instance_port": 30000,
+            "resource_spec": {"redis": {"spec_name": "2c_16g_200g"}},
             "redis": [
                 {
                     "ip": "2.2.2.2",
                     "bk_host_id": 101,
                     "bk_cloud_id": 0,
+                    "bk_cpu": 2,
+                    "bk_mem": 16384,
+                    "bk_disk": 200,
+                    "bk_svr_device_cls_name": "SA5.MEDIUM4",
                 }
             ],
         }
@@ -275,11 +320,39 @@ def test_resource_apply_service_logs_applied_host_summary():
     assert mock_log_info.call_count == 1
     summary_log = mock_log_info.call_args_list[0].args[0]
     assert "演练资源申请完成，共 1 台主机 request_id=req-123" in summary_log
-    assert "10:cache.example.db" in summary_log
-    assert "    1.1.1.1:30000: 2.2.2.2" in summary_log
+    assert summary_log == "\n".join(
+        [
+            "演练资源申请完成，共 1 台主机 request_id=req-123",
+            "cache.example.db",
+            "    2.2.2.2 (2 cores 16GB RAM 200GB disk)",
+            "        1.1.1.1:30000 4 cores 32GB RAM 500GB disk",
+        ]
+    )
 
 
-def test_resource_apply_service_log_summary_groups_instances_by_applied_ip():
+def test_resource_apply_service_format_applied_host_spec_uses_storage_device_fallback():
+    service = RedisExerciseResourceApplyService()
+    redis_host = {
+        "bk_cpu": 4,
+        "bk_mem": 32768,
+        "storage_device": {"/data": {"size": 500}},
+        "bk_svr_device_cls_name": "S5.4XLARGE16",
+    }
+
+    assert service._format_applied_host_spec(redis_host) == "4 cores 32GB RAM 500GB disk S5.4XLARGE16"
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.get_instance_machine")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.filter")
+def test_resource_apply_service_log_summary_groups_instances_by_applied_ip(
+    mock_cluster_filter, mock_get_instance_machine
+):
+    mock_cluster_filter.return_value = [
+        SimpleNamespace(id=10, immute_domain="cache.example.db"),
+        SimpleNamespace(id=11, immute_domain="cache.other.db"),
+    ]
+    mock_get_instance_machine.return_value = _mock_source_machine(4, 32, 500, "S5.4XLARGE16")
+
     service = RedisExerciseResourceApplyService()
     infos = [
         {
@@ -287,21 +360,45 @@ def test_resource_apply_service_log_summary_groups_instances_by_applied_ip():
             "cluster_domain": "cache.example.db",
             "instance_ip": "1.1.1.1",
             "instance_port": 30000,
-            "redis": [{"ip": "2.2.2.2"}],
+            "redis": [
+                {
+                    "ip": "2.2.2.2",
+                    "bk_cpu": 2,
+                    "bk_mem": 8192,
+                    "bk_disk": 100,
+                    "bk_svr_device_cls_name": "S5.LARGE8",
+                }
+            ],
         },
         {
             "cluster_id": 10,
             "cluster_domain": "cache.example.db",
             "instance_ip": "1.1.1.1",
             "instance_port": 30001,
-            "redis": [{"ip": "2.2.2.2"}],
+            "redis": [
+                {
+                    "ip": "2.2.2.2",
+                    "bk_cpu": 2,
+                    "bk_mem": 8192,
+                    "bk_disk": 100,
+                    "bk_svr_device_cls_name": "S5.LARGE8",
+                }
+            ],
         },
         {
             "cluster_id": 11,
             "cluster_domain": "cache.other.db",
             "instance_ip": "3.3.3.3",
             "instance_port": 30000,
-            "redis": [{"ip": "4.4.4.4"}],
+            "redis": [
+                {
+                    "ip": "4.4.4.4",
+                    "bk_cpu": 4,
+                    "bk_mem": 16384,
+                    "bk_disk": 200,
+                    "bk_svr_device_cls_name": "S5.4XLARGE16",
+                }
+            ],
         },
     ]
 
@@ -310,10 +407,48 @@ def test_resource_apply_service_log_summary_groups_instances_by_applied_ip():
     assert summary == "\n".join(
         [
             "applied",
-            "10:cache.example.db",
-            "    1.1.1.1:30000,1.1.1.1:30001: 2.2.2.2",
-            "11:cache.other.db",
-            "    3.3.3.3:30000: 4.4.4.4",
+            "cache.example.db",
+            "    2.2.2.2 (2 cores 8GB RAM 100GB disk)",
+            "        1.1.1.1:30000 4 cores 32GB RAM 500GB disk",
+            "        1.1.1.1:30001 4 cores 32GB RAM 500GB disk",
+            "cache.other.db",
+            "    4.4.4.4 (4 cores 16GB RAM 200GB disk)",
+            "        3.3.3.3:30000 4 cores 32GB RAM 500GB disk",
+        ]
+    )
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.get_instance_machine")
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Cluster.objects.filter")
+def test_resource_apply_service_log_summary_shows_no_resource_with_instance_spec(
+    mock_cluster_filter, mock_get_instance_machine
+):
+    mock_cluster_filter.return_value = [SimpleNamespace(id=10, immute_domain="cache.example.db")]
+    mock_get_instance_machine.return_value = _mock_source_machine(2, 3, 120, "S5.MEDIUM4")
+
+    service = RedisExerciseResourceApplyService()
+    infos = [
+        {
+            "cluster_id": 10,
+            "cluster_domain": "cache.example.db",
+            "instance_ip": "5.5.5.5",
+            "instance_port": 30000,
+        }
+    ]
+
+    summary = service._build_resource_apply_log_summary(
+        infos,
+        header="failed",
+        include_applied_ip=False,
+        no_resource_label="(no resource)",
+    )
+
+    assert summary == "\n".join(
+        [
+            "failed",
+            "cache.example.db",
+            "    (no resource)",
+            "        5.5.5.5:30000 (2 cores 3GB RAM 120GB disk)",
         ]
     )
 
@@ -418,6 +553,35 @@ def test_build_ds_flow_data_fills_resource_spec_from_source_machine(mock_get_mac
     redis_spec = flow_data["infos"][0]["resource_spec"]["redis"]
     assert redis_spec["id"] == 42
     assert redis_spec["count"] == 1
+
+
+@patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Report")
+def test_reconcile_report_deduplicates_existing_snapshot(mock_report_model):
+    from backend.db_report.models import RedisRollbackExerciseReport as Report
+
+    report = Report()
+    report.task_message = "\n".join(
+        [
+            "[2026-06-17 13:00:18] [INFO]: resource apply summary",
+            "21000560:cache.example.db",
+        ]
+    )
+    report.task_stage = TaskStage.DONE
+    report.save = MagicMock()
+    mock_report_model.objects.get.return_value = report
+
+    service = RedisExerciseBestEffortCleanupService()
+    service.trans_data = RedisRollbackExerciseContext()
+    service.trans_data.task_msg = [
+        "[2026-06-17 13:00:18] [INFO]: resource apply summary\n21000560:cache.example.db",
+        "[2026-06-17 13:06:47] [INFO]: cleanup finished",
+    ]
+
+    service._reconcile_report(15)
+
+    assert report.task_message.count("resource apply summary") == 1
+    assert "cleanup finished" in report.task_message
+    report.save.assert_called_once()
 
 
 @patch("backend.flow.plugins.components.collections.redis.redis_rollback_exercise.Report")


### PR DESCRIPTION
- 新增 `SystemSettingsEnum.REDIS_AFFINITY_CHECK` 与 `RedisAffinityCheckConfig`（`from_settings()` / `save_to_settings()`），支持 `enabled`、集群类型、业务/集群忽略、`bk_cloud_ids` 白名单 → 可按环境精确控制巡检范围
- 资源申请摘要改为层级结构（集群 domain → 申请主机 → CPU/内存/磁盘/机型 → 源实例及原规格），规格文案统一英文 → 可直接对照申请机与源实例规格

## 测试 & 风险

- 单测已覆盖亲和性 `enabled` 退出、`bk_cloud_ids` 白名单/全量云区域、层级资源摘要格式、`merge_task_message` 前缀快照去重、`resource_apply_logged` 防重复
- 亲和性巡检默认行为与改前一致（`enabled=True`、`bk_cloud_ids=[]`）；`SystemSettings` 需按需写入配置；演练报告 `task_message` 格式变化为预期，无对外 API breaking change