### PR TITLE
feat(mysql): switch-to-new-grant-clone #18398

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/fetch_metrics.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/fetch_metrics.py
@@ -40,7 +40,12 @@ def _fetch_metric_of_cluster_instances(
     query_builder.end_time = end_time_str
 
     domains_match_filter = "|".join(cluster_domains)
+    logger.info(f"cluster_domains: {cluster_domains}, domains_match_filter: {domains_match_filter}")
+
     res = []
+    if not cluster_domains:
+        return res
+
     try:
         result = _query_promql_metrics_with_roles(domains_match_filter, [], query_builder)
 

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py
@@ -76,6 +76,8 @@ from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_standardize_bill impo
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.tdbctl_upgrade_bill import SubmitBillTdbctlUpgradeInputSerializer
 from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.flow.engine.bamboo.scene.common.builder import Builder
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import mysql_clone_grants_from_file_subflow
+from backend.flow.engine.bamboo.scene.spider.clone_grants_from_file import spider_clone_grants_from_file_subflow
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.mcp import McpTicketToolPermission
 
@@ -547,18 +549,23 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
         }
 
         if m.cluster_type == ClusterType.TenDBHA:
-            from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import clone_grants_from_file_subflow
+            p = mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(data),
+                bk_cloud_id=bk_cloud_id,
+                bk_biz_id=m.bk_biz_id,
+                source_address=source_address,
+                dest_addresses=dest_addresses,
+            )
         else:
-            from backend.flow.engine.bamboo.scene.spider.clone_grants_from_file import clone_grants_from_file_subflow
-
-        p = clone_grants_from_file_subflow(
-            root_id=root_id,
-            data=copy.deepcopy(data),
-            bk_cloud_id=bk_cloud_id,
-            bk_biz_id=m.bk_biz_id,
-            source_address=source_address,
-            dest_addresses=dest_addresses,
-        )
+            p = spider_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(data),
+                bk_cloud_id=bk_cloud_id,
+                bk_biz_id=m.bk_biz_id,
+                source_address=source_address,
+                dest_addresses=dest_addresses,
+            )
 
         rp = Builder(root_id=root_id, data=copy.deepcopy(data), need_random_pass_cluster_ids=cluster_ids)
         rp.add_sub_pipeline(p)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/__init__.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/__init__.py
@@ -8,4 +8,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .subflow import clone_grants_from_file_subflow
+from .subflow import mysql_clone_grants_from_file_subflow

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/subflow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/clone_grants_from_file/subflow.py
@@ -36,7 +36,7 @@ from backend.flow.utils.mysql.mysql_act_dataclass import DownloadMediaKwargs, Ex
 logger = logging.getLogger("flow")
 
 
-def clone_grants_from_file_subflow(
+def mysql_clone_grants_from_file_subflow(
     root_id: str,
     data: Dict,
     bk_cloud_id: int,

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/master_and_slave_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/master_and_slave_switch.py
@@ -20,13 +20,13 @@ from backend.db_meta.models import Cluster
 from backend.db_meta.models.extra_process import ExtraProcessInstance
 from backend.flow.consts import ACCOUNT_PREFIX, AUTH_ADDRESS_DIVIDER, InstanceStatus
 from backend.flow.engine.bamboo.scene.common.builder import Conditions, SubBuilder
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import mysql_clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.cluster_entrys import get_tendb_ha_entry
 from backend.flow.engine.bamboo.scene.mysql.common.common_sub_flow import check_sub_flow
 from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldComponent
 from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
 from backend.flow.plugins.components.collections.common.pause import PauseComponent
 from backend.flow.plugins.components.collections.mysql.add_user_for_cluster_switch import AddSwitchUserComponent
-from backend.flow.plugins.components.collections.mysql.clone_user import CloneUserComponent
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.plugins.components.collections.mysql.exec_switch_for_source_act import (
@@ -39,7 +39,6 @@ from backend.flow.utils.mysql.mysql_act_dataclass import (
     AddSwitchUserKwargs,
     CreateDnsKwargs,
     ExecActuatorKwargs,
-    InstanceUserCloneKwargs,
     RecycleDnsRecordKwargs,
 )
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
@@ -137,24 +136,25 @@ def master_and_slave_switch_v2(
     )
     cluster_switch_sub_pipeline.add_parallel_acts(acts_list=acts_list)
 
-    clone_kwargs = InstanceUserCloneKwargs(
-        clone_data=[
-            {
-                "source": f"{cluster_info['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                "target": f"{cluster_info['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                "bk_cloud_id": cluster.bk_cloud_id,
-            },
-            {
-                "source": f"{cluster_info['old_slave_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                "target": f"{cluster_info['new_slave_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                "bk_cloud_id": cluster.bk_cloud_id,
-            },
+    cluster_switch_sub_pipeline.add_parallel_sub_pipeline(
+        sub_flow_list=[
+            mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(ticket_data),
+                bk_cloud_id=cluster.bk_cloud_id,
+                bk_biz_id=cluster.bk_biz_id,
+                source_address=f"{cluster_info['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
+                dest_addresses=[f"{cluster_info['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}"],
+            ),
+            mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(ticket_data),
+                bk_cloud_id=cluster.bk_cloud_id,
+                bk_biz_id=cluster.bk_biz_id,
+                source_address=f"{cluster_info['old_slave_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
+                dest_addresses=[f"{cluster_info['new_slave_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}"],
+            ),
         ]
-    )
-    cluster_switch_sub_pipeline.add_act(
-        act_name=_("新master克隆旧master权限,新slave克隆旧slave权限"),
-        act_component_code=CloneUserComponent.code,
-        kwargs=asdict(clone_kwargs),
     )
 
     # 代理层、账号等等。
@@ -173,8 +173,6 @@ def master_and_slave_switch_v2(
     domain_map = get_tendb_ha_entry(cluster.id)
     cluster_info["master_domain"] = domain_map["master_domain"]
     cluster_info["slave_domain"] = domain_map["slave_domain"]
-    # cluster_info["proxy_ip_list"] = [x.machine.ip for x in mysql_proxy]
-    # cluster_info["proxy_port"] = mysql_proxy[0].port
     cluster_info["id"] = cluster.id
 
     cluster_sw_kwargs = ExecActuatorKwargs(cluster=cluster_info, bk_cloud_id=cluster.bk_cloud_id)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/single_recover_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/single_recover_switch.py
@@ -18,7 +18,7 @@ from backend.db_meta.models import Cluster
 from backend.flow.consts import TendbSingleRestoreType
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
-from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import clone_grants_from_file_subflow
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import mysql_clone_grants_from_file_subflow
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.plugins.components.collections.mysql.mysql_check_slave_delay import MySQLCheckSlaveDelayComponent
@@ -105,7 +105,7 @@ def single_migrate_switch_sub_flow(
     if len(clone_data) > 0:
         for ele in clone_data:
             sub_pipeline.add_sub_pipeline(
-                sub_flow=clone_grants_from_file_subflow(
+                sub_flow=mysql_clone_grants_from_file_subflow(
                     root_id=root_id,
                     data=copy.deepcopy(ticket_data),
                     bk_cloud_id=cluster.bk_cloud_id,

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/slave_recover_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/common/slave_recover_switch.py
@@ -19,7 +19,7 @@ from backend.db_meta.enums import InstanceStatus
 from backend.db_meta.models import Cluster
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
-from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import clone_grants_from_file_subflow
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import mysql_clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.cluster_entrys import get_tendb_ha_entry
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.mysql_check_slave_delay import MySQLCheckSlaveDelayComponent
@@ -166,7 +166,7 @@ def slave_migrate_switch_sub_flow(
     if len(clone_data) > 0:
         for ele in clone_data:
             sub_pipeline.add_sub_pipeline(
-                sub_flow=clone_grants_from_file_subflow(
+                sub_flow=mysql_clone_grants_from_file_subflow(
                     root_id=root_id,
                     data=copy.deepcopy(ticket_data),
                     bk_cloud_id=cluster.bk_cloud_id,

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_master_slave_switch.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_master_slave_switch.py
@@ -25,6 +25,7 @@ from backend.db_meta.models.extra_process import ExtraProcessInstance
 from backend.flow.consts import ACCOUNT_PREFIX, AUTH_ADDRESS_DIVIDER
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import mysql_clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.common_sub_flow import (
     check_long_active_process_sub_flow,
     check_sub_flow,
@@ -35,7 +36,6 @@ from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.subflow impor
     standardize_mysql_cluster_by_ip_subflow,
 )
 from backend.flow.plugins.components.collections.mysql.add_user_for_cluster_switch import AddSwitchUserComponent
-from backend.flow.plugins.components.collections.mysql.clone_user import CloneUserComponent
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.plugins.components.collections.mysql.mysql_db_meta import MySQLDBMetaComponent
@@ -49,7 +49,6 @@ from backend.flow.utils.mysql.mysql_act_dataclass import (
     DBMetaOPKwargs,
     DownloadMediaKwargs,
     ExecActuatorKwargs,
-    InstanceUserCloneKwargs,
     RecycleDnsRecordKwargs,
 )
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
@@ -212,38 +211,25 @@ class MySQLMasterSlaveSwitchFlow(object):
                     ),
                 )
 
-                # 阶段2 从实例的账号信息克隆到主实例上
-                cluster_switch_sub_pipeline.add_act(
-                    act_name=_("新master克隆旧master权限"),
-                    act_component_code=CloneUserComponent.code,
-                    kwargs=asdict(
-                        InstanceUserCloneKwargs(
-                            clone_data=[
-                                {
-                                    "source": f"{cluster['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}",
-                                    "target": f"{cluster['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}",
-                                    "bk_cloud_id": cluster["bk_cloud_id"],
-                                },
-                            ]
-                        )
-                    ),
+                cluster_switch_sub_pipeline.add_sub_pipeline(
+                    mysql_clone_grants_from_file_subflow(
+                        root_id=self.root_id,
+                        data=copy.deepcopy(self.data),
+                        bk_cloud_id=cluster["bk_cloud_id"],
+                        bk_biz_id=sub_sub_flow_context["bk_biz_id"],
+                        source_address=f"{cluster['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}",
+                        dest_addresses=[f"{cluster['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}"],
+                    )
                 )
-
-                # 阶段2.1 主实例的账号信息克隆到从实例上
-                cluster_switch_sub_pipeline.add_act(
-                    act_name=_("旧master克隆新master权限"),
-                    act_component_code=CloneUserComponent.code,
-                    kwargs=asdict(
-                        InstanceUserCloneKwargs(
-                            clone_data=[
-                                {
-                                    "source": f"{cluster['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}",
-                                    "target": f"{cluster['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}",
-                                    "bk_cloud_id": cluster["bk_cloud_id"],
-                                },
-                            ]
-                        )
-                    ),
+                cluster_switch_sub_pipeline.add_sub_pipeline(
+                    mysql_clone_grants_from_file_subflow(
+                        root_id=self.root_id,
+                        data=copy.deepcopy(self.data),
+                        bk_cloud_id=cluster["bk_cloud_id"],
+                        bk_biz_id=sub_sub_flow_context["bk_biz_id"],
+                        source_address=f"{cluster['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}",
+                        dest_addresses=[f"{cluster['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster['mysql_port']}"],
+                    )
                 )
 
                 # 阶段3 执行主从切换的原子任务
@@ -549,38 +535,25 @@ def master_slave_mutual_switch_subflow(
             ),
         )
 
-        # 阶段2 从实例的账号信息克隆到主实例上
-        mutual_switch_sub_pipeline.add_act(
-            act_name=_("新master克隆旧master权限"),
-            act_component_code=CloneUserComponent.code,
-            kwargs=asdict(
-                InstanceUserCloneKwargs(
-                    clone_data=[
-                        {
-                            "source": f"{cluster_info['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                            "target": f"{cluster_info['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                            "bk_cloud_id": cluster_info["bk_cloud_id"],
-                        },
-                    ]
-                )
-            ),
+        mutual_switch_sub_pipeline.add_sub_pipeline(
+            mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(context_data),
+                bk_cloud_id=cluster_info["bk_cloud_id"],
+                bk_biz_id=bk_biz_id,
+                source_address=f"{cluster_info['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
+                dest_addresses=[f"{cluster_info['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}"],
+            )
         )
-
-        # 阶段2.1 主实例的账号信息克隆到从实例上
-        mutual_switch_sub_pipeline.add_act(
-            act_name=_("旧master克隆新master权限"),
-            act_component_code=CloneUserComponent.code,
-            kwargs=asdict(
-                InstanceUserCloneKwargs(
-                    clone_data=[
-                        {
-                            "source": f"{cluster_info['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                            "target": f"{cluster_info['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
-                            "bk_cloud_id": cluster_info["bk_cloud_id"],
-                        },
-                    ]
-                )
-            ),
+        mutual_switch_sub_pipeline.add_sub_pipeline(
+            mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(context_data),
+                bk_cloud_id=cluster_info["bk_cloud_id"],
+                bk_biz_id=bk_biz_id,
+                source_address=f"{cluster_info['new_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}",
+                dest_addresses=[f"{cluster_info['old_master_ip']}{AUTH_ADDRESS_DIVIDER}{cluster_info['mysql_port']}"],
+            )
         )
 
         # 阶段3 执行主从切换的原子任务

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_restore_slave_remote_flow.py
@@ -25,7 +25,7 @@ from backend.db_package.models import Package
 from backend.flow.consts import MediumEnum
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
-from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file.subflow import clone_grants_from_file_subflow
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file.subflow import mysql_clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.cluster_entrys import get_tendb_ha_entry
 from backend.flow.engine.bamboo.scene.mysql.common.common_sub_flow import install_mysql_in_cluster_sub_flow
 from backend.flow.engine.bamboo.scene.mysql.common.get_master_config import get_instance_config
@@ -755,7 +755,7 @@ class MySQLRestoreSlaveRemoteFlow(object):
             #  克隆权限
             if master.is_stand_by:
                 tendb_migrate_pipeline.add_sub_pipeline(
-                    sub_flow=clone_grants_from_file_subflow(
+                    sub_flow=mysql_clone_grants_from_file_subflow(
                         root_id=self.root_id,
                         data=copy.deepcopy(self.data),
                         bk_cloud_id=cluster_model.bk_cloud_id,

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/__init__.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/__init__.py
@@ -8,4 +8,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .subflow import clone_grants_from_file_subflow
+from .subflow import spider_clone_grants_from_file_subflow

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/subflow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/clone_grants_from_file/subflow.py
@@ -14,11 +14,11 @@ from typing import Dict
 from backend.flow.consts import DBA_ROOT_USER
 from backend.flow.engine.bamboo.scene.common.builder import SubProcess
 from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import (
-    clone_grants_from_file_subflow as m_clone_subflow,
+    mysql_clone_grants_from_file_subflow as m_clone_subflow,
 )
 
 
-def clone_grants_from_file_subflow(
+def spider_clone_grants_from_file_subflow(
     root_id: str,
     data: Dict,
     bk_cloud_id: int,

--- a/dbm-ui/backend/flow/engine/bamboo/scene/spider/common/common_sub_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/spider/common/common_sub_flow.py
@@ -7,6 +7,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import copy
 from dataclasses import asdict
 
 from django.utils.crypto import get_random_string
@@ -14,20 +15,21 @@ from django.utils.translation import gettext as _
 
 from backend.configuration.constants import DBType
 from backend.constants import IP_PORT_DIVIDER
-from backend.db_meta.enums import ClusterEntryRole, ClusterType, InstanceStatus, MachineType, TenDBClusterSpiderRole
+from backend.db_meta.enums import ClusterEntryRole, ClusterType, InstanceStatus, TenDBClusterSpiderRole
 from backend.db_meta.models import Cluster, ProxyInstance
 from backend.flow.consts import AUTH_ADDRESS_DIVIDER, LONG_JOB_TIMEOUT, TDBCTL_USER, DnsOpType, PrivRole
 from backend.flow.engine.bamboo.scene.common.builder import SubBuilder
 from backend.flow.engine.bamboo.scene.common.download_file import add_db_actuator_download_to_pipeline
 from backend.flow.engine.bamboo.scene.common.entrys_manager import BuildEntrysManageSubflow
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
+from backend.flow.engine.bamboo.scene.mysql.clone_grants_from_file import mysql_clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.mysql.common.common_sub_flow import check_sub_flow, init_machine_sub_flow
+from backend.flow.engine.bamboo.scene.spider.clone_grants_from_file import spider_clone_grants_from_file_subflow
 from backend.flow.engine.bamboo.scene.spider.common.exceptions import AddSpiderNodeFailedException
 from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldComponent
 from backend.flow.plugins.components.collections.common.delete_cc_service_instance import DelCCServiceInstComponent
 from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
 from backend.flow.plugins.components.collections.mysql.clear_machine import SpiderRemoteClearMachineComponent
-from backend.flow.plugins.components.collections.mysql.clone_user import CloneUserComponent
 from backend.flow.plugins.components.collections.mysql.dns_manage import MySQLDnsManageComponent
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptComponent
 from backend.flow.plugins.components.collections.mysql.sync_master import SyncMasterComponent
@@ -50,7 +52,6 @@ from backend.flow.utils.mysql.mysql_act_dataclass import (
     DelServiceInstKwargs,
     DownloadMediaKwargs,
     ExecActuatorKwargs,
-    InstanceUserCloneKwargs,
     MysqlSyncMasterKwargs,
 )
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
@@ -345,27 +346,18 @@ def add_spider_slaves_sub_flow(
                 )
             )
 
-        acts_list = []
-        for spider in add_spider_slaves:
-            acts_list.append(
-                {
-                    "act_name": _("克隆权限到spider节点[{}->{}]".format(tmp_spider.machine.ip, spider["ip"])),
-                    "act_component_code": CloneUserComponent.code,
-                    "kwargs": asdict(
-                        InstanceUserCloneKwargs(
-                            clone_data=[
-                                {
-                                    "source": tmp_spider.ip_port,
-                                    "target": f"{spider['ip']}{AUTH_ADDRESS_DIVIDER}{tmp_spider.port}",
-                                    "machine_type": MachineType.SPIDER.value,
-                                    "bk_cloud_id": cluster.bk_cloud_id,
-                                },
-                            ],
-                        )
-                    ),
-                }
+        sub_pipeline.add_sub_pipeline(
+            spider_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(parent_global_data),
+                bk_cloud_id=cluster.bk_cloud_id,
+                bk_biz_id=cluster.bk_biz_id,
+                source_address=tmp_spider.ip_port,
+                dest_addresses=[
+                    f"{spider['ip']}{AUTH_ADDRESS_DIVIDER}{tmp_spider.port}" for spider in add_spider_slaves
+                ],
             )
-        sub_pipeline.add_parallel_acts(acts_list=acts_list)
+        )
 
     # 阶段7 添加从域名
     # 冷恢复场景：从域名摘除/重建由上层统一处理（Pre-Stage 摘除旧 IP；Stage 3 之后由元数据维护新映射），此处跳过
@@ -591,28 +583,27 @@ def add_spider_masters_sub_flow(
         )
 
     if is_clone_user:
-        # 阶段7 集群的业务账号信息克隆到新的spider实例上, 因为目前spider中控实例无法有克隆权限的操作，只能在这里做
-        acts_list = []
-        for spider in add_spider_masters:
-            acts_list.append(
-                {
-                    "act_name": _("克隆权限到spider节点[{}->{}]".format(tmp_spider.machine.ip, spider["ip"])),
-                    "act_component_code": CloneUserComponent.code,
-                    "kwargs": asdict(
-                        InstanceUserCloneKwargs(
-                            clone_data=[
-                                {
-                                    "source": tmp_spider.ip_port,
-                                    "target": f"{spider['ip']}{AUTH_ADDRESS_DIVIDER}{tmp_spider.port}",
-                                    "machine_type": MachineType.SPIDER.value,
-                                    "bk_cloud_id": cluster.bk_cloud_id,
-                                },
-                            ],
-                        )
-                    ),
-                }
+        if not tmp_spider:
+            raise AddSpiderNodeFailedException(
+                message=_(
+                    "[{}]构建流程失败，集群找不到相应角色[{}]的且running状态的spider实例作为权限克隆的来源，请检查集群".format(
+                        cluster.immute_domain, TenDBClusterSpiderRole.SPIDER_MASTER
+                    )
+                )
             )
-        sub_pipeline.add_parallel_acts(acts_list=acts_list)
+
+        sub_pipeline.add_sub_pipeline(
+            spider_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(parent_global_data),
+                bk_cloud_id=cluster.bk_cloud_id,
+                bk_biz_id=cluster.bk_biz_id,
+                source_address=tmp_spider.ip_port,
+                dest_addresses=[
+                    f"{spider['ip']}{AUTH_ADDRESS_DIVIDER}{tmp_spider.port}" for spider in add_spider_masters
+                ],
+            )
+        )
 
     if not is_add_spider_mnt:
         # 阶段8 待添加中控实例建立主从数据同步关系
@@ -1063,30 +1054,30 @@ def remote_migrate_switch_sub_flow(
         )
     )
 
-    clone_data = []
+    clone_sub_pipes = []
     for tuple_info in migrate_tuples:
-        clone_data.append(
-            {
-                "source": f"{tuple_info['old_master']}",
-                "target": f"{tuple_info['new_master']}",
-                "machine_type": MachineType.REMOTE.value,
-                "bk_cloud_id": cluster.bk_cloud_id,
-            }
+        clone_sub_pipes.append(
+            mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(parent_global_data),
+                bk_cloud_id=cluster.bk_cloud_id,
+                bk_biz_id=cluster.bk_biz_id,
+                source_address=f"{tuple_info['old_master']}",
+                dest_addresses=[f"{tuple_info['new_master']}"],
+            )
         )
-        clone_data.append(
-            {
-                "source": f"{tuple_info['old_slave']}",
-                "target": f"{tuple_info['new_slave']}",
-                "machine_type": MachineType.REMOTE.value,
-                "bk_cloud_id": cluster.bk_cloud_id,
-            }
+        clone_sub_pipes.append(
+            mysql_clone_grants_from_file_subflow(
+                root_id=root_id,
+                data=copy.deepcopy(parent_global_data),
+                bk_cloud_id=cluster.bk_cloud_id,
+                bk_biz_id=cluster.bk_biz_id,
+                source_address=f"{tuple_info['old_slave']}",
+                dest_addresses=[f"{tuple_info['new_slave']}"],
+            )
         )
 
-    sub_pipeline.add_act(
-        act_name=_("克隆权限"),
-        act_component_code=CloneUserComponent.code,
-        kwargs=asdict(InstanceUserCloneKwargs(clone_data=clone_data)),
-    )
+    sub_pipeline.add_parallel_sub_pipeline(sub_flow_list=clone_sub_pipes)
 
     sub_pipeline.add_act(
         act_name=_("切换期间屏蔽新机器告警30分钟"),


### PR DESCRIPTION
MySQL 主从互换
MySQL 主从迁移
MySQL Slave重建
MySQL Slave原地重建
MySQL 迁移升级
TenDB Cluster 扩容接入层
TenDB Cluster 接入层迁移升级
TenDB Cluster 替换接入层
TenDB Cluster 集群容量变更
TenDB Cluster 主从迁移

以上单据权限克隆切换为新的基于文件的版本
1. 完成单据流程验证
2. 完成结果正确性验证

剩余未切换单据

MySQL/TenDBCluster DB 权限克隆单据