### PR TITLE
fix(backend): reverse_api鉴权失败改抛PermissionDenied避免误报未处理异常

### DIFF
--- a/dbm-ui/backend/db_proxy/reverse_api/base_reverse_api_view.py
+++ b/dbm-ui/backend/db_proxy/reverse_api/base_reverse_api_view.py
@@ -14,6 +14,7 @@ from types import FunctionType
 
 from django.utils.translation import gettext as _
 from rest_framework import permissions
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 
 from backend import env
@@ -44,8 +45,9 @@ class IPHasRegisteredPermission(permissions.BasePermission):
             validate_machine_ip(bk_cloud_id, request)
 
         except Exception as e:  # noqa
-            # if not found:
-            raise Exception(_("访问受限，不存在于DBM平台 {}".format(e)))
+            # IP 未注册属于预期的鉴权拒绝，抛 PermissionDenied 返回 403，
+            # 避免被当作未处理异常记录 error 日志并误报 500
+            raise PermissionDenied(_("访问受限，不存在于DBM平台 {}".format(e)))
 
         return True
 


### PR DESCRIPTION
closes #18562

## 根因

reverse_api 的 IP 鉴权类 `IPHasRegisteredPermission.has_permission` 在校验失败（机器 IP 未注册到 DBM）时抛裸 `Exception`。该异常不属于 DRF 的 `APIException`，落入 `backend/bk_web/handlers.py` 异常处理器最底部，导致以 error 级别打出「捕获未处理异常」错误栈并对外返回 500，而非语义正确的 403。

排查 trace：`a8d0631017e3385bded1de8c5b2ce95a`。

## 修复

将鉴权失败时抛出的 `Exception` 改为 DRF 的 `PermissionDenied`，使其被正确识别为 403，且不再被记录为未处理异常，消除误报告警。

## 验证

- 未注册 IP 调 `/apis/proxypass/reverse_api/mysql/list_instance_info/?bk_cloud_id=0`，期望返回 403，错误日志不再出现「捕获未处理异常」。
- 已注册机器 IP 调用应正常返回。