### PR TITLE
feat(other): MySQL回档演练支持V2 Alpha阶段备份重装 #18571

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/mysql_backup_rollback/gen_task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/mysql_backup_rollback/gen_task.py
@@ -88,7 +88,7 @@ def build_resource_apply_params(task_id: str, storage_spec: list, mysql_version:
         "os_type": "Linux",
         "storage_spec": storage_spec,
     }
-    logger.info(_("apply details: {}").format(details))
+    logger.debug(_("apply details: {}").format(details))
     # 如果MySQL版本大于等于8.0，则排除tlinux 1.2操作系统
 
     if mysql_version and mysql_version_parse(mysql_version) >= 8000000:
@@ -174,11 +174,11 @@ def calculate_recovery_min_disk_size_gb(
                 data_dir_size_mb = data_dir_size_mb * 2.6
         else:
             data_dir_size_mb = data_dir_size_mb * 4.3
-        logger.info(_("计算后的数据目录大小: {} MB").format(data_dir_size_mb))
+        logger.debug(_("计算后的数据目录大小: {} MB").format(data_dir_size_mb))
         min_disk_size = int(data_dir_size_mb / 1024)
     else:
         min_disk_size = calculate_min_disk_size(total_filesize)
-    logger.info(_("计算后的最小磁盘大小: {} GB").format(min_disk_size))
+    logger.debug(_("计算后的最小磁盘大小: {} GB").format(min_disk_size))
     return min_disk_size
 
 
@@ -198,20 +198,20 @@ def get_master_storage_spec(cluster: Cluster) -> list:
     try:
         main_storage = cluster.main_storage_instances().first()
         if not main_storage:
-            logger.info(_("集群 {} 未找到 master 节点，退避为单盘模式申请").format(cluster.immute_domain))
+            logger.debug(_("集群 {} 未找到 master 节点，退避为单盘模式申请").format(cluster.immute_domain))
             return []
 
         spec_config = main_storage.machine.spec_config or {}
         storage_spec = spec_config.get("storage_spec") or []
         if not storage_spec:
-            logger.info(
+            logger.debug(
                 _("集群 {} master 节点(IP {}) 无 storage_spec 信息，退避为单盘模式申请").format(
                     cluster.immute_domain, main_storage.machine.ip
                 )
             )
             return []
 
-        logger.info(
+        logger.debug(
             _("集群 {} master 节点(IP {}) storage_spec: {}").format(
                 cluster.immute_domain, main_storage.machine.ip, storage_spec
             )
@@ -256,7 +256,7 @@ def build_recovery_storage_spec(
 
     master_storage_spec = get_master_storage_spec(cluster)
     if not master_storage_spec:
-        logger.info(_("集群 {} 按单盘模式申请，最小容量: {} GB").format(cluster.immute_domain, min_disk_size_gb))
+        logger.debug(_("集群 {} 按单盘模式申请，最小容量: {} GB").format(cluster.immute_domain, min_disk_size_gb))
         return fallback_spec
 
     # 解析 master 规格构建多盘申请，任何异常都退避到单盘模式
@@ -294,7 +294,7 @@ def build_recovery_storage_spec(
             logger.warning(_("集群 {} 解析 master 规格后为空，退避为单盘模式申请").format(cluster.immute_domain))
             return fallback_spec
 
-        logger.info(_("集群 {} 申请 storage_spec(基于 master 盘符布局): {}").format(cluster.immute_domain, storage_spec_list))
+        logger.debug(_("集群 {} 申请 storage_spec(基于 master 盘符布局): {}").format(cluster.immute_domain, storage_spec_list))
         return storage_spec_list
     except Exception as e:
         logger.warning(
@@ -470,13 +470,13 @@ def gen_rollback_task():
         )
 
         if not backup_results.exists():
-            logger.info(_("集群 {} 没有可用的备份记录").format(cluster.immute_domain))
+            logger.debug(_("集群 {} 没有可用的备份记录").format(cluster.immute_domain))
             continue
 
         # 选择最新的备份记录
         backup_result = backup_results.first()
         if not backup_result:
-            logger.info(_("集群 {} 没有找到备份记录").format(cluster.immute_domain))
+            logger.debug(_("集群 {} 没有找到备份记录").format(cluster.immute_domain))
             continue
 
         logger.debug(
@@ -493,7 +493,7 @@ def gen_rollback_task():
     # 第三阶段：生成回档任务
     for cluster, backup_result, backup_size in cluster_backup_info:
         backup_file_size_gb = bytes_to_gb(backup_size)
-        logger.info(_("开始处理集群 {} 的备份，备份大小: {:.2f} GB").format(cluster.immute_domain, backup_file_size_gb))
+        logger.debug(_("开始处理集群 {} 的备份，备份大小: {:.2f} GB").format(cluster.immute_domain, backup_file_size_gb))
 
         # 格式化备份信息，保持与原有格式兼容
         backup_result.backup_consistent_time = backup_result.backup_consistent_time.isoformat()
@@ -523,7 +523,7 @@ def gen_rollback_task():
         backup_type = backup_record.get("backup_type", "")
 
         # 打印备份信息
-        logger.info(_("演练备份记录: {}").format(backup_record))
+        logger.debug(_("演练备份记录: {}").format(backup_record))
         root_id = generate_root_id()
         task = MySQLBackupRecoverTask(
             bk_biz_id=backup_record["bk_biz_id"],
@@ -594,7 +594,7 @@ def gen_rollback_task():
         # 申请资源成功后，获取资源申请结果
         try:
             resource_request_id, apply_data = resp["request_id"], resp["data"]
-            logger.info(f"resource_request_id: {resource_request_id}, apply_data: {apply_data}")
+            logger.debug(f"resource_request_id: {resource_request_id}, apply_data: {apply_data}")
             mch_info = apply_data[0]["data"][0]
             rollback_host = {
                 "ip": mch_info["ip"],
@@ -930,7 +930,7 @@ def _prepare_cluster_data(num: int):
     exclude_biz_ids.extend(ignored_biz_ids)
     exclude_cluster_id.extend(ignored_cluster_ids)
 
-    logger.info(
+    logger.debug(
         _("演练忽略配置: 忽略业务 {} 个 {}, 忽略集群 {} 个 {}").format(
             len(ignored_biz_ids), ignored_biz_ids, len(ignored_cluster_ids), ignored_cluster_ids
         )
@@ -1036,7 +1036,7 @@ def _collect_unpracticed_clusters(exclude_biz_ids, exclude_cluster_id, global_pr
 
     if unpracticed_biz_ids:
         logger.info(_("发现 {} 个从未演练过的业务，包含 {} 个集群，将获得最高优先级").format(len(unpracticed_biz_ids), unpracticed_biz_clusters))
-        logger.info(_("从未演练过的业务ID列表: {}").format(sorted(list(unpracticed_biz_ids))))
+        logger.debug(_("从未演练过的业务ID列表: {}").format(sorted(list(unpracticed_biz_ids))))
     else:
         logger.info(_("未发现从未演练过的业务"))
 
@@ -1090,6 +1090,11 @@ def _collect_valid_candidates(global_priority_queue, target_tendbcluster, target
     # 统计待检查的集群总数
     total_candidate_clusters = len(global_priority_queue)
     logger.info(_("开始检查候选集群，总计 {} 个集群待检查").format(total_candidate_clusters))
+    logger.info(
+        _("本轮候选收集配额: TenDBCluster 目标 {} (最多检查 {}), TenDBHA 目标 {} (最多检查 {})").format(
+            target_tendbcluster, max_needed_tendbcluster, target_tendbha, max_needed_tendbha
+        )
+    )
 
     while global_priority_queue:
         task = heapq.heappop(global_priority_queue)
@@ -1097,7 +1102,7 @@ def _collect_valid_candidates(global_priority_queue, target_tendbcluster, target
         total_clusters_checked += 1
 
         # 打印优先级信息
-        logger.info(
+        logger.debug(
             _("从优先级队列取出集群: {} (ID: {}), 业务ID: {}, 优先级: {}, 集群类型: {}").format(
                 cluster.immute_domain, cluster.id, cluster.bk_biz_id, task.priority, cluster.cluster_type
             )
@@ -1107,10 +1112,30 @@ def _collect_valid_candidates(global_priority_queue, target_tendbcluster, target
 
         # 根据集群类型检查是否已收集足够数量
         if cluster.cluster_type == ClusterType.TenDBCluster:
+            if max_needed_tendbcluster == 0:
+                logger.info(
+                    _("集群 {} (ID: {}, 类型: TenDBCluster) 本轮目标数量为 0，跳过备份检查").format(cluster.immute_domain, cluster.id)
+                )
+                continue
             if tendbcluster_count >= max_needed_tendbcluster:
+                logger.info(
+                    _("集群 {} (ID: {}, 类型: TenDBCluster) 候选已收集足够({}/{}), 跳过备份检查").format(
+                        cluster.immute_domain, cluster.id, tendbcluster_count, max_needed_tendbcluster
+                    )
+                )
                 continue
         elif cluster.cluster_type == ClusterType.TenDBHA:
+            if max_needed_tendbha == 0:
+                logger.info(
+                    _("集群 {} (ID: {}, 类型: TenDBHA) 本轮目标数量为 0，跳过备份检查").format(cluster.immute_domain, cluster.id)
+                )
+                continue
             if tendbha_count >= max_needed_tendbha:
+                logger.info(
+                    _("集群 {} (ID: {}, 类型: TenDBHA) 候选已收集足够({}/{}), 跳过备份检查").format(
+                        cluster.immute_domain, cluster.id, tendbha_count, max_needed_tendbha
+                    )
+                )
                 continue
 
         # 检查集群是否有有效的备份记录
@@ -1306,7 +1331,7 @@ def get_exercise_clusters(num: int) -> list:
     # 记录演练成功次数统计
     for cluster in rs:
         success_count = recover_success_map.get(cluster.immute_domain, 0)
-        logger.info(_("选中集群 {} ({}): 历史演练成功次数 {}").format(cluster.immute_domain, cluster.cluster_type, success_count))
+        logger.debug(_("选中集群 {} ({}): 历史演练成功次数 {}").format(cluster.immute_domain, cluster.cluster_type, success_count))
 
     return rs
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/mysql_backup_rollback/task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/mysql_backup_rollback/task.py
@@ -21,7 +21,8 @@ from .gen_task import gen_rollback_task
 logger = logging.getLogger("root")
 
 
-@register_periodic_task(run_every=crontab(minute="*/3"))
+# 分钟偏移 +1，避免与 */2、*/5 等周期任务在同一分钟撞点
+@register_periodic_task(run_every=crontab(minute="1-59/5"))
 def backup_data_recovery_task():
     logger.info("start backup data recovery task")
     gen_rollback_task()

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_rollback_exercise.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/mysql_rollback_exercise.py
@@ -9,6 +9,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import copy
+import logging
+import pathlib
 from dataclasses import asdict
 from datetime import datetime
 from typing import Dict, Optional
@@ -17,14 +19,17 @@ from django.db.models import Q
 from django.utils.crypto import get_random_string
 from django.utils.translation import gettext as _
 
+from backend import env
 from backend.components.dbresource.client import DBResourceApi
 from backend.configuration.constants import MYSQL_DATA_RESTORE_TIME, DBType
-from backend.db_meta.enums import ClusterType, InstanceInnerRole
+from backend.db_meta.enums import ClusterType, InstanceInnerRole, VersionPhase
 from backend.db_meta.models import Cluster
+from backend.db_package.exceptions import DBPackageBaseException
 from backend.db_package.models import Package
 from backend.db_periodic_task.models import TaskStatus
 from backend.db_services.cmdb.biz import get_or_create_resource_module, get_resource_biz
-from backend.flow.consts import MediumEnum, RollbackType
+from backend.db_services.ipchooser.constants import BkOsType
+from backend.flow.consts import DBA_ROOT_USER, MediumEnum, MysqlVersionToDBBackupForMap, RollbackType
 from backend.flow.engine.bamboo.scene.common.builder import Builder, Conditions, SubBuilder
 from backend.flow.engine.bamboo.scene.common.machine_os_init import insert_host_event
 from backend.flow.engine.bamboo.scene.mysql.common.domain_util import generate_valid_domain
@@ -32,6 +37,8 @@ from backend.flow.engine.bamboo.scene.mysql.common.get_master_config import get_
 from backend.flow.engine.bamboo.scene.mysql.common.mysql_restore_download_sub_flow import (
     mysql_restore_download_sub_flow,
 )
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.departs import DeployPeripheralToolsDepart
+from backend.flow.engine.bamboo.scene.mysql.deploy_peripheraltools.push_config import gen_reload_departs_config
 from backend.flow.engine.bamboo.scene.mysql.mysql_single_apply_flow import MySQLSingleApplyFlow
 from backend.flow.engine.bamboo.scene.mysql.mysql_single_destroy_flow import MySQLSingleDestroyFlow
 from backend.flow.plugins.components.collections.common.add_alarm_shield import AddAlarmShieldComponent
@@ -47,10 +54,73 @@ from backend.flow.plugins.components.collections.mysql.mysql_backup_recovery_exe
     MySQLBackupRecoverTaskMetaComponent,
 )
 from backend.flow.plugins.components.collections.mysql.mysql_os_init import CleanDataBakDirComponent
+from backend.flow.plugins.components.collections.mysql.trans_flies import TransFileComponent
+from backend.flow.utils.mysql.act_payload.mysql.peripheraltools import PeripheralToolsPayload
 from backend.flow.utils.mysql.common.mysql_cluster_info import get_version_and_charset
-from backend.flow.utils.mysql.mysql_act_dataclass import ExecActuatorKwargs
+from backend.flow.utils.mysql.mysql_act_dataclass import DownloadMediaKwargs, ExecActuatorKwargs
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
 from backend.flow.utils.mysql.mysql_context_dataclass import MySQLRollbackExerciseContext
+
+logger = logging.getLogger("flow")
+
+# V2 备份介质取自 version_series.name=beta（非 latest）；优先 alpha，无则兼容 release
+_BACKUP_VERSION_SERIES_NAME = "beta"
+_BACKUP_PHASE_PRIORITY = [VersionPhase.ALPHA.value, VersionPhase.RELEASE.value]
+
+
+def _get_v2_package_by_phase(
+    db_type: str,
+    pkg_type: str,
+    phase: str,
+    permit_os_type: str = BkOsType.LINUX.value,
+) -> Optional[Package]:
+    """
+    获取指定数据库类型、介质类型和版本阶段（phase）的 V2 备份介质包
+
+    逻辑说明：
+    - 根据给定的 db_type、pkg_type、phase 检索可用、并启用的备份包，限定 version_series 名称为 beta
+    - 默认按 permit_os_type=Linux 过滤介质包
+    - 若存在多个备份包，优先选择 full_version 数值最大者；
+      同一版本时，优先选择 recommend 和 priority 高的包
+
+    返回：
+    - 若找到符合条件的 Package 实例则返回，否则返回 None
+    """
+    packages = list(
+        Package.objects.filter(
+            enable=True,
+            permit_os_type=permit_os_type,
+            db_version__phase=phase,
+            db_version__enable=True,
+            db_version__version_series__name=_BACKUP_VERSION_SERIES_NAME,
+            db_version__version_series__distribution__db_type=db_type,
+            db_version__version_series__distribution__pkg_type=pkg_type,
+        ).select_related("db_version")
+    )
+    if not packages:
+        return None
+    # 按 full_version 数值比较取最大版本，recommend/priority 作为同版本时的 tiebreaker
+    return max(
+        packages,
+        key=lambda pkg: (pkg.db_version.full_version_n, pkg.db_version.recommend, pkg.priority),
+    )
+
+
+def _resolve_v2_backup_package(db_type: str, pkg_type: str, permit_os_type: str = BkOsType.LINUX.value) -> Package:
+    for phase in _BACKUP_PHASE_PRIORITY:
+        pkg = _get_v2_package_by_phase(db_type, pkg_type, phase, permit_os_type=permit_os_type)
+        if pkg:
+            logger.info(
+                _("V2 备份包命中 series={}, phase={}, pkg_type={}, package_id={}").format(
+                    _BACKUP_VERSION_SERIES_NAME, phase, pkg_type, pkg.id
+                )
+            )
+            return pkg
+    raise DBPackageBaseException(
+        _("未找到 V2 备份介质: series={}, pkg_type={}, permit_os_type={}").format(
+            _BACKUP_VERSION_SERIES_NAME, pkg_type, permit_os_type
+        )
+    )
 
 
 class MySQLRollbackExerciseFlow(object):
@@ -199,6 +269,7 @@ class MySQLRollbackExerciseFlow(object):
                 skip_install_bk_plugin=True,
             )
         )
+        sub_pipeline.add_sub_pipeline(self._build_reinstall_v2_dbbackup_subflow(cluster_class))
         # 屏蔽告警
         sub_pipeline.add_act(
             act_name=_("屏蔽集群 {} 告警12小时").format(cluster_class.name),
@@ -402,3 +473,52 @@ class MySQLRollbackExerciseFlow(object):
         # )
         # 更新任务状态
         return sub_pipeline.build_sub_process(sub_name=_("{}回档演练".format(cluster_class.immute_domain)))
+
+    def _build_reinstall_v2_dbbackup_subflow(self, cluster_class: Cluster):
+        backup_pkg_type = MysqlVersionToDBBackupForMap[self.data["db_version"]]
+        backup_pkg = _resolve_v2_backup_package(DBType.MySQL.value, backup_pkg_type)
+        rollback_ip = self.rollback_host["ip"]
+        instance = "{}:{}".format(rollback_ip, self.rollback_port)
+
+        sub_pipeline = SubBuilder(root_id=self.root_id, data=copy.deepcopy(self.data))
+        sub_pipeline.add_act(
+            act_name=_("下发V2备份介质"),
+            act_component_code=TransFileComponent.code,
+            kwargs=asdict(
+                DownloadMediaKwargs(
+                    bk_cloud_id=cluster_class.bk_cloud_id,
+                    exec_ip=rollback_ip,
+                    file_list=[f"{env.BKREPO_PROJECT}/{env.BKREPO_BUCKET}/{backup_pkg.path}"],
+                )
+            ),
+        )
+        sub_pipeline.add_act(
+            act_name=_("重装备份程序 {}").format(rollback_ip),
+            act_component_code=ExecuteDBActuatorScriptComponent.code,
+            kwargs=asdict(
+                ExecActuatorKwargs(
+                    exec_ip=[rollback_ip],
+                    run_as_system_user=DBA_ROOT_USER,
+                    payload_class=PeripheralToolsPayload.payload_class_path(),
+                    get_mysql_payload_func=PeripheralToolsPayload.deploy_binary.__name__,
+                    bk_cloud_id=cluster_class.bk_cloud_id,
+                    cluster={
+                        "departs": [DeployPeripheralToolsDepart.MySQLDBBackup],
+                        "dbbackup_pkg_override": {
+                            "pkg": pathlib.Path(backup_pkg.path).name,
+                            "pkg_md5": backup_pkg.md5,
+                        },
+                    },
+                )
+            ),
+        )
+        sub_pipeline.add_sub_pipeline(
+            sub_flow=gen_reload_departs_config(
+                root_id=self.root_id,
+                data=copy.deepcopy(self.data),
+                bk_cloud_id=cluster_class.bk_cloud_id,
+                instances=[instance],
+                departs=[DeployPeripheralToolsDepart.MySQLDBBackup],
+            )
+        )
+        return sub_pipeline.build_sub_process(sub_name=_("重装 V2 备份程序"))

--- a/dbm-ui/backend/flow/utils/mysql/act_payload/mysql/peripheraltools.py
+++ b/dbm-ui/backend/flow/utils/mysql/act_payload/mysql/peripheraltools.py
@@ -88,7 +88,13 @@ class PeripheralToolsPayload(PayloadBase, MySQLAccountMixed, ProxyAccountMixed):
 
         if DeployPeripheralToolsDepart.MySQLDBBackup in departs:
             departs = remove_departs(departs, DeployPeripheralToolsDepart.MySQLDBBackup)
-            if m.machine_type == MachineType.PROXY:
+            dbbackup_override = self.cluster.get("dbbackup_pkg_override")
+            if dbbackup_override:
+                depart_pkgs[DeployPeripheralToolsDepart.MySQLDBBackup] = {
+                    "pkg": dbbackup_override["pkg"],
+                    "pkg_md5": dbbackup_override["pkg_md5"],
+                }
+            elif m.machine_type == MachineType.PROXY:
                 pass
             else:
                 if m.machine_type == MachineType.SPIDER:


### PR DESCRIPTION
## Summary

MySQL 回档演练在实例部署完成后、备份恢复前，新增 V2 备份程序重装步骤：

- 通过 V2 版本管理选取备份介质包（`Distribution.pkg_type` → `dbbackup` / `dbbackup-txsql`）
- **版本系列固定为 `beta`**（`version_series.name = beta`，非 `latest`）
- 阶段优先级：`alpha` → `release`（均在 V2 内兼容，不回退 V1 `Package.get_latest_package`）
- 下发介质 → `deploy_binary` 重装 → 推送 dbbackup 配置

## 版本选取说明

| 维度 | 值 |
|------|-----|
| 版本系列 | **`beta`** |
| 阶段优先级 | `alpha` > `release` |
| pkg_type | 由 `MysqlVersionToDBBackupForMap[db_version]` 决定 |

Alpha 包需在版本管理中挂到对应发行版下的 **`beta` 系列**。

## Test plan

- [ ] 确认 V2 中存在 `version_series.name=beta` 且 `phase=alpha` 的备份 DBVersion 及关联 Package
- [ ] 无 Alpha 时验证可命中 `beta` 系列下 `phase=release` 的包
- [ ] 触发 MySQL 回档演练，确认「重装Alpha阶段备份程序」子流程成功
- [ ] 确认 `peripheraltools.deploy_binary` 在未传 `dbbackup_pkg_override` 时行为不变

Closes #18571
