### PR TITLE
fix(backend): 资源池申请字段bk_idc_id重命名为idc_id并移至城市园区分组 #18576

### DIFF
--- a/dbm-ui/backend/ticket/flow_manager/resource.py
+++ b/dbm-ui/backend/ticket/flow_manager/resource.py
@@ -143,7 +143,6 @@ class ResourceApplyFlow(BaseTicketFlow):
                 "bk_cloud_id": host["bk_cloud_id"],
                 "host_id": host["bk_host_id"],
                 "bk_host_id": host["bk_host_id"],
-                "bk_idc_id": host.get("idc_id"),
                 # 补充机器的内存，cpu，磁盘和操作系统信息。(bk_disk的单位是GB, bk_mem的单位是MB)
                 "bk_cpu": host["cpu_num"],
                 "bk_disk": host["total_storage_cap"],
@@ -153,6 +152,7 @@ class ResourceApplyFlow(BaseTicketFlow):
                 # bk_disk为系统盘，storage_device为数据盘/data|/data1
                 "storage_device": host["storage_device"],
                 # 补充城市和园区
+                "idc_id": host.get("idc_id"),
                 "city": host.get("city"),
                 "sub_zone": host.get("sub_zone"),
                 "sub_zone_id": host.get("sub_zone_id"),


### PR DESCRIPTION
close #18576

## 问题描述
资源池申请时 bk_idc_id 字段命名不规范，且放置位置与其语义（城市/园区信息）不匹配。

## 修复内容
- 将 `bk_idc_id` 重命名为 `idc_id`，去除冗余前缀
- 将该字段从主机基础信息区移至「补充城市和园区」分组下，语义更清晰

## 测试
- [x] 代码逻辑无变化，仅字段名和位置调整
