### PR TITLE
fix(redis): 正则引擎格式兼容 #18572

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
@@ -453,7 +453,6 @@ func (task *RedisInsKeyPatternTask) getSafeRegexPattern(keyRegex string) (shellG
 		regPartten = strings.ReplaceAll(regPartten, "\\d", "[0-9]")
 		regPartten = strings.ReplaceAll(regPartten, "\\D", "[^0-9]")
 		regPartten = strings.ReplaceAll(regPartten, "\\w", "[a-zA-Z0-9_]")
-		regPartten = strings.ReplaceAll(regPartten, "\\W", "[^a-zA-Z0-9_]")
 
 		if shellGrepPattern == "" {
 			if strings.HasPrefix(regPartten, "^") {

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
@@ -450,6 +450,10 @@ func (task *RedisInsKeyPatternTask) getSafeRegexPattern(keyRegex string) (shellG
 		regPartten = strings.ReplaceAll(regPartten, "|", "\\|")
 		regPartten = strings.ReplaceAll(regPartten, ".", "\\.")
 		regPartten = strings.ReplaceAll(regPartten, "*", ".*")
+		regPartten = strings.ReplaceAll(regPartten, "\\d", "[0-9]")
+		regPartten = strings.ReplaceAll(regPartten, "\\D", "[^0-9]")
+		regPartten = strings.ReplaceAll(regPartten, "\\w", "[a-zA-Z0-9_]")
+		regPartten = strings.ReplaceAll(regPartten, "\\W", "[^a-zA-Z0-9_]")
 
 		if shellGrepPattern == "" {
 			if strings.HasPrefix(regPartten, "^") {


### PR DESCRIPTION
Cache 集群：redis-shake 接收到的是 ut:u:t:[0-9]+，Go 正则引擎完美解析，提取出数字 Key。

SSD / Tendisplus 集群：拼接的命令变成了 grep -E "^ut:u:t:[0-9]+"，grep 也能完美识别并提取出数字 Key。

====》 兼容 \d ,\w