### PR TITLE
fix(redis): 正则引擎格式兼容 #18572

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_keyspattern.go
@@ -450,6 +450,9 @@ func (task *RedisInsKeyPatternTask) getSafeRegexPattern(keyRegex string) (shellG
 		regPartten = strings.ReplaceAll(regPartten, "|", "\\|")
 		regPartten = strings.ReplaceAll(regPartten, ".", "\\.")
 		regPartten = strings.ReplaceAll(regPartten, "*", ".*")
+		regPartten = strings.ReplaceAll(regPartten, "\\d", "[0-9]")
+		regPartten = strings.ReplaceAll(regPartten, "\\D", "[^0-9]")
+		regPartten = strings.ReplaceAll(regPartten, "\\w", "[a-zA-Z0-9_]")
 
 		if shellGrepPattern == "" {
 			if strings.HasPrefix(regPartten, "^") {


### PR DESCRIPTION

业务无感知：业务依然可以按照习惯输入 t:\d+。

Cache 集群：redis-shake 接收到的是 t:[0-9]+，Go 正则引擎完美解析，提取出数字 Key。

SSD / Tendisplus 集群：拼接的命令变成了 grep -E "^t:[0-9]+"，grep 也能完美识别并提取出数字 Key。

