### PR TITLE
feat(redis): refactor metrics query with intrinsic dimensions #18585

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
@@ -11,6 +11,12 @@ specific language governing permissions and limitations under the License.
 from backend.db_report.enums import MetaCheckSubType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.db_report.models import MetaCheckReport, RedisCheckReport
+from backend.dbm_aiagent.mcp_tools.redis.enums import (
+    BUCKET_DIMENSION,
+    CAPACITY_TYPE_DIMENSION,
+    CMD_DIMENSION,
+    MOUNT_POINT_DIMENSION,
+)
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsAggFunction as AggFunction
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, RedisReportSubtype
 
@@ -120,6 +126,11 @@ TREND_UNIT_BY_METRIC_KEY = {
 #   means users can choose to aggregate at cluster level (group_by=None) or ip level (group_by=[MetricsGroupBy.IP]).
 #   The outer query wraps the inner query: "max by (cluster_domain) (inner_query)" or
 #   "max by (cluster_domain, ip) (inner_query)".
+#
+# - intrinsic_dimensions: List of IntrinsicDimension objects describing metric-specific breakdowns
+#   (e.g. cmd, latency bucket, capacity used/total/available) that are ALWAYS applied internally and are
+#   NOT user-selectable. NATURAL_LABEL dims are appended to the inner/outer "by" clauses; SYNTHESIZED dims
+#   are produced by a dedicated builder via label_replace. They are composed into result keys by key_order.
 #
 # Example for redis_cpu with required_dimensions=["ip"], supported_group_by=["cluster_domain", "ip"]:
 #   Inner query (always): max by (cluster_domain, ip) (max_over_time(...))
@@ -276,12 +287,13 @@ METRIC_REGISTRY = {
             MetricsGroupBy.CLUSTER_DOMAIN,
             MetricsGroupBy.IP,
             MetricsGroupBy.INSTANCE,
-            MetricsGroupBy.CMD,
         ],
-        "required_dimensions": ["ip", "instance_port", "cmd"],
+        "intrinsic_dimensions": [CMD_DIMENSION],
+        "required_dimensions": ["ip", "instance_port"],
     },
     "capacity_memory": {
         "is_capacity": True,
+        "intrinsic_dimensions": [CAPACITY_TYPE_DIMENSION],
         "sub_metrics": {
             "used": "bkmonitor:exporter_dbm_redis_exporter:redis_memory_used_bytes{{{filters}}}",
             "total": "bkmonitor:exporter_dbm_redis_exporter:redis_config_maxmemory{{{filters}}}",
@@ -295,6 +307,13 @@ METRIC_REGISTRY = {
     },
     "capacity_disk": {
         "is_capacity": True,
+        # capacity_type (used/total/available) + per physical mount_point breakdown -> used@<ip>@<mount_point>.
+        "intrinsic_dimensions": [CAPACITY_TYPE_DIMENSION, MOUNT_POINT_DIMENSION],
+        # df_*_mb is a filesystem-level metric: instances sharing a data-dir mount report identical
+        # values. Deduplicate each physical disk once (max per cluster_domain,ip,mount_point) and keep
+        # that granularity in the output, mirroring the db_monitor capacity policy; otherwise a shared
+        # disk is multiplied by the number of co-located instances.
+        "capacity_dedup": {"agg": AggFunction.MAX, "by": ["cluster_domain", "ip", "mount_point"]},
         "sub_metrics": {
             "used": "bkmonitor:exporter_dbm_redis_exporter:redis_datadir_df_used_mb{{{filters}}} * 1024 * 1024",
             "total": "bkmonitor:exporter_dbm_redis_exporter:redis_datadir_df_total_mb{{{filters}}} * 1024 * 1024",
@@ -455,9 +474,9 @@ METRIC_REGISTRY = {
             MetricsGroupBy.CLUSTER_DOMAIN,
             MetricsGroupBy.IP,
             MetricsGroupBy.INSTANCE,
-            MetricsGroupBy.CMD,
         ],
-        "required_dimensions": ["ip", "instance_port", "cmd"],
+        "intrinsic_dimensions": [CMD_DIMENSION],
+        "required_dimensions": ["ip", "instance_port"],
         "instance_filter_mode": "instance_label",
     },
     "predixy_latency_distribution": {
@@ -488,7 +507,8 @@ METRIC_REGISTRY = {
             "overall": AggFunction.SUM,
             "stats": [AggFunction.MAX, AggFunction.MIN],
         },
-        "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.BUCKET],
+        "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP],
+        "intrinsic_dimensions": [BUCKET_DIMENSION],
         "required_dimensions": ["ip"],  # Inner query needs ip dimension for per-IP bucket counts
     },
     # Twemproxy proxy metrics
@@ -640,9 +660,9 @@ METRIC_REGISTRY = {
             MetricsGroupBy.CLUSTER_DOMAIN,
             MetricsGroupBy.IP,
             MetricsGroupBy.INSTANCE,
-            MetricsGroupBy.CMD,
         ],
-        "required_dimensions": ["ip", "instance_port", "cmd"],
+        "intrinsic_dimensions": [CMD_DIMENSION],
+        "required_dimensions": ["ip", "instance_port"],
         "instance_filter_mode": "instance_label",
     },
     "twemproxy_latency_distribution": {
@@ -672,7 +692,8 @@ METRIC_REGISTRY = {
             "overall": AggFunction.SUM,
             "stats": [AggFunction.MAX, AggFunction.MIN],
         },
-        "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.BUCKET],
+        "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP],
+        "intrinsic_dimensions": [BUCKET_DIMENSION],
         "required_dimensions": ["ip"],  # Inner query needs ip dimension for per-IP bucket counts
     },
 }

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/enums.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/enums.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from dataclasses import dataclass
 from typing import List, Tuple
 
 from blue_krill.data_types.enum import EnumField, StrStructuredEnum
@@ -58,13 +59,6 @@ class MetricsInstanceRole(StrStructuredEnum):
     SLAVE = EnumField("redis_slave", "Redis slave")
 
 
-class MetricsStatsType(StrStructuredEnum):
-    """Type of statistical computation for metric results."""
-
-    VERTICAL = EnumField("vertical", "Vertical (temporal stats on aggregated series)")
-    HORIZONTAL = EnumField("horizontal", "Horizontal (stats across instances per time point)")
-
-
 class MetricsAggregationLevel(StrStructuredEnum):
     """Level at which metrics are aggregated."""
 
@@ -84,31 +78,75 @@ class MetricsAggFunction(StrStructuredEnum):
 
 
 class MetricsGroupBy(StrStructuredEnum):
-    """Dimension for grouping metric results."""
+    """User-selectable structural dimension for grouping metric results.
+
+    Only the cluster-structure dimensions are user-facing here. Metric-specific
+    breakdowns (command, latency bucket, capacity sub-type, ...) are modelled as
+    internal "intrinsic dimensions" (see ``IntrinsicDimension``) and are applied
+    automatically by the query service -- they are never user-selectable.
+    """
 
     IP = EnumField("ip", "IP address")
     INSTANCE = EnumField("instance", "Instance (ip:port)")
-    CMD = EnumField("cmd", "Command")
     CLUSTER_DOMAIN = EnumField("cluster_domain", "Cluster domain")
-    BUCKET = EnumField("bucket", "Latency bucket (distribution metrics only)")
 
     @classmethod
     def get_cluster_api_choices(cls) -> List[str]:
-        """User-visible group_by values for cluster-level Redis metrics MCP APIs (CMD is service-injected)."""
-
-        return [cls.IP.value, cls.INSTANCE.value, cls.BUCKET.value, cls.CLUSTER_DOMAIN.value]
+        """User-visible group_by values for cluster-level Redis metrics MCP APIs."""
+        return [cls.IP.value, cls.INSTANCE.value, cls.CLUSTER_DOMAIN.value]
 
     @classmethod
     def get_machine_api_choices(cls) -> List[str]:
         """User-visible group_by values for machine-level APIs; cluster_domain omitted (scope fixes cluster)."""
-
-        return [cls.IP.value, cls.INSTANCE.value, cls.BUCKET.value]
+        return [cls.IP.value, cls.INSTANCE.value]
 
     @classmethod
     def get_instance_api_choices(cls) -> List[str]:
         """User-visible group_by values for instance-level APIs; cluster_domain and ip omitted."""
+        return [cls.INSTANCE.value]
 
-        return [cls.INSTANCE.value, cls.BUCKET.value]
+
+class IntrinsicDimensionKind(StrStructuredEnum):
+    """How an intrinsic dimension is realized in the PromQL query pipeline."""
+
+    NATURAL_LABEL = EnumField("natural_label", "Real PromQL label, added to the by() clause")
+    SYNTHESIZED = EnumField("synthesized", "Produced via label_replace by a dedicated query builder")
+
+
+@dataclass(frozen=True)
+class IntrinsicDimension:
+    """A metric-specific breakdown applied internally (not a user-facing group_by).
+
+    Attributes:
+        promql_label: The PromQL label name carried on result series
+            (e.g. "cmd", "bucket_label", "capacity_type").
+        kind: NATURAL_LABEL dims are appended to the inner/outer ``by(...)`` clauses;
+            SYNTHESIZED dims are emitted by a dedicated builder via ``label_replace``.
+        key_order: Relative ordering when composing result keys (lower comes first).
+
+    To add a new metric-specific dimension:
+      1. Declare an ``IntrinsicDimension`` instance here.
+      2. Attach it to the relevant ``METRIC_REGISTRY`` entry via ``intrinsic_dimensions``.
+      3. For NATURAL_LABEL: ensure the source metric actually exposes that label.
+         For SYNTHESIZED: ensure a builder emits it via ``label_replace``.
+    """
+
+    promql_label: str
+    kind: IntrinsicDimensionKind
+    key_order: int = 100
+
+
+# Canonical intrinsic dimensions. Reference these from METRIC_REGISTRY entries.
+#
+# key_order controls placement in composed result keys. The scope identifier (ip / ip:port) is
+# inserted by the query service at SCOPE_KEY_ORDER (50): dims with key_order < 50 precede the scope,
+# dims with key_order > 50 follow it. So capacity_type/bucket/cmd lead the key, while mount_point
+# trails the scope -> e.g. "used@<ip>@<mount_point>".
+CMD_DIMENSION = IntrinsicDimension("cmd", IntrinsicDimensionKind.NATURAL_LABEL, key_order=20)
+BUCKET_DIMENSION = IntrinsicDimension("bucket_label", IntrinsicDimensionKind.SYNTHESIZED, key_order=10)
+CAPACITY_TYPE_DIMENSION = IntrinsicDimension("capacity_type", IntrinsicDimensionKind.SYNTHESIZED, key_order=5)
+# Disk capacity is per physical mount; mount_point trails the scope so keys read used@<ip>@<mount_point>.
+MOUNT_POINT_DIMENSION = IntrinsicDimension("mount_point", IntrinsicDimensionKind.NATURAL_LABEL, key_order=60)
 
 
 class RedisReportSubtype(StrStructuredEnum):

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/impl/redis_metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/impl/redis_metrics.py
@@ -14,10 +14,10 @@ from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
 from backend.db_meta.enums import InstanceRole
 from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
-from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, MetricsInstanceRole, MetricsStatsType, MetricType
+from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, MetricsInstanceRole, MetricType
 from backend.dbm_aiagent.mcp_tools.redis.models import InstanceFilter, MetricsQueryBatch
 from backend.dbm_aiagent.mcp_tools.redis.tools.redis_metrics_svc import RedisMetricsQueryService
-from backend.dbm_aiagent.mcp_tools.redis.utils import calculate_time_range_window, generate_mermaid_line_chart
+from backend.dbm_aiagent.mcp_tools.redis.utils import calculate_time_range_window
 
 _PROXY_ONLY_METRICS = {MetricType.LATENCY_DISTRIBUTION}
 _BACKEND_ONLY_METRICS = {MetricType.CAPACITY}
@@ -354,7 +354,6 @@ def query_redis_metrics_series(
     metric_type: MetricType,
     time_range: tuple,
     time_window: int,
-    mermaid_format: bool = False,
     group_by: Optional[List[MetricsGroupBy]] = None,
     include_meta: bool = False,
 ) -> dict:
@@ -362,7 +361,7 @@ def query_redis_metrics_series(
     Query Redis cluster time-series metrics.
 
     Iterates over batches (each with a single instance_role), queries per batch,
-    and merges results. Returns aggregated time series data (and optionally mermaid chart code).
+    and merges results. Returns aggregated time series data.
     """
     metrics_svc = RedisMetricsQueryService()
     merged_series_by_scope: Dict[str, object] = {}
@@ -383,8 +382,6 @@ def query_redis_metrics_series(
             clusters=batch.clusters,
             metric_type=metric_type,
             time_range=time_range,
-            need_stats=False,
-            need_overall=True,
             time_window=time_window,
             instance_role=batch.instance_role,
             ip_filters=batch.ip_filters,
@@ -407,32 +404,6 @@ def query_redis_metrics_series(
 
     result = {"series": result_series}
 
-    if mermaid_format and result_series:
-        y_labels = {
-            MetricType.CPU_USAGE: "%CPU",
-            MetricType.MEMORY_USAGE: "%Memory",
-            MetricType.IO_USAGE: "%IO",
-            MetricType.DISK_USAGE: "%Disk",
-            MetricType.CONNECTIONS: "Connections",
-            MetricType.QPS: "Queries/sec",
-            MetricType.HOST_LATENCY: "Latency (μs)",
-            MetricType.COMMAND_LATENCY: "Latency (μs)",
-            MetricType.LATENCY_DISTRIBUTION: "Requests",
-            MetricType.CAPACITY: "Bytes",
-        }
-
-        title = (
-            f"{metric_type.value.upper()} (multi-entity)"
-            if len(merged_series_by_scope) > 1
-            else metric_type.value.upper()
-        )
-        result["mermaid_code"] = generate_mermaid_line_chart(
-            title=title,
-            series_data=result_series,
-            y_label=y_labels.get(metric_type, "Value"),
-        )
-        result.pop("series")
-
     if include_meta:
         entity_meta = _merge_entity_meta(batches)
         if entity_meta:
@@ -450,16 +421,15 @@ def query_redis_metrics_stats(
     time_range: tuple,
     time_window: int,
     group_by: Optional[List[MetricsGroupBy]] = None,
-    stats_type: MetricsStatsType = MetricsStatsType.VERTICAL,
     include_meta: bool = False,
 ) -> dict:
     """
-    Query Redis cluster scalar statistics.
+    Query Redis cluster scalar statistics over the timeline.
 
-    Iterates over batches (each with a single instance_role), queries per batch,
-    and merges results. Returns computed statistics (min, max, avg, median, p95, cv, trend, etc.).
+    Iterates over batches (each with a single instance_role), queries per batch, and merges
+    results. Each series is reduced to timeline statistics (min, max, avg, median, p95, cv,
+    trend, latest) computed over the query window.
     """
-    is_vertical = stats_type == MetricsStatsType.VERTICAL
     metrics_svc = RedisMetricsQueryService()
     merged_series_by_scope: Dict[str, object] = {}
     all_partial_errors: List[dict] = []
@@ -479,14 +449,11 @@ def query_redis_metrics_stats(
             clusters=batch.clusters,
             metric_type=metric_type,
             time_range=time_range,
-            need_stats=not is_vertical,
-            need_overall=is_vertical,
             time_window=time_window,
             instance_role=batch.instance_role,
             ip_filters=batch.ip_filters,
             instance_filters=batch.instance_filters,
             group_by=group_by,
-            vertical_stats=is_vertical,
         )
 
         merged_series_by_scope.update(series_by_scope)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/models.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/models.py
@@ -62,8 +62,6 @@ class MetricsQueryParams:
     instance_filters: Optional[List[InstanceFilter]] = None  # Optional ip:port pair filter (instance scope)
 
     # Output options
-    need_stats: bool = True  # Whether to include statistical queries
-    need_overall: bool = True  # Whether to include overall time series queries
     group_by: Optional[
         List[MetricsGroupBy]
     ] = None  # Explicit dimensions for grouping results (e.g., [cluster_domain, ip, port])
@@ -72,35 +70,19 @@ class MetricsQueryParams:
 @dataclass
 class MetricSeries:
     """
-    Statistical measures and raw time series for metrics.
+    Raw time series and the timeline statistics derived from them.
 
-    This class supports three aggregation levels:
-    1. INSTANCE (ip:port): Metrics for a single instance
-       - raw_series: {"ip:port": [[value, timestamp], ...]}
-       - stats_series_by_key: {"ip:port": {MIN: [...], MAX: [...], AVG: [...], STDDEV: [...]}}
-         (Inner dict keys are MetricsAggFunction enum values)
-       - statistics: scalar values computed from stats_series_by_key
+    ``raw_series`` maps a result key to its [[value, timestamp], ...] points. The key is composed of
+    the metric's intrinsic breakdown values (cmd / latency bucket / capacity sub-type) and the scope
+    identifier, depending on aggregation level:
+    1. INSTANCE (ip:port): keyed by intrinsic breakdown, or "ip:port" when none.
+    2. MACHINE (ip): one entry per instance/breakdown on that machine.
+    3. CLUSTER: one entry per group_by/breakdown dimension value across the cluster.
 
-    2. MACHINE (ip): Metrics aggregated across all instances on one machine
-       - raw_series: {"ip:port1": [...], "ip:port2": [...], ...} for all ports on that IP
-       - stats_series_by_key: {"ip": {MIN: [...], MAX: [...], AVG: [...], STDDEV: [...]}}
-       - statistics: scalar values computed from stats_series_by_key
-
-    3. CLUSTER: Metrics aggregated across all machines in the cluster
-       - raw_series: {"ip1": [...], "ip2": [...], ...} for all IPs in cluster
-       - stats_series_by_key: {"cluster_domain": {MIN: [...], MAX: [...], AVG: [...], STDDEV: [...]}}
-       - statistics: scalar values computed from stats_series_by_key
-
-    Statistics are computed from stats_series_by_key:
-    - For each key in stats_series_by_key, statistics are calculated from the respective series
-    - min: min(values) from stats_series_by_key[key][MetricsAggFunction.MIN]
-    - max: max(values) from stats_series_by_key[key][MetricsAggFunction.MAX]
-    - avg: average(values) from stats_series_by_key[key][MetricsAggFunction.AVG]
-    - stddev: max(values) from stats_series_by_key[key][MetricsAggFunction.STDDEV] (represents peak variability)
-    - median, p95, cv, trend: calculated from stats_series_by_key[key][MetricsAggFunction.AVG]
+    ``statistics`` holds scalar timeline stats per ``raw_series`` key (min, max, avg, median, p95,
+    cv, trend, latest), computed over each series' values across the time window.
     """
 
     aggregation_level: MetricsAggregationLevel
     raw_series: Optional[Dict[str, List[List[float]]]] = None
-    stats_series_by_key: Optional[Dict[str, Dict[str, List[List[float]]]]] = None
     statistics: Optional[Dict[str, Dict[str, float]]] = None

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_metrics.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
-from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, MetricsStatsType, MetricType
+from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, MetricType
 
 # Shown on metric_type where capacity is allowed, and on capacity-related response fields.
 _CAPACITY_METRIC_USER_GUIDANCE = _(
@@ -19,6 +19,14 @@ _CAPACITY_METRIC_USER_GUIDANCE = _(
     "when describing current state, lean on `latest` together with used/available. "
     "If total (or its min/max over the window) differs from that steady baseline across the period, "
     "it usually reflects scale-out, scale-in, or topology changes rather than continuous drift."
+)
+
+# Metric-specific breakdowns (per command, per latency bucket, capacity used/total/available) are applied
+# automatically by the service and are NOT user-selectable group_by options.
+_AUTOMATIC_BREAKDOWN_NOTE = _(
+    "Metric-specific breakdowns are applied automatically and are not group_by options: "
+    "command_latency is broken down per command; latency_distribution per latency bucket; "
+    "capacity into used/available/total."
 )
 
 
@@ -60,11 +68,13 @@ class RedisMetricsTimeWindowSerializer(serializers.Serializer):
 # Cluster scope: proxy vs backend (master/slave)
 # ---------------------------------------------------------------------------
 
-_GROUP_BY_HELP_CLUSTER = _(
-    "Dimensions to break results down by. Omit (or null) for a cluster-wide aggregate. "
-    "Choices: 'ip' (per host), 'instance' (per ip:port), "
-    "'bucket' (latency buckets; for latency_distribution), "
-    "'cluster_domain' (per cluster; rarely needed at cluster scope)."
+_GROUP_BY_HELP_CLUSTER = (
+    _(
+        "Dimensions to break results down by. Omit (or null) for a cluster-wide aggregate. "
+        "Choices: 'ip' (per host), 'instance' (per ip:port), "
+        "'cluster_domain' (per cluster; rarely needed at cluster scope). "
+    )
+    + _AUTOMATIC_BREAKDOWN_NOTE
 )
 
 
@@ -87,8 +97,8 @@ class RedisMetricsClusterProxyInputSerializer(ClusterDomainsFieldMixin, RedisMet
             "Metric to query (proxy nodes; capacity is not available at proxy). "
             "[Resource] cpu_usage, memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
-            "[Latency] host_latency, command_latency (group_by cmd is auto-added), "
-            "latency_distribution (per bucket when grouped by bucket). "
+            "[Latency] host_latency, command_latency (broken down per command automatically), "
+            "latency_distribution (broken down per latency bucket automatically). "
         ),
     )
     group_by = serializers.ListField(
@@ -109,7 +119,7 @@ class RedisMetricsClusterBackendInputSerializer(ClusterDomainsFieldMixin, RedisM
             "Metric to query (backend nodes; latency_distribution is proxy-only). "
             "[Resource] cpu_usage, memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
-            "[Latency] host_latency, command_latency (group_by cmd is auto-added). "
+            "[Latency] host_latency, command_latency (broken down per command automatically). "
             "[Capacity] capacity (used/available/total memory in bytes). "
         )
         + _CAPACITY_METRIC_USER_GUIDANCE,
@@ -145,7 +155,7 @@ class RedisMetricsMachineInputSerializer(RedisMetricsTimeWindowSerializer):
             "latency_distribution is proxy-only, capacity is backend-only. "
             "[Resource] cpu_usage, memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
-            "[Latency] host_latency, command_latency (group_by cmd is auto-added), latency_distribution. "
+            "[Latency] host_latency, command_latency (broken down per command automatically), latency_distribution. "
             "[Capacity] capacity. "
         )
         + _CAPACITY_METRIC_USER_GUIDANCE,
@@ -157,10 +167,10 @@ class RedisMetricsMachineInputSerializer(RedisMetricsTimeWindowSerializer):
         default=[MetricsGroupBy.IP.value],
         help_text=_(
             "Dimensions to break results down by. Default: ['ip']. Pass null for aggregate on this host. "
-            "Choices: 'ip', 'instance' (ip:port on this machine), "
-            "'bucket' (for latency_distribution). "
-            "'cluster_domain' is not listed here — scope is already a single resolved cluster."
-        ),
+            "Choices: 'ip', 'instance' (ip:port on this machine). "
+            "'cluster_domain' is not listed here — scope is already a single resolved cluster. "
+        )
+        + _AUTOMATIC_BREAKDOWN_NOTE,
     )
 
 
@@ -185,7 +195,7 @@ class RedisMetricsInstanceInputSerializer(RedisMetricsTimeWindowSerializer):
             "are not available at instance scope. "
             "latency_distribution is proxy-only; capacity is backend-only. "
             "[Throughput] connections, qps. "
-            "[Latency] host_latency, command_latency (group_by cmd is auto-added), latency_distribution. "
+            "[Latency] host_latency, command_latency (broken down per command automatically), latency_distribution. "
             "[Capacity] capacity. "
         )
         + _CAPACITY_METRIC_USER_GUIDANCE,
@@ -197,10 +207,10 @@ class RedisMetricsInstanceInputSerializer(RedisMetricsTimeWindowSerializer):
         default=[MetricsGroupBy.INSTANCE.value],
         help_text=_(
             "Dimensions to break results down by. Default: ['instance']. Pass null for aggregate on this instance. "
-            "Choices: 'instance' (ip:port; same vocabulary as cluster APIs), "
-            "'bucket' (for latency_distribution). "
-            "'cluster_domain' and 'ip' are omitted — scope already fixes cluster and host."
-        ),
+            "Choices: 'instance' (ip:port; same vocabulary as cluster APIs). "
+            "'cluster_domain' and 'ip' are omitted — scope already fixes cluster and host. "
+        )
+        + _AUTOMATIC_BREAKDOWN_NOTE,
     )
 
     def validate(self, attrs):
@@ -213,70 +223,39 @@ class RedisMetricsInstanceInputSerializer(RedisMetricsTimeWindowSerializer):
 
 
 # ---------------------------------------------------------------------------
-# Series / stats field mixins
+# Concrete input serializers (series vs stats share the same inputs)
 # ---------------------------------------------------------------------------
 
 
-class SeriesFieldMixin(serializers.Serializer):
-    mermaid_format = serializers.BooleanField(
-        default=False,
-        help_text=_(
-            "Set True to receive a pre-rendered mermaid xychart-beta chart in the 'mermaid_code' response field. "
-            "When mermaid_code is generated, the raw series data is omitted from the response. "
-            "IMPORTANT: output the returned mermaid_code verbatim -- do NOT modify or regenerate it."
-        ),
-    )
-
-
-class StatsFieldMixin(serializers.Serializer):
-    stats_type = serializers.ChoiceField(
-        choices=MetricsStatsType.get_choices(),
-        default=MetricsStatsType.VERTICAL.value,
-        help_text=_(
-            "How to compute statistics. "
-            "'vertical' (default): aggregates all instances into one cluster-wide series first, "
-            "then computes min/max/avg/p95/trend over time. "
-            "Use when asking 'what was the cluster-wide peak total QPS?' "
-            "'horizontal': computes stats across instances at each time point, then summarizes. "
-            "Use when asking 'which instance had the highest QPS?'"
-        ),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Concrete input serializers (scope x mode)
-# ---------------------------------------------------------------------------
-
-
-class RedisClusterProxySeriesInputSerializer(SeriesFieldMixin, RedisMetricsClusterProxyInputSerializer):
+class RedisClusterProxySeriesInputSerializer(RedisMetricsClusterProxyInputSerializer):
     pass
 
 
-class RedisClusterProxyStatsInputSerializer(StatsFieldMixin, RedisMetricsClusterProxyInputSerializer):
+class RedisClusterProxyStatsInputSerializer(RedisMetricsClusterProxyInputSerializer):
     pass
 
 
-class RedisClusterBackendSeriesInputSerializer(SeriesFieldMixin, RedisMetricsClusterBackendInputSerializer):
+class RedisClusterBackendSeriesInputSerializer(RedisMetricsClusterBackendInputSerializer):
     pass
 
 
-class RedisClusterBackendStatsInputSerializer(StatsFieldMixin, RedisMetricsClusterBackendInputSerializer):
+class RedisClusterBackendStatsInputSerializer(RedisMetricsClusterBackendInputSerializer):
     pass
 
 
-class RedisMachineSeriesInputSerializer(SeriesFieldMixin, RedisMetricsMachineInputSerializer):
+class RedisMachineSeriesInputSerializer(RedisMetricsMachineInputSerializer):
     pass
 
 
-class RedisMachineStatsInputSerializer(StatsFieldMixin, RedisMetricsMachineInputSerializer):
+class RedisMachineStatsInputSerializer(RedisMetricsMachineInputSerializer):
     pass
 
 
-class RedisInstanceSeriesInputSerializer(SeriesFieldMixin, RedisMetricsInstanceInputSerializer):
+class RedisInstanceSeriesInputSerializer(RedisMetricsInstanceInputSerializer):
     pass
 
 
-class RedisInstanceStatsInputSerializer(StatsFieldMixin, RedisMetricsInstanceInputSerializer):
+class RedisInstanceStatsInputSerializer(RedisMetricsInstanceInputSerializer):
     pass
 
 
@@ -295,19 +274,17 @@ class RedisMetricsSeriesOutputSerializer(serializers.Serializer):
             "The key depends on scope: "
             "instance scope -> key is 'ip:port'; "
             "machine scope -> one key per instance on that machine ('ip:port1', 'ip:port2', ...); "
-            "cluster scope -> key is cluster_domain, or group_by dimension values (ip, instance, bucket). "
+            "cluster scope -> key is cluster_domain, or group_by dimension values (ip, instance, and metric-specific fields). "
             "Value units match the metric_type: % for usage metrics, count for connections, "
             "ops/s for qps, μs for latency, bytes for capacity. "
             "For capacity, separate series correspond to used, available, and total. "
+            "Disk-based capacity (e.g. Tendisplus/TendisSSD) is broken down per physical mount point. "
+            "At cluster scope (default group_by or group_by=['cluster_domain']), keys look like "
+            "'used@<mount_point>' with values summed across all hosts; at ip scope "
+            "(group_by=['ip']), keys look like 'used@<ip>@<mount_point>'. Sum across mount-point "
+            "series client-side for a host or cluster total. "
         )
         + _CAPACITY_METRIC_USER_GUIDANCE,
-    )
-    mermaid_code = serializers.CharField(
-        required=False,
-        help_text=_(
-            "Pre-rendered mermaid xychart-beta chart code. Present only when mermaid_format=True "
-            "and series data exists. Render this directly in a mermaid code block -- do NOT modify it."
-        ),
     )
     partial_errors = serializers.JSONField(
         required=False,
@@ -321,22 +298,21 @@ class RedisMetricsStatsOutputSerializer(serializers.Serializer):
     statistics = serializers.JSONField(
         required=False,
         help_text=_(
-            "Dict keyed by group dimension (cluster_domain when no group_by, otherwise ip / instance / "
-            "cmd / bucket). Each value is a dict containing: "
+            "Dict keyed by group/breakdown dimension (cluster_domain when no group_by, otherwise ip / instance, "
+            "plus automatic breakdowns: command for command_latency, latency bucket for latency_distribution). "
+            "Each value is a dict of timeline statistics computed over the query window: "
             "min -- minimum observed value; "
             "max -- maximum observed value; "
             "avg -- arithmetic mean; "
             "median -- 50th percentile; "
             "p95 -- 95th percentile; "
-            "cv -- coefficient of variation in % (higher = more volatile); "
+            "cv -- coefficient of variation in % (higher = more volatile over time); "
             "trend -- slope per minute (positive = increasing, negative = decreasing); "
             "trend_unit -- unit string for the trend value; "
             "latest -- most recent data point value of the series. "
-            "With stats_type='vertical': these stats describe the aggregated cluster-wide series over time "
-            "(e.g. max = peak total cluster QPS). "
-            "With stats_type='horizontal': these stats describe the spread across instances "
-            "(e.g. max = highest value any single instance reached). "
-            "For metric_type=capacity, keys distinguish used, available, and total. "
+            "For metric_type=capacity, keys distinguish used, available, and total; disk-based capacity "
+            "is further broken down per mount point. At cluster scope keys look like 'used@<mount_point>' "
+            "(summed across hosts); at ip scope 'used@<ip>@<mount_point>'. "
         )
         + _CAPACITY_METRIC_USER_GUIDANCE,
     )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/tools/redis_metrics_svc.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/tools/redis_metrics_svc.py
@@ -27,6 +27,7 @@ from backend.dbm_aiagent.mcp_tools.redis.constants import (
     TREND_UNIT_BY_METRIC_KEY,
     UNIFY_QUERY_PARAMS,
 )
+from backend.dbm_aiagent.mcp_tools.redis.enums import IntrinsicDimensionKind
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsAggFunction as AggFunction
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsAggregationLevel as AggregationLevel
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy
@@ -36,6 +37,13 @@ from backend.dbm_aiagent.mcp_tools.redis.models import InstanceFilter, MetricSer
 from backend.dbm_aiagent.mcp_tools.redis.utils import resolve_metric_key
 
 logger = logging.getLogger("root")
+
+# Result-key composition: a series key is built by ordering the metric's intrinsic dimension values
+# and the scope identifier (ip / ip:port) by key_order, then joining with "@". The scope identifier is
+# inserted at SCOPE_KEY_ORDER, so intrinsic dims with a smaller key_order lead the key (capacity_type,
+# bucket, cmd) and those with a larger key_order trail the scope (mount_point) -> e.g.
+# "used@<ip>@<mount_point>".
+SCOPE_KEY_ORDER = 50
 
 
 class RedisMetricsQueryService:
@@ -117,6 +125,24 @@ class RedisMetricsQueryService:
             filters.append(ip_matcher)
         return ",".join(filters)
 
+    @staticmethod
+    def _intrinsic_dimensions(metric_config: dict) -> list:
+        """Return the metric's declared IntrinsicDimension objects (metric-specific breakdowns)."""
+        return metric_config.get("intrinsic_dimensions") or []
+
+    @classmethod
+    def _natural_label_intrinsic_dims(cls, metric_config: dict) -> List[str]:
+        """PromQL labels for NATURAL_LABEL intrinsic dims; appended to inner/outer by() clauses.
+
+        SYNTHESIZED intrinsic dims (e.g. bucket_label, capacity_type) are emitted by their
+        dedicated builders via label_replace, so they are intentionally excluded here.
+        """
+        return [
+            dim.promql_label
+            for dim in cls._intrinsic_dimensions(metric_config)
+            if dim.kind == IntrinsicDimensionKind.NATURAL_LABEL
+        ]
+
     def _resolve_inner_dimensions(self, params: MetricsQueryParams) -> str:
         """
         Resolve dimensions for the inner/base PromQL query.
@@ -126,7 +152,7 @@ class RedisMetricsQueryService:
         - machine scope: ip
         - instance scope: ip,instance_port
 
-        Metric-required dimensions are then merged on top.
+        Metric-required dimensions and NATURAL_LABEL intrinsic dimensions are merged on top.
 
         Args:
             params: MetricsQueryParams object
@@ -148,6 +174,11 @@ class RedisMetricsQueryService:
             if req_dim not in dimensions:
                 dimensions.append(req_dim)
 
+        # NATURAL_LABEL intrinsic dimensions must exist at base granularity (e.g. cmd)
+        for label in self._natural_label_intrinsic_dims(params.metric_config):
+            if label not in dimensions:
+                dimensions.append(label)
+
         return ",".join(dimensions)
 
     def _resolve_outer_dimensions(self, params: MetricsQueryParams) -> str:
@@ -168,55 +199,51 @@ class RedisMetricsQueryService:
         """
         group_by_list = params.group_by
         supported_group_by = params.metric_config.get("supported_group_by", [])
+        # NATURAL_LABEL intrinsic dims are always part of the outer aggregation (internal group-by)
+        natural_intrinsic_labels = self._natural_label_intrinsic_dims(params.metric_config)
 
-        # Scope-first defaults when group_by is omitted
+        # Scope-first defaults when user group_by is omitted
         if not group_by_list:
             if params.aggregation_level == AggregationLevel.MACHINE:
-                return "ip"
-            if params.aggregation_level == AggregationLevel.INSTANCE:
-                return "ip,instance_port"
-            return "cluster_domain"
+                dimensions = ["ip"]
+            elif params.aggregation_level == AggregationLevel.INSTANCE:
+                dimensions = ["ip", "instance_port"]
+            else:
+                dimensions = ["cluster_domain"]
+        else:
+            # Start with cluster_domain for explicit group_by behavior
+            dimensions = ["cluster_domain"]
 
-        # Start with cluster_domain for explicit group_by behavior
-        dimensions = ["cluster_domain"]
+            # Validate and add each (structural) group_by dimension
+            for group_by in group_by_list:
+                group_by_value = group_by.value
 
-        # Validate and add each group_by dimension
-        for group_by in group_by_list:
-            group_by_value = group_by.value
+                # Validate against supported options (direct enum comparison)
+                if group_by not in supported_group_by:
+                    supported_values = [g.value for g in supported_group_by]
+                    raise ValueError(
+                        f"group_by '{group_by_value}' not supported for this metric. "
+                        f"Supported options: {supported_values}"
+                    )
 
-            # Validate against supported options (direct enum comparison)
-            if group_by not in supported_group_by:
-                supported_values = [g.value for g in supported_group_by]
-                raise ValueError(
-                    f"group_by '{group_by_value}' not supported for this metric. "
-                    f"Supported options: {supported_values}"
-                )
+                # Map enum to actual dimension name and add if not already present
+                if group_by == MetricsGroupBy.IP:
+                    if "ip" not in dimensions:
+                        dimensions.append("ip")
+                elif group_by == MetricsGroupBy.INSTANCE:
+                    if "ip" not in dimensions or "instance_port" not in dimensions:
+                        to_move = ["ip", "instance_port"]
+                        dimensions = [d for d in dimensions if d not in to_move] + to_move
+                elif group_by == MetricsGroupBy.CLUSTER_DOMAIN:
+                    # cluster_domain is already in dimensions, skip
+                    pass
 
-            # Map enum to actual dimension name and add if not already present
-            if group_by == MetricsGroupBy.IP:
-                if "ip" not in dimensions:
-                    dimensions.append("ip")
-            elif group_by == MetricsGroupBy.INSTANCE:
-                if "ip" not in dimensions or "instance_port" not in dimensions:
-                    to_move = ["ip", "instance_port"]
-                    dimensions = [d for d in dimensions if d not in to_move] + to_move
-            elif group_by == MetricsGroupBy.CMD:
-                if "cmd" not in dimensions:
-                    dimensions.append("cmd")
-            elif group_by == MetricsGroupBy.BUCKET:
-                if "bucket_label" not in dimensions:
-                    dimensions.append("bucket_label")
-            elif group_by == MetricsGroupBy.CLUSTER_DOMAIN:
-                # cluster_domain is already in dimensions, skip
-                pass
+        # Append NATURAL_LABEL intrinsic dims (e.g. cmd) regardless of user group_by
+        for label in natural_intrinsic_labels:
+            if label not in dimensions:
+                dimensions.append(label)
 
         return ",".join(dimensions)
-
-    def _parse_query_type(self, query_type: str) -> Optional[AggFunction]:
-        try:
-            return AggFunction(query_type)
-        except (ValueError, KeyError):
-            return None
 
     def _prepare_query_context(
         self, params: MetricsQueryParams
@@ -301,27 +328,7 @@ class RedisMetricsQueryService:
                 # First bucket: just use upper (no subtraction needed)
                 inner_promql = upper_inner
 
-            # Generate stats queries if needed
-            if params.need_stats and stats_aggs:
-                for stat_agg in stats_aggs:
-                    # Wrap inner query with stats aggregation
-                    outer_promql = f"{stat_agg.value} by ({outer_dims}) ({inner_promql})"
-
-                    # Add label_replace to mark this as a bucket query with stat type
-                    outer_promql = f'label_replace({outer_promql}, "bucket_label", "{bucket_label}", "", "")'
-                    outer_promql = f'label_replace({outer_promql}, "query_type", "{stat_agg.value}", "", "")'
-
-                    query_configs.append(
-                        {
-                            "data_source_label": "prometheus",
-                            "data_type_label": "time_series",
-                            "promql": outer_promql,
-                            "interval": params.time_window,
-                            "alias": f"{bucket_label}_{stat_agg.value}",
-                        }
-                    )
-
-            # Bucket type needs to calculate stats from overall series
+            # Overall bucket time series; timeline stats are derived from it later
             outer_promql = f"{overall_agg.value} by ({outer_dims}) ({inner_promql})"
             outer_promql = f'label_replace({outer_promql}, "bucket_label", "{bucket_label}", "", "")'
             outer_promql = f'label_replace({outer_promql}, "query_type", "overall", "", "")'
@@ -343,6 +350,14 @@ class RedisMetricsQueryService:
 
         Capacity metrics produce 3 sub-metric series, each labeled with a capacity_type
         dimension (used/total/available). Available is computed as total - used in PromQL.
+
+        Memory capacity is per-instance, so the inner query sums each instance's bytes. Disk capacity
+        is a filesystem-level metric (df of the data-dir mount): co-located instances report identical
+        values, so when ``capacity_dedup`` is configured the inner query collapses each physical disk
+        once (max by cluster_domain,ip,mount_point). The outer query then respects user ``group_by``:
+        cluster scope sums across hosts per mount_point (keys like used@/data); ip scope keeps per-host
+        keys (used@<ip>@/data). Without dedup, summing per instance_port would multiply a shared disk
+        by the number of instances on it.
         """
         inner_dims, outer_dims, filters_str, overall_agg, stats_aggs = self._prepare_query_context(params)
 
@@ -357,8 +372,19 @@ class RedisMetricsQueryService:
         used_base = used_template.format(filters=filters_str)
         total_base = total_template.format(filters=filters_str)
 
-        used_inner = f"{overall_agg.value} by ({inner_dims}) ({used_base})"
-        total_inner = f"{overall_agg.value} by ({inner_dims}) ({total_base})"
+        dedup = params.metric_config.get("capacity_dedup")
+        if dedup:
+            inner_agg = dedup.get("agg", AggFunction.MAX)
+            dedup_dims = ",".join(dedup.get("by", ["cluster_domain", "ip", "mount_point"]))
+            used_inner = f"{inner_agg.value} by ({dedup_dims}) ({used_base})"
+            total_inner = f"{inner_agg.value} by ({dedup_dims}) ({total_base})"
+            # Disk df is host-level; instance_port is not meaningful for outer aggregation.
+            if "instance_port" in outer_dims.split(","):
+                outer_dims = ",".join(dim for dim in outer_dims.split(",") if dim != "instance_port")
+        else:
+            used_inner = f"{overall_agg.value} by ({inner_dims}) ({used_base})"
+            total_inner = f"{overall_agg.value} by ({inner_dims}) ({total_base})"
+
         avail_inner = f"clamp_min(({total_inner}) - ({used_inner}), 0)"
 
         sub_metric_queries = {
@@ -370,34 +396,19 @@ class RedisMetricsQueryService:
         query_configs = []
 
         for cap_type, inner_promql in sub_metric_queries.items():
-            if params.need_stats and stats_aggs:
-                for stat_agg in stats_aggs:
-                    outer_promql = f"{stat_agg.value} by ({outer_dims}) ({inner_promql})"
-                    outer_promql = f'label_replace({outer_promql}, "capacity_type", "{cap_type}", "", "")'
-                    outer_promql = f'label_replace({outer_promql}, "query_type", "{stat_agg.value}", "", "")'
-                    query_configs.append(
-                        {
-                            "data_source_label": "prometheus",
-                            "data_type_label": "time_series",
-                            "promql": outer_promql,
-                            "interval": params.time_window,
-                            "alias": f"{cap_type}_{stat_agg.value}",
-                        }
-                    )
-
-            if params.need_overall:
-                outer_promql = f"{overall_agg.value} by ({outer_dims}) ({inner_promql})"
-                outer_promql = f'label_replace({outer_promql}, "capacity_type", "{cap_type}", "", "")'
-                outer_promql = f'label_replace({outer_promql}, "query_type", "overall", "", "")'
-                query_configs.append(
-                    {
-                        "data_source_label": "prometheus",
-                        "data_type_label": "time_series",
-                        "promql": outer_promql,
-                        "interval": params.time_window,
-                        "alias": cap_type,
-                    }
-                )
+            # Overall capacity time series per sub-type; timeline stats are derived from it later
+            outer_promql = f"{overall_agg.value} by ({outer_dims}) ({inner_promql})"
+            outer_promql = f'label_replace({outer_promql}, "capacity_type", "{cap_type}", "", "")'
+            outer_promql = f'label_replace({outer_promql}, "query_type", "overall", "", "")'
+            query_configs.append(
+                {
+                    "data_source_label": "prometheus",
+                    "data_type_label": "time_series",
+                    "promql": outer_promql,
+                    "interval": params.time_window,
+                    "alias": cap_type,
+                }
+            )
 
         return query_configs, None
 
@@ -476,38 +487,18 @@ class RedisMetricsQueryService:
                 time_window=params.time_window,
             )
 
-        # Step 5: Build outer aggregation queries (wrap inner query)
-        # For stats mode: wrap inner query with stats aggregation functions
-        if params.need_stats and stats_aggs:
-            for stat_agg in stats_aggs:
-                # Outer aggregation: stats_agg by (outer_dims) (inner_query)
-                outer_promql = f"{stat_agg.value} by ({outer_dims}) ({inner_promql})"
-                outer_promql = f'label_replace({outer_promql}, "query_type", "{stat_agg.value}", "", "")'
-
-                query_configs.append(
-                    {
-                        "data_source_label": "prometheus",
-                        "data_type_label": "time_series",
-                        "promql": outer_promql,
-                        "interval": params.time_window,
-                        "alias": stat_agg.value,
-                    }
-                )
-
-        # Step 6: Build queries for overall mode (if needed)
-        if params.need_overall:
-            # Outer aggregation: overall_agg by (outer_dims) (inner_query)
-            outer_promql = f"{overall_agg.value} by ({outer_dims}) ({inner_promql})"
-            outer_promql = f'label_replace({outer_promql}, "query_type", "overall", "", "")'
-            query_configs.append(
-                {
-                    "data_source_label": "prometheus",
-                    "data_type_label": "time_series",
-                    "promql": outer_promql,
-                    "interval": params.time_window,
-                    "alias": "overall",
-                }
-            )
+        # Step 5: Build the overall time-series query (timeline stats are derived from it later)
+        outer_promql = f"{overall_agg.value} by ({outer_dims}) ({inner_promql})"
+        outer_promql = f'label_replace({outer_promql}, "query_type", "overall", "", "")'
+        query_configs.append(
+            {
+                "data_source_label": "prometheus",
+                "data_type_label": "time_series",
+                "promql": outer_promql,
+                "interval": params.time_window,
+                "alias": "overall",
+            }
+        )
 
         return query_configs, None
 
@@ -757,64 +748,62 @@ class RedisMetricsQueryService:
         return datapoints
 
     @staticmethod
-    def _build_stats_key(dimensions: dict, cluster_domain: str, aggregation_level: AggregationLevel) -> str:
+    def _build_series_key(
+        dimensions: dict,
+        cluster_domain: str,
+        aggregation_level: AggregationLevel,
+        intrinsic_dims: list,
+    ) -> str:
         """
-        Build a key for storing statistics series based on dimensions.
+        Build a result-series key from intrinsic breakdown values plus the scope identifier.
 
-        Iterates over all dimensions and builds key by joining them in priority order.
-        Priority order: bucket_label > cmd > ip:port/ip > other dimensions > cluster_domain (fallback)
+        Intrinsic dimension values and the scope identifier (ip:port / ip) are ordered together by
+        key_order (the scope is inserted at SCOPE_KEY_ORDER) and joined with "@". So dims ordered
+        before the scope lead the key (capacity_type, bucket, cmd) and dims ordered after it trail
+        the scope (mount_point). Falls back to the scope key when nothing else applies.
 
         Args:
-            dimensions: Series dimensions dict containing ip, port, cmd, bucket_label, etc.
-            cluster_domain: Cluster domain name
+            dimensions: Series dimensions dict (ip, instance_port, cmd, bucket_label, capacity_type, ...)
+            cluster_domain: Cluster domain name (fallback key)
+            aggregation_level: The level of aggregation being performed
+            intrinsic_dims: The metric's IntrinsicDimension objects (carry promql_label + key_order)
 
         Returns:
-            Key string for organizing stats series (e.g., "ip:port", "cmd", "cmd@ip:port")
+            Key string, e.g. "GET", "(4ms,8ms]@1.1.1.1:30000", "used", "used@1.1.1.1@/data1".
         """
-        # Define dimension priority order and excluded dimensions
-        dimension_priority = ["bucket_label", "cmd"]
-        excluded = {"cluster_domain", "ip", "instance_port", "query_type"}
+        ordered = []  # (key_order, value)
 
-        key_parts = []
+        for dim in intrinsic_dims:
+            value = dimensions.get(dim.promql_label)
+            if value:
+                ordered.append((dim.key_order, value))
 
-        # Process priority dimensions first
-        for dim_name in dimension_priority:
-            if dim_name in dimensions and dimensions[dim_name]:
-                key_parts.append(dimensions[dim_name])
-
-        # Handle ip:port combination (special case - combine ip and port)
-        ip = dimensions.get("ip")
-        port = dimensions.get("instance_port")
-        instance = dimensions.get("instance")
-        if instance and (not ip or not port) and ":" in instance:
-            parsed_ip, parsed_port = instance.rsplit(":", 1)
-            ip = ip or parsed_ip
-            port = port or parsed_port
+        # Scope identifier (ip:port / ip) — only present when outer PromQL retains ip (user group_by).
+        _, ip, port = RedisMetricsQueryService._extract_scope_dimensions(dimensions)
+        port = dimensions.get("port") or port
+        scope_val = None
         if aggregation_level == AggregationLevel.CLUSTER:
             if ip and port:
-                key_parts.append(f"{ip}:{port}")
+                scope_val = f"{ip}:{port}"
             elif ip:
-                key_parts.append(ip)
+                scope_val = ip
         elif aggregation_level == AggregationLevel.MACHINE and ip and port:
-            key_parts.append(f"{ip}:{port}")
+            scope_val = f"{ip}:{port}"
+        if scope_val is not None:
+            ordered.append((SCOPE_KEY_ORDER, scope_val))
 
-        # Process remaining dimensions (excluding already processed and excluded ones)
-        for dim_name, dim_value in dimensions.items():
-            if dim_name not in excluded and dim_name not in dimension_priority and dim_value:
-                key_parts.append(dim_value)
+        if ordered:
+            ordered.sort(key=lambda item: item[0])
+            return "@".join(value for _, value in ordered)
 
-        # Fallback to scope key if no other dimensions
-        if not key_parts:
-            if aggregation_level == AggregationLevel.MACHINE:
-                return dimensions.get("ip") or cluster_domain
-            if aggregation_level == AggregationLevel.INSTANCE:
-                if dimensions.get("ip") and dimensions.get("instance_port"):
-                    return f'{dimensions["ip"]}:{dimensions["instance_port"]}'
-                return dimensions.get("ip") or cluster_domain
-            return cluster_domain
-
-        # Join parts with "@" separator
-        return "@".join(key_parts)
+        # Fallback to scope key when no breakdown/scope parts were produced
+        if aggregation_level == AggregationLevel.MACHINE:
+            return ip or cluster_domain
+        if aggregation_level == AggregationLevel.INSTANCE:
+            if ip and port:
+                return f"{ip}:{port}"
+            return ip or cluster_domain
+        return cluster_domain
 
     @staticmethod
     def _extract_scope_dimensions(dimensions: dict) -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -834,23 +823,25 @@ class RedisMetricsQueryService:
     def _parse_response(
         self,
         response: dict,
+        metric_config: dict,
         aggregation_level: AggregationLevel = AggregationLevel.CLUSTER,
     ) -> Dict[str, MetricSeries]:
         """
         Parse the unify_query response into MetricSeries per cluster.
 
-        The API returns series with a "query_type" dimension (injected via label_replace).
-        We use this to determine what type of statistic each series represents.
-        Query types are parsed to AggFunction enum values and used as dictionary keys in stats_series_by_key.
+        All queries are "overall" time series (timeline stats are computed afterwards from
+        raw_series). Series are keyed by intrinsic breakdown values (cmd / bucket / capacity_type)
+        plus the scope identifier, composed via ``_build_series_key``.
 
         Args:
             response: Response from BKMonitor unify_query API
+            metric_config: Metric configuration dict (provides intrinsic_dimensions for key composition)
             aggregation_level: The level of aggregation being performed
 
         Returns:
             Dict mapping entity key to MetricSeries
-            Note: stats_series_by_key uses AggFunction enum values as keys (e.g., AggFunction.MIN, AggFunction.MAX)
         """
+        intrinsic_dims = self._intrinsic_dimensions(metric_config)
         series_by_cluster = defaultdict(lambda: MetricSeries(aggregation_level=aggregation_level))
         series_list = response.get("series", [])
 
@@ -867,67 +858,24 @@ class RedisMetricsQueryService:
 
             self.normalize_timestamps(datapoints)
 
-            # Get query_type from dimensions (injected via label_replace)
+            # Get query_type from dimensions (injected via label_replace); only "overall" is expected
             query_type_str = dimensions.get("query_type")
 
             if not query_type_str:
                 logger.warning(f"No query_type in dimensions: {dimensions}")
                 continue
 
-            # Parse query_type to enum (for stats aggregations) or keep as string (for "overall")
-            query_type_enum = self._parse_query_type(query_type_str)
+            if query_type_str != "overall":
+                logger.warning(f"Unexpected query_type (timeline-only stats): {query_type_str}")
+                continue
 
-            # Handle statistical aggregations (min, max, avg, stddev)
-            # Store datapoints only - scalar calculation will be done in _calculate_stats
-            if query_type_enum is not None:
-                # Skip if no valid datapoints
-                if not datapoints or not any(point[0] is not None for point in datapoints):
-                    continue
+            if series_by_cluster[entity_key].raw_series is None:
+                series_by_cluster[entity_key].raw_series = {}
 
-                # Initialize stats_series_by_key if needed
-                if series_by_cluster[entity_key].stats_series_by_key is None:
-                    series_by_cluster[entity_key].stats_series_by_key = {}
-
-                # Build key for this stats series
-                key_value = self._build_stats_key(dimensions, cluster_domain or "unknown", aggregation_level)
-
-                # Initialize dict for this key if not exists
-                if key_value not in series_by_cluster[entity_key].stats_series_by_key:
-                    series_by_cluster[entity_key].stats_series_by_key[key_value] = {}
-
-                # Store the datapoints for this query_type (use enum as key)
-                series_by_cluster[entity_key].stats_series_by_key[key_value][query_type_enum] = datapoints
-
-            elif query_type_str == "overall":
-                # Build key based on aggregation level and available dimensions
-                if not series_by_cluster[entity_key].raw_series:
-                    series_by_cluster[entity_key].raw_series = {}
-
-                # Check if this is a latency distribution bucket (has bucket_label)
-                bucket_label = dimensions.get("bucket_label")
-                if bucket_label:
-                    _, ip, port = self._extract_scope_dimensions(dimensions)
-                    port = dimensions.get("port") or port
-                    cmd = dimensions.get("cmd")
-
-                    parts = [bucket_label]
-                    if cmd:
-                        parts.append(cmd)
-                    if aggregation_level == AggregationLevel.CLUSTER:
-                        if ip and port:
-                            parts.append(f"{ip}:{port}")
-                        elif ip:
-                            parts.append(ip)
-                    elif aggregation_level == AggregationLevel.MACHINE and ip and port:
-                        parts.append(f"{ip}:{port}")
-                    key_value = "@".join(parts)
-                else:
-                    # Use the same key-building logic as stats series
-                    key_value = self._build_stats_key(dimensions, cluster_domain or "unknown", aggregation_level)
-
-                series_by_cluster[entity_key].raw_series[key_value] = datapoints
-            else:
-                logger.warning(f"Unknown query_type: {query_type_str}")
+            key_value = self._build_series_key(
+                dimensions, cluster_domain or "unknown", aggregation_level, intrinsic_dims
+            )
+            series_by_cluster[entity_key].raw_series[key_value] = datapoints
 
         return dict(series_by_cluster)
 
@@ -953,75 +901,30 @@ class RedisMetricsQueryService:
         stats["cv"] = (stddev / stats["avg"]) * 100 if stats["avg"] != 0 else 0.0
         return stats
 
-    def _compute_stats_from_agg_series(
-        self,
-        stats_series_dict: dict,
-        interval_sec: Optional[int] = None,
-        trend_unit: str = "",
-    ) -> dict:
-        """
-        Compute stats dict from stats_series_by_key entry (MIN/MAX/AVG/STDDEV series).
-        Returns dict with min, max, avg, median, p95, trend, trend_unit, cv (stddev dropped).
-        """
-        stats = {}
-        if AggFunction.MIN in stats_series_dict:
-            min_values = [p[0] for p in stats_series_dict[AggFunction.MIN] if p[0] is not None]
-            if min_values:
-                stats["min"] = min(min_values)
-        if AggFunction.MAX in stats_series_dict:
-            max_values = [p[0] for p in stats_series_dict[AggFunction.MAX] if p[0] is not None]
-            if max_values:
-                stats["max"] = max(max_values)
-                stats["latest"] = max_values[-1]
-        if AggFunction.AVG in stats_series_dict:
-            avg_values = [p[0] for p in stats_series_dict[AggFunction.AVG] if p[0] is not None]
-            if avg_values:
-                stats["avg"] = sum(avg_values) / len(avg_values)
-                stats["median"] = self._calculate_median(avg_values)
-                stats["p95"] = self._calculate_p95(avg_values)
-                stats["trend"] = self._calculate_trend(avg_values, interval_sec=interval_sec)
-                if trend_unit:
-                    stats["trend_unit"] = trend_unit
-        if AggFunction.STDDEV in stats_series_dict:
-            stddev_values = [p[0] for p in stats_series_dict[AggFunction.STDDEV] if p[0] is not None]
-            if stddev_values:
-                stats["stddev"] = max(stddev_values)
-        if "avg" in stats:
-            stats["cv"] = (stats["stddev"] / stats["avg"]) * 100 if stats.get("stddev") and stats["avg"] != 0 else 0.0
-        stats.pop("stddev", None)
-        return stats
-
     def _calculate_stats(
         self,
         metric_series: MetricSeries,
         metric_config: dict,
         time_window: int = 60,
         metric_key: Optional[str] = None,
-        vertical_stats: bool = False,
     ) -> None:
         """
-        Calculate scalar statistics from parsed time series data.
+        Calculate scalar timeline statistics from the parsed raw time series.
 
-        For bucket metrics or vertical_stats: Calculates stats from raw_series (temporal stats).
-        For simple metrics (horizontal): Calculates stats from stats_series_by_key (cross-instance stats).
+        Stats (min/max/avg/median/p95/cv/trend/latest) are always computed over each
+        series' timeline (per intrinsic/scope key in raw_series).
 
         Args:
             metric_series: MetricSeries object with parsed datapoints
-                Note: stats_series_by_key uses AggFunction enum values as keys (e.g., AggFunction.MIN, AggFunction.MAX)
-            metric_config: Metric configuration dict from METRIC_REGISTRY
+            metric_config: Metric configuration dict from METRIC_REGISTRY (reserved for future use)
             time_window: Time between consecutive data points (seconds), used to normalize trend to per-minute
             metric_key: Key from METRIC_REGISTRY, used to resolve trend_unit for output
-            vertical_stats: When True, compute temporal stats from the aggregated raw_series
         """
         if metric_series.statistics is None:
             metric_series.statistics = {}
 
         trend_unit = TREND_UNIT_BY_METRIC_KEY.get(metric_key, "") if metric_key else ""
-
-        if "buckets" in metric_config or vertical_stats:
-            self._calculate_stats_from_raw_series(metric_series, interval_sec=time_window, trend_unit=trend_unit)
-        else:
-            self._calculate_stats_for_simple_metric(metric_series, interval_sec=time_window, trend_unit=trend_unit)
+        self._calculate_stats_from_raw_series(metric_series, interval_sec=time_window, trend_unit=trend_unit)
 
     def _calculate_stats_from_raw_series(
         self,
@@ -1029,7 +932,7 @@ class RedisMetricsQueryService:
         interval_sec: Optional[int] = None,
         trend_unit: str = "",
     ) -> None:
-        """Calculate stats from raw_series (used for bucket metrics and vertical stats)."""
+        """Calculate timeline stats for each series in raw_series."""
         if not metric_series.raw_series:
             return
         for key_value, datapoints in metric_series.raw_series.items():
@@ -1040,35 +943,16 @@ class RedisMetricsQueryService:
                 values, interval_sec=interval_sec, trend_unit=trend_unit
             )
 
-    def _calculate_stats_for_simple_metric(
-        self,
-        metric_series: MetricSeries,
-        interval_sec: Optional[int] = None,
-        trend_unit: str = "",
-    ) -> None:
-        """Calculate stats from stats_series_by_key for simple metrics."""
-        if not metric_series.stats_series_by_key:
-            return
-        for key_value, stats_series_dict in metric_series.stats_series_by_key.items():
-            stats = self._compute_stats_from_agg_series(
-                stats_series_dict, interval_sec=interval_sec, trend_unit=trend_unit
-            )
-            if stats:
-                metric_series.statistics[key_value] = stats
-
     def _query_metrics_single_type(
         self,
         clusters: List[Cluster],
         metric_type: MetricType,
         time_range: Tuple[int, int],
-        need_stats: bool,
-        need_overall: bool,
         time_window: int = 60,
         instance_role: InstanceRole = InstanceRole.MASTER,
         ip_filters: Optional[List[str]] = None,
         instance_filters: Optional[List[InstanceFilter]] = None,
         group_by: Optional[List[MetricsGroupBy]] = None,
-        vertical_stats: bool = False,
     ) -> Tuple[Optional[Dict[str, MetricSeries]], Optional[dict]]:
         if not clusters:
             logger.error("No clusters provided for metrics query")
@@ -1085,10 +969,8 @@ class RedisMetricsQueryService:
         if group_by is None:
             group_by = []
 
-        # Auto-inject CMD dimension for command_latency so users see per-command results by default
-        if metric_type == MetricType.COMMAND_LATENCY:
-            if MetricsGroupBy.CMD not in group_by:
-                group_by = list(group_by) + [MetricsGroupBy.CMD]
+        # Per-metric breakdowns (e.g. cmd) are applied automatically as intrinsic dimensions
+        # during query construction; no need to inject them into the user-facing group_by here.
 
         # Resolve metric key from registry
         metric_key = resolve_metric_key(cluster.cluster_type, metric_type, instance_role)
@@ -1114,8 +996,6 @@ class RedisMetricsQueryService:
             instance_role=instance_role,
             ip_filters=ip_filters,
             instance_filters=instance_filters,
-            need_stats=need_stats,
-            need_overall=need_overall,
             group_by=group_by,
         )
 
@@ -1142,8 +1022,6 @@ class RedisMetricsQueryService:
                     instance_role=query_params.instance_role,
                     ip_filters=None,
                     instance_filters=[pair],
-                    need_stats=query_params.need_stats,
-                    need_overall=query_params.need_overall,
                     group_by=query_params.group_by,
                 )
                 pair_query_configs, _ = self._build_queries(pair_query_params)
@@ -1191,13 +1069,11 @@ class RedisMetricsQueryService:
         if not response.get("series"):
             return None, empty_series_error
 
-        series_by_cluster = self._parse_response(response, aggregation_level)
+        series_by_cluster = self._parse_response(response, metric_config, aggregation_level)
         if not series_by_cluster:
             return None, empty_series_error
         for series in series_by_cluster.values():
-            self._calculate_stats(
-                series, metric_config, time_window=time_window, metric_key=metric_key, vertical_stats=vertical_stats
-            )
+            self._calculate_stats(series, metric_config, time_window=time_window, metric_key=metric_key)
 
         return series_by_cluster, None
 
@@ -1206,31 +1082,28 @@ class RedisMetricsQueryService:
         clusters: List[Cluster],
         metric_type: MetricType,
         time_range: Tuple[int, int],
-        need_stats: bool,
-        need_overall: bool,
         time_window: int = 60,
         instance_role: InstanceRole = InstanceRole.MASTER,
         ip_filters: Optional[List[str]] = None,
         instance_filters: Optional[List[InstanceFilter]] = None,
         group_by: Optional[List[MetricsGroupBy]] = None,
-        vertical_stats: bool = False,
     ) -> Tuple[Dict[str, MetricSeries], List[dict]]:
         """
         Query metrics for one or more clusters, with optional filtering by machine/instance.
+
+        Builds the overall time series and computes timeline statistics from it. Metric-specific
+        breakdowns (e.g. cmd, latency bucket, capacity sub-type) are applied automatically as
+        intrinsic dimensions and are not part of the user-facing group_by.
 
         Args:
             clusters: Cluster objects
             metric_type: Type of metric (MetricType enum)
             time_range: Tuple of (start_time, end_time) in Unix timestamp
-            need_stats: Whether to include statistical queries (min/max/avg/stddev)
-            need_overall: Whether to include overall time series queries
             time_window: Time window in seconds
             instance_role: Role of instances to query (InstanceRole enum)
             ip_filters: Optional IP filters
             instance_filters: Optional ip:port pair filters
-            group_by: Optional list of dimensions for grouping results (e.g., [cluster_domain, ip], [instance]).
-                Note: For COMMAND_LATENCY, CMD is always auto-injected regardless of group_by value.
-            vertical_stats: When True, compute temporal stats from the aggregated raw_series
+            group_by: Optional structural grouping dimensions (e.g. [cluster_domain, ip], [instance]).
 
         Returns:
             Tuple of (merged MetricSeries dict, partial errors)
@@ -1260,14 +1133,11 @@ class RedisMetricsQueryService:
                     clusters=type_clusters,
                     metric_type=metric_type,
                     time_range=time_range,
-                    need_stats=need_stats,
-                    need_overall=need_overall,
                     time_window=time_window,
                     instance_role=instance_role,
                     ip_filters=ip_filters,
                     instance_filters=instance_filters,
                     group_by=group_by,
-                    vertical_stats=vertical_stats,
                 )
                 if batch_result is not None:
                     break

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/utils.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/utils.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 import logging
 import math
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Optional, Tuple
 
 from backend.db_services.redis.util import (
     is_predixy_proxy_type,
@@ -82,132 +82,6 @@ def resolve_metric_key(
         return None
 
     return metric_key
-
-
-def generate_mermaid_line_chart(
-    title: str,
-    series_data: Dict[str, List[List[float]]],
-    y_label: str,
-    y_min: Optional[float] = None,
-    y_max: Optional[float] = None,
-) -> str:
-    """
-    Generate mermaid xychart-beta line chart from time series data.
-    Supports multiple series - each key in series_data becomes a separate line.
-
-    Args:
-        title: Chart title (e.g., "cluster.example.com CPU Usage")
-        series_data: Dict with one or more keys, each containing [[value, timestamp], ...] data
-                     Example: {"<ip>": [[50, 1706515200000], ...], "<ip>": [[45, 1706515200000], ...]}
-        y_label: Y-axis label (e.g., "%CPU", "Memory %", "Connections")
-        y_min: Optional minimum y-axis value (auto-calculated if None)
-        y_max: Optional maximum y-axis value (auto-calculated if None)
-
-    Returns:
-        Formatted mermaid chart code ready to render
-    """
-    if not series_data:
-        return ""
-
-    # Collect all values and timestamps from all series
-    all_values = []
-    all_timestamps_set = set()
-    series_by_key = {}
-
-    for key, datapoints in series_data.items():
-        if not datapoints:
-            continue
-
-        values = [point[0] for point in datapoints]
-        timestamps = [point[1] for point in datapoints]
-
-        all_values.extend(values)
-        all_timestamps_set.update(timestamps)
-        series_by_key[key] = {"values": values, "timestamps": timestamps}
-
-    if not all_values or not all_timestamps_set:
-        return ""
-
-    # Use timestamps from first series for x-axis (assuming all series share same timestamps)
-    first_key = list(series_by_key.keys())[0]
-    reference_timestamps = series_by_key[first_key]["timestamps"]
-
-    # Format timestamps based on time range
-    time_range_hours = (reference_timestamps[-1] - reference_timestamps[0]) / 3600
-    x_labels = _format_timestamps(reference_timestamps, time_range_hours)
-
-    # Auto-calculate y-axis range if not provided
-    if y_min is None:
-        y_min = max(0, min(all_values) * 0.9)  # 10% padding below
-    if y_max is None:
-        y_max = max(all_values) * 1.1  # 10% padding above
-
-    # Build mermaid code
-    x_labels_string = ", ".join(f'"{label}"' for label in x_labels)
-    mermaid_lines = [
-        "```mermaid",
-        "---",
-        "config:",
-        "  xyChart:",
-        "    width: 1000",
-        "    height: 700",
-        "  themeVariables:",
-        "    xyChart:",
-        '      plotColorPalette: "#FF0000, #0000FF, #00FF00, #FFA500, #FF00FF, #00FFFF, #FFA07A, #98FB98"',
-        "---",
-        "xychart-beta",
-        f'    title "{title}"',
-        f"    x-axis [{x_labels_string}]",
-        f'    y-axis "{y_label}" {y_min:.0f} --> {y_max:.0f}',
-    ]
-
-    # Add a line for each series
-    for key, data in series_by_key.items():
-        formatted_values = [f"{v:.2f}" for v in data["values"]]
-        mermaid_lines.append(f'    line "{key}" [{", ".join(formatted_values)}]')
-
-    mermaid_lines.append("```")
-
-    return "\n".join(mermaid_lines)
-
-
-def _format_timestamps(timestamps: List[int], time_range_hours: float) -> List[str]:
-    """Format Unix timestamps for chart x-axis labels"""
-    if not timestamps:
-        return []
-    datetimes = [datetime.fromtimestamp(ts) for ts in timestamps]
-
-    # Strategy 1: Try HH:MM format
-    hhmm_labels = [dt.strftime("%H:%M") for dt in datetimes]
-    if len(hhmm_labels) == len(set(hhmm_labels)):
-        # No duplicates - use compact HH:MM format
-        return hhmm_labels
-
-    # Strategy 2: Mark day boundaries
-    dates = [dt.date() for dt in datetimes]
-    unique_dates = set(dates)
-
-    if len(unique_dates) == 1:
-        # Single day with duplicate times (shouldn't happen, but fallback)
-        return hhmm_labels
-
-    # Strategy 3: Multiple days - mark first occurrence of each new day
-    result = []
-    prev_date = None
-
-    for dt in datetimes:
-        current_date = dt.date()
-
-        if prev_date is None or current_date == prev_date:
-            # Same day - use HH:MM
-            result.append(dt.strftime("%H:%M"))
-        else:
-            # New day - use MM-DD HH:MM for first timestamp of new day
-            result.append(dt.strftime("%m-%d %H:%M"))
-
-        prev_date = current_date
-
-    return result
 
 
 def calculate_time_range_window(

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/views/metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/views/metrics.py
@@ -21,7 +21,7 @@ from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import (
 )
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
 from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
-from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, MetricsInstanceRole, MetricsStatsType, MetricType
+from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy, MetricsInstanceRole, MetricType
 from backend.dbm_aiagent.mcp_tools.redis.impl.redis_metrics import (
     query_redis_metrics_series,
     query_redis_metrics_stats,
@@ -78,7 +78,6 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             metric_type=MetricType(self.get_param("metric_type")),
             time_range=time_range,
             time_window=time_window,
-            mermaid_format=self.get_param("mermaid_format", False),
             group_by=self._parse_group_by(),
             include_meta=self.get_param("include_meta", False),
         )
@@ -99,7 +98,6 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             time_range=time_range,
             time_window=time_window,
             group_by=self._parse_group_by(),
-            stats_type=MetricsStatsType(self.get_param("stats_type", MetricsStatsType.VERTICAL.value)),
             include_meta=self.get_param("include_meta", False),
         )
         if partial_errors:
@@ -115,8 +113,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query time-series metrics for Redis cluster PROXY nodes. "
             "Applicable metrics: cpu_usage, memory_usage, io_usage, disk_usage, connections, qps, "
             "host_latency, command_latency, latency_distribution (not capacity). "
-            "group_by: ip, instance, bucket, cluster_domain. "
-            "Keep max_len_datapoints<=15 to avoid context length issues; mermaid_code output AS-IS."
+            "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic). "
+            "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
         request_slz=RedisClusterProxySeriesInputSerializer,
         response_slz=RedisMetricsSeriesOutputSerializer,
@@ -144,7 +142,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query scalar statistics (min/max/avg/p95/cv/trend) for Redis cluster PROXY nodes. "
             "Applicable metrics: cpu_usage, memory_usage, io_usage, disk_usage, connections, qps, "
             "host_latency, command_latency, latency_distribution (not capacity). "
-            "group_by: ip, instance, bucket, cluster_domain."
+            "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisClusterProxyStatsInputSerializer,
         response_slz=RedisMetricsStatsOutputSerializer,
@@ -177,8 +175,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query time-series metrics for Redis cluster MASTER nodes. "
             "Applicable metrics: cpu_usage, memory_usage, io_usage, disk_usage, connections, qps, "
             "host_latency, command_latency, capacity (not latency_distribution). "
-            "group_by: ip, instance, bucket, cluster_domain. "
-            "Keep max_len_datapoints<=15 to avoid context length issues; mermaid_code output AS-IS."
+            "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic). "
+            "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
         request_slz=RedisClusterBackendSeriesInputSerializer,
         response_slz=RedisMetricsSeriesOutputSerializer,
@@ -206,7 +204,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query scalar statistics (min/max/avg/p95/cv/trend) for Redis cluster MASTER nodes. "
             "Applicable metrics: cpu_usage, memory_usage, io_usage, disk_usage, connections, qps, "
             "host_latency, command_latency, capacity (not latency_distribution). "
-            "group_by: ip, instance, bucket, cluster_domain."
+            "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisClusterBackendStatsInputSerializer,
         response_slz=RedisMetricsStatsOutputSerializer,
@@ -239,8 +237,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query time-series metrics for Redis cluster SLAVE nodes. "
             "Applicable metrics: cpu_usage, memory_usage, io_usage, disk_usage, connections, qps, "
             "host_latency, command_latency, capacity (not latency_distribution). "
-            "group_by: ip, instance, bucket, cluster_domain. "
-            "Keep max_len_datapoints<=15 to avoid context length issues; mermaid_code output AS-IS."
+            "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic). "
+            "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
         request_slz=RedisClusterBackendSeriesInputSerializer,
         response_slz=RedisMetricsSeriesOutputSerializer,
@@ -268,7 +266,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query scalar statistics (min/max/avg/p95/cv/trend) for Redis cluster SLAVE nodes. "
             "Applicable metrics: cpu_usage, memory_usage, io_usage, disk_usage, connections, qps, "
             "host_latency, command_latency, capacity (not latency_distribution). "
-            "group_by: ip, instance, bucket, cluster_domain."
+            "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisClusterBackendStatsInputSerializer,
         response_slz=RedisMetricsStatsOutputSerializer,
@@ -301,8 +299,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query time-series metrics for a specific machine (by IP). "
             "Cluster and instance role are auto-resolved. "
             "All metric types are accepted; latency_distribution is proxy-only, capacity is backend-only. "
-            "group_by: ip, instance, bucket (not cluster_domain). "
-            "Keep max_len_datapoints<=15 to avoid context length issues; mermaid_code output AS-IS."
+            "group_by: ip, instance (not cluster_domain; per-command/bucket/capacity breakdowns are automatic). "
+            "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
         request_slz=RedisMachineSeriesInputSerializer,
         response_slz=RedisMetricsSeriesOutputSerializer,
@@ -331,7 +329,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Query scalar statistics (min/max/avg/p95/cv/trend) for a specific machine (by IP). "
             "Cluster and instance role are auto-resolved. "
             "All metric types are accepted; latency_distribution is proxy-only, capacity is backend-only. "
-            "group_by: ip, instance, bucket (not cluster_domain)."
+            "group_by: ip, instance (not cluster_domain; per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisMachineStatsInputSerializer,
         response_slz=RedisMetricsStatsOutputSerializer,
@@ -366,8 +364,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Cluster and instance role are auto-resolved. "
             "Metrics: connections, qps, host_latency, command_latency, latency_distribution (proxy), "
             "capacity (backend); not host resource metrics (cpu/memory/io/disk). "
-            "group_by: instance, bucket (not cluster_domain or ip). "
-            "Keep max_len_datapoints<=15 to avoid context length issues; mermaid_code output AS-IS."
+            "group_by: instance (not cluster_domain or ip; per-command/bucket/capacity breakdowns are automatic). "
+            "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
         request_slz=RedisInstanceSeriesInputSerializer,
         response_slz=RedisMetricsSeriesOutputSerializer,
@@ -397,7 +395,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
             "Cluster and instance role are auto-resolved. "
             "Metrics: connections, qps, host_latency, command_latency, latency_distribution (proxy), "
             "capacity (backend); not host resource metrics (cpu/memory/io/disk). "
-            "group_by: instance, bucket (not cluster_domain or ip)."
+            "group_by: instance (not cluster_domain or ip; per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisInstanceStatsInputSerializer,
         response_slz=RedisMetricsStatsOutputSerializer,

--- a/dbm-ui/backend/tests/dbm_aiagent/mcp_tools/redis/test_capacity_disk_group_by.py
+++ b/dbm-ui/backend/tests/dbm_aiagent/mcp_tools/redis/test_capacity_disk_group_by.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for capacity_disk outer aggregation respecting user group_by.
+"""
+import re
+
+import pytest
+
+from backend.dbm_aiagent.mcp_tools.redis.constants import METRIC_REGISTRY
+from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsAggregationLevel, MetricsGroupBy, MetricType
+from backend.dbm_aiagent.mcp_tools.redis.models import MetricsQueryParams
+from backend.dbm_aiagent.mcp_tools.redis.tools.redis_metrics_svc import RedisMetricsQueryService
+
+
+def _capacity_disk_params(group_by=None):
+    return MetricsQueryParams(
+        cluster_domains=["test.cluster"],
+        metric_type=MetricType.CAPACITY,
+        metric_config=METRIC_REGISTRY["capacity_disk"],
+        aggregation_level=MetricsAggregationLevel.CLUSTER,
+        group_by=group_by,
+    )
+
+
+def _extract_outer_by(promql: str) -> str:
+    match = re.search(r"sum by \(([^)]+)\)", promql)
+    assert match, f"no outer sum by clause in: {promql}"
+    return match.group(1)
+
+
+def _extract_inner_by(promql: str) -> str:
+    match = re.search(r"max by \(([^)]+)\)", promql)
+    assert match, f"no inner max by clause in: {promql}"
+    return match.group(1)
+
+
+@pytest.fixture
+def svc():
+    return RedisMetricsQueryService()
+
+
+class TestCapacityDiskPromQL:
+    @pytest.mark.parametrize(
+        "group_by,expected_outer",
+        [
+            (None, "cluster_domain,mount_point"),
+            ([MetricsGroupBy.CLUSTER_DOMAIN], "cluster_domain,mount_point"),
+            ([MetricsGroupBy.IP], "cluster_domain,ip,mount_point"),
+        ],
+    )
+    def test_outer_by_respects_group_by(self, svc, group_by, expected_outer):
+        query_configs, _ = svc._build_capacity_queries(_capacity_disk_params(group_by=group_by))
+        used_promql = next(cfg["promql"] for cfg in query_configs if cfg["alias"] == "used")
+        assert _extract_inner_by(used_promql) == "cluster_domain,ip,mount_point"
+        assert _extract_outer_by(used_promql) == expected_outer
+
+    def test_instance_group_by_strips_instance_port_from_outer(self, svc):
+        query_configs, _ = svc._build_capacity_queries(_capacity_disk_params(group_by=[MetricsGroupBy.INSTANCE]))
+        used_promql = next(cfg["promql"] for cfg in query_configs if cfg["alias"] == "used")
+        assert _extract_outer_by(used_promql) == "cluster_domain,ip,mount_point"
+        assert "instance_port" not in _extract_outer_by(used_promql)
+
+
+class TestCapacityDiskSeriesKeys:
+    def test_cluster_scope_key_without_ip(self, svc):
+        intrinsic_dims = svc._intrinsic_dimensions(METRIC_REGISTRY["capacity_disk"])
+        key = svc._build_series_key(
+            {"capacity_type": "used", "mount_point": "/data"},
+            "test.cluster",
+            MetricsAggregationLevel.CLUSTER,
+            intrinsic_dims,
+        )
+        assert key == "used@/data"
+
+    def test_ip_scope_key_includes_ip(self, svc):
+        intrinsic_dims = svc._intrinsic_dimensions(METRIC_REGISTRY["capacity_disk"])
+        key = svc._build_series_key(
+            {"capacity_type": "used", "ip": "1.1.1.1", "mount_point": "/"},
+            "test.cluster",
+            MetricsAggregationLevel.CLUSTER,
+            intrinsic_dims,
+        )
+        assert key == "used@1.1.1.1@/"
+
+    def test_parse_cluster_aggregated_response(self, svc):
+        response = {
+            "series": [
+                {
+                    "dimensions": {
+                        "cluster_domain": "test.cluster",
+                        "mount_point": "/",
+                        "capacity_type": "used",
+                        "query_type": "overall",
+                    },
+                    "datapoints": [[100.0, 1_700_000_000]],
+                }
+            ]
+        }
+        parsed = svc._parse_response(
+            response,
+            METRIC_REGISTRY["capacity_disk"],
+            MetricsAggregationLevel.CLUSTER,
+        )
+        assert list(parsed["test.cluster"].raw_series.keys()) == ["used@/"]
+
+    def test_parse_ip_scoped_response(self, svc):
+        response = {
+            "series": [
+                {
+                    "dimensions": {
+                        "cluster_domain": "test.cluster",
+                        "ip": "1.1.1.1",
+                        "mount_point": "/",
+                        "capacity_type": "used",
+                        "query_type": "overall",
+                    },
+                    "datapoints": [[100.0, 1_700_000_000]],
+                },
+                {
+                    "dimensions": {
+                        "cluster_domain": "test.cluster",
+                        "ip": "2.2.2.2",
+                        "mount_point": "/",
+                        "capacity_type": "used",
+                        "query_type": "overall",
+                    },
+                    "datapoints": [[80.0, 1_700_000_000]],
+                },
+            ]
+        }
+        parsed = svc._parse_response(
+            response,
+            METRIC_REGISTRY["capacity_disk"],
+            MetricsAggregationLevel.CLUSTER,
+        )
+        keys = list(parsed["test.cluster"].raw_series.keys())
+        assert sorted(keys) == ["used@1.1.1.1@/", "used@2.2.2.2@/"]


### PR DESCRIPTION
## 这条 PR 解决什么

- Redis MCP 指标查询中 `group_by` 与 cmd/bucket/capacity 内建维度混杂、`stats_type` 双路径难维护、以及 `capacity_disk` 在 cluster 维度无法跨主机聚合/共享盘重复计数等问题

## 具体改动

- **group_by 语义不清**：引入 `IntrinsicDimension`（cmd / bucket / capacity_type / mount_point），由服务自动拆分 → API 仅暴露 `cluster_domain` / `ip` / `instance` 三类结构维度
- **stats_type 双路径**：移除 `vertical`/`horizontal` 及独立 stats PromQL → 统一从 `raw_series` 计算 timeline 统计（min/max/avg/median/p95/cv/trend/latest）
- **capacity_disk cluster 仍带 IP**：outer PromQL 尊重 `group_by` → cluster 级 `used@<mount_point>` 跨主机求和，ip 级 `used@<ip>@<mount_point>`
- **共享数据盘重复计数**：`capacity_dedup` 先 `max by (cluster_domain,ip,mount_point)` 再外层 `sum`，对齐 db_monitor 容量策略
- **mermaid 输出难维护**：移除 `mermaid_format` / `mermaid_code` 及 `generate_mermaid_line_chart` 生成逻辑

## 测试 & 风险

- 单测已覆盖 `capacity_disk` outer `by` 子句（cluster/ip/instance）、series key 解析（`used@/data` vs `used@ip@/data`）
- MCP API 移除 `stats_type`、`mermaid_format`，`group_by` 不再接受 `cmd`/`bucket`；需重新生成 `mcp_resources.yaml`，Agent 调用方需适配