### PR TITLE
feat(redis): merge conf check into paced batch node with per-checker config #18603

### DIFF
--- a/dbm-ui/backend/components/base.py
+++ b/dbm-ui/backend/components/base.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os.path
 import sys
+import tempfile
 import time
 from typing import Any, Callable, Dict, List
 from urllib import parse
@@ -521,21 +522,36 @@ class DataAPI(object):
 
         return result
 
+    @staticmethod
+    def _write_file_atomically(file_path: str, content: str):
+        directory = os.path.dirname(file_path)
+        fd, tmp_path = tempfile.mkstemp(prefix=".{}.".format(os.path.basename(file_path)), dir=directory, text=True)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, file_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
     def _fetch_client_crt(self):
         client_crt, client_key = f"{CLIENT_CRT_PATH}/{SSLEnum.CLIENT_CRT}", f"{CLIENT_CRT_PATH}/{SSLEnum.CLIENT_KEY}"
-        # 如何证书已存在，则直接返回即可
+        # 如果证书已存在，则直接返回即可
         ssl = SystemSettings.get_setting_value(key=SSL_KEY, default={})
         # 这里需要判断是否本地化以及文件夹是否存在，有可能pod重启导致秘钥文件丢失
-        if ssl and ssl.get("local") and os.path.exists(CLIENT_CRT_PATH):
+        if ssl and ssl.get("local") and os.path.isfile(client_crt) and os.path.isfile(client_key):
             return client_crt, client_key
 
         # 本地写入crt和key文件，防止每次都需要write IO
-        os.makedirs(CLIENT_CRT_PATH)
-        with open(client_crt, "w+") as f:
-            f.write(ssl[SSLEnum.CLIENT_CRT.value])
+        os.makedirs(CLIENT_CRT_PATH, exist_ok=True)
+        # 并发场景下其他请求可能已写完，直接复用磁盘文件，无需再次读库
+        if os.path.isfile(client_crt) and os.path.isfile(client_key):
+            return client_crt, client_key
 
-        with open(client_key, "w+") as f:
-            f.write(ssl[SSLEnum.CLIENT_KEY.value])
+        self._write_file_atomically(client_crt, ssl[SSLEnum.CLIENT_CRT.value])
+        self._write_file_atomically(client_key, ssl[SSLEnum.CLIENT_KEY.value])
 
         # 记录秘钥已经本地化
         ssl["local"] = True

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/check_conf.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/check_conf.py
@@ -9,35 +9,32 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-import json
 import logging
-from collections import defaultdict
 from dataclasses import asdict, dataclass, field, fields
 from datetime import timedelta
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from backend.configuration.constants import SystemSettingsEnum
-from backend.db_meta.enums import ClusterPhase
 from backend.db_meta.models import Cluster
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.db_report.models.redis_check_report import RedisCheckReport
+from backend.flow.plugins.components.collections.redis.conf_check.candidate_selection import (
+    get_candidate_cluster_tuples,
+)
+from backend.flow.plugins.components.collections.redis.conf_check.redis_candidates import (
+    REDIS_CONF_CHECK_CANDIDATES_KEY,
+    REDIS_CONF_CHECK_CANDIDATES_TTL,
+    push_candidate_cluster_ids,
+)
 from backend.flow.plugins.components.collections.redis.conf_check.registry import get_candidate_cluster_types
 from backend.flow.utils.redis.redis_report_utils import RedisReportWriter
 from backend.ticket.models import SystemSettings, TicketType
 from backend.utils.basic import generate_root_id
-from backend.utils.redis import RedisConn
 
 logger = logging.getLogger("root")
-
-
-REDIS_CONF_CHECK_CANDIDATES_KEY = "dbm:redis_conf_check:candidates:{root_id}"
-# TTL for candidates key in Redis (1 hour)
-REDIS_CONF_CHECK_CANDIDATES_TTL = 3600
-# Special field name for metadata in the hash
-REDIS_CONF_CHECK_META_FIELD = "_meta"
 
 # All conf checkers report under one subtype on RedisCheckReport.
 CONF_CHECK_SUBTYPE = RedisCheckSubType.ConfigInconsistent.value
@@ -57,10 +54,15 @@ class RedisConfCheckConfig:
     bk_cloud_ids: Optional[List[int]] = field(default_factory=list)
 
     batch_size: int = 100  # amount of clusters to check each batch in flow
-    batch_interval: int = 10  # sec to wait between batches
-    interval: int = 10  # seconds between polls
-    max_retries: int = 120  # timeout = interval * max_retries
+    batch_interval: int = 10  # seconds to wait between pipeline batches (not job poll interval)
+    interval: int = 10  # seconds between host-job status polls; timeout ~= interval * max_retries
+    max_retries: int = 120
     drs_chunk_size: int = 20  # amount of addresses per DRS redis_rpc call
+    drs_chunks_per_tick: int = 1  # DRS redis_rpc chunks per schedule tick
+    password_batch_size: int = 200  # clusters per get_password call when prefetching passwords
+    # Per-checker overrides of global fields, keyed by checker.name (e.g. "role", "predixy_servers").
+    # predixy_servers: {"ignore_question_ip_in_memory": false} skips memory servers with ip "?".
+    customized: Optional[Dict[str, Dict]] = field(default_factory=dict)
 
     @classmethod
     def from_settings(cls) -> "RedisConfCheckConfig":
@@ -89,19 +91,9 @@ def _get_config() -> RedisConfCheckConfig:
     return RedisConfCheckConfig.from_settings()
 
 
-def _get_candidate_clusters(config: RedisConfCheckConfig) -> List:
-    """Return [(bk_cloud_id, cluster_id), ...] of online clusters of supported types."""
-    query = Cluster.objects.filter(
-        cluster_type__in=config.cluster_types,
-        phase=ClusterPhase.ONLINE,
-    )
-    if config.bizs_ignored:
-        query = query.exclude(bk_biz_id__in=config.bizs_ignored)
-    if config.clusters_ignored:
-        query = query.exclude(id__in=config.clusters_ignored)
-    if config.bk_cloud_ids:
-        query = query.filter(bk_cloud_id__in=config.bk_cloud_ids)
-    return list(query.values_list("bk_cloud_id", "id"))
+def _get_candidate_clusters(config: RedisConfCheckConfig) -> List[Tuple[int, int]]:
+    """Return deduplicated [(bk_cloud_id, cluster_id), ...] across all registered checkers."""
+    return get_candidate_cluster_tuples(config)
 
 
 def check_redis_conf():
@@ -110,7 +102,7 @@ def check_redis_conf():
 
     1. Read configuration from SystemSettings
     2. Select candidate clusters (union of all checkers' cluster types)
-    3. Store candidates in a Redis Hash and trigger RedisConfCheckFlow
+    3. Store candidates in a Redis list and trigger RedisConfCheckFlow
     4. Clean up expired reports
     """
     logger.info(_("Starting Redis conf check"))
@@ -127,30 +119,22 @@ def check_redis_conf():
 
     logger.info(_("Found {} clusters for conf check").format(len(cluster_tuples)))
 
-    cloud_to_clusters = defaultdict(list)
-    for bk_cloud_id, cluster_id in cluster_tuples:
-        cloud_to_clusters[bk_cloud_id].append(cluster_id)
+    candidate_ids = [cluster_id for _bk_cloud_id, cluster_id in cluster_tuples]
+    existing_ids = set(Cluster.objects.filter(id__in=candidate_ids).values_list("id", flat=True))
+    valid_cluster_ids = sorted(cluster_id for cluster_id in candidate_ids if cluster_id in existing_ids)
+    if len(valid_cluster_ids) < len(set(candidate_ids)):
+        logger.warning(
+            _("Skipped {} cluster(s) not found in meta").format(len(set(candidate_ids)) - len(valid_cluster_ids))
+        )
+    if not valid_cluster_ids:
+        logger.info(_("No valid clusters found for conf check"))
+        return
 
     root_id = generate_root_id()
     candidates_key = REDIS_CONF_CHECK_CANDIDATES_KEY.format(root_id=root_id)
     try:
-        hash_data = {
-            str(bk_cloud_id): json.dumps(cluster_ids) for bk_cloud_id, cluster_ids in cloud_to_clusters.items()
-        }
-        hash_data[REDIS_CONF_CHECK_META_FIELD] = json.dumps(
-            {
-                "total_cloud_groups": len(cloud_to_clusters),
-                "total_clusters": len(cluster_tuples),
-                "created_at": root_id,
-            }
-        )
-        RedisConn.hset(candidates_key, mapping=hash_data)
-        RedisConn.expire(candidates_key, REDIS_CONF_CHECK_CANDIDATES_TTL)
-        logger.info(
-            _("Stored {} cloud groups ({} clusters) in Redis Hash: {}").format(
-                len(cloud_to_clusters), len(cluster_tuples), candidates_key
-            )
-        )
+        pushed = push_candidate_cluster_ids(candidates_key, valid_cluster_ids, ttl=REDIS_CONF_CHECK_CANDIDATES_TTL)
+        logger.info(_("Stored {} clusters in Redis list: {}").format(pushed, candidates_key))
     except Exception as e:
         logger.exception(_("Failed to store candidates in Redis: {}").format(str(e)))
         return
@@ -165,6 +149,9 @@ def check_redis_conf():
         "interval": config.interval,
         "max_retries": config.max_retries,
         "drs_chunk_size": config.drs_chunk_size,
+        "drs_chunks_per_tick": config.drs_chunks_per_tick,
+        "password_batch_size": config.password_batch_size,
+        "checker_customized": config.customized or {},
     }
 
     try:

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/task.py
@@ -12,12 +12,12 @@ import logging
 
 from celery.schedules import crontab
 
-from backend.db_periodic_task.local_tasks.db_meta.db_meta_check.redis_cluster_check.check_conf import check_redis_conf
 from backend.db_periodic_task.local_tasks.redis_tasks.agent_checks import (
     CheckBackendDataSkewTask,
     CheckBackendLoadSkewTask,
     CheckClusterCapacityGrowthTask,
 )
+from backend.db_periodic_task.local_tasks.redis_tasks.check_conf import check_redis_conf
 from backend.db_periodic_task.local_tasks.redis_tasks.check_exporter import CheckRedisUpMetricTask
 from backend.db_periodic_task.local_tasks.register import register_periodic_task
 from backend.db_report.repo.task_record_repo import TaskRecordRepo

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_conf_check.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_conf_check.py
@@ -8,30 +8,19 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-import json
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from django.utils.translation import gettext as _
 
-from backend.db_meta.models import Cluster
 from backend.flow.engine.bamboo.scene.common.builder import Builder
-from backend.flow.plugins.components.collections.common.delay import DelayComponent
-from backend.flow.plugins.components.collections.redis.conf_check.components import (
-    RedisConfCheckCollectComponent,
-    RedisConfCheckReportComponent,
-)
-from backend.flow.utils.redis.redis_context_dataclass import RedisConfCheckContext
-from backend.utils.redis import RedisConn
+from backend.flow.plugins.components.collections.redis.conf_check.components import RedisConfCheckBatchComponent
+from backend.flow.plugins.components.collections.redis.conf_check.redis_candidates import count_candidate_cluster_ids
 
 logger = logging.getLogger("flow")
 
 DEFAULT_BATCH_SIZE = 2000
 DEFAULT_BATCH_INTERVAL = 10  # seconds to wait between batches
-
-# Redis Hash key pattern (must match check_conf.py)
-REDIS_CONF_CHECK_CANDIDATES_KEY = "dbm:redis_conf_check:candidates:{root_id}"
-REDIS_CONF_CHECK_META_FIELD = "_meta"
 
 
 class RedisConfCheckFlow(object):
@@ -43,9 +32,11 @@ class RedisConfCheckFlow(object):
     work (reading predixy.conf) is delivered as one consolidated job per host.
 
     Flow structure (per batch of clusters):
-    1. RedisConfCheckCollectService: deliver one combined on-host script per host.
-    2. RedisConfCheckReportService: poll host jobs, gather DRS state, evaluate
-       every checker, write reports.
+    1. RedisConfCheckBatchService: issue host scripts, poll jobs, pace DRS calls,
+       evaluate every checker, write reports, optional inter-batch delay — one node.
+
+    Candidate cluster IDs live in a Redis list (candidates_key); each batch act
+    reads its slice by batch_num — cluster IDs are not embedded in pipeline kwargs.
     """
 
     def __init__(self, root_id: str, data: Optional[Dict]):
@@ -61,77 +52,28 @@ class RedisConfCheckFlow(object):
                 "batch_interval": 10,
                 "interval": 5,
                 "max_retries": 120,
-                "drs_chunk_size": 20
+                "drs_chunk_size": 20,
+                "drs_chunks_per_tick": 1,
+                "password_batch_size": 200,
+                "checker_customized": {},
             }
         """
         self.root_id = root_id
         self.ticket_data = data
-
-    def _load_candidates_from_redis_hash(self, candidates_key: str) -> List[Dict]:
-        """
-        Load candidate cluster infos from a Redis Hash.
-
-        Hash structure:
-        - Field "_meta": {"total_cloud_groups": int, "total_clusters": int, ...}
-        - Field "<bk_cloud_id>": [cluster_id1, cluster_id2, ...] (JSON array)
-
-        Returns: [{"bk_cloud_id": x, "cluster_ids": [...]}, ...]
-        """
-        try:
-            hash_data = RedisConn.hgetall(candidates_key)
-            if not hash_data:
-                logger.warning(f"No data found in Redis Hash for key: {candidates_key}")
-                return []
-
-            infos = []
-            for field, value in hash_data.items():
-                field_str = field.decode() if isinstance(field, bytes) else field
-                value_str = value.decode() if isinstance(value, bytes) else value
-                if field_str == REDIS_CONF_CHECK_META_FIELD:
-                    continue
-                bk_cloud_id = int(field_str)
-                cluster_ids = json.loads(value_str)
-                infos.append({"bk_cloud_id": bk_cloud_id, "cluster_ids": cluster_ids})
-
-            logger.info(f"Loaded {len(infos)} cloud groups from Redis Hash: {candidates_key}")
-            RedisConn.delete(candidates_key)
-            return infos
-        except Exception as e:
-            logger.exception(f"Failed to load candidates from Redis Hash: {e}")
-            return []
-
-    def _prepare_cluster_data_list(self, infos: List[Dict]) -> List[Dict]:
-        """Flatten cloud groups into a list of {cluster_id, bk_cloud_id} for valid clusters."""
-        candidate_ids = [cluster_id for info in infos for cluster_id in info.get("cluster_ids", [])]
-        existing_ids = set(Cluster.objects.filter(id__in=candidate_ids).values_list("id", flat=True))
-        cluster_data_list = []
-        for info in infos:
-            bk_cloud_id = info.get("bk_cloud_id", 0)
-            for cluster_id in info.get("cluster_ids", []):
-                if cluster_id not in existing_ids:
-                    logger.warning(f"Cluster {cluster_id} not found, skipping")
-                    continue
-                cluster_data_list.append({"cluster_id": cluster_id, "bk_cloud_id": bk_cloud_id})
-        return cluster_data_list
 
     def run_flow(self):
         """Execute the conf check workflow in batches."""
         redis_pipeline = Builder(root_id=self.root_id, data=self.ticket_data)
 
         candidates_key = self.ticket_data.get("candidates_key", "")
-        if candidates_key:
-            infos = self._load_candidates_from_redis_hash(candidates_key)
-        else:
-            infos = self.ticket_data.get("infos", [])
-
-        if not infos:
-            logger.warning("No cluster infos provided for conf check")
+        if not candidates_key:
+            logger.warning("No candidates_key provided for conf check")
             redis_pipeline.run_pipeline()
             return
 
-        cluster_data_list = self._prepare_cluster_data_list(infos)
-        if not cluster_data_list:
-            logger.warning("No valid clusters to check")
+        total_clusters = count_candidate_cluster_ids(candidates_key)
+        if total_clusters == 0:
+            logger.warning("No cluster candidates found in Redis for conf check")
             redis_pipeline.run_pipeline()
             return
 
@@ -140,43 +82,31 @@ class RedisConfCheckFlow(object):
         interval = self.ticket_data.get("interval", None)
         max_retries = self.ticket_data.get("max_retries", None)
         drs_chunk_size = self.ticket_data.get("drs_chunk_size", None)
+        drs_chunks_per_tick = self.ticket_data.get("drs_chunks_per_tick", None)
+        password_batch_size = self.ticket_data.get("password_batch_size", None)
 
-        total_clusters = len(cluster_data_list)
         total_batches = (total_clusters + batch_size - 1) // batch_size
         logger.info(f"Starting conf check for {total_clusters} clusters in {total_batches} batches")
 
         for batch_idx in range(total_batches):
-            start_idx = batch_idx * batch_size
-            end_idx = min(start_idx + batch_size, total_clusters)
-            batch_clusters = cluster_data_list[start_idx:end_idx]
             batch_num = batch_idx + 1
 
             redis_pipeline.add_act(
-                act_name=_("批次{}/{}: 下发配置检查脚本 ({}个集群)").format(batch_num, total_batches, len(batch_clusters)),
-                act_component_code=RedisConfCheckCollectComponent.code,
+                act_name=_("批次{}/{}: 配置检查").format(batch_num, total_batches),
+                act_component_code=RedisConfCheckBatchComponent.code,
                 kwargs={
-                    "node_name": f"conf_check_collect_batch_{batch_num}",
-                    "clusters": batch_clusters,
-                },
-            )
-
-            redis_pipeline.add_act(
-                act_name=_("批次{}/{}: 采集状态并处理检查结果").format(batch_num, total_batches),
-                act_component_code=RedisConfCheckReportComponent.code,
-                kwargs={
-                    "node_name": f"conf_check_report_batch_{batch_num}",
-                    "clusters": batch_clusters,
+                    "node_name": f"conf_check_batch_{batch_num}",
+                    "candidates_key": candidates_key,
+                    "batch_num": batch_num,
+                    "batch_size": batch_size,
+                    "total_batches": total_batches,
                     "interval": interval,
                     "max_retries": max_retries,
                     "drs_chunk_size": drs_chunk_size,
+                    "drs_chunks_per_tick": drs_chunks_per_tick,
+                    "password_batch_size": password_batch_size,
+                    "delay_after_seconds": batch_interval if batch_idx < total_batches - 1 else 0,
                 },
             )
 
-            if batch_idx < total_batches - 1 and batch_interval > 0:
-                redis_pipeline.add_act(
-                    act_name=_("批次{}/{}: 等待{}秒后继续下一批次").format(batch_num, total_batches, batch_interval),
-                    act_component_code=DelayComponent.code,
-                    kwargs={"delay_seconds": batch_interval},
-                )
-
-        redis_pipeline.run_pipeline(init_trans_data_class=RedisConfCheckContext())
+        redis_pipeline.run_pipeline()

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/base.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/base.py
@@ -58,7 +58,7 @@ class BaseConfChecker(abc.ABC):
        script and delivers a single job per host.
     3. ``drs_request(target)`` -> optional ``(command, password_key)`` describing
        the live-state query issued via ``DRSApi.redis_rpc``.
-    4. ``evaluate(target, drs_result, host_block)`` -> report rows.
+    4. ``evaluate(target, drs_result, host_block, checker_config, drs_error)`` -> report rows.
 
     Adding a new check = subclass this and decorate with ``@redis_conf_checker``.
     """
@@ -100,11 +100,18 @@ class BaseConfChecker(abc.ABC):
 
     @abc.abstractmethod
     def evaluate(
-        self, target: CheckTarget, drs_result: Optional[str], host_block: Optional[Dict]
+        self,
+        target: CheckTarget,
+        drs_result: Optional[str],
+        host_block: Optional[Dict],
+        checker_config: Optional[Dict] = None,
+        drs_error: Optional[str] = None,
     ) -> List[ConfCheckResult]:
         """
         Compare live state (drs_result) and/or on-host config (host_block) against
         the expected state and return report rows. ``drs_result`` is None when the
-        DRS query failed; ``host_block`` is None when no on-host data was collected.
+        DRS query failed (see ``drs_error`` for the reason); ``host_block`` is None
+        or carries ``{"error": reason}`` when no on-host data was collected.
+        ``checker_config`` carries per-checker overrides from REDIS_CONF_CHECK.customized.
         """
         raise NotImplementedError

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/candidate_selection.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/candidate_selection.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Candidate cluster selection for REDIS_CONF_CHECK periodic task.
+Kept outside db_periodic_task.local_tasks so flow unit tests can import safely.
+"""
+from typing import Dict, List, Tuple
+
+from backend.db_meta.enums import ClusterPhase
+from backend.db_meta.models import Cluster
+
+from .registry import CHECKER_REGISTRY
+
+
+def checker_query_filters(config, checker) -> Dict:
+    """Merge global config with per-checker customized overrides for candidate selection."""
+    overrides = (getattr(config, "customized", None) or {}).get(checker.name, {})
+    cluster_types = overrides.get("cluster_types") or checker.cluster_types
+    global_cluster_types = getattr(config, "cluster_types", None)
+    if global_cluster_types:
+        cluster_types = [ctype for ctype in cluster_types if ctype in global_cluster_types]
+    return {
+        "cluster_types": cluster_types,
+        "bizs_ignored": overrides.get("bizs_ignored", getattr(config, "bizs_ignored", None)) or [],
+        "clusters_ignored": overrides.get("clusters_ignored", getattr(config, "clusters_ignored", None)) or [],
+        "bk_cloud_ids": overrides.get("bk_cloud_ids", getattr(config, "bk_cloud_ids", None)) or [],
+    }
+
+
+def get_candidate_cluster_tuples(config) -> List[Tuple[int, int]]:
+    """Return deduplicated [(bk_cloud_id, cluster_id), ...] across all registered checkers."""
+    seen = set()
+    result: List[Tuple[int, int]] = []
+    for checker in CHECKER_REGISTRY:
+        filters = checker_query_filters(config, checker)
+        if not filters["cluster_types"]:
+            continue
+        query = Cluster.objects.filter(
+            cluster_type__in=filters["cluster_types"],
+            phase=ClusterPhase.ONLINE,
+        )
+        if filters["bizs_ignored"]:
+            query = query.exclude(bk_biz_id__in=filters["bizs_ignored"])
+        if filters["clusters_ignored"]:
+            query = query.exclude(id__in=filters["clusters_ignored"])
+        if filters["bk_cloud_ids"]:
+            query = query.filter(bk_cloud_id__in=filters["bk_cloud_ids"])
+        for bk_cloud_id, cluster_id in query.values_list("bk_cloud_id", "id"):
+            key = (bk_cloud_id, cluster_id)
+            if key not in seen:
+                seen.add(key)
+                result.append(key)
+    return result

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import datetime
 import json
 import logging
 import re
@@ -29,8 +30,7 @@ from backend.db_report.enums import ReportStateType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.flow.consts import SUCCESS_LIST
 from backend.flow.plugins.components.collections.common.base_service import BaseService
-from backend.flow.utils.base.payload_handler import PayloadHandler
-from backend.flow.utils.redis.redis_context_dataclass import RedisConfCheckContext
+from backend.flow.utils.base.payload_handler import DEFAULT_REDIS_PASSWORD_BATCH_SIZE, PayloadHandler
 from backend.flow.utils.redis.redis_report_utils import RedisReportWriter
 from backend.flow.utils.redis.redis_script_template import (
     CONF_CHECK_SCRIPT_HEADER,
@@ -39,9 +39,17 @@ from backend.flow.utils.redis.redis_script_template import (
 from backend.utils.string import base64_encode
 
 from .base import CheckTarget
+from .errors import format_password_drs_error, mark_host_targets
+from .password_cache import get_cached_cluster_passwords, put_cached_cluster_passwords
+from .redis_candidates import (
+    REDIS_CONF_CHECK_CANDIDATES_TTL,
+    delete_candidates_key,
+    renew_candidates_key_ttl,
+    slice_candidate_cluster_ids,
+)
 from .registry import CHECKER_REGISTRY
 
-logger = logging.getLogger("json")
+logger = logging.getLogger("flow")
 
 # <CONFCHK checker="predixy_servers" port="50000">{json}</CONFCHK>
 CONFCHK_PATTERN = re.compile(
@@ -50,8 +58,14 @@ CONFCHK_PATTERN = re.compile(
 
 MAX_WORKERS = getattr(settings, "CONCURRENT_NUMBER", 10)
 DEFAULT_DRS_GROUP_CHUNK_SIZE = 20
+DEFAULT_DRS_CHUNKS_PER_TICK = 1
 DEFAULT_POLL_INTERVAL = 5  # seconds
 DEFAULT_POLL_MAX_RETRIES = 120  # default timeout = interval * max_retries = 10min
+
+PHASE_POLL_JOBS = "poll_jobs"
+PHASE_RUN_DRS = "run_drs"
+PHASE_EVALUATE = "evaluate"
+PHASE_BATCH_DELAY = "batch_delay"
 
 # All conf-check findings (role mismatch, predixy fail/drift) share one subtype.
 CONF_CHECK_SUBTYPE = RedisCheckSubType.ConfigInconsistent.value
@@ -84,6 +98,30 @@ def _load_batch_clusters(clusters: List[Dict]) -> Dict[int, Cluster]:
             Prefetch("proxyinstance_set", queryset=proxy_qs),
         )
     }
+
+
+def _resolve_batch_clusters(kwargs: Dict) -> List[Dict]:
+    """Load this act's cluster slice from Redis (renew TTL) or return empty list."""
+    candidates_key = kwargs.get("candidates_key")
+    batch_num = int(kwargs.get("batch_num") or 0)
+    batch_size = int(kwargs.get("batch_size") or 0)
+    if not candidates_key or batch_num < 1 or batch_size < 1:
+        return []
+
+    renew_candidates_key_ttl(candidates_key, REDIS_CONF_CHECK_CANDIDATES_TTL)
+    cluster_ids = slice_candidate_cluster_ids(candidates_key, batch_num, batch_size)
+    if not cluster_ids:
+        return []
+
+    rows = Cluster.objects.filter(id__in=cluster_ids).values("id", "bk_cloud_id")
+    id_to_cloud = {row["id"]: row["bk_cloud_id"] for row in rows}
+    clusters = []
+    for cluster_id in cluster_ids:
+        if cluster_id not in id_to_cloud:
+            logger.warning("conf_check cluster %s not found in meta, skipping", cluster_id)
+            continue
+        clusters.append({"cluster_id": cluster_id, "bk_cloud_id": id_to_cloud[cluster_id]})
+    return clusters
 
 
 def _target_to_info(cluster: Cluster, checker, target: CheckTarget) -> Dict:
@@ -131,339 +169,458 @@ def _build_target_infos(clusters: List[Dict]) -> Tuple[List[Dict], Dict]:
     return target_infos, metrics
 
 
-class RedisConfCheckCollectService(BaseService):
-    """
-    Deliver the on-host portion of every checker for a batch of clusters.
+def _build_host_map(target_infos: List[Dict]) -> Dict[Tuple[int, str], Dict]:
+    """host_key (bk_cloud_id, ip) -> {"snippets": [...], "conf_targets": [...]}"""
+    host_map: Dict[Tuple[int, str], Dict] = {}
+    checker_targets_by_host: Dict[Tuple[str, int, str], List[CheckTarget]] = defaultdict(list)
+    for target_info in target_infos:
+        checker = _checker_by_name(target_info["checker"])
+        if checker is None or not checker.requires_host_script:
+            continue
+        target = _target_from_info(target_info)
+        checker_targets_by_host[(checker.name, target.bk_cloud_id, target.ip)].append(target)
 
-    Targets needing on-host work are grouped by host, and all applicable
-    checkers' snippets for a host are concatenated into ONE script delivered as a
-    single Job per host. Checkers that read live state only (via DRS) contribute
-    no snippet, so hosts with only DRS checkers produce no job.
-
-    kwargs:
-        - clusters: [{"cluster_id": int, "bk_cloud_id": int}, ...]
-        - node_name: str
-    """
-
-    def _execute(self, data, parent_data) -> bool:
-        kwargs = data.get_one_of_inputs("kwargs")
-        trans_data = data.get_one_of_inputs("trans_data")
-        if trans_data is None or trans_data == "${trans_data}":
-            trans_data = RedisConfCheckContext()
-
-        node_name = kwargs.get("node_name", self.__class__.__name__)
-        clusters = kwargs.get("clusters", [])
-        flow_id = self.runtime_attrs.get("root_pipeline_id", "")
-
-        target_infos, metrics = _build_target_infos(clusters)
-        trans_data.target_infos = target_infos
-        trans_data.check_metrics = metrics
-
-        # host_key (bk_cloud_id, ip) -> {"snippets": [...], "conf_targets": [...]}
-        host_map: Dict[Tuple[int, str], Dict] = {}
-        checker_targets_by_host: Dict[Tuple[str, int, str], List[CheckTarget]] = defaultdict(list)
-        for target_info in target_infos:
-            checker = _checker_by_name(target_info["checker"])
-            if checker is None or not checker.requires_host_script:
-                continue
-            target = _target_from_info(target_info)
-            checker_targets_by_host[(checker.name, target.bk_cloud_id, target.ip)].append(target)
-
-        for (checker_name, bk_cloud_id, ip), host_targets in checker_targets_by_host.items():
-            checker = _checker_by_name(checker_name)
-            if checker is None:
-                continue
-            snippet = checker.host_script_snippet(host_targets)
-            if not snippet:
-                continue
-            entry = host_map.setdefault((bk_cloud_id, ip), {"snippets": [], "conf_targets": []})
-            entry["snippets"].append(snippet)
-            for target in host_targets:
-                entry["conf_targets"].append(
-                    {"checker": checker.name, "port": target.port, "cluster_id": target.cluster_id}
-                )
-
-        if not host_map:
-            self.log_info(_("[{}] 本批次无需下发主机脚本(全部通过DRS采集)").format(node_name))
-            trans_data.job_infos = []
-            trans_data.check_metrics = {
-                **getattr(trans_data, "check_metrics", {}),
-                "host_job_count": 0,
-                "host_script_count": 0,
-            }
-            data.outputs["trans_data"] = trans_data
-            return True
-
-        self.log_info(_("[{}] 准备下发 {} 个主机配置检查脚本").format(node_name, len(host_map)))
-
-        job_infos = []
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            future_map = {}
-            for (bk_cloud_id, ip), entry in host_map.items():
-                script = CONF_CHECK_SCRIPT_HEADER + "\n".join(entry["snippets"])
-                future = executor.submit(self._fast_execute_script, script, ip, bk_cloud_id, flow_id, node_name)
-                future_map[future] = (bk_cloud_id, ip, entry["conf_targets"])
-
-            for future in as_completed(future_map):
-                bk_cloud_id, ip, conf_targets = future_map[future]
-                try:
-                    job_instance_id = future.result()
-                    if job_instance_id:
-                        job_infos.append(
-                            {
-                                "job_instance_id": job_instance_id,
-                                "bk_cloud_id": bk_cloud_id,
-                                "exec_ip": ip,
-                                "conf_targets": conf_targets,
-                            }
-                        )
-                    else:
-                        self.log_warning(_("[{}] 主机 {} 脚本下发失败").format(node_name, ip))
-                except Exception as e:
-                    self.log_error(_("[{}] 主机 {} 脚本下发异常: {}").format(node_name, ip, e))
-
-        self.log_info(_("[{}] 成功下发 {} 个主机脚本").format(node_name, len(job_infos)))
-        trans_data.job_infos = job_infos
-        trans_data.check_metrics = {
-            **getattr(trans_data, "check_metrics", {}),
-            "host_job_count": len(job_infos),
-            "host_script_count": len(host_map),
-        }
-        data.outputs["trans_data"] = trans_data
-        return True
-
-    def _fast_execute_script(
-        self, script_content: str, exec_ip: str, bk_cloud_id: int, flow_id: str, node_name: str
-    ) -> Optional[int]:
-        body = {
-            "bk_scope_type": "biz_set",
-            "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
-            "task_name": f"DBM_{flow_id}_{node_name}_{exec_ip}",
-            "script_content": base64_encode(script_content),
-            "script_language": 1,  # shell
-            "target_server": {"ip_list": [{"bk_cloud_id": bk_cloud_id, "ip": exec_ip}]},
-        }
-        resp = JobApi.fast_execute_script({**redis_fast_execute_script_common_kwargs, **body}, raw=True)
-        if not resp.get("result") or not resp.get("data"):
-            logger.error(f"conf_check fast_execute_script failed on {exec_ip}: {resp.get('message')}")
-            return None
-        return resp["data"]["job_instance_id"]
-
-    def inputs_format(self) -> List:
-        return [
-            Service.InputItem(name="kwargs", key="kwargs", type="dict", required=True),
-            Service.InputItem(name="global_data", key="global_data", type="dict", required=True),
-            Service.InputItem(name="trans_data", key="trans_data", type="dict", required=True),
-        ]
-
-    def outputs_format(self) -> List:
-        return [Service.OutputItem(name="trans_data", key="trans_data", type="dict")]
-
-
-class RedisConfCheckCollectComponent(Component):
-    name = __name__
-    code = "redis_conf_check_collect"
-    bound_service = RedisConfCheckCollectService
-
-
-class RedisConfCheckReportService(BaseService):
-    """
-    Poll the per-host conf-read jobs, gather live state via DRS, evaluate every
-    checker and write reports. Uses __need_schedule__ to avoid blocking workers.
-
-    kwargs:
-        - clusters: [{"cluster_id": int, "bk_cloud_id": int}, ...]
-        - node_name, interval, max_retries
-    """
-
-    __need_schedule__ = True
-    interval = StaticIntervalGenerator(DEFAULT_POLL_INTERVAL)
-
-    def _execute(self, data, parent_data) -> bool:
-        kwargs = data.get_one_of_inputs("kwargs")
-        trans_data = data.get_one_of_inputs("trans_data")
-        if trans_data is None or trans_data == "${trans_data}":
-            trans_data = RedisConfCheckContext()
-
-        node_name = kwargs.get("node_name", self.__class__.__name__)
-        poll_interval = kwargs.get("interval") or DEFAULT_POLL_INTERVAL
-        max_retries = kwargs.get("max_retries") or DEFAULT_POLL_MAX_RETRIES
-        drs_chunk_size = kwargs.get("drs_chunk_size") or DEFAULT_DRS_GROUP_CHUNK_SIZE
-        self.interval = StaticIntervalGenerator(poll_interval)
-
-        job_infos = getattr(trans_data, "job_infos", []) or []
-        self.log_info(_("[{}] 开始处理, 待轮询主机脚本任务数: {}").format(node_name, len(job_infos)))
-
-        data.outputs.pending_jobs = {info["job_instance_id"]: info for info in job_infos}
-        data.outputs.completed_jobs = []
-        data.outputs.failed_jobs = []
-        data.outputs.poll_count = 0
-        data.outputs.max_retries = max_retries
-        data.outputs.drs_chunk_size = drs_chunk_size
-        data.outputs.job_status_check_count = 0
-        data.outputs.job_log_fetch_count = 0
-        return True
-
-    def _schedule(self, data, parent_data, callback_data=None) -> bool:
-        kwargs = data.get_one_of_inputs("kwargs")
-        global_data = data.get_one_of_inputs("global_data")
-        trans_data = data.get_one_of_inputs("trans_data")
-        if trans_data is None or trans_data == "${trans_data}":
-            trans_data = RedisConfCheckContext()
-        node_name = kwargs.get("node_name", self.__class__.__name__)
-        creator = global_data.get("created_by", "system")
-        clusters = kwargs.get("clusters", [])
-
-        pending_jobs = data.outputs.pending_jobs
-        completed_jobs = data.outputs.completed_jobs
-        failed_jobs = data.outputs.failed_jobs
-        poll_count = data.outputs.poll_count + 1
-        data.outputs.poll_count = poll_count
-        max_retries = data.outputs.get("max_retries", DEFAULT_POLL_MAX_RETRIES)
-        drs_chunk_size = data.outputs.get("drs_chunk_size", DEFAULT_DRS_GROUP_CHUNK_SIZE)
-
-        if poll_count > max_retries and pending_jobs:
-            self.log_warning(_("[{}] 轮询超时, {} 个主机脚本未完成").format(node_name, len(pending_jobs)))
-            for job_info in pending_jobs.values():
-                failed_jobs.append(job_info)
-            pending_jobs.clear()
-
-        if pending_jobs:
-            jobs_to_check = list(pending_jobs.keys())
-            data.outputs.job_status_check_count = data.outputs.get("job_status_check_count", 0) + len(jobs_to_check)
-            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                future_to_job_id = {
-                    executor.submit(self._check_job_status, job_id): job_id for job_id in jobs_to_check
-                }
-                for future in as_completed(future_to_job_id):
-                    job_id = future_to_job_id[future]
-                    try:
-                        status, step_instance_id = future.result()
-                        if status == "completed":
-                            job_info = pending_jobs.pop(job_id)
-                            job_info["step_instance_id"] = step_instance_id
-                            completed_jobs.append(job_info)
-                        elif status == "failed":
-                            job_info = pending_jobs.pop(job_id)
-                            job_info["step_instance_id"] = step_instance_id
-                            failed_jobs.append(job_info)
-                    except Exception as e:
-                        logger.error(f"Error checking job {job_id}: {e}")
-
-            data.outputs.pending_jobs = pending_jobs
-            data.outputs.completed_jobs = completed_jobs
-            data.outputs.failed_jobs = failed_jobs
-
-            if pending_jobs:
-                self.log_info(_("[{}] 轮询#{}: 仍有 {} 个主机脚本运行中").format(node_name, poll_count, len(pending_jobs)))
-                return True
-
-        # All host jobs done (or none). Pull conf data from logs, then evaluate every checker.
-        host_conf_data = self._collect_host_conf_data(completed_jobs)
-        data.outputs.job_log_fetch_count = len(completed_jobs)
-        if failed_jobs:
-            self.log_warning(_("[{}] {} 个主机脚本执行失败, 相关配置比对将标记为异常").format(node_name, len(failed_jobs)))
-
-        target_infos = getattr(trans_data, "target_infos", []) or []
-        ok, abnormal = self._evaluate_and_report(
-            clusters, host_conf_data, creator, target_infos=target_infos, drs_chunk_size=drs_chunk_size
-        )
-        self.log_info(
-            _(
-                "[{}] 配置检查完成: 正常 {} 项, 异常 {} 项, Job状态查询 {} 次, 日志拉取 {} 次".format(
-                    node_name,
-                    ok,
-                    abnormal,
-                    data.outputs.get("job_status_check_count", 0),
-                    data.outputs.get("job_log_fetch_count", 0),
-                )
+    for (checker_name, bk_cloud_id, ip), host_targets in checker_targets_by_host.items():
+        checker = _checker_by_name(checker_name)
+        if checker is None:
+            continue
+        snippet = checker.host_script_snippet(host_targets)
+        if not snippet:
+            continue
+        entry = host_map.setdefault((bk_cloud_id, ip), {"snippets": [], "conf_targets": []})
+        entry["snippets"].append(snippet)
+        for target in host_targets:
+            entry["conf_targets"].append(
+                {"checker": checker.name, "port": target.port, "cluster_id": target.cluster_id}
             )
-        )
+    return host_map
 
-        self.finish_schedule()
-        return True
 
-    def _check_job_status(self, job_instance_id: int) -> Tuple[str, Optional[int]]:
-        payload = {
-            "bk_scope_type": "biz_set",
-            "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
-            "job_instance_id": job_instance_id,
-            "return_ip_result": True,
-        }
+def _fast_execute_script(
+    script_content: str, exec_ip: str, bk_cloud_id: int, flow_id: str, node_name: str
+) -> Tuple[Optional[int], Optional[str]]:
+    body = {
+        "bk_scope_type": "biz_set",
+        "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
+        "task_name": f"DBM_{flow_id}_{node_name}_{exec_ip}",
+        "script_content": base64_encode(script_content),
+        "script_language": 1,  # shell
+        "target_server": {"ip_list": [{"bk_cloud_id": bk_cloud_id, "ip": exec_ip}]},
+    }
+    try:
+        resp = JobApi.fast_execute_script({**redis_fast_execute_script_common_kwargs, **body}, raw=True)
+    except Exception as e:
+        logger.error(f"conf_check fast_execute_script raised on {exec_ip}: {e}")
+        return None, "job_issue_exception: {}".format(e)
+    if not resp.get("result") or not resp.get("data"):
+        msg = resp.get("message") or "no_data"
+        logger.error(f"conf_check fast_execute_script failed on {exec_ip}: {msg}")
+        return None, "job_issue_failed: {}".format(msg)
+    return resp["data"]["job_instance_id"], None
+
+
+def _report_row(
+    target_info: Dict,
+    report_day: int,
+    creator: str,
+    *,
+    state: str,
+    msg: str,
+    ip: str,
+    port: int,
+) -> Dict:
+    return {
+        "cluster_id": target_info["cluster_id"],
+        "subtype": CONF_CHECK_SUBTYPE,
+        "cluster": target_info["cluster"],
+        "cluster_type": target_info["cluster_type"],
+        "bk_biz_id": target_info["bk_biz_id"],
+        "bk_cloud_id": target_info["bk_cloud_id"],
+        "report_day": report_day,
+        "creator": creator,
+        "state": state,
+        "msg": msg,
+        "instance": "{}:{}".format(ip, port),
+    }
+
+
+def _issue_host_jobs(
+    host_map: Dict[Tuple[int, str], Dict],
+    flow_id: str,
+    node_name: str,
+    log_warning,
+    log_error,
+    host_conf_data: Dict[Tuple[str, str, int], Dict],
+) -> Tuple[List[Dict], int]:
+    if not host_map:
+        return [], 0
+
+    job_infos = []
+    issue_failure_count = 0
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        future_map = {}
+        for (bk_cloud_id, ip), entry in host_map.items():
+            script = CONF_CHECK_SCRIPT_HEADER + "\n".join(entry["snippets"])
+            future = executor.submit(_fast_execute_script, script, ip, bk_cloud_id, flow_id, node_name)
+            future_map[future] = (bk_cloud_id, ip, entry["conf_targets"])
+
+        for future in as_completed(future_map):
+            bk_cloud_id, ip, conf_targets = future_map[future]
+            try:
+                job_instance_id, issue_reason = future.result()
+                if job_instance_id:
+                    job_infos.append(
+                        {
+                            "job_instance_id": job_instance_id,
+                            "bk_cloud_id": bk_cloud_id,
+                            "exec_ip": ip,
+                            "conf_targets": conf_targets,
+                        }
+                    )
+                else:
+                    log_warning(_("[{}] 主机 {} 脚本下发失败").format(node_name, ip))
+                    mark_host_targets(host_conf_data, ip, conf_targets, issue_reason or "job_issue_failed")
+                    issue_failure_count += 1
+            except Exception as e:
+                log_error(_("[{}] 主机 {} 脚本下发异常: {}").format(node_name, ip, e))
+                mark_host_targets(host_conf_data, ip, conf_targets, "job_issue_exception: {}".format(e))
+                issue_failure_count += 1
+    return job_infos, issue_failure_count
+
+
+def _check_job_status(job_instance_id: int) -> Tuple[str, Optional[int]]:
+    payload = {
+        "bk_scope_type": "biz_set",
+        "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
+        "job_instance_id": job_instance_id,
+        "return_ip_result": True,
+    }
+    try:
         resp = JobApi.get_job_instance_status(payload, raw=True)
-        if not resp.get("result") or not resp.get("data"):
-            return "running", None
-        if not resp["data"]["finished"]:
-            return "running", None
-
-        job_status = resp["data"]["job_instance"]["status"]
-        step_instance_id = (
-            resp["data"]["step_instance_list"][0]["step_instance_id"] if resp["data"]["step_instance_list"] else None
+    except Exception as e:
+        logger.error(f"conf_check get_job_instance_status raised for job {job_instance_id}: {e}")
+        return "running", None
+    if not resp.get("result") or not resp.get("data"):
+        logger.warning(
+            "conf_check get_job_instance_status no data for job %s: %s",
+            job_instance_id,
+            resp.get("message"),
         )
-        return ("completed", step_instance_id) if job_status in SUCCESS_LIST else ("failed", step_instance_id)
+        return "running", None
+    if not resp["data"]["finished"]:
+        return "running", None
 
-    def _collect_host_conf_data(self, completed_jobs: List[Dict]) -> Dict[Tuple[str, str, int], Dict]:
-        """
-        Fetch each host's log (in parallel) and parse the tagged <CONFCHK> blocks.
+    job_status = resp["data"]["job_instance"]["status"]
+    step_instance_id = (
+        resp["data"]["step_instance_list"][0]["step_instance_id"] if resp["data"]["step_instance_list"] else None
+    )
+    return ("completed", step_instance_id) if job_status in SUCCESS_LIST else ("failed", step_instance_id)
 
-        Returns: {(checker_name, ip, port): body_dict}
-        """
-        host_conf_data: Dict[Tuple[str, str, int], Dict] = {}
-        if not completed_jobs:
-            return host_conf_data
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            future_to_job = {executor.submit(self._get_job_ip_log, job): job for job in completed_jobs}
-            for future in as_completed(future_to_job):
-                job = future_to_job[future]
-                try:
-                    log_content = future.result()
-                except Exception as e:
-                    logger.error(f"Error fetching log for job {job.get('job_instance_id')}: {e}")
-                    continue
-                if not log_content:
-                    continue
-                for match in CONFCHK_PATTERN.finditer(log_content):
-                    checker_name = match.group("checker")
-                    port = int(match.group("port"))
-                    try:
-                        body = json.loads(match.group("body"))
-                    except json.JSONDecodeError:
-                        body = {"error": "bad_json"}
-                    host_conf_data[(checker_name, job["exec_ip"], port)] = body
+def _poll_jobs_once(
+    pending_jobs: Dict[int, Dict],
+    completed_jobs: List[Dict],
+    failed_jobs: List[Dict],
+) -> Tuple[Dict[int, Dict], List[Dict], List[Dict], int]:
+    """One schedule tick of job status polling. Returns (pending, completed, failed, checks_count)."""
+    if not pending_jobs:
+        return pending_jobs, completed_jobs, failed_jobs, 0
+
+    jobs_to_check = list(pending_jobs.keys())
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        future_to_job_id = {executor.submit(_check_job_status, job_id): job_id for job_id in jobs_to_check}
+        for future in as_completed(future_to_job_id):
+            job_id = future_to_job_id[future]
+            try:
+                status, step_instance_id = future.result()
+                if status == "completed":
+                    job_info = pending_jobs.pop(job_id)
+                    job_info["step_instance_id"] = step_instance_id
+                    completed_jobs.append(job_info)
+                elif status == "failed":
+                    job_info = pending_jobs.pop(job_id)
+                    job_info["step_instance_id"] = step_instance_id
+                    job_info["failure_reason"] = "job_failed"
+                    failed_jobs.append(job_info)
+            except Exception as e:
+                logger.error(f"Error checking job {job_id}: {e}")
+    return pending_jobs, completed_jobs, failed_jobs, len(jobs_to_check)
+
+
+def _get_job_ip_log(job: Dict) -> Tuple[str, Optional[str]]:
+    step_instance_id = job.get("step_instance_id")
+    if not step_instance_id:
+        return "", "no_step_instance_id"
+    payload = {
+        "bk_scope_type": "biz_set",
+        "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
+        "job_instance_id": job["job_instance_id"],
+        "step_instance_id": step_instance_id,
+        "bk_cloud_id": job["bk_cloud_id"],
+        "ip": job["exec_ip"],
+    }
+    try:
+        resp = JobApi.get_job_instance_ip_log(payload, raw=True)
+    except Exception as e:
+        logger.error(f"conf_check get_job_instance_ip_log raised for job {job.get('job_instance_id')}: {e}")
+        return "", "log_fetch_exception: {}".format(e)
+    if not resp.get("result"):
+        logger.warning(
+            "conf_check get_job_instance_ip_log no result for job %s: %s",
+            job.get("job_instance_id"),
+            resp.get("message"),
+        )
+        return "", "log_fetch_failed: {}".format(resp.get("message") or "no_result")
+    return resp.get("data", {}).get("log_content", ""), None
+
+
+def _collect_host_conf_data(completed_jobs: List[Dict]) -> Dict[Tuple[str, str, int], Dict]:
+    """Fetch each host log and parse tagged <CONFCHK> blocks into host_conf_data."""
+    host_conf_data: Dict[Tuple[str, str, int], Dict] = {}
+    if not completed_jobs:
         return host_conf_data
 
-    def _get_job_ip_log(self, job: Dict) -> str:
-        step_instance_id = job.get("step_instance_id")
-        if not step_instance_id:
-            return ""
-        payload = {
-            "bk_scope_type": "biz_set",
-            "bk_scope_id": env.JOB_BLUEKING_BIZ_ID,
-            "job_instance_id": job["job_instance_id"],
-            "step_instance_id": step_instance_id,
-            "bk_cloud_id": job["bk_cloud_id"],
-            "ip": job["exec_ip"],
-        }
-        resp = JobApi.get_job_instance_ip_log(payload, raw=True)
-        if not resp.get("result"):
-            return ""
-        return resp.get("data", {}).get("log_content", "")
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        future_to_job = {executor.submit(_get_job_ip_log, job): job for job in completed_jobs}
+        for future in as_completed(future_to_job):
+            job = future_to_job[future]
+            conf_targets = job.get("conf_targets", [])
+            log_content, log_err = future.result()
+            if log_err:
+                mark_host_targets(host_conf_data, job["exec_ip"], conf_targets, log_err)
+                continue
+            if not log_content:
+                mark_host_targets(host_conf_data, job["exec_ip"], conf_targets, "empty_log")
+                continue
+            matched_ports = set()
+            for match in CONFCHK_PATTERN.finditer(log_content):
+                checker_name = match.group("checker")
+                port = int(match.group("port"))
+                matched_ports.add(port)
+                try:
+                    body = json.loads(match.group("body"))
+                except json.JSONDecodeError:
+                    body = {"error": "bad_json"}
+                host_conf_data[(checker_name, job["exec_ip"], port)] = body
+            for ct in conf_targets:
+                if ct["port"] not in matched_ports:
+                    mark_host_targets(host_conf_data, job["exec_ip"], [ct], "no_confchk_output")
+    return host_conf_data
 
-    def _evaluate_and_report(
-        self,
-        clusters: List[Dict],
-        host_conf_data: Dict[Tuple[str, str, int], Dict],
-        creator: str,
-        target_infos: Optional[List[Dict]] = None,
-        drs_chunk_size: int = DEFAULT_DRS_GROUP_CHUNK_SIZE,
-    ) -> Tuple[int, int]:
-        """Run DRS (bounded + batched), evaluate every checker, write reports."""
-        writer = RedisReportWriter()
-        report_day = int(timezone.now().strftime("%Y%m%d"))
-        if not target_infos:
-            target_infos, metrics = _build_target_infos(clusters)
-            self.log_info(
+
+# group_key: (bk_cloud_id, cluster_id, password_key, command)
+DrsChunkKey = Tuple[int, int, str, str]
+DrsChunk = Tuple[DrsChunkKey, List[str]]
+
+
+def _build_drs_chunk_queue(target_infos: List[Dict], chunk_size: int) -> List[DrsChunk]:
+    groups: Dict[DrsChunkKey, set] = defaultdict(set)
+    for target_info in target_infos:
+        checker = _checker_by_name(target_info["checker"])
+        if checker is None:
+            continue
+        target = _target_from_info(target_info)
+        drs_req = checker.drs_request(target)
+        if not drs_req:
+            continue
+        command, password_key = drs_req
+        groups[(target.bk_cloud_id, target_info["cluster_id"], password_key, command)].add(target.address)
+
+    chunk_size = max(int(chunk_size or DEFAULT_DRS_GROUP_CHUNK_SIZE), 1)
+    chunks: List[DrsChunk] = []
+    for group_key, address_set in groups.items():
+        for address_chunk in _chunks(sorted(address_set), chunk_size):
+            chunks.append((group_key, address_chunk))
+    return chunks
+
+
+def _build_password_cache(
+    cluster_ids: set, password_batch_size: int = DEFAULT_REDIS_PASSWORD_BATCH_SIZE
+) -> Tuple[Dict[int, Dict], Dict[int, str]]:
+    if not cluster_ids:
+        return {}, {}
+
+    password_cache, missing, password_errors = get_cached_cluster_passwords(set(cluster_ids))
+    if not missing:
+        return password_cache, password_errors
+
+    cluster_cache = {cluster.id: cluster for cluster in Cluster.objects.filter(id__in=missing)}
+    to_fetch: List[Cluster] = []
+    for cluster_id in missing:
+        cluster = cluster_cache.get(cluster_id)
+        if cluster is None:
+            password_cache[cluster_id] = {}
+            password_errors[cluster_id] = "cluster_not_in_meta"
+            continue
+        to_fetch.append(cluster)
+
+    if to_fetch:
+        fetch_errors: Dict[int, str] = {}
+        fetched = PayloadHandler.redis_batch_get_cluster_passwords(
+            to_fetch, chunk_size=password_batch_size, errors_out=fetch_errors
+        )
+        password_cache.update(fetched)
+        password_errors.update(fetch_errors)
+
+    put_cached_cluster_passwords(
+        {cluster_id: password_cache[cluster_id] for cluster_id in missing if cluster_id in password_cache},
+        errors={cluster_id: password_errors[cluster_id] for cluster_id in missing if cluster_id in password_errors},
+    )
+    return password_cache, password_errors
+
+
+def _get_password_cache_for_drs(
+    data, password_batch_size: Optional[int] = None
+) -> Tuple[Dict[int, Dict], Dict[int, str]]:
+    """Resolve passwords from process-local cache only; never persist secrets in data.outputs."""
+    if not data.outputs.drs_chunk_queue:
+        return {}, {}
+    cluster_ids = {chunk[0][1] for chunk in data.outputs.drs_chunk_queue}
+    if password_batch_size is None:
+        kwargs = data.get_one_of_inputs("kwargs") or {}
+        password_batch_size = kwargs.get("password_batch_size") or DEFAULT_REDIS_PASSWORD_BATCH_SIZE
+    return _build_password_cache(cluster_ids, password_batch_size)
+
+
+def _init_batch_schedule_outputs(
+    data,
+    *,
+    phase: str,
+    target_infos: List[Dict],
+    pending_jobs: Dict,
+    host_conf_data: Dict,
+    drs_chunk_queue: List,
+) -> None:
+    """Persist only state that must survive bamboo schedule ticks between phases."""
+    data.outputs.target_infos = target_infos
+    data.outputs.phase = phase
+    data.outputs.pending_jobs = pending_jobs
+    data.outputs.completed_jobs = []
+    data.outputs.failed_jobs = []
+    data.outputs.host_conf_data = host_conf_data
+    data.outputs.poll_count = 0
+    data.outputs.drs_chunk_queue = drs_chunk_queue
+    data.outputs.drs_cursor = 0
+    data.outputs.drs_result_map = {}
+    data.outputs.drs_error_map = {}
+
+
+def _redis_rpc_chunk(
+    bk_cloud_id: int,
+    command: str,
+    addresses: List[str],
+    password: str,
+    errors_out: Dict[Tuple[int, str, str], str],
+) -> Dict[Tuple[int, str, str], str]:
+    out: Dict[Tuple[int, str, str], str] = {}
+    try:
+        resp = DRSApi.redis_rpc(
+            {
+                "addresses": addresses,
+                "db_num": 0,
+                "password": password,
+                "command": command,
+                "bk_cloud_id": bk_cloud_id,
+            }
+        )
+        for item in resp or []:
+            address = item.get("address")
+            result = item.get("result")
+            if address and result:
+                out[(bk_cloud_id, command, address)] = result
+            elif address is not None:
+                errors_out[(bk_cloud_id, command, address)] = "empty_result: {}".format(
+                    item.get("error_msg") or "no_result"
+                )
+    except Exception as e:
+        logger.error(f"DRS '{command}' failed for bk_cloud_id={bk_cloud_id} ({len(addresses)} addrs): {e}")
+        for address in addresses:
+            errors_out[(bk_cloud_id, command, address)] = "drs_rpc_error: {}".format(e)
+    return out
+
+
+def _run_single_drs_chunk(
+    group_key: DrsChunkKey,
+    addresses: List[str],
+    password_cache: Dict[int, Dict],
+    password_errors: Dict[int, str],
+    errors_out: Dict[Tuple[int, str, str], str],
+) -> Dict[Tuple[int, str, str], str]:
+    bk_cloud_id, cluster_id, password_key, command = group_key
+    pwd_err = password_errors.get(cluster_id)
+    if pwd_err:
+        err = format_password_drs_error(pwd_err)
+        for address in addresses:
+            errors_out.setdefault((bk_cloud_id, command, address), err)
+        return {}
+    passwords = password_cache.get(cluster_id, {})
+    password = passwords.get(password_key, "")
+    return _redis_rpc_chunk(bk_cloud_id, command, addresses, password, errors_out)
+
+
+# Resolved-password DRS group key: (bk_cloud_id, password, command) -> address set
+ResolvedDrsGroupKey = Tuple[int, str, str]
+
+
+def _run_drs_groups(
+    drs_groups: Dict[ResolvedDrsGroupKey, set],
+    chunk_size: int = DEFAULT_DRS_GROUP_CHUNK_SIZE,
+    errors_out: Optional[Dict[Tuple[int, str, str], str]] = None,
+) -> Dict[Tuple[int, str, str], str]:
+    """Issue chunked redis_rpc per (bk_cloud_id, password, command) group."""
+    if not drs_groups:
+        return {}
+    chunk_size = max(int(chunk_size or DEFAULT_DRS_GROUP_CHUNK_SIZE), 1)
+    drs_result_map: Dict[Tuple[int, str, str], str] = {}
+    chunk_errors: Dict[Tuple[int, str, str], str] = errors_out if errors_out is not None else {}
+
+    drs_chunks: List[Tuple[ResolvedDrsGroupKey, List[str]]] = []
+    for group_key, address_set in drs_groups.items():
+        for address_chunk in _chunks(sorted(address_set), chunk_size):
+            drs_chunks.append((group_key, address_chunk))
+
+    def run_resolved_group(group_key: ResolvedDrsGroupKey, addresses: List[str]) -> Tuple[Dict, Dict]:
+        bk_cloud_id, password, command = group_key
+        local_errors: Dict[Tuple[int, str, str], str] = {}
+        out = _redis_rpc_chunk(bk_cloud_id, command, addresses, password, local_errors)
+        return out, local_errors
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = [executor.submit(run_resolved_group, group_key, addrs) for group_key, addrs in drs_chunks]
+        for future in as_completed(futures):
+            chunk_result, local_errors = future.result()
+            drs_result_map.update(chunk_result)
+            chunk_errors.update(local_errors)
+    return drs_result_map
+
+
+def _evaluate_and_report(
+    clusters: List[Dict],
+    host_conf_data: Dict[Tuple[str, str, int], Dict],
+    creator: str,
+    *,
+    target_infos: Optional[List[Dict]] = None,
+    drs_result_map: Optional[Dict[Tuple[int, str, str], str]] = None,
+    drs_error_map: Optional[Dict[Tuple[int, str, str], str]] = None,
+    checker_customized: Optional[Dict[str, Dict]] = None,
+    log_info=None,
+) -> Tuple[int, int]:
+    """Evaluate pre-collected checker inputs and write reports. DRS must be fetched in schedule."""
+    writer = RedisReportWriter()
+    report_day = int(timezone.now().strftime("%Y%m%d"))
+    checker_customized = checker_customized or {}
+    drs_result_map = drs_result_map if drs_result_map is not None else {}
+    drs_error_map = drs_error_map if drs_error_map is not None else {}
+    if not target_infos:
+        target_infos, metrics = _build_target_infos(clusters)
+        logger.warning(
+            "conf check target_infos missing, rebuilt: clusters=%s targets=%s collect_calls=%s",
+            metrics["cluster_count"],
+            metrics["target_count"],
+            metrics["checker_target_collect_calls"],
+        )
+        if log_info:
+            log_info(
                 _(
                     "配置检查target缺失, 已fallback重建: clusters={}, targets={}, collect_calls={}".format(
                         metrics["cluster_count"], metrics["target_count"], metrics["checker_target_collect_calls"]
@@ -471,128 +628,324 @@ class RedisConfCheckReportService(BaseService):
                 )
             )
 
-        # Build eval tasks + the DRS request groups.
-        # eval_tasks: [(target_info, checker, target, command, host_block)]
-        eval_tasks = []
-        # drs_groups: (bk_cloud_id, password, command) -> set(addresses)
-        drs_groups: Dict[Tuple[int, str, str], set] = defaultdict(set)
-        password_cache: Dict[int, Dict] = {}
-        drs_cluster_ids = set()
-        for target_info in target_infos:
-            checker = _checker_by_name(target_info["checker"])
-            if checker is None:
-                continue
-            target = _target_from_info(target_info)
-            drs_req = checker.drs_request(target)
-            if drs_req:
-                drs_cluster_ids.add(target_info["cluster_id"])
+    eval_tasks = []
+    for target_info in target_infos:
+        checker = _checker_by_name(target_info["checker"])
+        if checker is None:
+            continue
+        target = _target_from_info(target_info)
+        drs_req = checker.drs_request(target)
+        command = drs_req[0] if drs_req else None
+        host_block = host_conf_data.get((checker.name, target.ip, target.port))
+        eval_tasks.append((target_info, checker, target, command, host_block))
 
-        cluster_cache = {cluster.id: cluster for cluster in Cluster.objects.filter(id__in=drs_cluster_ids)}
-        for cluster_id in drs_cluster_ids:
-            cluster = cluster_cache.get(cluster_id)
-            if cluster is None:
-                continue
-            try:
-                password_cache[cluster_id] = PayloadHandler.redis_get_cluster_password(cluster)
-            except Exception as e:
-                logger.error(f"get password for cluster {cluster_id} failed: {e}")
-                password_cache[cluster_id] = {}
-
-        for target_info in target_infos:
-            checker = _checker_by_name(target_info["checker"])
-            if checker is None:
-                continue
-            target = _target_from_info(target_info)
-            command = None
-            drs_req = checker.drs_request(target)
-            if drs_req:
-                command, password_key = drs_req
-                passwords = password_cache.get(target_info["cluster_id"], {})
-                password = passwords.get(password_key, "")
-                drs_groups[(target.bk_cloud_id, password, command)].add(target.address)
-            host_block = host_conf_data.get((checker.name, target.ip, target.port))
-            eval_tasks.append((target_info, checker, target, command, host_block))
-
-        drs_result_map = self._run_drs_groups(drs_groups, chunk_size=drs_chunk_size)
-
-        ok_count = 0
-        abnormal_count = 0
-        report_rows = []
-        for target_info, checker, target, command, host_block in eval_tasks:
-            drs_result = drs_result_map.get((target.bk_cloud_id, command, target.address)) if command else None
-            try:
-                results = checker.evaluate(target, drs_result, host_block)
-            except Exception as e:
-                logger.error(f"checker {checker.name} evaluate failed for {target.address}: {e}")
-                continue
-            for result in results:
-                report_rows.append(
-                    {
-                        "cluster_id": target_info["cluster_id"],
-                        "subtype": CONF_CHECK_SUBTYPE,
-                        "cluster": target_info["cluster"],
-                        "cluster_type": target_info["cluster_type"],
-                        "bk_biz_id": target_info["bk_biz_id"],
-                        "bk_cloud_id": target_info["bk_cloud_id"],
-                        "report_day": report_day,
-                        "creator": creator,
-                        "state": result.state,
-                        "msg": result.msg,
-                        "instance": "{}:{}".format(result.ip, result.port),
-                    }
+    report_rows = []
+    for target_info, checker, target, command, host_block in eval_tasks:
+        drs_result = drs_result_map.get((target.bk_cloud_id, command, target.address)) if command else None
+        drs_error = drs_error_map.get((target.bk_cloud_id, command, target.address)) if command else None
+        checker_config = checker_customized.get(checker.name, {})
+        try:
+            results = checker.evaluate(
+                target, drs_result, host_block, checker_config=checker_config, drs_error=drs_error
+            )
+        except Exception as e:
+            logger.error(f"checker {checker.name} evaluate failed for {target.address}: {e}")
+            report_rows.append(
+                _report_row(
+                    target_info,
+                    report_day,
+                    creator,
+                    state=ReportStateType.ABNORMAL.value,
+                    msg=_("evaluate_internal_error[{}]: {}").format(checker.name, e),
+                    ip=target.ip,
+                    port=target.port,
                 )
-                if result.state == ReportStateType.NORMAL.value:
-                    ok_count += 1
-                else:
-                    abnormal_count += 1
-        writer.write_redis_reports(report_rows)
-        return ok_count, abnormal_count
-
-    def _run_drs_groups(
-        self, drs_groups: Dict[Tuple[int, str, str], set], chunk_size: int = DEFAULT_DRS_GROUP_CHUNK_SIZE
-    ) -> Dict[Tuple[int, str, str], str]:
-        """Issue chunked batched redis_rpc calls per (bk_cloud_id, password, command), bounded by MAX_WORKERS."""
-        drs_result_map: Dict[Tuple[int, str, str], str] = {}
-        if not drs_groups:
-            return drs_result_map
-        chunk_size = max(int(chunk_size or DEFAULT_DRS_GROUP_CHUNK_SIZE), 1)
-
-        def run_chunk(group_key: Tuple[int, str, str], addresses: List[str]) -> Dict[Tuple[int, str, str], str]:
-            bk_cloud_id, password, command = group_key
-            out: Dict[Tuple[int, str, str], str] = {}
-            try:
-                resp = DRSApi.redis_rpc(
-                    {
-                        "addresses": addresses,
-                        "db_num": 0,
-                        "password": password,
-                        "command": command,
-                        "bk_cloud_id": bk_cloud_id,
-                    }
+            )
+            continue
+        for result in results:
+            report_rows.append(
+                _report_row(
+                    target_info,
+                    report_day,
+                    creator,
+                    state=result.state,
+                    msg=result.msg,
+                    ip=result.ip,
+                    port=result.port,
                 )
-                for item in resp or []:
-                    out[(bk_cloud_id, command, item["address"])] = item.get("result")
-            except Exception as e:
-                logger.error(f"DRS '{command}' failed for bk_cloud_id={bk_cloud_id} ({len(addresses)} addrs): {e}")
-            return out
+            )
+    collapsed_rows = _collapse_conf_check_report_rows(report_rows)
+    writer.write_redis_reports(collapsed_rows)
+    ok_count = sum(1 for row in collapsed_rows if row["state"] == ReportStateType.NORMAL.value)
+    abnormal_count = sum(1 for row in collapsed_rows if row["state"] != ReportStateType.NORMAL.value)
+    return ok_count, abnormal_count
 
-        drs_chunks = []
-        for group_key, address_set in drs_groups.items():
-            addresses = sorted(address_set)
-            for address_chunk in _chunks(addresses, chunk_size):
-                drs_chunks.append((group_key, address_chunk))
 
-        logger.info(
-            "Redis conf check DRS: groups=%s chunks=%s addresses=%s",
-            len(drs_groups),
-            len(drs_chunks),
-            sum(len(chunk) for _, chunk in drs_chunks),
+def _collapse_conf_check_report_rows(report_rows: List[Dict]) -> List[Dict]:
+    """
+    Per cluster: emit one cluster-level NORMAL row when all instances pass;
+    otherwise emit only abnormal instance rows.
+    """
+    by_cluster: Dict[int, List[Dict]] = defaultdict(list)
+    for row in report_rows:
+        by_cluster[row["cluster_id"]].append(row)
+
+    collapsed: List[Dict] = []
+    for rows in by_cluster.values():
+        abnormal_rows = [row for row in rows if row["state"] != ReportStateType.NORMAL.value]
+        if abnormal_rows:
+            collapsed.extend(abnormal_rows)
+            continue
+        if not rows:
+            continue
+        sample = rows[0]
+        collapsed.append(
+            {
+                **sample,
+                "instance": "all",
+                "msg": _("集群{}配置检查通过").format(sample["cluster"]),
+            }
         )
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [executor.submit(run_chunk, group_key, address_chunk) for group_key, address_chunk in drs_chunks]
-            for future in as_completed(futures):
-                drs_result_map.update(future.result())
-        return drs_result_map
+    return collapsed
+
+
+class RedisConfCheckBatchService(BaseService):
+    """
+    Per-batch conf check in a single scheduled node: issue host scripts in
+    _execute, then poll jobs, pace DRS chunks, evaluate and report in _schedule.
+
+    kwargs:
+        - candidates_key, batch_num, batch_size, total_batches
+        - node_name, interval, max_retries, drs_chunk_size, drs_chunks_per_tick
+        - delay_after_seconds: wait before finishing (merged inter-batch delay; 0 on last batch)
+    """
+
+    __need_schedule__ = True
+    interval = StaticIntervalGenerator(DEFAULT_POLL_INTERVAL)
+
+    @staticmethod
+    def _set_schedule_interval(service, seconds: float) -> None:
+        """Adjust poll wake-up interval in place (bamboo reads interval.interval, not a new generator)."""
+        wait_seconds = max(int(seconds), 1)
+        if isinstance(service.interval, StaticIntervalGenerator):
+            service.interval.interval = wait_seconds
+        else:
+            service.interval = StaticIntervalGenerator(wait_seconds)
+
+    @staticmethod
+    def _finish_batch(service, kwargs: Dict) -> None:
+        candidates_key = kwargs.get("candidates_key")
+        batch_num = int(kwargs.get("batch_num") or 0)
+        total_batches = int(kwargs.get("total_batches") or 0)
+        if candidates_key and batch_num == total_batches:
+            delete_candidates_key(candidates_key)
+        service.finish_schedule()
+
+    def _execute(self, data, parent_data) -> bool:
+        kwargs = data.get_one_of_inputs("kwargs")
+        node_name = kwargs.get("node_name", self.__class__.__name__)
+        clusters = _resolve_batch_clusters(kwargs)
+        flow_id = self.runtime_attrs.get("root_pipeline_id", "")
+
+        poll_interval = kwargs.get("interval") or DEFAULT_POLL_INTERVAL
+        drs_chunk_size = kwargs.get("drs_chunk_size") or DEFAULT_DRS_GROUP_CHUNK_SIZE
+        self.interval = StaticIntervalGenerator(poll_interval)
+
+        if not clusters:
+            self.log_warning(_("[{}] 本批次无待检查集群, 跳过").format(node_name))
+            _init_batch_schedule_outputs(
+                data,
+                phase=PHASE_EVALUATE,
+                target_infos=[],
+                pending_jobs={},
+                host_conf_data={},
+                drs_chunk_queue=[],
+            )
+            return True
+
+        target_infos, metrics = _build_target_infos(clusters)
+        host_map = _build_host_map(target_infos)
+        drs_chunk_queue = _build_drs_chunk_queue(target_infos, drs_chunk_size)
+
+        if host_map:
+            self.log_info(_("[{}] 准备下发 {} 个主机配置检查脚本").format(node_name, len(host_map)))
+            host_conf_data: Dict[Tuple[str, str, int], Dict] = {}
+            job_infos, issue_failure_count = _issue_host_jobs(
+                host_map,
+                flow_id,
+                node_name,
+                self.log_warning,
+                self.log_error,
+                host_conf_data,
+            )
+            self.log_info(_("[{}] 成功下发 {} 个主机脚本").format(node_name, len(job_infos)))
+            if issue_failure_count:
+                self.log_warning(_("[{}] {} 个主机脚本下发失败, 相关配置比对将标记为异常").format(node_name, issue_failure_count))
+        else:
+            self.log_info(_("[{}] 本批次无需下发主机脚本(全部通过DRS采集)").format(node_name))
+            job_infos = []
+            host_conf_data = {}
+
+        metrics = {
+            **metrics,
+            "host_job_count": len(job_infos),
+            "host_script_count": len(host_map),
+            "drs_chunk_count": len(drs_chunk_queue),
+        }
+
+        pending_jobs = {info["job_instance_id"]: info for info in job_infos}
+        if pending_jobs:
+            phase = PHASE_POLL_JOBS
+        elif drs_chunk_queue:
+            phase = PHASE_RUN_DRS
+        else:
+            phase = PHASE_EVALUATE
+
+        _init_batch_schedule_outputs(
+            data,
+            phase=phase,
+            target_infos=target_infos,
+            pending_jobs=pending_jobs,
+            host_conf_data=host_conf_data,
+            drs_chunk_queue=drs_chunk_queue,
+        )
+
+        self.log_info(
+            _("[{}] 批次初始化: targets={}, host_jobs={}, drs_chunks={}, phase={}").format(
+                node_name, metrics["target_count"], len(pending_jobs), len(drs_chunk_queue), phase
+            )
+        )
+        return True
+
+    def _schedule(self, data, parent_data, callback_data=None) -> bool:
+        kwargs = data.get_one_of_inputs("kwargs")
+        global_data = data.get_one_of_inputs("global_data")
+        node_name = kwargs.get("node_name", self.__class__.__name__)
+        creator = global_data.get("created_by", "system")
+
+        phase = data.outputs.phase
+        target_infos = data.outputs.target_infos
+        max_retries = kwargs.get("max_retries") or DEFAULT_POLL_MAX_RETRIES
+        drs_chunks_per_tick = max(int(kwargs.get("drs_chunks_per_tick") or DEFAULT_DRS_CHUNKS_PER_TICK), 1)
+        password_batch_size = max(int(kwargs.get("password_batch_size") or DEFAULT_REDIS_PASSWORD_BATCH_SIZE), 1)
+
+        if phase == PHASE_POLL_JOBS:
+            poll_count = data.outputs.poll_count + 1
+            data.outputs.poll_count = poll_count
+            pending_jobs = data.outputs.pending_jobs
+            completed_jobs = data.outputs.completed_jobs
+            failed_jobs = data.outputs.failed_jobs
+
+            if poll_count > max_retries and pending_jobs:
+                self.log_warning(_("[{}] 轮询超时, {} 个主机脚本未完成").format(node_name, len(pending_jobs)))
+                for job_info in pending_jobs.values():
+                    job_info["failure_reason"] = "job_timeout"
+                    failed_jobs.append(job_info)
+                pending_jobs.clear()
+
+            if pending_jobs:
+                pending_jobs, completed_jobs, failed_jobs, _status_checks = _poll_jobs_once(
+                    pending_jobs, completed_jobs, failed_jobs
+                )
+                data.outputs.pending_jobs = pending_jobs
+                data.outputs.completed_jobs = completed_jobs
+                data.outputs.failed_jobs = failed_jobs
+
+                if pending_jobs:
+                    self.log_info(_("[{}] 轮询#{}: 仍有 {} 个主机脚本运行中").format(node_name, poll_count, len(pending_jobs)))
+                    return True
+
+            host_conf_data = dict(data.outputs.host_conf_data)
+            host_conf_data.update(_collect_host_conf_data(completed_jobs))
+            for job in failed_jobs:
+                mark_host_targets(
+                    host_conf_data,
+                    job["exec_ip"],
+                    job.get("conf_targets", []),
+                    job.get("failure_reason") or "job_failed",
+                )
+            data.outputs.host_conf_data = host_conf_data
+            failed_job_count = len(failed_jobs)
+            data.outputs.completed_jobs = []
+            data.outputs.failed_jobs = []
+            if failed_job_count:
+                self.log_warning(_("[{}] {} 个主机脚本执行失败, 相关配置比对将标记为异常").format(node_name, failed_job_count))
+
+            if data.outputs.drs_chunk_queue:
+                data.outputs.phase = PHASE_RUN_DRS
+                return True
+            data.outputs.phase = PHASE_EVALUATE
+            phase = PHASE_EVALUATE
+
+        if phase == PHASE_RUN_DRS:
+            drs_chunk_queue = data.outputs.drs_chunk_queue
+            drs_cursor = data.outputs.drs_cursor
+            password_cache, password_errors = _get_password_cache_for_drs(data, password_batch_size)
+            drs_result_map = data.outputs.drs_result_map
+            drs_error_map = data.outputs.drs_error_map
+
+            end = min(drs_cursor + drs_chunks_per_tick, len(drs_chunk_queue))
+            for idx in range(drs_cursor, end):
+                group_key, addresses = drs_chunk_queue[idx]
+                drs_result_map.update(
+                    _run_single_drs_chunk(
+                        group_key,
+                        addresses,
+                        password_cache,
+                        password_errors,
+                        drs_error_map,
+                    )
+                )
+            data.outputs.drs_cursor = end
+            data.outputs.drs_result_map = drs_result_map
+            data.outputs.drs_error_map = drs_error_map
+
+            if end < len(drs_chunk_queue):
+                self.log_info(_("[{}] DRS进度: {}/{} chunks").format(node_name, end, len(drs_chunk_queue)))
+                return True
+
+            data.outputs.drs_chunk_queue = []
+            data.outputs.phase = PHASE_EVALUATE
+            phase = PHASE_EVALUATE
+
+        if phase == PHASE_EVALUATE:
+            ok, abnormal = _evaluate_and_report(
+                [],
+                data.outputs.host_conf_data,
+                creator,
+                target_infos=target_infos,
+                drs_result_map=data.outputs.drs_result_map,
+                drs_error_map=data.outputs.drs_error_map,
+                checker_customized=global_data.get("checker_customized") or {},
+                log_info=self.log_info,
+            )
+            self.log_info(_("[{}] 配置检查完成: 正常 {} 项, 异常 {} 项").format(node_name, ok, abnormal))
+            delay_after_seconds = int(kwargs.get("delay_after_seconds") or 0)
+            if delay_after_seconds > 0:
+                target_time = timezone.now() + datetime.timedelta(seconds=delay_after_seconds)
+                data.outputs.phase = PHASE_BATCH_DELAY
+                data.outputs.delay_target_time = target_time
+                self._set_schedule_interval(self, min(delay_after_seconds, 60))
+                self.log_info(_("[{}] 批次间隔等待 {} 秒后继续下一批次, 预计 {}").format(node_name, delay_after_seconds, target_time))
+                return True
+            self._finish_batch(self, kwargs)
+            return True
+
+        if phase == PHASE_BATCH_DELAY:
+            remaining_seconds = (data.outputs.delay_target_time - timezone.now()).total_seconds()
+            if remaining_seconds <= 0:
+                self.log_info(_("[{}] 批次间隔等待完成").format(node_name))
+                self._finish_batch(self, kwargs)
+                return True
+            if remaining_seconds > self.interval.interval:
+                self._set_schedule_interval(self, min(remaining_seconds / 2, 60))
+            else:
+                self._set_schedule_interval(self, remaining_seconds)
+            self.log_info(_("[{}] 批次间隔等待中, 剩余 {} 秒").format(node_name, int(remaining_seconds)))
+            return True
+
+        logger.warning("conf check batch unknown phase: %s", phase)
+        return False
 
     def inputs_format(self) -> List:
         return [
@@ -605,7 +958,7 @@ class RedisConfCheckReportService(BaseService):
         return []
 
 
-class RedisConfCheckReportComponent(Component):
+class RedisConfCheckBatchComponent(Component):
     name = __name__
-    code = "redis_conf_check_report"
-    bound_service = RedisConfCheckReportService
+    code = "redis_conf_check_batch"
+    bound_service = RedisConfCheckBatchService

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/errors.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/errors.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Shared conf-check collection error codes and classifiers."""
+
+from typing import Dict, List, Tuple
+
+HostConfKey = Tuple[str, str, int]
+
+
+def format_password_drs_error(reason: str) -> str:
+    return "password_unavailable: {}".format(reason)
+
+
+def is_host_collection_error(err: str) -> bool:
+    """True when host_block['error'] reflects Job/log pipeline failure, not conf read."""
+    if not err or err in ("conf_not_found", "no_host_data"):
+        return False
+    return err in (
+        "job_failed",
+        "job_timeout",
+        "empty_log",
+        "no_confchk_output",
+        "no_step_instance_id",
+        "bad_json",
+    ) or (err.startswith("log_fetch_") or err.startswith("job_issue_"))
+
+
+def mark_host_targets(
+    host_conf_data: Dict[HostConfKey, Dict], exec_ip: str, conf_targets: List[Dict], reason: str
+) -> None:
+    for ct in conf_targets:
+        host_conf_data.setdefault((ct["checker"], exec_ip, ct["port"]), {"error": reason})

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/password_cache.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/password_cache.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+Process-local TTL cache for redis cluster passwords during conf-check runs.
+
+697 batches may revisit the same cluster; caching avoids repeated get_password calls
+within a single pipeline-schedule worker process.
+
+Note: this is module-level state per OS process. Under Celery prefork each worker has
+its own cache, so batches scheduled on different workers cannot share entries. That is
+acceptable here because conf-check batches run serially on one pipeline and the same
+schedule worker usually handles every tick; cross-worker sharing would need Redis
+(and careful secret handling). The 30min TTL also limits staleness when idle.
+"""
+import time
+from threading import Lock
+from typing import Dict, Optional, Set, Tuple
+
+PASSWORD_CACHE_TTL_SECONDS = 30 * 60
+
+# cluster_id -> (cached_at, passwords, password_error)
+_lock = Lock()
+_cache: Dict[int, Tuple[float, Dict, Optional[str]]] = {}
+
+
+def _entry_valid(entry: Tuple[float, Dict, Optional[str]], now: float) -> bool:
+    return entry and (now - entry[0]) < PASSWORD_CACHE_TTL_SECONDS
+
+
+def get_cached_cluster_passwords(cluster_ids: Set[int]) -> Tuple[Dict[int, Dict], Set[int], Dict[int, str]]:
+    """Return cached passwords, ids still needing fetch, and cached per-cluster errors."""
+    now = time.time()
+    hit: Dict[int, Dict] = {}
+    missing: Set[int] = set()
+    errors: Dict[int, str] = {}
+    with _lock:
+        for cluster_id in cluster_ids:
+            entry = _cache.get(cluster_id)
+            if _entry_valid(entry, now):
+                hit[cluster_id] = entry[1]
+                if entry[2]:
+                    errors[cluster_id] = entry[2]
+            else:
+                missing.add(cluster_id)
+    return hit, missing, errors
+
+
+def put_cached_cluster_passwords(
+    passwords: Dict[int, Dict],
+    errors: Optional[Dict[int, str]] = None,
+) -> None:
+    if not passwords and not errors:
+        return
+    now = time.time()
+    errors = errors or {}
+    with _lock:
+        for cluster_id, password_map in passwords.items():
+            _cache[cluster_id] = (now, password_map, errors.get(cluster_id))
+        for cluster_id, error in errors.items():
+            if cluster_id in passwords:
+                continue
+            _cache[cluster_id] = (now, {}, error)

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/predixy_servers_checker.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/predixy_servers_checker.py
@@ -14,11 +14,27 @@ from django.utils.translation import gettext as _
 
 from backend.db_meta.enums import ClusterType, InstanceStatus
 from backend.db_report.enums import ReportStateType
-from backend.flow.utils.redis.redis_proxy_util import decode_predixy_info_servers
+from backend.flow.utils.redis.redis_proxy_util import PredixyInfoServer, decode_predixy_info_servers
 from backend.flow.utils.redis.redis_script_template import build_predixy_conf_check_snippet
 
 from .base import BaseConfChecker, CheckTarget, ConfCheckResult
+from .errors import is_host_collection_error
 from .registry import redis_conf_checker
+
+QUESTION_MARK_MEMORY_IP = "?"
+IGNORE_QUESTION_IP_IN_MEMORY_KEY = "ignore_question_ip_in_memory"
+
+
+def _memory_server_ip(server: str) -> str:
+    return server.split(":", 1)[0]
+
+
+def _apply_memory_server_filters(
+    servers: List[PredixyInfoServer], ignore_question_ip_in_memory: bool
+) -> List[PredixyInfoServer]:
+    if not ignore_question_ip_in_memory:
+        return servers
+    return [item for item in servers if _memory_server_ip(item.server) != QUESTION_MARK_MEMORY_IP]
 
 
 @redis_conf_checker
@@ -87,45 +103,65 @@ class PredixyServersChecker(BaseConfChecker):
         return "info servers", "redis_proxy_password"
 
     def evaluate(
-        self, target: CheckTarget, drs_result: Optional[str], host_block: Optional[Dict]
+        self,
+        target: CheckTarget,
+        drs_result: Optional[str],
+        host_block: Optional[Dict],
+        checker_config: Optional[Dict] = None,
+        drs_error: Optional[str] = None,
     ) -> List[ConfCheckResult]:
         """Combine CurrentIsFail + conf drift into a single row per proxy."""
         addr = target.address
+        checker_config = checker_config or {}
+        ignore_question_ip_in_memory = bool(checker_config.get(IGNORE_QUESTION_IP_IN_MEMORY_KEY, False))
 
         if not drs_result:
+            reason = drs_error or "proxy_unreachable_or_empty"
             return [
                 ConfCheckResult(
                     ip=target.ip,
                     port=target.port,
                     state=ReportStateType.ABNORMAL.value,
-                    msg=_("Predixy {} INFO Servers 查询失败(proxy不可达?)").format(addr),
+                    msg=_("Predixy {} INFO Servers 查询失败({})").format(addr, reason),
                 )
             ]
 
-        servers = decode_predixy_info_servers(drs_result)
+        raw_servers = decode_predixy_info_servers(drs_result)
+        if not raw_servers:
+            return [
+                ConfCheckResult(
+                    ip=target.ip,
+                    port=target.port,
+                    state=ReportStateType.ABNORMAL.value,
+                    msg=_("Predixy {} INFO Servers 返回为空(empty_drs_snapshot)").format(addr),
+                )
+            ]
+
+        servers = _apply_memory_server_filters(raw_servers, ignore_question_ip_in_memory)
         in_memory = {s.server for s in servers}
         failed_in_memory = sorted({s.server for s in servers if s.current_is_fail == 1})
         meta_set = set(target.extra.get("meta_servers", []))
 
         issues = []
-        # 1) CurrentIsFail backends -> predixy keeps retrying and floods the error log
         if failed_in_memory:
             issues.append("failed_in_memory={}".format(failed_in_memory))
 
-        # 2) Drift between live servers and the on-disk config file
         if not host_block or "servers" not in host_block:
-            err = host_block.get("error", "no_host_data") if host_block else "no_host_data"
-            issues.append(_("无法读取predixy.conf进行比对({})").format(err))
+            err = host_block.get("error") if host_block else "no_host_data"
+            if err and is_host_collection_error(err):
+                issues.append(_("主机配置采集失败({})").format(err))
+            else:
+                issues.append(_("无法读取predixy.conf进行比对({})").format(err))
         else:
             conf_set = set(host_block["servers"])
             failed_in_conf = sorted(set(failed_in_memory) & conf_set)
             if failed_in_conf:
                 issues.append("failed_in_conf={}".format(failed_in_conf))
 
-            only_in_memory = sorted(in_memory - conf_set)  # live predixy has it, config file does not
-            only_in_conf = sorted(conf_set - in_memory)  # in conf but predixy has no such server -> stale
-            only_in_meta = sorted(meta_set - in_memory - conf_set)  # online storage missing from both views
-            not_in_meta = sorted(conf_set - meta_set)  # conf must also match online cluster storage instances
+            only_in_memory = sorted(in_memory - conf_set)
+            only_in_conf = sorted(conf_set - in_memory)
+            only_in_meta = sorted(meta_set - in_memory - conf_set)
+            not_in_meta = sorted(conf_set - meta_set)
             if only_in_memory or only_in_conf or only_in_meta or not_in_meta:
                 issues.append(
                     "servers_mismatch: only_in_memory={}, only_in_conf={}, only_in_meta={}, not_in_meta={}".format(

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/redis_candidates.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/redis_candidates.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Redis list storage for conf-check candidate cluster IDs.
+
+Candidates are RPUSH'd in sorted order; each pipeline batch act reads a fixed
+slice via LRANGE using batch_num. TTL is renewed at each batch start; the list
+is deleted when the last batch completes.
+"""
+import logging
+from typing import List
+
+from backend.utils.redis import RedisConn
+
+logger = logging.getLogger("flow")
+
+REDIS_CONF_CHECK_CANDIDATES_KEY = "dbm:redis_conf_check:candidates:{root_id}"
+REDIS_CONF_CHECK_CANDIDATES_TTL = 3600  # seconds; renewed at each batch _execute
+
+
+def _parse_cluster_id(raw) -> int:
+    if isinstance(raw, bytes):
+        return int(raw.decode())
+    return int(raw)
+
+
+def push_candidate_cluster_ids(key: str, cluster_ids: List[int], ttl: int = REDIS_CONF_CHECK_CANDIDATES_TTL) -> int:
+    """Replace the candidate list with sorted unique cluster IDs and set TTL."""
+    sorted_ids = sorted(set(cluster_ids))
+    if sorted_ids:
+        # Idempotent: clear any stale list before push (e.g. accidental root_id reuse).
+        RedisConn.delete(key)
+        RedisConn.rpush(key, *sorted_ids)
+    RedisConn.expire(key, ttl)
+    return len(sorted_ids)
+
+
+def slice_candidate_cluster_ids(key: str, batch_num: int, batch_size: int) -> List[int]:
+    """Return cluster IDs for batch_num (1-based) via LRANGE index slice."""
+    if batch_num < 1 or batch_size < 1:
+        return []
+    start = (batch_num - 1) * batch_size
+    end = start + batch_size - 1
+    try:
+        raw_items = RedisConn.lrange(key, start, end) or []
+    except Exception as e:
+        logger.error("conf_check LRANGE failed for key=%s batch_num=%s: %s", key, batch_num, e)
+        return []
+    return [_parse_cluster_id(item) for item in raw_items]
+
+
+def renew_candidates_key_ttl(key: str, ttl: int = REDIS_CONF_CHECK_CANDIDATES_TTL) -> None:
+    RedisConn.expire(key, ttl)
+
+
+def count_candidate_cluster_ids(key: str) -> int:
+    try:
+        return int(RedisConn.llen(key) or 0)
+    except Exception as e:
+        logger.error("conf_check LLEN failed for key=%s: %s", key, e)
+        return 0
+
+
+def delete_candidates_key(key: str) -> None:
+    try:
+        RedisConn.delete(key)
+    except Exception as e:
+        logger.warning("conf_check DELETE failed for key=%s: %s", key, e)

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/role_checker.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/role_checker.py
@@ -62,18 +62,24 @@ class RoleChecker(BaseConfChecker):
         return "INFO REPLICATION", "redis_password"
 
     def evaluate(
-        self, target: CheckTarget, drs_result: Optional[str], host_block: Optional[Dict]
+        self,
+        target: CheckTarget,
+        drs_result: Optional[str],
+        host_block: Optional[Dict],
+        checker_config: Optional[Dict] = None,
+        drs_error: Optional[str] = None,
     ) -> List[ConfCheckResult]:
         meta_role = target.extra.get("meta_role", "")
         expected = ROLE_NORMALIZE.get(meta_role, meta_role)
 
         if not drs_result:
+            reason = drs_error or "drs_no_result"
             return [
                 ConfCheckResult(
                     ip=target.ip,
                     port=target.port,
                     state=ReportStateType.ABNORMAL.value,
-                    msg=_("角色检查失败: 无法执行 INFO REPLICATION (meta_role={})").format(meta_role),
+                    msg=_("角色检查失败: 无法执行 INFO REPLICATION (meta_role={}, 原因={})").format(meta_role, reason),
                 )
             ]
 

--- a/dbm-ui/backend/flow/utils/base/payload_handler.py
+++ b/dbm-ui/backend/flow/utils/base/payload_handler.py
@@ -11,6 +11,8 @@ specific language governing permissions and limitations under the License.
 import base64
 import logging
 import re
+from collections import defaultdict
+from typing import Dict, List, Optional
 
 from backend import env
 from backend.components import DBConfigApi, DBPrivManagerApi, DRSApi
@@ -35,6 +37,13 @@ apply_list = [
 ]
 
 logger = logging.getLogger("flow")
+
+DEFAULT_REDIS_PASSWORD_BATCH_SIZE = 200
+REDIS_PASSWORD_QUERY_USERS = [
+    {"username": UserName.REDIS_DEFAULT.value, "component": MySQLPrivComponent.REDIS_PROXY_ADMIN.value},
+    {"username": UserName.REDIS_DEFAULT.value, "component": MySQLPrivComponent.REDIS_PROXY.value},
+    {"username": UserName.REDIS_DEFAULT.value, "component": MySQLPrivComponent.REDIS.value},
+]
 
 
 class PayloadHandler(object):
@@ -318,25 +327,9 @@ class PayloadHandler(object):
         }
 
     @staticmethod
-    def redis_get_cluster_password(cluster: Cluster):
-        """
-        获取redis集群的密码
-        - 优先从密码服务中获取
-        - 如果密码服务为空,则从dbconfig中获取
-        """
-        # cluster_port 先全部统一设置为 0,便于DBHA获取密码
-        cluster_port = 0
-        query_params = {
-            "instances": [{"ip": str(cluster.id), "port": cluster_port, "bk_cloud_id": cluster.bk_cloud_id}],
-            "users": [
-                {"username": UserName.REDIS_DEFAULT.value, "component": MySQLPrivComponent.REDIS_PROXY_ADMIN.value},
-                {"username": UserName.REDIS_DEFAULT.value, "component": MySQLPrivComponent.REDIS_PROXY.value},
-                {"username": UserName.REDIS_DEFAULT.value, "component": MySQLPrivComponent.REDIS.value},
-            ],
-        }
-        data = DBPrivManagerApi.get_password(query_params)
+    def _parse_redis_password_items(items: List[Dict]) -> Dict[str, str]:
         ret = {"redis_password": "", "redis_proxy_admin_password": "", "redis_proxy_password": ""}
-        for item in data["items"]:
+        for item in items:
             if (
                 item["username"] == UserName.REDIS_DEFAULT.value
                 and item["component"] == MySQLPrivComponent.REDIS_PROXY_ADMIN.value
@@ -352,11 +345,81 @@ class PayloadHandler(object):
                 and item["component"] == MySQLPrivComponent.REDIS.value
             ):
                 ret["redis_password"] = base64.b64decode(item["password"]).decode("utf-8")
-        if (
-            ret["redis_password"] == ""
-            and ret["redis_proxy_password"] == ""
-            and ret["redis_proxy_admin_password"] == ""
-        ):
+        return ret
+
+    @staticmethod
+    def _redis_passwords_empty(passwords: Dict[str, str]) -> bool:
+        return (
+            passwords["redis_password"] == ""
+            and passwords["redis_proxy_password"] == ""
+            and passwords["redis_proxy_admin_password"] == ""
+        )
+
+    @staticmethod
+    def redis_batch_get_cluster_passwords(
+        clusters: List[Cluster],
+        chunk_size: int = DEFAULT_REDIS_PASSWORD_BATCH_SIZE,
+        errors_out: Optional[Dict[int, str]] = None,
+    ) -> Dict[int, Dict]:
+        """Fetch redis passwords for many clusters via batched get_password calls."""
+        if not clusters:
+            return {}
+
+        chunk_size = max(int(chunk_size or DEFAULT_REDIS_PASSWORD_BATCH_SIZE), 1)
+        password_cache: Dict[int, Dict] = {}
+        for start in range(0, len(clusters), chunk_size):
+            chunk = clusters[start : start + chunk_size]
+            instances = [{"ip": str(cluster.id), "port": 0, "bk_cloud_id": cluster.bk_cloud_id} for cluster in chunk]
+            data = None
+            last_error = None
+            for attempt in range(2):
+                try:
+                    data = DBPrivManagerApi.get_password({"instances": instances, "users": REDIS_PASSWORD_QUERY_USERS})
+                    break
+                except Exception as e:
+                    last_error = e
+                    if attempt == 0:
+                        logger.warning("batch get redis password failed for %s clusters, retrying: %s", len(chunk), e)
+            if data is None:
+                logger.error("batch get redis password failed for %s clusters: %s", len(chunk), last_error)
+                for cluster in chunk:
+                    passwords = PayloadHandler.redis_get_cluster_pass_from_dbconfig(cluster)
+                    password_cache[cluster.id] = passwords
+                    if errors_out is not None and PayloadHandler._redis_passwords_empty(passwords):
+                        errors_out[cluster.id] = str(last_error)
+                continue
+
+            items_by_cluster_id: Dict[int, List[Dict]] = defaultdict(list)
+            for item in data.get("items", []):
+                try:
+                    cluster_id = int(item["ip"])
+                except (KeyError, TypeError, ValueError):
+                    continue
+                items_by_cluster_id[cluster_id].append(item)
+
+            for cluster in chunk:
+                passwords = PayloadHandler._parse_redis_password_items(items_by_cluster_id.get(cluster.id, []))
+                if PayloadHandler._redis_passwords_empty(passwords):
+                    passwords = PayloadHandler.redis_get_cluster_pass_from_dbconfig(cluster)
+                password_cache[cluster.id] = passwords
+        return password_cache
+
+    @staticmethod
+    def redis_get_cluster_password(cluster: Cluster):
+        """
+        获取redis集群的密码
+        - 优先从密码服务中获取
+        - 如果密码服务为空,则从dbconfig中获取
+        """
+        # cluster_port 先全部统一设置为 0,便于DBHA获取密码
+        cluster_port = 0
+        query_params = {
+            "instances": [{"ip": str(cluster.id), "port": cluster_port, "bk_cloud_id": cluster.bk_cloud_id}],
+            "users": REDIS_PASSWORD_QUERY_USERS,
+        }
+        data = DBPrivManagerApi.get_password(query_params)
+        ret = PayloadHandler._parse_redis_password_items(data["items"])
+        if PayloadHandler._redis_passwords_empty(ret):
             # 密码服务为空,从dbconfig中获取
             ret = PayloadHandler.redis_get_cluster_pass_from_dbconfig(cluster)
         return ret

--- a/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_context_dataclass.py
@@ -230,17 +230,3 @@ class TendisplusLightningContext:
     tendis_backup_info: list = None  # 执行备份后的信息
     ticket_id: int = None  # 代表dts job id,对应表tb_tendis_dts_job
     dst_cluster: str = None  # 代表目标集群
-
-
-@dataclass()
-class RedisConfCheckContext:
-    """
-    Redis conf check context for passing data between components via trans_data.
-
-    Carries the per-host on-host script job infos so the report service can poll
-    them and pull back the conf-file data parsed from each host's log.
-    """
-
-    job_infos: list = field(default_factory=list)  # Per-host job execution info for polling
-    target_infos: list = field(default_factory=list)  # Serialized checker targets shared by collect/report
-    check_metrics: dict = field(default_factory=dict)  # Lightweight counters for troubleshooting overhead

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_conf_check.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_conf_check.py
@@ -14,13 +14,26 @@ Pure-logic unit tests for the unified REDIS_CONF_CHECK checkers. These exercise
 returns subtype-less rows carrying only state + msg per instance.
 """
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from backend.db_report.enums import ReportStateType
+from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.flow.plugins.components.collections.redis.conf_check.base import CheckTarget
+from backend.flow.plugins.components.collections.redis.conf_check.candidate_selection import (
+    checker_query_filters,
+    get_candidate_cluster_tuples,
+)
 from backend.flow.plugins.components.collections.redis.conf_check.components import (
     CONFCHK_PATTERN,
-    RedisConfCheckReportService,
+    PHASE_BATCH_DELAY,
+    PHASE_EVALUATE,
+    PHASE_POLL_JOBS,
+    PHASE_RUN_DRS,
+    RedisConfCheckBatchService,
+    _collapse_conf_check_report_rows,
+    _collect_host_conf_data,
+    _run_drs_groups,
+    _run_single_drs_chunk,
     _target_from_info,
     _target_to_info,
 )
@@ -76,6 +89,13 @@ class TestRoleChecker:
     def test_role_drs_failure_is_abnormal(self):
         results = RoleChecker().evaluate(_storage_target("redis_slave"), None, None)
         assert results[0].state == ABNORMAL
+
+    def test_role_drs_error_reason_in_msg(self):
+        results = RoleChecker().evaluate(
+            _storage_target("redis_slave"), None, None, drs_error="drs_rpc_error: timeout"
+        )
+        assert results[0].state == ABNORMAL
+        assert "drs_rpc_error: timeout" in results[0].msg
 
 
 class TestPredixyServersChecker:
@@ -156,6 +176,59 @@ class TestPredixyServersChecker:
         assert results[0].state == ABNORMAL
         assert "查询失败" in results[0].msg
 
+    def test_drs_error_reason_in_msg(self):
+        results = self.checker.evaluate(
+            _proxy_target(), None, {"servers": []}, drs_error="drs_rpc_error: connection refused"
+        )
+        assert results[0].state == ABNORMAL
+        assert "drs_rpc_error: connection refused" in results[0].msg
+
+    def test_empty_drs_snapshot_is_abnormal(self):
+        results = self.checker.evaluate(_proxy_target(), "# Servers\n\n", {"servers": ["1.1.1.1:30000"]})
+        assert results[0].state == ABNORMAL
+        assert "empty_drs_snapshot" in results[0].msg
+
+    def test_host_collection_error_vs_conf_not_found(self):
+        drs = _predixy_info_servers([("1.1.1.1:30000", 0)])
+        job_fail = self.checker.evaluate(_proxy_target(), drs, {"error": "job_failed"})
+        assert "主机配置采集失败" in job_fail[0].msg
+        assert "job_failed" in job_fail[0].msg
+        bad_json = self.checker.evaluate(_proxy_target(), drs, {"error": "bad_json"})
+        assert "主机配置采集失败" in bad_json[0].msg
+        conf_miss = self.checker.evaluate(_proxy_target(), drs, {"error": "conf_not_found"})
+        assert "predixy.conf" in conf_miss[0].msg
+        assert "conf_not_found" in conf_miss[0].msg
+
+    def test_question_ip_in_memory_flagged_by_default(self):
+        drs = _predixy_info_servers([("1.1.1.1:30000", 0), ("?:30000", 0)])
+        host_block = {"servers": ["1.1.1.1:30000"]}
+        results = self.checker.evaluate(_proxy_target(), drs, host_block)
+        assert results[0].state == ABNORMAL
+        assert "?:30000" in results[0].msg
+
+    def test_question_ip_in_memory_ignored_when_configured(self):
+        drs = _predixy_info_servers([("1.1.1.1:30000", 0), ("?:30000", 0)])
+        host_block = {"servers": ["1.1.1.1:30000"]}
+        results = self.checker.evaluate(
+            _proxy_target(meta_servers=["1.1.1.1:30000"]),
+            drs,
+            host_block,
+            checker_config={"ignore_question_ip_in_memory": True},
+        )
+        assert results[0].state == NORMAL
+
+    def test_question_ip_failed_in_memory_ignored_when_configured(self):
+        drs = _predixy_info_servers([("1.1.1.1:30000", 0), ("?:30000", 1)])
+        host_block = {"servers": ["1.1.1.1:30000"]}
+        results = self.checker.evaluate(
+            _proxy_target(meta_servers=["1.1.1.1:30000"]),
+            drs,
+            host_block,
+            checker_config={"ignore_question_ip_in_memory": True},
+        )
+        assert results[0].state == NORMAL
+        assert "failed_in_memory=['" not in results[0].msg
+
 
 class TestConfCheckScript:
     def test_snippet_embeds_ports(self):
@@ -210,9 +283,58 @@ class TestConfCheckTargetSerialization:
         assert restored.extra["meta_role"] == "redis_master"
 
 
+class TestConfCheckReportCollapse:
+    def _row(self, cluster_id: int, instance: str, state: str = NORMAL) -> dict:
+        return {
+            "cluster_id": cluster_id,
+            "subtype": RedisCheckSubType.ConfigInconsistent.value,
+            "cluster": "cache{}.test.db".format(cluster_id),
+            "cluster_type": "TendisPredixyRedisCluster",
+            "bk_biz_id": 1001,
+            "bk_cloud_id": 0,
+            "report_day": 20260630,
+            "creator": "pytest",
+            "state": state,
+            "msg": "detail",
+            "instance": instance,
+        }
+
+    def test_all_instances_pass_emits_single_cluster_row(self):
+        rows = [
+            self._row(1, "1.1.1.1:30000"),
+            self._row(1, "1.1.1.2:30000"),
+        ]
+        collapsed = _collapse_conf_check_report_rows(rows)
+        assert len(collapsed) == 1
+        assert collapsed[0]["instance"] == "all"
+        assert collapsed[0]["state"] == NORMAL
+        assert "配置检查通过" in collapsed[0]["msg"]
+
+    def test_any_instance_fail_emits_only_abnormal_rows(self):
+        rows = [
+            self._row(1, "1.1.1.1:30000", NORMAL),
+            self._row(1, "1.1.1.2:30000", ABNORMAL),
+        ]
+        collapsed = _collapse_conf_check_report_rows(rows)
+        assert len(collapsed) == 1
+        assert collapsed[0]["instance"] == "1.1.1.2:30000"
+        assert collapsed[0]["state"] == ABNORMAL
+
+    def test_clusters_collapsed_independently(self):
+        rows = [
+            self._row(1, "1.1.1.1:30000", NORMAL),
+            self._row(1, "1.1.1.2:30000", NORMAL),
+            self._row(2, "2.2.2.2:30000", ABNORMAL),
+        ]
+        collapsed = _collapse_conf_check_report_rows(rows)
+        assert len(collapsed) == 2
+        by_cluster = {row["cluster_id"]: row for row in collapsed}
+        assert by_cluster[1]["instance"] == "all"
+        assert by_cluster[2]["instance"] == "2.2.2.2:30000"
+
+
 class TestConfCheckDrsChunking:
     def test_drs_chunk_failure_does_not_drop_other_chunks(self):
-        service = RedisConfCheckReportService()
         drs_groups = {(0, "pwd", "INFO REPLICATION"): {"1.1.1.1:30000", "1.1.1.2:30000", "1.1.1.3:30000"}}
 
         def fake_redis_rpc(payload):
@@ -225,9 +347,392 @@ class TestConfCheckDrsChunking:
             "backend.flow.plugins.components.collections.redis.conf_check.components.DRSApi.redis_rpc",
             side_effect=fake_redis_rpc,
         ) as redis_rpc:
-            result_map = service._run_drs_groups(drs_groups, chunk_size=1)
+            errors = {}
+            result_map = _run_drs_groups(drs_groups, chunk_size=1, errors_out=errors)
 
         assert redis_rpc.call_count == 3
         assert result_map[(0, "INFO REPLICATION", "1.1.1.1:30000")] == "role:master"
         assert result_map[(0, "INFO REPLICATION", "1.1.1.3:30000")] == "role:master"
         assert (0, "INFO REPLICATION", "1.1.1.2:30000") not in result_map
+        assert "drs_rpc_error: boom" in errors[(0, "INFO REPLICATION", "1.1.1.2:30000")]
+
+    def test_run_single_drs_chunk_empty_result_records_error(self):
+        with patch(
+            "backend.flow.plugins.components.collections.redis.conf_check.components.DRSApi.redis_rpc",
+            return_value=[{"address": "1.1.1.1:30000", "result": "", "error_msg": "auth failed"}],
+        ):
+            errors = {}
+            result = _run_single_drs_chunk(
+                (0, 1, "redis_password", "INFO REPLICATION"),
+                ["1.1.1.1:30000"],
+                {1: {"redis_password": "pwd"}},
+                {},
+                errors,
+            )
+        assert result == {}
+        assert errors[(0, "INFO REPLICATION", "1.1.1.1:30000")] == "empty_result: auth failed"
+
+
+class TestConfCheckHostCollectionErrors:
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._get_job_ip_log",
+        return_value=("", "log_fetch_failed: permission denied"),
+    )
+    def test_collect_host_conf_data_log_fetch_error(self, _log):
+        jobs = [
+            {
+                "job_instance_id": 1,
+                "exec_ip": "1.1.1.1",
+                "conf_targets": [{"checker": "predixy_servers", "port": 50000, "cluster_id": 1}],
+            }
+        ]
+        conf_data = _collect_host_conf_data(jobs)
+        assert conf_data[("predixy_servers", "1.1.1.1", 50000)] == {"error": "log_fetch_failed: permission denied"}
+
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._get_job_ip_log",
+        return_value=("noise without tags\n", None),
+    )
+    def test_collect_host_conf_data_no_confchk_output(self, _log):
+        jobs = [
+            {
+                "job_instance_id": 2,
+                "exec_ip": "1.1.1.1",
+                "conf_targets": [{"checker": "predixy_servers", "port": 50000, "cluster_id": 1}],
+            }
+        ]
+        conf_data = _collect_host_conf_data(jobs)
+        assert conf_data[("predixy_servers", "1.1.1.1", 50000)] == {"error": "no_confchk_output"}
+
+
+class TestConfCheckPasswordBatch:
+    def test_batch_get_password_groups_items_by_cluster_id(self):
+        from backend.flow.utils.base.payload_handler import PayloadHandler
+
+        clusters = [
+            SimpleNamespace(id=1, bk_cloud_id=0, bk_biz_id=1, immute_domain="c1", db_module_id=1, proxy_version=""),
+            SimpleNamespace(id=2, bk_cloud_id=0, bk_biz_id=1, immute_domain="c2", db_module_id=1, proxy_version=""),
+        ]
+        encoded = "cGFzcw=="
+
+        def fake_get_password(query_params):
+            assert len(query_params["instances"]) == 2
+            return {
+                "items": [
+                    {
+                        "ip": "1",
+                        "username": "default",
+                        "component": "redis",
+                        "password": encoded,
+                    },
+                    {
+                        "ip": "2",
+                        "username": "default",
+                        "component": "redis_proxy",
+                        "password": encoded,
+                    },
+                ]
+            }
+
+        with patch(
+            "backend.flow.utils.base.payload_handler.DBPrivManagerApi.get_password",
+            side_effect=fake_get_password,
+        ):
+            result = PayloadHandler.redis_batch_get_cluster_passwords(clusters, chunk_size=10)
+
+        assert result[1]["redis_password"] == "pass"
+        assert result[2]["redis_proxy_password"] == "pass"
+
+    @patch(
+        (
+            "backend.flow.plugins.components.collections.redis.conf_check.components."
+            "PayloadHandler.redis_batch_get_cluster_passwords"
+        ),
+        return_value={1: {"redis_password": "pwd"}},
+    )
+    @patch("backend.flow.plugins.components.collections.redis.conf_check.components.Cluster.objects.filter")
+    def test_build_password_cache_uses_batch_api(self, cluster_filter, _batch):
+        from backend.flow.plugins.components.collections.redis.conf_check.components import _build_password_cache
+        from backend.flow.plugins.components.collections.redis.conf_check.password_cache import (
+            put_cached_cluster_passwords,
+        )
+
+        put_cached_cluster_passwords({99: {"redis_password": "cached"}})
+        cluster = SimpleNamespace(id=1, bk_cloud_id=0)
+        cluster_filter.return_value = [cluster]
+        cache, password_errors = _build_password_cache({1, 2, 99}, password_batch_size=50)
+        assert cache[99]["redis_password"] == "cached"
+        assert cache[1]["redis_password"] == "pwd"
+        assert password_errors[2] == "cluster_not_in_meta"
+        _batch.assert_called_once()
+        assert _batch.call_args.kwargs["chunk_size"] == 50
+
+
+class TestConfCheckBatchPhases:
+    def _make_service(self):
+        service = RedisConfCheckBatchService()
+        service.log_info = MagicMock()
+        service.log_warning = MagicMock()
+        service.log_error = MagicMock()
+        service.finish_schedule = MagicMock()
+        return service
+
+    def _make_data(self, **output_kwargs):
+        outputs = SimpleNamespace(**output_kwargs)
+        data = MagicMock()
+        data.get_one_of_inputs.side_effect = lambda key: {
+            "kwargs": {
+                "node_name": "test_batch",
+                "candidates_key": "dbm:redis_conf_check:candidates:test",
+                "batch_num": 1,
+                "batch_size": 10,
+                "total_batches": 1,
+                "interval": 1,
+                "max_retries": 3,
+                "drs_chunk_size": 1,
+                "drs_chunks_per_tick": 1,
+            },
+            "global_data": {"created_by": "tester"},
+        }.get(key)
+        data.outputs = outputs
+        return data
+
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._resolve_batch_clusters",
+        return_value=[{"cluster_id": 1, "bk_cloud_id": 0}],
+    )
+    @patch.object(
+        RedisConfCheckBatchService,
+        "runtime_attrs",
+        new_callable=PropertyMock,
+        return_value={"root_pipeline_id": "testroot"},
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._build_target_infos",
+        return_value=([{"checker": "role", "cluster_id": 1}], {"target_count": 1}),
+    )
+    @patch("backend.flow.plugins.components.collections.redis.conf_check.components._build_host_map", return_value={})
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._build_drs_chunk_queue",
+        return_value=[((0, 1, "redis_password", "INFO REPLICATION"), ["1.1.1.1:30000"])] * 3,
+    )
+    def test_pure_drs_batch_skips_poll_jobs(self, _queue, _host_map, _targets, _runtime, _resolve):
+        service = self._make_service()
+        data = self._make_data()
+        service._execute(data, {})
+        assert data.outputs.phase == PHASE_RUN_DRS
+        assert data.outputs.pending_jobs == {}
+
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._resolve_batch_clusters",
+        return_value=[{"cluster_id": 1, "bk_cloud_id": 0}],
+    )
+    @patch.object(
+        RedisConfCheckBatchService,
+        "runtime_attrs",
+        new_callable=PropertyMock,
+        return_value={"root_pipeline_id": "testroot"},
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._build_target_infos",
+        return_value=([{"checker": "predixy_servers", "cluster_id": 1}], {"target_count": 1}),
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._build_host_map",
+        return_value={(0, "1.1.1.1"): {"snippets": ["echo"], "conf_targets": []}},
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._build_drs_chunk_queue",
+        return_value=[],
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._issue_host_jobs",
+        return_value=([{"job_instance_id": 99, "bk_cloud_id": 0, "exec_ip": "1.1.1.1", "conf_targets": []}], 0),
+    )
+    def test_host_script_batch_starts_poll_jobs(self, _issue, _queue, _host_map, _targets, _runtime, _resolve):
+        service = self._make_service()
+        data = self._make_data()
+        service._execute(data, {})
+        assert data.outputs.phase == PHASE_POLL_JOBS
+        assert 99 in data.outputs.pending_jobs
+
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._run_single_drs_chunk",
+        return_value={(0, "INFO REPLICATION", "1.1.1.1:30000"): "role:master"},
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._get_password_cache_for_drs",
+        return_value=({1: {"redis_password": "pwd"}}, {}),
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._evaluate_and_report",
+        return_value=(1, 0),
+    )
+    def test_drs_chunks_paced_across_ticks(self, _evaluate, _passwords, _run_chunk):
+        service = self._make_service()
+        queue = [((0, 1, "redis_password", "INFO REPLICATION"), ["1.1.1.1:30000"])] * 3
+        data = self._make_data(
+            phase=PHASE_RUN_DRS,
+            target_infos=[],
+            poll_count=0,
+            drs_chunk_queue=queue,
+            drs_cursor=0,
+            drs_result_map={},
+            drs_error_map={},
+            host_conf_data={},
+        )
+
+        assert service._schedule(data, {}) is True
+        assert data.outputs.drs_cursor == 1
+        service.finish_schedule.assert_not_called()
+
+        assert service._schedule(data, {}) is True
+        assert data.outputs.drs_cursor == 2
+        service.finish_schedule.assert_not_called()
+
+        assert service._schedule(data, {}) is True
+        assert data.outputs.drs_cursor == 3
+        assert data.outputs.phase == PHASE_EVALUATE
+        service.finish_schedule.assert_called_once()
+        assert _run_chunk.call_count == 3
+
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components.delete_candidates_key",
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._evaluate_and_report",
+        return_value=(1, 0),
+    )
+    def test_evaluate_enters_batch_delay_before_finish(self, _evaluate, _delete):
+        from django.utils import timezone
+
+        service = self._make_service()
+        data = MagicMock()
+        data.get_one_of_inputs.side_effect = lambda key: {
+            "kwargs": {
+                "node_name": "test_batch",
+                "clusters": [],
+                "candidates_key": "dbm:redis_conf_check:candidates:test",
+                "batch_num": 1,
+                "total_batches": 2,
+                "delay_after_seconds": 10,
+            },
+            "global_data": {"created_by": "tester"},
+        }.get(key)
+        data.outputs = SimpleNamespace(
+            phase=PHASE_EVALUATE,
+            target_infos=[],
+            host_conf_data={},
+            drs_result_map={},
+            drs_error_map={},
+            drs_chunk_queue=[],
+        )
+
+        assert service._schedule(data, {}) is True
+        assert data.outputs.phase == PHASE_BATCH_DELAY
+        assert service.interval.interval == 10
+        service.finish_schedule.assert_not_called()
+
+        data.outputs.delay_target_time = timezone.now()
+        assert service._schedule(data, {}) is True
+        service.finish_schedule.assert_called_once()
+        _delete.assert_not_called()
+
+
+class TestRedisConfCheckCandidates:
+    @patch("backend.flow.plugins.components.collections.redis.conf_check.redis_candidates.RedisConn")
+    def test_push_and_slice_by_batch_num(self, redis_conn):
+        from backend.flow.plugins.components.collections.redis.conf_check.redis_candidates import (
+            push_candidate_cluster_ids,
+            slice_candidate_cluster_ids,
+        )
+
+        redis_conn.lrange.return_value = [b"3", b"4"]
+
+        push_candidate_cluster_ids("test:key", [2, 1, 2], ttl=3600)
+        redis_conn.delete.assert_called_once_with("test:key")
+        redis_conn.rpush.assert_called_once_with("test:key", 1, 2)
+        redis_conn.expire.assert_called_with("test:key", 3600)
+
+        ids = slice_candidate_cluster_ids("test:key", batch_num=2, batch_size=2)
+        redis_conn.lrange.assert_called_with("test:key", 2, 3)
+        assert ids == [3, 4]
+
+    @patch("backend.flow.plugins.components.collections.redis.conf_check.redis_candidates.RedisConn")
+    def test_count_candidates(self, redis_conn):
+        from backend.flow.plugins.components.collections.redis.conf_check.redis_candidates import (
+            count_candidate_cluster_ids,
+        )
+
+        redis_conn.llen.return_value = 5
+        assert count_candidate_cluster_ids("test:key") == 5
+
+    @patch("backend.flow.engine.bamboo.scene.redis.redis_conf_check.Builder")
+    @patch(
+        "backend.flow.engine.bamboo.scene.redis.redis_conf_check.count_candidate_cluster_ids",
+        return_value=3,
+    )
+    def test_flow_act_kwargs_omit_clusters(self, _count, builder_cls):
+        from backend.flow.engine.bamboo.scene.redis.redis_conf_check import RedisConfCheckFlow
+
+        builder = MagicMock()
+        builder_cls.return_value = builder
+        RedisConfCheckFlow(
+            "root",
+            {"candidates_key": "dbm:redis_conf_check:candidates:root", "batch_size": 2},
+        ).run_flow()
+
+        assert builder.add_act.call_count == 2
+        for call in builder.add_act.call_args_list:
+            kwargs = call.kwargs["kwargs"]
+            assert "clusters" not in kwargs
+            assert kwargs["candidates_key"] == "dbm:redis_conf_check:candidates:root"
+            assert "batch_num" in kwargs
+
+
+class TestConfCheckCustomizedConfig:
+    def test_checker_query_filters_bk_cloud_override(self):
+        config = SimpleNamespace(bk_cloud_ids=[], customized={"role": {"bk_cloud_ids": [0]}}, cluster_types=None)
+        from backend.flow.plugins.components.collections.redis.conf_check.role_checker import RoleChecker
+
+        filters = checker_query_filters(config, RoleChecker())
+        assert filters["bk_cloud_ids"] == [0]
+
+    @patch("backend.flow.plugins.components.collections.redis.conf_check.candidate_selection.Cluster")
+    def test_customized_excludes_checker_by_cloud(self, cluster_model):
+        from backend.flow.plugins.components.collections.redis.conf_check.predixy_servers_checker import (
+            PredixyServersChecker,
+        )
+        from backend.flow.plugins.components.collections.redis.conf_check.role_checker import RoleChecker
+
+        role_qs = MagicMock()
+        role_qs.exclude.return_value = role_qs
+        role_qs.filter.return_value = role_qs
+        role_qs.values_list.return_value = [(0, 1)]
+
+        predixy_qs = MagicMock()
+        predixy_qs.exclude.return_value = predixy_qs
+        predixy_qs.filter.return_value = predixy_qs
+        predixy_qs.values_list.return_value = [(1, 2)]
+
+        def filter_side_effect(**kwargs):
+            types = set(kwargs.get("cluster_type__in", []))
+            if types == set(RoleChecker().cluster_types):
+                return role_qs
+            if types == set(PredixyServersChecker().cluster_types):
+                return predixy_qs
+            return MagicMock(values_list=MagicMock(return_value=[]))
+
+        cluster_model.objects.filter.side_effect = filter_side_effect
+
+        config = SimpleNamespace(
+            cluster_types=None,
+            bizs_ignored=[],
+            clusters_ignored=[],
+            bk_cloud_ids=[],
+            customized={"role": {"bk_cloud_ids": [0]}, "predixy_servers": {"bk_cloud_ids": [1]}},
+        )
+        result = get_candidate_cluster_tuples(config)
+        assert (0, 1) in result
+        assert (1, 2) in result
+        assert len(result) == 2


### PR DESCRIPTION
## 这条 PR 解决什么

- Redis 配置巡检在集群规模大时 pipeline 节点过多、kwargs 载荷冗余、密码接口 CPU 尖峰，以及 Job/DRS 失败难以在报告中定位

## 具体改动

- **Pipeline 节点膨胀**：多 checker/阶段合并为 `RedisConfCheckBatchComponent` 单节点 schedule 状态机 → `poll_jobs` / `run_drs` / `evaluate` / `batch_delay` 在同一 act 内串行完成，去掉批次间独立 `DelayComponent`
- **FlowTree 大载荷**：候选集群写入 Redis List，batch act 仅传 `candidates_key` + `batch_num`，运行时 `LRANGE` 取片 → pipeline kwargs 不再内嵌整批 `clusters`
- **密码接口 CPU 尖峰**：新增 `redis_batch_get_cluster_passwords` 批量拉取 + 进程内 30min TTL 缓存 + `password_batch_size` 可配 → 大幅减少 `get_password` HTTP 次数
- **DRS 突发调用**：`drs_chunks_per_tick` 按 schedule tick 分批执行 DRS，`evaluate` 阶段不再补跑 DRS → 平滑 `er_schedule` worker 负载
- **Job/DRS 失败不可观测**：统一 `errors.py` 错误分类与 `mark_host_targets`，下发/轮询/日志采集/密码不可用写入报告具体 reason → 报告可直接区分采集失败与配置不一致
- **Checker 差异化配置**：`customized` 支持按 checker 覆盖 `bk_cloud_ids`、`cluster_types` 等；predixy 支持 `ignore_question_ip_in_memory` → 可按云区域/检查项精细开关
- **SSL 证书并发写盘**：`DataAPI._fetch_client_crt` 原子写盘并复用已存在文件 → 避免并发场景下证书写半文件

## 测试 & 风险

- 单测已覆盖 batch 各 phase 跳转、DRS 分 tick、密码批量缓存、Redis 候选分片、flow kwargs 不含 clusters、Job/日志失败标记、checker `customized`、报告折叠与 DRS 错误透传
- 仅影响 Redis 配置巡检（`REDIS_CONF_CHECK`）链路；配置项新增字段向后兼容；巡检仍走 Bamboo schedule，批次内行为与旧多节点编排等价，报告 reason 文案会有细化属预期