### PR TITLE
feat(backend): list_cluster_module_conf_files单conf_file时以conf_type标签命名 #18665

### DIFF
--- a/dbm-ui/backend/db_services/dbconfig/handlers.py
+++ b/dbm-ui/backend/db_services/dbconfig/handlers.py
@@ -512,6 +512,12 @@ class DBConfigHandler:
                 continue
             cf["conf_file"] = cf["name"] = deploy_info.get(cf["conf_file"], "")
 
+        # 单 conf_file 的 conf_type 以 conf_type 标签命名
+        single_conf_types = {ct for ct, conf_files in conf_type_map.items() if len(conf_files) == 1}
+        for cf in results:
+            if cf["conf_type"] in single_conf_types:
+                cf["name"] = str(ConfType.get_choice_label(cf["conf_type"]))
+
         return results
 
     def delete_module_config(self, params: Dict[str, Any]) -> Any:


### PR DESCRIPTION
## 改动说明

`list_cluster_module_conf_files` 返回结果中 `name` 字段的赋值逻辑优化：

- 1个 `conf_type` 下有多个 `conf_file` 时：保持原逻辑（取 `ConfFile` 的标签值）
- 1个 `conf_type` 下有且仅有1个 `conf_file` 时：以 `conf_type` 的标签值命名

close #18665