### PR TITLE
fix(mysql): optimize-cluster-skew-task #18687

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/fetch_metrics.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/fetch_metrics.py
@@ -54,8 +54,26 @@ def _fetch_metric_of_cluster_instances(
                     "avg": s["stat"]["avg"][1],
                 }
             )
+        logger.info(
+            "fetch metric done: metric=%s cluster_count=%d instance_count=%d",
+            metric_name,
+            len(cluster_domains),
+            len(res),
+        )
+        if not res:
+            logger.warning(
+                "fetch metric empty: metric=%s cluster_count=%d domains=%s",
+                metric_name,
+                len(cluster_domains),
+                domains_match_filter,
+            )
     except Exception:  # noqa
-        logger.exception("query %s metrics failed", domains_match_filter)
+        logger.exception(
+            "fetch metric failed: metric=%s cluster_count=%d domains=%s",
+            metric_name,
+            len(cluster_domains),
+            domains_match_filter,
+        )
 
     return res
 
@@ -77,23 +95,37 @@ def _fetch_key_metrics_of_cluster_instances(
         )
         res[metric_name] = metric_res
 
+    logger.info(
+        "fetch key metrics done: cluster_type=%s cluster_count=%d instance_counts=%s",
+        cluster_type.value,
+        len(cluster_domains),
+        {metric_name: len(instances) for metric_name, instances in res.items()},
+    )
     return res
 
 
 def _query_promql_metrics_with_roles(
     cluster_domain_pattern: str, instance_roles: list[str], p: PromQLQueryBuilder
 ) -> dict:
-    if not p.filters or not p.group_by:
-        raise Exception("filters or group_by in {} is None".format(p))
+    filters = p.filters if p.filters is not None else []
 
-    p.filters.append({"label_name": "cluster_domain", "op": "match", "value": cluster_domain_pattern})
+    if not p.group_by:
+        raise Exception("group_by in {} is None".format(p))
+
+    if not filters:
+        filters = [{"label_name": "cluster_domain", "op": "match", "value": cluster_domain_pattern}]
+    else:
+        filters.append({"label_name": "cluster_domain", "op": "match", "value": cluster_domain_pattern})
+
     if "cluster_domain" not in p.group_by:
         p.group_by.append("cluster_domain")
 
     if instance_roles:
-        p.filters.append({"label_name": "instance_role", "op": "match", "value": "|".join(instance_roles)})
+        filters.append({"label_name": "instance_role", "op": "match", "value": "|".join(instance_roles)})
         if "instance_role" not in p.group_by:
             p.group_by.append("instance_role")
+
+    p.filters = filters
 
     promql_dict = p.prepare_promql()
     expr = promql_dict.pop("expression", None)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/skew_detect.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/skew_detect.py
@@ -11,22 +11,22 @@ specific language governing permissions and limitations under the License.
 import logging
 import time
 from collections import defaultdict
-from concurrent.futures import as_completed
-from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from itertools import islice
 from typing import Any, Generator, Iterable
 
 import numpy as np
+from blueapps.core.celery.celery import app
+from django.core.cache import cache
 
 from backend.db_meta.enums import ClusterType
-from backend.db_meta.models import Cluster
 from backend.db_periodic_task.local_tasks.mysql_cluster_skew.calculate_skew_data.fetch_metrics import (
     _fetch_key_metrics_of_cluster_instances,
 )
 from backend.db_report.models.cluster_skew_detection import ClusterSkewDetection
 
 logger = logging.getLogger("celery.mysql_skew_detect.calculate_skew_data.skew_detect")
+
 
 # 偏离详情字典结构，由 _detect_skew_by_gini 产出，贯穿 analyze → save 全流程
 # DeviationDict = {
@@ -172,16 +172,26 @@ def _detect_clusters_skew(
             per_cluster[inst["cluster_domain"]][metric_name].append(inst)
 
     skew_results = {}
+    no_metrics_count = 0
     for cluster_domain in cluster_domains:
         cluster_metrics = dict(per_cluster.get(cluster_domain, {}))
         if not cluster_metrics:
-            logger.error(f"{cluster_domain} no metrics data")
+            no_metrics_count += 1
+            logger.error("analyze failed, no metrics: cluster_domain=%s", cluster_domain)
             continue
 
         skew_result = _analyze_cluster_skew(cluster_metrics)
         if any(skew_result.values()):
             skew_results[cluster_domain] = skew_result
     analyze_elapsed = time.monotonic() - t_analyze
+
+    logger.info(
+        "analyze done: cluster_count=%d skew_count=%d no_metrics_count=%d elapsed=%.2fs",
+        len(cluster_domains),
+        len(skew_results),
+        no_metrics_count,
+        analyze_elapsed,
+    )
 
     return skew_results, fetch_elapsed, analyze_elapsed
 
@@ -203,6 +213,7 @@ def _save_skew_records(skew_results: dict[str, dict], now: datetime) -> tuple[in
         (写入记录数, 写入耗时秒数)
     """
     if not skew_results:
+        logger.info("write skip, no skew results")
         return 0, 0.0
 
     dt = now.date()
@@ -230,53 +241,57 @@ def _save_skew_records(skew_results: dict[str, dict], now: datetime) -> tuple[in
     try:
         ClusterSkewDetection.objects.using("doris").bulk_create(records)
     except Exception:  # noqa
-        logger.exception("write result to doris failed")
+        logger.exception("write failed: record_count=%d skew_cluster_count=%d", len(records), len(skew_results))
         raise
     write_elapsed = time.monotonic() - t_write
+
+    logger.info(
+        "write done: record_count=%d skew_cluster_count=%d elapsed=%.2fs",
+        len(records),
+        len(skew_results),
+        write_elapsed,
+    )
 
     return len(records), write_elapsed
 
 
-def _calculate_clusters_skew(cluster_type: ClusterType, cluster_domains: list[str], now: datetime) -> None:
+@app.task
+def calculate_clusters_skew(cluster_type: str, cluster_domains: list[str], lock_key: str) -> None:
     """单批集群的完整处理流程：fetch → analyze → write，结束后记录各步耗时。"""
-    skew_results, fetch_elapsed, analyze_elapsed = _detect_clusters_skew(cluster_type, cluster_domains, now)
-    record_count, write_elapsed = _save_skew_records(skew_results, now)
 
     logger.info(
-        "batch done: %d clusters, %d records, fetch=%.2fs analyze=%.2fs write=%.2fs",
+        "batch start: cluster_type=%s lock_key=%s cluster_count=%d",
+        cluster_type,
+        lock_key,
         len(cluster_domains),
-        record_count,
-        fetch_elapsed,
-        analyze_elapsed,
-        write_elapsed,
     )
-
-
-def _calculate_mysql_skew(cluster_type: ClusterType, pool_size: int, batch_size: int) -> None:
-    """对指定集群类型的所有集群做偏斜检测并写入 Doris。
-
-    将全量集群域名按 batch_size 分批，用线程池并发执行。
-    每个线程处理一批集群的 fetch → analyze → write 全流程。
-    """
-    # 前置检查 Doris 可用性，不可用则跳过整轮检测
     try:
-        ClusterSkewDetection.objects.using("doris").exists()
+        now = datetime.now()
+        skew_results, fetch_elapsed, analyze_elapsed = _detect_clusters_skew(
+            ClusterType(cluster_type), cluster_domains, now
+        )
+        record_count, write_elapsed = _save_skew_records(skew_results, now)
+
+        logger.info(
+            "batch done: cluster_type=%s lock_key=%s cluster_count=%d skew_count=%d record_count=%d "
+            "fetch=%.2fs analyze=%.2fs write=%.2fs",
+            cluster_type,
+            lock_key,
+            len(cluster_domains),
+            len(skew_results),
+            record_count,
+            fetch_elapsed,
+            analyze_elapsed,
+            write_elapsed,
+        )
     except Exception:  # noqa
-        logger.warning("doris is unavailable, skip skew detection")
-        return
-
-    now = datetime.now()
-
-    domains = list(Cluster.objects.filter(cluster_type=cluster_type).values_list("immute_domain", flat=True))
-
-    with ThreadPoolExecutor(max_workers=pool_size) as pool:
-        futures = {}
-        for batch in _batched(domains, batch_size):
-            f = pool.submit(_calculate_clusters_skew, cluster_type, batch, now)
-            futures[f] = batch
-
-        for f in as_completed(futures):
-            try:
-                f.result()
-            except Exception:  # noqa
-                logger.exception("failed for domains %s", futures[f])
+        logger.exception(
+            "batch failed: cluster_type=%s lock_key=%s cluster_count=%d",
+            cluster_type,
+            lock_key,
+            len(cluster_domains),
+        )
+        raise
+    finally:
+        if cache.get(lock_key) == 1:
+            cache.delete(lock_key)

--- a/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/tasks.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/mysql_cluster_skew/calculate_skew_data/tasks.py
@@ -9,43 +9,136 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import logging
-import threading
+import math
 
 from celery.schedules import crontab
+from django.core.cache import cache
+from django.db.models.functions import Mod
 
 from backend.db_meta.enums import ClusterType
-from backend.db_periodic_task.local_tasks import register_periodic_task
+from backend.db_meta.models import Cluster
+from backend.db_periodic_task.local_tasks import register_periodic_task, start_new_span
 from backend.db_periodic_task.local_tasks.mysql_cluster_skew.calculate_skew_data.skew_detect import (
-    _calculate_mysql_skew,
+    calculate_clusters_skew,
 )
+from backend.db_periodic_task.utils import TimeUnit, calculate_countdown
+from backend.db_report.models.cluster_skew_detection import ClusterSkewDetection
 
 logger = logging.getLogger("celery.mysql_cluster_skew.calculate_skew_data.task")
 
-calculate_tendbha_skew_lock = threading.Lock()
-calculate_tendbcluster_skew_lock = threading.Lock()
+
+def _dispatch_cluster_skew_task(cluster_type: ClusterType, batch_size: int):
+    """按集群类型分发倾斜检测 Celery 子任务。
+
+    防雪崩策略：
+    1. 分片：按 cluster id 取模将集群拆成多批，每批最多 batch_size 个，避免单次任务处理全量集群。
+    2. 错峰：通过 calculate_countdown 将各批次随机平摊到 5 分钟窗口内执行，削峰填谷。
+    3. 运行中跳过：投递前 cache.add 占位锁；若上一周期同批次任务尚未完成（锁未释放），跳过本次投递，
+       防止任务堆积拖垮 worker / 监控查询。
+       子任务结束后在 finally 中释放锁；apply_async 失败时也会主动 delete 锁。
+
+    :param cluster_type: 集群类型（TenDBHA / TenDBCluster）
+    :param batch_size: 每批处理的集群数量上限
+    """
+    try:
+        ClusterSkewDetection.objects.using("doris").exists()
+    except Exception:  # noqa
+        logger.warning("dispatch skip, doris unavailable: cluster_type=%s", cluster_type.value)
+        return
+
+    clusters_q = Cluster.objects.filter(cluster_type=cluster_type)
+    cluster_count = clusters_q.count()
+    hash_cnt = math.ceil(cluster_count / batch_size)
+    scheduled, skipped_lock, empty_batch = 0, 0, 0
+
+    logger.info(
+        "dispatch start: cluster_type=%s cluster_count=%d hash_cnt=%d batch_size=%d",
+        cluster_type.value,
+        cluster_count,
+        hash_cnt,
+        batch_size,
+    )
+
+    for hash_value in range(hash_cnt):
+        lock_key = f"mysql_cluster_skew:{cluster_type.value}:{hash_value}"
+
+        cluster_domains = list(
+            clusters_q.annotate(id_hash_value=Mod("id", hash_cnt))
+            .filter(id_hash_value=hash_value)
+            .values_list("immute_domain", flat=True)
+        )
+        if not cluster_domains:
+            empty_batch += 1
+            logger.warning("empty batch: cluster_type=%s hash_value=%d", cluster_type.value, hash_value)
+            continue
+
+        countdown = calculate_countdown(count=hash_cnt, index=hash_value, duration=2 * TimeUnit.MINUTE)
+
+        if not cache.add(lock_key, 1, timeout=3600):
+            skipped_lock += 1
+            logger.warning("batch skip, lock held: lock_key=%s cluster_count=%d", lock_key, len(cluster_domains))
+            continue
+
+        try:
+            with start_new_span(calculate_clusters_skew):
+                calculate_clusters_skew.apply_async(
+                    args=[cluster_type.value, cluster_domains, lock_key],
+                    countdown=countdown,
+                    soft_time_limit=240,
+                    time_limit=360,
+                )
+            scheduled += 1
+            logger.info(
+                "batch scheduled: lock_key=%s hash_value=%d cluster_count=%d countdown=%ds",
+                lock_key,
+                hash_value,
+                len(cluster_domains),
+                countdown,
+            )
+        except Exception:  # noqa
+            logger.exception(
+                "batch schedule failed: lock_key=%s hash_value=%d cluster_count=%d",
+                lock_key,
+                hash_value,
+                len(cluster_domains),
+            )
+            cache.delete(lock_key)
+
+    logger.info(
+        "dispatch done: cluster_type=%s scheduled=%d skipped_lock=%d empty_batch=%d total_hash=%d",
+        cluster_type.value,
+        scheduled,
+        skipped_lock,
+        empty_batch,
+        hash_cnt,
+    )
 
 
 @register_periodic_task(run_every=crontab(minute="*/5"))
 def calculate_tendbha_skew():
-    if calculate_tendbha_skew_lock.acquire(blocking=False):
-        try:
-            _calculate_mysql_skew(cluster_type=ClusterType.TenDBHA, pool_size=10, batch_size=20)
-        except Exception:  # noqa
-            logger.exception("calculate tendbha skew failed")
-        finally:
-            calculate_tendbha_skew_lock.release()
-    else:
-        logger.warning("tendbha lock not acquired")
+    dispatch_key = f"mysql_cluster_skew:dispatch:{ClusterType.TenDBHA.value}"
+    if not cache.add(dispatch_key, 1, timeout=600):
+        logger.warning("dispatch skip, lock held: %s", dispatch_key)
+        return
+    try:
+        _dispatch_cluster_skew_task(ClusterType.TenDBHA, 20)
+    except Exception:  # noqa
+        logger.exception("dispatch failed: %s", dispatch_key)
+        raise
+    finally:
+        cache.delete(dispatch_key)
 
 
 @register_periodic_task(run_every=crontab(minute="*/5"))
 def calculate_tendbcluster_skew():
-    if calculate_tendbcluster_skew_lock.acquire(blocking=False):
-        try:
-            _calculate_mysql_skew(cluster_type=ClusterType.TenDBCluster, pool_size=10, batch_size=5)
-        except Exception:  # noqa
-            logger.exception("calculate tendbcluster skew failed")
-        finally:
-            calculate_tendbcluster_skew_lock.release()
-    else:
-        logger.warning("tendbcluster lock not acquired")
+    dispatch_key = f"mysql_cluster_skew:dispatch:{ClusterType.TenDBCluster.value}"
+    if not cache.add(dispatch_key, 1, timeout=600):
+        logger.warning("dispatch skip, lock held: %s", dispatch_key)
+        return
+    try:
+        _dispatch_cluster_skew_task(ClusterType.TenDBCluster, 5)
+    except Exception:  # noqa
+        logger.exception("dispatch failed: %s", dispatch_key)
+        raise
+    finally:
+        cache.delete(dispatch_key)


### PR DESCRIPTION
#### 1. 调度模型：同步线程池 → Celery 异步分片

- **Before**：周期任务内用 `ThreadPoolExecutor`（10 线程）同步跑完全量集群，单 worker 进程内阻塞执行
- **After**：周期任务只负责 dispatch，按 `cluster id % hash_cnt` 分片，每批投递独立 Celery 子任务 `calculate_clusters_skew`

#### 2. 三层防雪崩

| 策略 | 实现 |
|------|------|
| 分片 | `Mod("id", hash_cnt)` 拆分批次，TenDBHA 每批 20、TenDBCluster 每批 5 |
| 错峰 | `calculate_countdown` 将各 batch 平摊到 2 分钟窗口内启动 |
| 运行中跳过 | batch 级 `cache.add(lock_key)`：上一轮子任务未完成则 skip；dispatch 级 cache lock 防整轮重叠 |

#### 3. 锁机制升级

- 移除进程内 `threading.Lock`（无法跨 worker）
- 改用 Redis cache lock，支持多 worker 场景下的分布式去重

#### 4. 可观测性增强

全链路结构化日志，成功带输入/输出，失败单独标识：

- **dispatch 层**：`dispatch start/done`、`batch scheduled`、`batch skip`
- **fetch 层**：`fetch metric done/empty/failed`、`fetch key metrics done`
- **detect 层**：`batch start/done/failed`、`analyze done`、`write done/failed`

#### 5. 其他修复

- `fetch_metrics.py`：用局部变量处理 `Optional filters`，消除类型检查告警
- 子任务 `finally` 中释放 batch lock，避免异常导致锁泄漏

### 行为变化

- 同一 hash batch 仍约每 5 分钟调度一次（cron 周期不变）
- 错峰窗口从 5 分钟缩到 2 分钟，避免尾部 batch countdown 与下一轮 cron 重叠导致 skip
- 单批异常不再拖垮整轮，仅影响该 batch