### PR TITLE
perf(redis): batch meta-check writes and fix thread ORM leaks #18691

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
@@ -13,20 +13,25 @@ import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field, fields
 from math import floor
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
+from django.db.models import Prefetch
 from django.utils.translation import gettext_lazy as _
 
 from backend.configuration.constants import AffinityEnum, DBType, SystemSettingsEnum
 from backend.configuration.models import DBAdministrator
 from backend.db_meta.enums import ClusterPhase, ClusterType, InstanceRole, MachineType
-from backend.db_meta.models import Cluster, StorageInstance
+from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_meta.models.city_map import BKSubzone
+from backend.db_meta.models.storage_instance_tuple import StorageInstanceTuple
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
 from backend.flow.utils.redis.redis_report_utils import (
+    META_CHECK_CLUSTER_PAGE_SIZE,
     RedisReportWriter,
+    _chunked,
     delete_old_meta_check_reports,
     is_cluster_labeled_with,
+    safe_write_meta_reports,
 )
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
 from backend.ticket.models import SystemSettings
@@ -79,10 +84,7 @@ class RedisAffinityCheckConfig:
         )
 
 
-def _get_candidate_clusters(config: RedisAffinityCheckConfig):
-    """
-    Get candidate clusters for affinity check based on configuration
-    """
+def _get_candidate_cluster_ids(config: RedisAffinityCheckConfig) -> List[int]:
     query = Cluster.objects.filter(cluster_type__in=config.cluster_types)
 
     if config.bizs_ignored:
@@ -94,7 +96,35 @@ def _get_candidate_clusters(config: RedisAffinityCheckConfig):
     if config.bk_cloud_ids:
         query = query.filter(bk_cloud_id__in=config.bk_cloud_ids)
 
-    return query
+    return list(query.values_list("id", flat=True))
+
+
+def _load_affinity_clusters_page(cluster_ids: List[int]) -> List[Cluster]:
+    if not cluster_ids:
+        return []
+    # as_ejector + receiver__machine: used by _check_master_machine_affinity for master→slave pairs
+    storage_qs = StorageInstance.objects.select_related("machine").prefetch_related(
+        Prefetch("as_ejector", queryset=StorageInstanceTuple.objects.select_related("receiver__machine")),
+    )
+    return list(
+        Cluster.objects.filter(id__in=cluster_ids).prefetch_related(
+            Prefetch("proxyinstance_set", queryset=ProxyInstance.objects.select_related("machine")),
+            Prefetch("storageinstance_set", queryset=storage_qs),
+            "tags",
+        )
+    )
+
+
+def _fetch_affinity_ignore_cluster_ids(cluster_ids: List[int], ignore_tickets: List[str]) -> Set[int]:
+    if not cluster_ids:
+        return set()
+    return set(
+        ClusterOperateRecord.objects.filter(
+            ticket__ticket_type__in=ignore_tickets,
+            ticket__status__in=TICKET_RUNNING_STATUS_SET,
+            cluster_id__in=cluster_ids,
+        ).values_list("cluster_id", flat=True)
+    )
 
 
 def check_redis_affinity():
@@ -188,14 +218,20 @@ class RedisAffinityChecker:
         Debug check a single cluster
         """
         self.__class__._subzone_map_cache = BKSubzone.get_subzone_map(get_cache=True)
-        cluster = Cluster.objects.get(immute_domain=cluster_domain)
-        self._check_cluster_affinity(cluster)
+        clusters = _load_affinity_clusters_page(
+            list(Cluster.objects.filter(immute_domain=cluster_domain).values_list("id", flat=True))
+        )
+        if not clusters:
+            logger.error("affinity_check: cluster %s not found", cluster_domain)
+            return
+        rows = self._check_cluster_affinity(clusters[0])
+        if rows:
+            safe_write_meta_reports(self._writer, rows, context=f"debug cluster={cluster_domain}")
 
     def check_all_clusters(self) -> None:
         """
         Check affinity for all Redis clusters
         """
-        # Snapshot subzone names at the beginning of this check run.
         self.__class__._subzone_map_cache = BKSubzone.get_subzone_map(get_cache=True)
 
         delete_old_meta_check_reports(
@@ -203,20 +239,39 @@ class RedisAffinityChecker:
             self._supported_cluster_types,
             self._writer.retention_days,
         )
-        for cluster in _get_candidate_clusters(self._config):
-            try:
-                self._check_cluster_affinity(cluster)
-            except Exception as e:
-                logger.error("affinity_check: error checking cluster %s: %s", cluster.immute_domain, e, exc_info=True)
 
-    def _check_cluster_affinity(self, cluster: Cluster) -> None:
+        all_cluster_ids = _get_candidate_cluster_ids(self._config)
+        ignore_cluster_ids = _fetch_affinity_ignore_cluster_ids(all_cluster_ids, self._ignore_tickets)
+        dba_cache: Dict[int, str] = {}
+
+        for page_ids in _chunked(all_cluster_ids, META_CHECK_CLUSTER_PAGE_SIZE):
+            page_rows: List[dict] = []
+            for cluster in _load_affinity_clusters_page(page_ids):
+                try:
+                    if self._should_ignore_cluster(cluster, ignore_cluster_ids):
+                        continue
+                    page_rows.extend(self._check_cluster_affinity(cluster, dba_cache))
+                except Exception as e:
+                    logger.error(
+                        "affinity_check: error checking cluster %s: %s",
+                        cluster.immute_domain,
+                        e,
+                        exc_info=True,
+                    )
+            if page_rows:
+                safe_write_meta_reports(self._writer, page_rows, context="affinity_check page")
+
+    def _check_cluster_affinity(self, cluster: Cluster, dba_cache: Optional[Dict[int, str]] = None) -> List[dict]:
         """
         Check master-slave affinity for a single cluster
         """
         logger.info("affinity_check: start checking cluster %s", cluster.immute_domain)
 
-        dba_list = DBAdministrator.get_biz_db_type_admins(bk_biz_id=cluster.bk_biz_id, db_type=DBType.Redis.value)
-        creator = dba_list[0] if dba_list else "admin"
+        dba_cache = dba_cache if dba_cache is not None else {}
+        if cluster.bk_biz_id not in dba_cache:
+            dba_list = DBAdministrator.get_biz_db_type_admins(bk_biz_id=cluster.bk_biz_id, db_type=DBType.Redis.value)
+            dba_cache[cluster.bk_biz_id] = dba_list[0] if dba_list else "admin"
+        creator = dba_cache[cluster.bk_biz_id]
         affinity_level = cluster.disaster_tolerance_level
 
         if affinity_level not in self._supported_levels:
@@ -225,19 +280,17 @@ class RedisAffinityChecker:
                 "Cannot perform affinity check: Unsupported affinity level '{}' for Redis. Supported levels are: {}"
             ).format(affinity_level, supported_levels_str)
             logger.warning("affinity_check: %s", msg)
-            self._writer.write_meta_report(
-                cluster=cluster,
-                ip="none",
-                port=None,
-                subtype=MetaCheckSubType.AffinityViolation,
-                msg=msg,
-                state=ReportStateType.WARNING,
-                creator=creator,
-            )
-            return
-
-        if self._should_ignore_cluster(cluster):
-            return
+            return [
+                {
+                    "cluster": cluster,
+                    "ip": "none",
+                    "port": None,
+                    "subtype": MetaCheckSubType.AffinityViolation,
+                    "msg": msg,
+                    "state": ReportStateType.WARNING,
+                    "creator": creator,
+                }
+            ]
 
         check_results = []
         expected_subzone_id = self._resolve_expected_subzone_id(cluster.zone_list or [])
@@ -250,7 +303,7 @@ class RedisAffinityChecker:
 
         # For proxies, we check the stats of their locations
         if not skip_proxy_check:
-            proxy_instances = cluster.proxyinstance_set.filter()
+            proxy_instances = list(cluster.proxyinstance_set.all())
             proxy_result = self._validate_proxies_affinity(
                 proxy_instances=proxy_instances,
                 affinity_level=affinity_level,
@@ -261,7 +314,9 @@ class RedisAffinityChecker:
             check_results.append(proxy_result)
 
         # For backends, we check each master-slave pair
-        master_instances = cluster.storageinstance_set.filter(instance_role=InstanceRole.REDIS_MASTER.value)
+        master_instances = [
+            inst for inst in cluster.storageinstance_set.all() if inst.instance_role == InstanceRole.REDIS_MASTER.value
+        ]
         backend_results = self._validate_backends_affinity(
             master_instances=master_instances,
             affinity_level=affinity_level,
@@ -272,14 +327,14 @@ class RedisAffinityChecker:
             result["identifier"] = identifier
             check_results.append(result)
 
-        self._create_affinity_reports(
+        return self._build_affinity_report_rows(
             cluster=cluster,
             affinity_level=affinity_level,
             check_results=check_results,
             creator=creator,
         )
 
-    def _should_ignore_cluster(self, cluster: Cluster) -> bool:
+    def _should_ignore_cluster(self, cluster: Cluster, ignore_cluster_ids: Set[int]) -> bool:
         """
         Check if cluster should be ignored (being destroyed, disabled, or has active operations)
         """
@@ -294,13 +349,10 @@ class RedisAffinityChecker:
             )
             return True
 
-        if ClusterOperateRecord.objects.filter(
-            ticket__ticket_type__in=self._ignore_tickets,
-            ticket__status__in=TICKET_RUNNING_STATUS_SET,
-            cluster_id=cluster.id,
-        ).exists():
+        if cluster.id in ignore_cluster_ids:
             logger.info(
-                f"affinity_check: will ignore cluster {cluster.immute_domain}, it has active destroy/disable ticket"
+                "affinity_check: will ignore cluster %s, it has active destroy/disable ticket",
+                cluster.immute_domain,
             )
             return True
 
@@ -701,8 +753,8 @@ class RedisAffinityChecker:
 
         for master_obj in master_instances:
             try:
-                slave_tuples = master_obj.as_ejector.all()
-                if not slave_tuples.exists():
+                slave_tuples = list(master_obj.as_ejector.all())
+                if not slave_tuples:
                     instances_without_slaves.append(master_obj.ip_port)
                     continue
                 for slave_tuple in slave_tuples:
@@ -876,30 +928,15 @@ class RedisAffinityChecker:
             return cls._append_suggestion(violation_msg, suggestion)
         return None
 
-    def _create_affinity_reports(
+    def _build_affinity_report_rows(
         self,
         cluster: Cluster,
         affinity_level: str,
         check_results: list[Dict],
         creator: str = "admin",
-    ) -> None:
+    ) -> List[dict]:
         """
-        Create affinity check reports
-
-        Strategy:
-        - If all checks pass: Create 1 cluster-level success record
-        - If any violations/warnings: Create individual records for each failed check only
-
-        Args:
-            cluster: Cluster object
-            affinity_level: Affinity level being checked
-            check_results: List of check results, each containing:
-                - result_type: str ('proxy_distribution', 'backend_pair', 'proxy_master_colocation')
-                - identifier: str (IP address or identifier for the report)
-                - state: ReportStateType
-                - msg: str
-                - machine_type: MachineType (optional, depends on result_type)
-                - proxy_count: int (only for proxy_distribution)
+        Build affinity check report rows for bulk write.
         """
         failed_checks = [result for result in check_results if result["state"] != ReportStateType.NORMAL.value]
         has_violations = len(failed_checks) > 0
@@ -918,33 +955,51 @@ class RedisAffinityChecker:
                 total_machines, affinity_level
             )
             logger.info("affinity_check: cluster %s passed affinity check", cluster.immute_domain)
+            return [
+                {
+                    "cluster": cluster,
+                    "ip": "all",
+                    "port": None,
+                    "subtype": MetaCheckSubType.AffinityViolation,
+                    "msg": msg,
+                    "state": ReportStateType.NORMAL,
+                    "creator": creator,
+                }
+            ]
 
-            self._writer.write_meta_report(
-                cluster=cluster,
-                ip="all",
-                port=None,
-                subtype=MetaCheckSubType.AffinityViolation,
-                msg=msg,
-                state=ReportStateType.NORMAL,
-                creator=creator,
+        total_warnings = sum(1 for result in failed_checks if result["state"] == ReportStateType.WARNING.value)
+        total_violations = len(failed_checks) - total_warnings
+        logger.warning(
+            "affinity_check: cluster %s has %s affinity violations and %s warnings",
+            cluster.immute_domain,
+            total_violations,
+            total_warnings,
+        )
+
+        rows = []
+        for result in failed_checks:
+            rows.append(
+                {
+                    "cluster": cluster,
+                    "ip": result["identifier"],
+                    "port": None,
+                    "subtype": MetaCheckSubType.AffinityViolation,
+                    "msg": result["msg"],
+                    "state": result["state"],
+                    "machine_type": result.get("machine_type"),
+                    "creator": creator,
+                }
             )
-        else:
-            total_warnings = sum(1 for result in failed_checks if result["state"] == ReportStateType.WARNING.value)
-            total_violations = len(failed_checks) - total_warnings
+        return rows
 
-            logger.warning(
-                f"affinity_check: cluster {cluster.immute_domain} has {total_violations} "
-                f"affinity violations and {total_warnings} warnings"
-            )
-
-            for result in failed_checks:
-                self._writer.write_meta_report(
-                    cluster=cluster,
-                    ip=result["identifier"],
-                    port=None,
-                    subtype=MetaCheckSubType.AffinityViolation,
-                    msg=result["msg"],
-                    state=result["state"],
-                    machine_type=result.get("machine_type"),
-                    creator=creator,
-                )
+    def _create_affinity_reports(
+        self,
+        cluster: Cluster,
+        affinity_level: str,
+        check_results: list[Dict],
+        creator: str = "admin",
+    ) -> None:
+        """Backward-compatible wrapper for single-cluster debug flows."""
+        rows = self._build_affinity_report_rows(cluster, affinity_level, check_results, creator)
+        if rows:
+            safe_write_meta_reports(self._writer, rows, context=f"cluster={cluster.immute_domain}")

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
@@ -11,54 +11,104 @@ specific language governing permissions and limitations under the License.
 
 import logging
 from collections import defaultdict
+from typing import Dict, List, Optional, Set, Union
 
-from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django.utils.translation import gettext_lazy as _
 
 from backend.configuration.constants import DBType
 from backend.configuration.models import DBAdministrator
 from backend.db_meta.enums import ClusterPhase, ClusterType, InstanceRole, InstanceStatus
-from backend.db_meta.models import Cluster
+from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
+from backend.db_meta.models.storage_instance_tuple import StorageInstanceTuple
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
 from backend.flow.utils.redis.redis_report_utils import (
+    META_CHECK_CLUSTER_PAGE_SIZE,
     RedisReportWriter,
+    _chunked,
     delete_old_meta_check_reports,
     is_cluster_labeled_with,
+    safe_write_meta_reports,
 )
 from backend.ticket.constants import TICKET_RUNNING_STATUS_SET, TicketType
 from backend.ticket.models.ticket import ClusterOperateRecord
 
 logger = logging.getLogger("root")
 
+IGNORE_TICKET_TYPES = [
+    TicketType.REDIS_INSTANCE_CLOSE.value,
+    TicketType.REDIS_PROXY_CLOSE.value,
+    TicketType.REDIS_DESTROY.value,
+    TicketType.REDIS_INSTANCE_DESTROY.value,
+]
+
+
+def _storage_prefetch_qs():
+    return StorageInstance.objects.select_related("machine").prefetch_related(
+        Prefetch("as_ejector", queryset=StorageInstanceTuple.objects.select_related("receiver__machine")),
+        Prefetch("as_receiver", queryset=StorageInstanceTuple.objects.select_related("ejector__machine")),
+    )
+
 
 def get_supported_clusters():
     return [
-        ClusterType.TendisTwemproxyRedisInstance.value,  # TendisCache 集群
-        ClusterType.TwemproxyTendisSSDInstance.value,  # TendisSSD 集群
-        ClusterType.TendisPredixyRedisCluster.value,  # RedisCluster 集群
-        ClusterType.TendisPredixyTendisplusCluster.value,  # Tendisplus 集群
-        ClusterType.TendisRedisInstance.value,  # Redis 主从
+        ClusterType.TendisTwemproxyRedisInstance.value,
+        ClusterType.TwemproxyTendisSSDInstance.value,
+        ClusterType.TendisPredixyRedisCluster.value,
+        ClusterType.TendisPredixyTendisplusCluster.value,
+        ClusterType.TendisRedisInstance.value,
     ]
 
 
-def check_redis_instance():
-    """
-    孤立实例检查 （孤立的proxy小于2个proxy，孤立的master，孤立的slave）
-     ALONE_PROXY
-     ALONE_MASTER
-     ALONE_SLAVE
+def _load_clusters_page(cluster_ids: List[int]):
+    if not cluster_ids:
+        return []
+    return list(
+        Cluster.objects.filter(id__in=cluster_ids).prefetch_related(
+            Prefetch("proxyinstance_set", queryset=ProxyInstance.objects.select_related("machine")),
+            Prefetch("storageinstance_set", queryset=_storage_prefetch_qs()),
+            "tags",
+        )
+    )
 
-    实例状态异常检查，需要排除掉(禁用、删除中 状态集群) （不属于RUNNING状态）
-     STATUS_ABNORMAL
-     REDIS_INSTANCE_CLOSE = TicketEnumField("REDIS_INSTANCE_CLOSE", _("Redis 主从禁用"), register_iam=False)
-     REDIS_PROXY_CLOSE = TicketEnumField("REDIS_PROXY_CLOSE", _("Redis 集群禁用"), register_iam=False)
-     REDIS_DESTROY = TicketEnumField("REDIS_DESTROY", _("Redis 集群删除"), _("集群管理"))
-     REDIS_INSTANCE_PROXY_CLOSE = TicketEnumField("REDIS_INSTANCE_PROXY_CLOSE", _("Redis 主从集群禁用"), register_iam=False)
-     REDIS_INSTANCE_DESTROY = TicketEnumField("REDIS_INSTANCE_DESTROY", _("Redis 主从集群删除"), _("集群管理"))
-    """
+
+def _fetch_ignore_cluster_ids(cluster_ids: List[int]) -> Set[int]:
+    if not cluster_ids:
+        return set()
+    return set(
+        ClusterOperateRecord.objects.filter(
+            ticket__ticket_type__in=IGNORE_TICKET_TYPES,
+            ticket__status__in=TICKET_RUNNING_STATUS_SET,
+            cluster_id__in=cluster_ids,
+        ).values_list("cluster_id", flat=True)
+    )
+
+
+def _resolve_creator(dba_cache: Dict[int, str], bk_biz_id: int) -> str:
+    if bk_biz_id not in dba_cache:
+        dba_list = DBAdministrator.get_biz_db_type_admins(bk_biz_id=bk_biz_id, db_type=DBType.Redis.value)
+        dba_cache[bk_biz_id] = dba_list[0] if dba_list else "admin"
+    return dba_cache[bk_biz_id]
+
+
+def _should_ignore_cluster(cluster: Cluster, ignore_cluster_ids: Set[int]) -> bool:
+    if cluster.phase != ClusterPhase.ONLINE.value:
+        logger.info(
+            "instance_check: will ignore cluster %s, cluster phase is %s (not online)",
+            cluster,
+            cluster.phase,
+        )
+        return True
+    if cluster.id in ignore_cluster_ids:
+        logger.info("instance_check: will ignore cluster %s , 4 it has destory label", cluster)
+        return True
+    return False
+
+
+def check_redis_instance():
     cluster_types = get_supported_clusters()
     writer = RedisReportWriter()
+    dba_cache: Dict[int, str] = {}
 
     delete_old_meta_check_reports(
         MetaCheckSubType.AloneInstance, cluster_types=cluster_types, days=writer.retention_days
@@ -67,258 +117,266 @@ def check_redis_instance():
         MetaCheckSubType.StatusAbnormal, cluster_types=cluster_types, days=writer.retention_days
     )
 
-    # 遍历集群
     query = Q(cluster_type__in=cluster_types)
-    for c in Cluster.objects.filter(query):
-        logger.info("instance_check: start by {}".format(c))
-        if check_ignore(c):
-            continue
+    all_cluster_ids = list(Cluster.objects.filter(query).values_list("id", flat=True))
+    ignore_cluster_ids = _fetch_ignore_cluster_ids(all_cluster_ids)
 
-        # Get cluster's DBA
-        dba_list = DBAdministrator.get_biz_db_type_admins(bk_biz_id=c.bk_biz_id, db_type=DBType.Redis.value)
-        creator = dba_list[0] if dba_list else "admin"
+    for page_ids in _chunked(all_cluster_ids, META_CHECK_CLUSTER_PAGE_SIZE):
+        page_rows: List[dict] = []
+        for cluster in _load_clusters_page(page_ids):
+            logger.info("instance_check: start by %s", cluster)
+            if _should_ignore_cluster(cluster, ignore_cluster_ids):
+                continue
 
-        cluster_has_lonely_issue = False
+            creator = _resolve_creator(dba_cache, cluster.bk_biz_id)
+            page_rows.extend(_check_single_cluster_instance(cluster, creator))
 
-        # proxy节点数不能小于2
-        skip_proxy_count_check = c.cluster_type == ClusterType.TendisRedisInstance.value or is_cluster_labeled_with(
-            c,
-            {"directmode": "true"},
+        if page_rows:
+            safe_write_meta_reports(writer, page_rows, context="instance_check page")
+
+
+def _check_single_cluster_instance(cluster: Cluster, creator: str) -> List[dict]:
+    report_rows: List[dict] = []
+    cluster_has_lonely_issue = False
+
+    skip_proxy_count_check = cluster.cluster_type == ClusterType.TendisRedisInstance.value or is_cluster_labeled_with(
+        cluster,
+        {"directmode": "true"},
+    )
+    proxy_instances = list(cluster.proxyinstance_set.all())
+    if not skip_proxy_count_check and len(proxy_instances) < 2:
+        cluster_has_lonely_issue = True
+        msg = _("cluster:{} now had proxies[{}] < 2").format(cluster.immute_domain, len(proxy_instances))
+        report_rows.append(
+            _alone_instance_row(cluster, ip="none", port=None, msg=msg, creator=creator, machine_type="")
         )
-        if not skip_proxy_count_check and c.proxyinstance_set.count() < 2:
+    else:
+        logger.info(
+            "cluster:%s proxy count check passed, proxies count: %s",
+            cluster.immute_domain,
+            len(proxy_instances),
+        )
+
+    master_slave_map, slave_master_map = defaultdict(list), defaultdict()
+    storage_instances = list(cluster.storageinstance_set.all())
+    for master_obj in storage_instances:
+        if master_obj.instance_role != InstanceRole.REDIS_MASTER.value:
+            continue
+        try:
+            slave_tuples = list(master_obj.as_ejector.all())
+            if not slave_tuples:
+                cluster_has_lonely_issue = True
+                logger.warning(
+                    "Warning: cluster %s master %s has no slave configured", cluster.immute_domain, master_obj
+                )
+                msg = _("集群{}的master：{} 获取slave失败").format(cluster.immute_domain, master_obj)
+                report_rows.append(_alone_instance_row(cluster, master_obj, msg, creator))
+                continue
+
+            slave_objs = [tuple_obj.receiver for tuple_obj in slave_tuples]
+            all_slaves_valid = True
+            for slave_obj in slave_objs:
+                master_slave_map[master_obj.machine.ip].append(slave_obj.machine.ip)
+                if master_obj.port != slave_obj.port:
+                    cluster_has_lonely_issue = True
+                    all_slaves_valid = False
+                    msg = _("集群{}的master实例：{} 的slave {} 端口不匹配").format(cluster.immute_domain, master_obj, slave_obj)
+                    report_rows.append(_alone_instance_row(cluster, master_obj, msg, creator))
+
+            if all_slaves_valid:
+                slave_ips = ", ".join(slave.machine.ip for slave in slave_objs)
+                logger.info(
+                    _("集群{}的master实例：{} slave关系正常，共{}个slave: {}").format(
+                        cluster.immute_domain, master_obj, len(slave_objs), slave_ips
+                    )
+                )
+        except Exception as e:
             cluster_has_lonely_issue = True
-            msg = _("cluster:{} now had proxies[{}] < 2").format(c.immute_domain, c.proxyinstance_set.count())
-            writer.write_meta_report(
-                cluster=c,
-                ip="none",
-                port=None,
-                subtype=MetaCheckSubType.AloneInstance,
-                msg=msg,
-                state=ReportStateType.ABNORMAL,
-                creator=creator,
+            logger.warning(
+                "Warning: unexpected error while checking master %s in cluster %s: %s",
+                master_obj,
+                cluster.immute_domain,
+                e,
             )
-        else:
-            msg = _("cluster:{} proxy count check passed, proxies count: {}").format(
-                c.immute_domain, c.proxyinstance_set.count()
-            )
-            logger.info(msg)
+            msg = _("集群{}的master实例：{} 检查时发生异常: {}").format(cluster.immute_domain, master_obj, e)
+            report_rows.append(_alone_instance_row(cluster, master_obj, msg, creator))
 
-        # 检查master对应的slave是否缺失
-        master_slave_map, slave_master_map = defaultdict(list), defaultdict()
-        for master_obj in c.storageinstance_set.filter(instance_role=InstanceRole.REDIS_MASTER.value):
-            try:
-                slave_tuples = master_obj.as_ejector.all()
-
-                if not slave_tuples.exists():
-                    cluster_has_lonely_issue = True
-                    logger.warning(
-                        "Warning: cluster {} master {} has no slave configured".format(c.immute_domain, master_obj)
-                    )
-                    msg = _("集群{}的master：{} 获取slave失败").format(c.immute_domain, master_obj)
-                    create_single_node_record(c, master_obj, msg, creator, writer)
-                    continue
-
-                slave_objs = [tuple_obj.receiver for tuple_obj in slave_tuples]
-                all_slaves_valid = True
-
-                for slave_obj in slave_objs:
-                    master_slave_map[master_obj.machine.ip].append(slave_obj.machine.ip)
-
-                    if master_obj.port != slave_obj.port:
-                        cluster_has_lonely_issue = True
-                        all_slaves_valid = False
-                        msg = _("集群{}的master实例：{} 的slave {} 端口不匹配").format(c.immute_domain, master_obj, slave_obj)
-                        create_single_node_record(c, master_obj, msg, creator, writer)
-
-                # Log the result
-                if all_slaves_valid:
-                    slave_count = len(slave_objs)
-                    slave_ips = ", ".join([s.machine.ip for s in slave_objs])
-                    logger.info(
-                        _("集群{}的master实例：{} slave关系正常，共{}个slave: {}").format(
-                            c.immute_domain, master_obj, slave_count, slave_ips
-                        )
-                    )
-            except Exception as e:
+    for slave_obj in storage_instances:
+        if slave_obj.instance_role != InstanceRole.REDIS_SLAVE.value:
+            continue
+        try:
+            receiver_tuples = list(slave_obj.as_receiver.all())
+            if not receiver_tuples:
                 cluster_has_lonely_issue = True
                 logger.warning(
-                    "Warning: unexpected error while checking master {} in cluster {}: {}".format(
-                        master_obj, c.immute_domain, str(e)
-                    )
+                    "Warning: cluster %s slave %s failed to get master_obj",
+                    cluster.immute_domain,
+                    slave_obj,
                 )
-                msg = _("集群{}的master实例：{} 检查时发生异常: {}").format(c.immute_domain, master_obj, str(e))
-                create_single_node_record(c, master_obj, msg, creator, writer)
+                msg = _("集群{}的slave：{} 获取master失败").format(cluster.immute_domain, slave_obj)
+                report_rows.append(_alone_instance_row(cluster, slave_obj, msg, creator))
                 continue
+            master_obj = receiver_tuples[0].ejector
 
-        # 检查slave对应的master是否缺失
-        for slave_obj in c.storageinstance_set.filter(instance_role=InstanceRole.REDIS_SLAVE.value):
-            try:
-                try:
-                    master_obj = slave_obj.as_receiver.get().ejector
-                except ObjectDoesNotExist:
-                    cluster_has_lonely_issue = True
-                    logger.warning(
-                        "Warning: cluster {} slave {} failed to get master_obj".format(c.immute_domain, slave_obj)
-                    )
-                    msg = _("集群{}的slave：{} 获取master失败").format(c.immute_domain, slave_obj)
-                    create_single_node_record(c, slave_obj, msg, creator, writer)
-                    continue
-
-                # 不支持一从多主
-                ifmaster = slave_master_map.get(slave_obj.machine.ip)
-                if ifmaster and ifmaster != master_obj.machine.ip:
-                    cluster_has_lonely_issue = True
-                    logger.warning(
-                        "Warning: cluster {} unsupport multiple masters for slave {}".format(
-                            c.immute_domain, slave_obj.machine.ip
-                        )
-                    )
-                    msg = _(
-                        "unsupport mutil master with cluster {} 4:{}".format(c.immute_domain, slave_obj.machine.ip)
-                    )
-                    create_single_node_record(c, slave_obj, msg, creator, writer)
-                    continue
-
-                else:
-                    slave_master_map[slave_obj.machine.ip] = master_obj.machine.ip
-                # 没获取到对应端口
-                if slave_obj.port != master_obj.port:
-                    cluster_has_lonely_issue = True
-                    msg = _("集群{}的slave实例：{} 没有master").format(c.immute_domain, slave_obj)
-                    create_single_node_record(c, slave_obj, msg, creator, writer)
-                else:
-                    logger.info(_("集群{}的slave实例：{} master关系正常").format(c.immute_domain, slave_obj))
-            except Exception as e:
+            ifmaster = slave_master_map.get(slave_obj.machine.ip)
+            if ifmaster and ifmaster != master_obj.machine.ip:
                 cluster_has_lonely_issue = True
                 logger.warning(
-                    "Warning: unexpected error while checking slave {} in cluster {}: {}".format(
-                        slave_obj, c.immute_domain, str(e)
-                    )
+                    "Warning: cluster %s unsupport multiple masters for slave %s",
+                    cluster.immute_domain,
+                    slave_obj.machine.ip,
                 )
-                msg = _("集群{}的slave实例：{} 检查时发生异常: {}").format(c.immute_domain, slave_obj, str(e))
-                create_single_node_record(c, slave_obj, msg, creator, writer)
+                msg = _("unsupport mutil master with cluster {} 4:{}").format(
+                    cluster.immute_domain, slave_obj.machine.ip
+                )
+                report_rows.append(_alone_instance_row(cluster, slave_obj, msg, creator))
                 continue
 
-        # Check instance status abnormality
-        cluster_has_status_issue = check_cluster_instance_status(c, creator, writer)
+            slave_master_map[slave_obj.machine.ip] = master_obj.machine.ip
+            if slave_obj.port != master_obj.port:
+                cluster_has_lonely_issue = True
+                msg = _("集群{}的slave实例：{} 没有master").format(cluster.immute_domain, slave_obj)
+                report_rows.append(_alone_instance_row(cluster, slave_obj, msg, creator))
+            else:
+                logger.info(_("集群{}的slave实例：{} master关系正常").format(cluster.immute_domain, slave_obj))
+        except Exception as e:
+            cluster_has_lonely_issue = True
+            logger.warning(
+                "Warning: unexpected error while checking slave %s in cluster %s: %s",
+                slave_obj,
+                cluster.immute_domain,
+                e,
+            )
+            msg = _("集群{}的slave实例：{} 检查时发生异常: {}").format(cluster.immute_domain, slave_obj, e)
+            report_rows.append(_alone_instance_row(cluster, slave_obj, msg, creator))
 
-        if not cluster_has_lonely_issue:
-            create_cluster_normal_report(c, MetaCheckSubType.AloneInstance.value, creator, writer)
+    status_rows, cluster_has_status_issue = _collect_status_abnormal_rows(
+        cluster, creator, instance_objs=storage_instances + proxy_instances
+    )
+    report_rows.extend(status_rows)
 
-        if not cluster_has_status_issue:
-            create_cluster_normal_report(c, MetaCheckSubType.StatusAbnormal.value, creator, writer)
+    if not cluster_has_lonely_issue:
+        report_rows.append(_cluster_normal_row(cluster, MetaCheckSubType.AloneInstance, creator))
+    if not cluster_has_status_issue:
+        report_rows.append(_cluster_normal_row(cluster, MetaCheckSubType.StatusAbnormal, creator))
+
+    return report_rows
 
 
-def check_cluster_instance_status(cluster: Cluster, creator: str = "admin", writer: RedisReportWriter = None) -> bool:
-    """Check all instances (storage and proxy) status in the cluster"""
+def _collect_status_abnormal_rows(
+    cluster: Cluster,
+    creator: str,
+    instance_objs: Optional[List[Union[StorageInstance, ProxyInstance]]] = None,
+) -> tuple[List[dict], bool]:
     cluster_has_status_issue = False
+    rows: List[dict] = []
 
-    # Check storage instance status
-    for instance_obj in cluster.storageinstance_set.filter():
+    if instance_objs is None:
+        instance_objs = list(cluster.storageinstance_set.all()) + list(cluster.proxyinstance_set.all())
+
+    for instance_obj in instance_objs:
         try:
-            if not check_status_create_abnormal(cluster, instance_obj, creator, writer):
+            if instance_obj.status != InstanceStatus.RUNNING:
                 cluster_has_status_issue = True
+                msg = _("集群{}的实例:{}实例状态异常:{}").format(cluster.immute_domain, instance_obj.ip_port, instance_obj.status)
+                rows.append(
+                    {
+                        "cluster": cluster,
+                        "ip": instance_obj.machine.ip,
+                        "port": instance_obj.port,
+                        "subtype": MetaCheckSubType.StatusAbnormal,
+                        "msg": msg,
+                        "state": ReportStateType.ABNORMAL,
+                        "machine_type": instance_obj.machine_type,
+                        "creator": creator,
+                    }
+                )
         except Exception as e:
             cluster_has_status_issue = True
             logger.warning(
-                "Warning: unexpected error while checking storage instance {} in cluster {}: {}".format(
-                    instance_obj, cluster.immute_domain, str(e)
-                )
+                "Warning: unexpected error while checking instance %s in cluster %s: %s",
+                instance_obj,
+                cluster.immute_domain,
+                e,
             )
 
-    # Check proxy instance status
-    for instance_obj in cluster.proxyinstance_set.filter():
-        try:
-            if not check_status_create_abnormal(cluster, instance_obj, creator, writer):
-                cluster_has_status_issue = True
-        except Exception as e:
-            cluster_has_status_issue = True
-            logger.warning(
-                "Warning: unexpected error while checking proxy instance {} in cluster {}: {}".format(
-                    instance_obj, cluster.immute_domain, str(e)
-                )
-            )
+    return rows, cluster_has_status_issue
 
-    return cluster_has_status_issue
+
+def _alone_instance_row(cluster, instance_obj=None, msg="", creator="admin", ip=None, port=None, machine_type=""):
+    if instance_obj is not None:
+        ip = instance_obj.machine.ip
+        port = instance_obj.port
+        machine_type = instance_obj.machine_type
+    return {
+        "cluster": cluster,
+        "ip": ip,
+        "port": port,
+        "subtype": MetaCheckSubType.AloneInstance,
+        "msg": msg,
+        "state": ReportStateType.ABNORMAL,
+        "machine_type": machine_type,
+        "creator": creator,
+    }
+
+
+def _cluster_normal_row(cluster, subtype, creator="admin"):
+    msg = _("集群{}所有实例检查通过").format(cluster.immute_domain)
+    logger.info("instance_check: cluster %s passed", cluster.immute_domain)
+    return {
+        "cluster": cluster,
+        "ip": "all",
+        "port": None,
+        "subtype": subtype,
+        "msg": msg,
+        "state": ReportStateType.NORMAL,
+        "creator": creator,
+    }
+
+
+# Backward-compatible helpers for external callers/tests.
+def check_cluster_instance_status(cluster: Cluster, creator: str = "admin", writer: RedisReportWriter = None) -> bool:
+    rows, has_issue = _collect_status_abnormal_rows(cluster, creator)
+    if writer and rows:
+        writer.write_meta_reports(rows)
+    return has_issue
 
 
 def check_ignore(cluster) -> bool:
-    if cluster.phase != ClusterPhase.ONLINE.value:
-        logger.info(
-            f"instance_check: will ignore cluster {cluster}, " f"cluster phase is {cluster.phase} (not online)"
-        )
-        return True
-    ignore_tickets = [
-        TicketType.REDIS_INSTANCE_CLOSE.value,
-        TicketType.REDIS_PROXY_CLOSE.value,
-        TicketType.REDIS_DESTROY.value,
-        TicketType.REDIS_INSTANCE_CLOSE.value,
-        TicketType.REDIS_INSTANCE_DESTROY.value,
-    ]
-    if ClusterOperateRecord.objects.filter(
-        ticket__ticket_type__in=ignore_tickets,
-        ticket__status__in=TICKET_RUNNING_STATUS_SET,
-        cluster_id=cluster.id,
-    ).exists():
-        logger.info("instance_check: will ignore cluster {} , 4 it has destory label".format(cluster))
-        return True
-    return False
+    return _should_ignore_cluster(cluster, _fetch_ignore_cluster_ids([cluster.id]))
 
 
 def check_status_create_abnormal(c, instance_obj, creator="admin", writer: RedisReportWriter = None):
-    """
-    实例状态检查并插入异常报告
-    Returns:
-        bool: True if instance status is normal, False if abnormal
-    """
     if instance_obj.status != InstanceStatus.RUNNING:
-        msg = _("集群{}的实例:{}实例状态异常:{}").format(c.immute_domain, instance_obj.ip_port, instance_obj.status)
-        _write = writer.write_meta_report if writer else RedisReportWriter().write_meta_report
-        _write(
-            cluster=c,
-            ip=instance_obj.machine.ip,
-            port=instance_obj.port,
-            subtype=MetaCheckSubType.StatusAbnormal,
-            msg=msg,
-            state=ReportStateType.ABNORMAL,
-            machine_type=instance_obj.machine_type,
-            creator=creator,
-        )
+        row = {
+            "cluster": c,
+            "ip": instance_obj.machine.ip,
+            "port": instance_obj.port,
+            "subtype": MetaCheckSubType.StatusAbnormal,
+            "msg": _("集群{}的实例:{}实例状态异常:{}").format(c.immute_domain, instance_obj.ip_port, instance_obj.status),
+            "state": ReportStateType.ABNORMAL,
+            "machine_type": instance_obj.machine_type,
+            "creator": creator,
+        }
+        if writer:
+            writer.write_meta_reports([row])
+        else:
+            RedisReportWriter().write_meta_reports([row])
         return False
     return True
 
 
 def create_single_node_record(c, instance_obj, msg, creator="admin", writer: RedisReportWriter = None):
-    """
-    孤立实例写入表中
-    """
-    _write = writer.write_meta_report if writer else RedisReportWriter().write_meta_report
-    _write(
-        cluster=c,
-        ip=instance_obj.machine.ip,
-        port=instance_obj.port,
-        subtype=MetaCheckSubType.AloneInstance,
-        msg=msg,
-        state=ReportStateType.ABNORMAL,
-        machine_type=instance_obj.machine_type,
-        creator=creator,
-    )
+    row = _alone_instance_row(c, instance_obj, msg, creator)
+    if writer:
+        writer.write_meta_reports([row])
+    else:
+        RedisReportWriter().write_meta_reports([row])
 
 
 def create_cluster_normal_report(c, report_type, creator="admin", writer: RedisReportWriter = None):
-    """
-    集群级别正常检查报告
-    当集群下所有实例检查都通过时，创建集群级别的正常报告
-    """
-    msg = _("集群{}所有实例检查通过").format(c.immute_domain)
-    _write = writer.write_meta_report if writer else RedisReportWriter().write_meta_report
-    _write(
-        cluster=c,
-        ip="all",
-        port=None,
-        subtype=report_type,
-        msg=msg,
-        state=ReportStateType.NORMAL,
-        creator=creator,
-    )
-    logger.info("instance_check: cluster {} passed".format(c.immute_domain))
+    row = _cluster_normal_row(c, report_type, creator)
+    if writer:
+        writer.write_meta_reports([row])
+    else:
+        RedisReportWriter().write_meta_reports([row])

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
@@ -544,54 +544,45 @@ def _run_single_drs_chunk(
     addresses: List[str],
     password_cache: Dict[int, Dict],
     password_errors: Dict[int, str],
-    errors_out: Dict[Tuple[int, str, str], str],
-) -> Dict[Tuple[int, str, str], str]:
+) -> Tuple[Dict[Tuple[int, str, str], str], Dict[Tuple[int, str, str], str]]:
     bk_cloud_id, cluster_id, password_key, command = group_key
+    local_errors: Dict[Tuple[int, str, str], str] = {}
     pwd_err = password_errors.get(cluster_id)
     if pwd_err:
         err = format_password_drs_error(pwd_err)
         for address in addresses:
-            errors_out.setdefault((bk_cloud_id, command, address), err)
-        return {}
+            local_errors[(bk_cloud_id, command, address)] = err
+        return {}, local_errors
     passwords = password_cache.get(cluster_id, {})
     password = passwords.get(password_key, "")
-    return _redis_rpc_chunk(bk_cloud_id, command, addresses, password, errors_out)
+    out = _redis_rpc_chunk(bk_cloud_id, command, addresses, password, local_errors)
+    return out, local_errors
 
 
-# Resolved-password DRS group key: (bk_cloud_id, password, command) -> address set
-ResolvedDrsGroupKey = Tuple[int, str, str]
+def _run_drs_chunk_slice(
+    chunk_slice: List[DrsChunk],
+    password_cache: Dict[int, Dict],
+    password_errors: Dict[int, str],
+) -> Tuple[Dict[Tuple[int, str, str], str], Dict[Tuple[int, str, str], str]]:
+    """Run DRS redis_rpc for queued chunks in parallel (bounded by MAX_WORKERS)."""
+    if not chunk_slice:
+        return {}, {}
+    if len(chunk_slice) == 1:
+        group_key, addresses = chunk_slice[0]
+        return _run_single_drs_chunk(group_key, addresses, password_cache, password_errors)
 
-
-def _run_drs_groups(
-    drs_groups: Dict[ResolvedDrsGroupKey, set],
-    chunk_size: int = DEFAULT_DRS_GROUP_CHUNK_SIZE,
-    errors_out: Optional[Dict[Tuple[int, str, str], str]] = None,
-) -> Dict[Tuple[int, str, str], str]:
-    """Issue chunked redis_rpc per (bk_cloud_id, password, command) group."""
-    if not drs_groups:
-        return {}
-    chunk_size = max(int(chunk_size or DEFAULT_DRS_GROUP_CHUNK_SIZE), 1)
-    drs_result_map: Dict[Tuple[int, str, str], str] = {}
-    chunk_errors: Dict[Tuple[int, str, str], str] = errors_out if errors_out is not None else {}
-
-    drs_chunks: List[Tuple[ResolvedDrsGroupKey, List[str]]] = []
-    for group_key, address_set in drs_groups.items():
-        for address_chunk in _chunks(sorted(address_set), chunk_size):
-            drs_chunks.append((group_key, address_chunk))
-
-    def run_resolved_group(group_key: ResolvedDrsGroupKey, addresses: List[str]) -> Tuple[Dict, Dict]:
-        bk_cloud_id, password, command = group_key
-        local_errors: Dict[Tuple[int, str, str], str] = {}
-        out = _redis_rpc_chunk(bk_cloud_id, command, addresses, password, local_errors)
-        return out, local_errors
-
+    result_map: Dict[Tuple[int, str, str], str] = {}
+    error_map: Dict[Tuple[int, str, str], str] = {}
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-        futures = [executor.submit(run_resolved_group, group_key, addrs) for group_key, addrs in drs_chunks]
+        futures = [
+            executor.submit(_run_single_drs_chunk, group_key, addresses, password_cache, password_errors)
+            for group_key, addresses in chunk_slice
+        ]
         for future in as_completed(futures):
-            chunk_result, local_errors = future.result()
-            drs_result_map.update(chunk_result)
-            chunk_errors.update(local_errors)
-    return drs_result_map
+            chunk_result, chunk_errors = future.result()
+            result_map.update(chunk_result)
+            error_map.update(chunk_errors)
+    return result_map, error_map
 
 
 def _evaluate_and_report(
@@ -885,17 +876,13 @@ class RedisConfCheckBatchService(BaseService):
             drs_error_map = data.outputs.drs_error_map
 
             end = min(drs_cursor + drs_chunks_per_tick, len(drs_chunk_queue))
-            for idx in range(drs_cursor, end):
-                group_key, addresses = drs_chunk_queue[idx]
-                drs_result_map.update(
-                    _run_single_drs_chunk(
-                        group_key,
-                        addresses,
-                        password_cache,
-                        password_errors,
-                        drs_error_map,
-                    )
-                )
+            chunk_results, chunk_errors = _run_drs_chunk_slice(
+                drs_chunk_queue[drs_cursor:end],
+                password_cache,
+                password_errors,
+            )
+            drs_result_map.update(chunk_results)
+            drs_error_map.update(chunk_errors)
             data.outputs.drs_cursor = end
             data.outputs.drs_result_map = drs_result_map
             data.outputs.drs_error_map = drs_error_map

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
@@ -24,7 +24,7 @@ from backend.flow.plugins.components.collections.common.base_service import Base
 from backend.flow.utils import dns_manage
 from backend.flow.utils.clb_manage import get_clb_by_ip
 from backend.flow.utils.polaris_manage import GetPolarisManageByName
-from backend.flow.utils.redis.redis_report_utils import RedisReportWriter
+from backend.flow.utils.redis.redis_report_utils import RedisReportWriter, safe_write_meta_reports
 from backend.utils.redis import RedisConn
 
 # Default batch size and interval for scheduled processing
@@ -49,63 +49,40 @@ class RedisEntryCheckService(BaseService):
 
     @staticmethod
     def _get_cluster_proxy_ips(cluster: Cluster) -> Set[str]:
-        """
-        Get all proxy IPs from cluster metadata
-
-        Args:
-            cluster: Cluster object
-
-        Returns:
-            Set of proxy IP addresses
-        """
-        return set(cluster.proxyinstance_set.values_list("machine__ip", flat=True))
+        return {proxy.machine.ip for proxy in cluster.proxyinstance_set.all()}
 
     @staticmethod
     def _get_cluster_storage_ips(cluster: Cluster) -> Set[str]:
-        """
-        Get all storage (backend Redis) IPs from cluster metadata
-
-        Args:
-            cluster: Cluster object
-
-        Returns:
-            Set of storage IP addresses (both master and slave)
-        """
-        return set(cluster.storageinstance_set.values_list("machine__ip", flat=True))
+        return {storage.machine.ip for storage in cluster.storageinstance_set.all()}
 
     @staticmethod
     def _get_cluster_master_ips(cluster: Cluster) -> Set[str]:
-        """
-        Get master storage IPs from cluster metadata
-
-        Args:
-            cluster: Cluster object
-
-        Returns:
-            Set of master IP addresses
-        """
-        return set(
-            cluster.storageinstance_set.filter(instance_inner_role=InstanceInnerRole.MASTER).values_list(
-                "machine__ip", flat=True
-            )
-        )
+        return {
+            storage.machine.ip
+            for storage in cluster.storageinstance_set.all()
+            if storage.instance_inner_role == InstanceInnerRole.MASTER
+        }
 
     @staticmethod
     def _get_cluster_slave_ips(cluster: Cluster) -> Set[str]:
-        """
-        Get slave storage IPs from cluster metadata
+        return {
+            storage.machine.ip
+            for storage in cluster.storageinstance_set.all()
+            if storage.instance_inner_role == InstanceInnerRole.SLAVE
+        }
 
-        Args:
-            cluster: Cluster object
-
-        Returns:
-            Set of slave IP addresses
-        """
-        return set(
-            cluster.storageinstance_set.filter(instance_inner_role=InstanceInnerRole.SLAVE).values_list(
-                "machine__ip", flat=True
+    @staticmethod
+    def _load_batch_clusters(cluster_ids: List[int]) -> Dict[int, Cluster]:
+        if not cluster_ids:
+            return {}
+        return {
+            cluster.id: cluster
+            for cluster in Cluster.objects.filter(id__in=cluster_ids).prefetch_related(
+                "proxyinstance_set__machine",
+                "storageinstance_set__machine",
+                "clusterentry_set",
             )
-        )
+        }
 
     def _get_dns_ips(self, cluster: Cluster, entry: ClusterEntry) -> Tuple[Set[str], Optional[str]]:
         """
@@ -287,27 +264,19 @@ class RedisEntryCheckService(BaseService):
 
         return None
 
-    def _create_cluster_report(self, cluster: Cluster, all_error_details: list, writer: RedisReportWriter):
-        """
-        Create a single meta check report for all entry inconsistencies in a cluster
-
-        Args:
-            cluster: Cluster object
-            all_error_details: List of error detail dicts from all entries
-            writer: ReportWriter instance for writing reports
-        """
+    @staticmethod
+    def _build_entry_report_row(cluster: Cluster, all_error_details: list) -> Dict:
         if not all_error_details:
-            writer.write_meta_report(
-                cluster=cluster,
-                ip=None,
-                port=None,
-                subtype=MetaCheckSubType.EntryInconsistent,
-                msg=_("All entries are consistent."),
-                state=ReportStateType.NORMAL,
-            )
-            return
+            return {
+                "cluster": cluster,
+                "ip": None,
+                "port": None,
+                "subtype": MetaCheckSubType.EntryInconsistent,
+                "msg": _("All entries are consistent."),
+                "state": ReportStateType.NORMAL,
+                "creator": "system",
+            }
 
-        # Build a comprehensive description for all inconsistencies
         description_parts = []
         for error_detail in all_error_details:
             entry_type = error_detail["entry_type"]
@@ -329,37 +298,22 @@ class RedisEntryCheckService(BaseService):
             if entry_desc_parts:
                 description_parts.append(_("{}  ({}): {}").format(entry_type, entry_name, "; ".join(entry_desc_parts)))
 
-        description = "; ".join(description_parts)
+        return {
+            "cluster": cluster,
+            "ip": None,
+            "port": None,
+            "subtype": MetaCheckSubType.EntryInconsistent,
+            "msg": "; ".join(description_parts),
+            "state": ReportStateType.ABNORMAL,
+            "creator": "system",
+        }
 
-        writer.write_meta_report(
-            cluster=cluster,
-            ip=None,
-            port=None,
-            subtype=MetaCheckSubType.EntryInconsistent,
-            msg=description,
-            state=ReportStateType.ABNORMAL,
-        )
-        self.log_warning(
-            _("Entry inconsistencies detected for cluster {}: {}").format(cluster.immute_domain, description)
-        )
-
-    def _check_single_cluster(self, cluster_id: int, writer: RedisReportWriter) -> Dict:
+    def _check_single_cluster(self, cluster: Cluster) -> Dict:
         """
-        Check entries for a single cluster
-
-        Args:
-            cluster_id: ID of the cluster to check
-
-        Returns:
-            Dict with check results
+        Check entries for a single preloaded cluster (external I/O only; no ORM).
         """
         try:
-            cluster = Cluster.objects.prefetch_related(
-                "proxyinstance_set", "storageinstance_set", "clusterentry_set"
-            ).get(id=cluster_id)
-
-            # Check each entry and collect all error details
-            entries = cluster.clusterentry_set.all()
+            entries = list(cluster.clusterentry_set.all())
             checked_count = 0
             all_error_details = []
 
@@ -369,18 +323,25 @@ class RedisEntryCheckService(BaseService):
                 if error_detail:
                     all_error_details.append(error_detail)
 
-            # Create a single report for the cluster (success or failure)
-            self._create_cluster_report(cluster, all_error_details, writer)
-
+            report_row = self._build_entry_report_row(cluster, all_error_details)
             inconsistent_count = len(all_error_details)
-            return {"cluster_id": cluster_id, "checked": checked_count, "inconsistent": inconsistent_count}
+            if inconsistent_count:
+                self.log_warning(
+                    _("Entry inconsistencies detected for cluster {}: {}").format(
+                        cluster.immute_domain, report_row["msg"]
+                    )
+                )
 
-        except Cluster.DoesNotExist:
-            self.log_warning(_("Cluster id={} not found, skipping").format(cluster_id))
-            return {"cluster_id": cluster_id, "checked": 0, "inconsistent": 0, "error": "Cluster not found"}
+            return {
+                "cluster_id": cluster.id,
+                "checked": checked_count,
+                "inconsistent": inconsistent_count,
+                "report_row": report_row,
+            }
+
         except Exception as e:
-            self.log_exception(_("Failed to check entries for cluster id={}: {}").format(cluster_id, str(e)))
-            return {"cluster_id": cluster_id, "checked": 0, "inconsistent": 0, "error": str(e)}
+            self.log_exception(_("Failed to check entries for cluster id={}: {}").format(cluster.id, str(e)))
+            return {"cluster_id": cluster.id, "checked": 0, "inconsistent": 0, "error": str(e)}
 
     def _pop_batch_from_redis(self, candidates_key: str, batch_size: int) -> List[int]:
         """
@@ -412,6 +373,14 @@ class RedisEntryCheckService(BaseService):
         except Exception as e:
             self.log_exception(_("Failed to pop batch from Redis: {}").format(e))
             return []
+
+    @staticmethod
+    def _requeue_batch_to_redis(candidates_key: str, batch_cluster_ids: List[int]) -> None:
+        """Put popped cluster ids back on the Redis list tail so a failed write can be retried."""
+        if not batch_cluster_ids:
+            return
+        # Candidates are LPUSHed then RPOPped; restore original order via reversed RPUSH.
+        RedisConn.rpush(candidates_key, *reversed(batch_cluster_ids))
 
     def _execute(self, data, parent_data) -> bool:
         """
@@ -513,27 +482,56 @@ class RedisEntryCheckService(BaseService):
             )
         )
 
-        # Process this batch
+        cluster_map = self._load_batch_clusters(batch_cluster_ids)
         writer = RedisReportWriter()
         batch_checked = 0
         batch_inconsistent = 0
+        report_rows = []
 
-        # Use ThreadPoolExecutor for parallel processing within the batch
-        max_workers = min(15, len(batch_cluster_ids))
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_cluster = {
-                executor.submit(self._check_single_cluster, cluster_id, writer): cluster_id
-                for cluster_id in batch_cluster_ids
-            }
+        clusters_to_check = []
+        for cluster_id in batch_cluster_ids:
+            cluster = cluster_map.get(cluster_id)
+            if cluster is None:
+                self.log_warning(_("Cluster id={} not found, skipping").format(cluster_id))
+                continue
+            clusters_to_check.append(cluster)
 
-            for future in as_completed(future_to_cluster):
-                cluster_id = future_to_cluster[future]
+        max_workers = min(15, len(clusters_to_check))
+        if max_workers > 0:
+            # Workers use preloaded cluster objects and external I/O only (no Django ORM / DB writes).
+            # ORM prefetch and report writes stay on this thread to avoid connection leaks.
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_cluster = {
+                    executor.submit(self._check_single_cluster, cluster): cluster.id for cluster in clusters_to_check
+                }
+
+                for future in as_completed(future_to_cluster):
+                    cluster_id = future_to_cluster[future]
+                    try:
+                        result = future.result()
+                        batch_checked += result.get("checked", 0)
+                        batch_inconsistent += result.get("inconsistent", 0)
+                        report_row = result.get("report_row")
+                        if report_row:
+                            report_rows.append(report_row)
+                    except Exception as e:
+                        self.log_exception(_("Exception checking cluster id={}: {}").format(cluster_id, e))
+
+        write_ok = True
+        if report_rows:
+            write_ok = safe_write_meta_reports(
+                writer,
+                report_rows,
+                context=f"entry_check batch={batch_num} key={candidates_key}",
+            )
+            if not write_ok:
                 try:
-                    result = future.result()
-                    batch_checked += result.get("checked", 0)
-                    batch_inconsistent += result.get("inconsistent", 0)
+                    self._requeue_batch_to_redis(candidates_key, batch_cluster_ids)
+                    self.log_warning(
+                        _("Re-queued {} cluster ids after report write failure").format(len(batch_cluster_ids))
+                    )
                 except Exception as e:
-                    self.log_exception(_("Exception checking cluster id={}: {}").format(cluster_id, e))
+                    self.log_exception(_("Failed to re-queue batch after write failure: {}").format(e))
 
         # Update totals in outputs
         total_checked += batch_checked
@@ -546,6 +544,9 @@ class RedisEntryCheckService(BaseService):
                 batch_num, total_batches, batch_checked, batch_inconsistent
             )
         )
+
+        if not write_ok:
+            return True
 
         # Update state for next iteration
         current_batch += 1

--- a/dbm-ui/backend/flow/utils/redis/redis_report_utils.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_report_utils.py
@@ -12,7 +12,7 @@ specific language governing permissions and limitations under the License.
 import logging
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -31,6 +31,9 @@ REDIS_REPORT_MODE_ADD = "add"
 REDIS_REPORT_MODE_UPSERT = "upsert"
 REDIS_REPORT_MODE_SET = {REDIS_REPORT_MODE_ADD, REDIS_REPORT_MODE_UPSERT}
 REDIS_REPORT_DEFAULT_RETENTION_DAYS = 30
+META_REPORT_WRITE_CHUNK = 500
+META_CHECK_CLUSTER_PAGE_SIZE = 300
+META_REPORT_LOOKBACK_HOURS = 36
 
 
 def _known_redis_report_subtypes() -> Set[str]:
@@ -139,6 +142,84 @@ def _resolve_write_mode(subtype_value: str, mode_config: RedisReportModeConfig) 
     return mode_config.default_mode
 
 
+def _enum_value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _chunked(items: List, size: int):
+    chunk_size = max(int(size or 1), 1)
+    for start in range(0, len(items), chunk_size):
+        yield items[start : start + chunk_size]
+
+
+def _meta_report_lookup_key(
+    cluster_domain: str,
+    ip: Optional[str],
+    port: Optional[int],
+    subtype: Any,
+    state: Any,
+) -> Tuple[str, Optional[str], Optional[int], str, str]:
+    return (cluster_domain, ip, port, _enum_value(subtype), _enum_value(state))
+
+
+def _prefetch_meta_last_records(
+    rows: List[Dict],
+    *,
+    lookback_hours: int = META_REPORT_LOOKBACK_HOURS,
+) -> Dict[Tuple[str, Optional[str], Optional[int], str, str], MetaCheckReport]:
+    if not rows:
+        return {}
+
+    cutoff = timezone.now() - timedelta(hours=lookback_hours)
+    cluster_domains = sorted({row["cluster"].immute_domain for row in rows})
+    subtypes = sorted({_enum_value(row["subtype"]) for row in rows})
+    states = sorted({_enum_value(row["state"]) for row in rows})
+
+    latest_by_key: Dict[Tuple[str, Optional[str], Optional[int], str, str], MetaCheckReport] = {}
+    for domain_chunk in _chunked(cluster_domains, META_REPORT_WRITE_CHUNK):
+        existing_rows = MetaCheckReport.objects.filter(
+            cluster__in=domain_chunk,
+            subtype__in=subtypes,
+            state__in=states,
+            create_at__gte=cutoff,
+        ).order_by("cluster", "ip", "port", "subtype", "state", "-create_at")
+        for existing in existing_rows:
+            key = _meta_report_lookup_key(
+                existing.cluster,
+                existing.ip,
+                existing.port,
+                existing.subtype,
+                existing.state,
+            )
+            latest_by_key.setdefault(key, existing)
+    return latest_by_key
+
+
+def _build_meta_report_instance(row: Dict, failed_days: int) -> MetaCheckReport:
+    cluster = row["cluster"]
+    now = timezone.now()
+    state = _enum_value(row["state"])
+    subtype = row["subtype"]
+    creator = row.get("creator", "system")
+    return MetaCheckReport(
+        bk_biz_id=cluster.bk_biz_id,
+        bk_cloud_id=cluster.bk_cloud_id,
+        ip=row.get("ip"),
+        port=row.get("port"),
+        cluster=cluster.immute_domain,
+        cluster_type=cluster.cluster_type,
+        state=state,
+        msg=row["msg"],
+        subtype=subtype,
+        failed_days=failed_days,
+        machine_type=row.get("machine_type", ""),
+        creator=creator,
+        updater=creator,
+        create_at=now,
+        update_at=now,
+    )
+
+
 class RedisReportWriter:
     """Loads report-mode config once on init and exposes write methods that reuse it."""
 
@@ -155,43 +236,119 @@ class RedisReportWriter:
         msg: str,
         state: ReportStateType,
         machine_type: str = "",
-        creator: str = "dba",
+        creator: str = "system",
     ) -> MetaCheckReport:
-        subtype_value = getattr(subtype, "value", subtype)
-        mode = _resolve_write_mode(subtype_value, self._mode_config)
-        report = get_last_record(cluster.immute_domain, ip, port, subtype, state)
-        failed_days = calculate_failed_days(state, report)
+        written = self.write_meta_reports(
+            [
+                {
+                    "cluster": cluster,
+                    "ip": ip,
+                    "port": port,
+                    "subtype": subtype,
+                    "msg": msg,
+                    "state": state,
+                    "machine_type": machine_type,
+                    "creator": creator,
+                }
+            ]
+        )
+        return written[0]
 
-        if mode == REDIS_REPORT_MODE_ADD or not report:
-            report = MetaCheckReport.objects.create(
-                bk_biz_id=cluster.bk_biz_id,
-                bk_cloud_id=cluster.bk_cloud_id,
-                ip=ip,
-                port=port,
-                cluster=cluster.immute_domain,
-                cluster_type=cluster.cluster_type,
-                state=state,
-                msg=msg,
-                subtype=subtype,
-                failed_days=failed_days,
-                machine_type=machine_type,
-                creator=creator,
-            )
-        else:
-            report.msg = msg
-            report.state = state
-            report.failed_days = failed_days
-            report.create_at = timezone.now()
-            report.save(update_fields=["msg", "state", "failed_days", "create_at", "update_at"])
+    def write_meta_reports(self, rows: List[Dict]) -> List[MetaCheckReport]:
+        """Write multiple MetaCheckReport rows with batched prefetch and chunked DB writes."""
+        if not rows:
+            return []
+
+        upsert_rows: List[Dict] = []
+        add_rows: List[Dict] = []
+        for row in rows:
+            subtype_value = _enum_value(row["subtype"])
+            mode = _resolve_write_mode(subtype_value, self._mode_config)
+            if mode == REDIS_REPORT_MODE_UPSERT:
+                upsert_rows.append(row)
+            else:
+                add_rows.append(row)
+
+        written: List[MetaCheckReport] = []
+        if upsert_rows:
+            written.extend(self._write_meta_reports_upsert(upsert_rows))
+        if add_rows:
+            written.extend(self._write_meta_reports_add(add_rows))
 
         logger.info(
-            _(
-                "meta_check: {} check report for {} {}:{} - state={}, failed_days={}, machine_type={}, creator={}".format(
-                    subtype, cluster.immute_domain, ip, port, state, failed_days, machine_type, creator
-                )
-            )
+            "meta_check: wrote %d meta reports (upsert=%d, add=%d)",
+            len(written),
+            len(upsert_rows),
+            len(add_rows),
         )
-        return report
+        return written
+
+    def _write_meta_reports_add(self, rows: List[Dict]) -> List[MetaCheckReport]:
+        latest_by_key = _prefetch_meta_last_records(rows)
+        to_create: List[MetaCheckReport] = []
+        for row in rows:
+            cluster = row["cluster"]
+            key = _meta_report_lookup_key(
+                cluster.immute_domain,
+                row.get("ip"),
+                row.get("port"),
+                row["subtype"],
+                row["state"],
+            )
+            failed_days = calculate_failed_days(_enum_value(row["state"]), latest_by_key.get(key))
+            report = _build_meta_report_instance(row, failed_days)
+            to_create.append(report)
+            latest_by_key[key] = report
+
+        written: List[MetaCheckReport] = []
+        for chunk in _chunked(to_create, META_REPORT_WRITE_CHUNK):
+            MetaCheckReport.objects.bulk_create(chunk)
+            written.extend(chunk)
+        return written
+
+    def _write_meta_reports_upsert(self, rows: List[Dict]) -> List[MetaCheckReport]:
+        latest_by_key = _prefetch_meta_last_records(rows)
+        to_update: List[MetaCheckReport] = []
+        to_create: List[MetaCheckReport] = []
+        now = timezone.now()
+
+        for row in rows:
+            cluster = row["cluster"]
+            key = _meta_report_lookup_key(
+                cluster.immute_domain,
+                row.get("ip"),
+                row.get("port"),
+                row["subtype"],
+                row["state"],
+            )
+            failed_days = calculate_failed_days(_enum_value(row["state"]), latest_by_key.get(key))
+            existing = latest_by_key.get(key)
+            if existing is None:
+                report = _build_meta_report_instance(row, failed_days)
+                to_create.append(report)
+                latest_by_key[key] = report
+                continue
+
+            existing.msg = row["msg"]
+            existing.state = _enum_value(row["state"])
+            existing.failed_days = failed_days
+            existing.create_at = now
+            existing.update_at = now
+            to_update.append(existing)
+
+        written: List[MetaCheckReport] = []
+        if to_update:
+            for chunk in _chunked(to_update, META_REPORT_WRITE_CHUNK):
+                MetaCheckReport.objects.bulk_update(
+                    chunk,
+                    fields=["msg", "state", "failed_days", "create_at", "update_at"],
+                )
+            written.extend(to_update)
+        if to_create:
+            for chunk in _chunked(to_create, META_REPORT_WRITE_CHUNK):
+                MetaCheckReport.objects.bulk_create(chunk)
+            written.extend(to_create)
+        return written
 
     def write_redis_report(
         self,
@@ -285,6 +442,29 @@ class RedisReportWriter:
         RedisCheckReport.objects.bulk_create(to_create)
         written.extend(to_create)
         return written
+
+
+def safe_write_meta_reports(
+    writer: RedisReportWriter,
+    rows: List[Dict],
+    *,
+    context: str = "",
+) -> bool:
+    """Write meta reports; log and return False instead of aborting the caller on DB errors."""
+    if not rows:
+        return True
+    try:
+        writer.write_meta_reports(rows)
+        return True
+    except Exception as e:
+        logger.error(
+            "meta_check: failed to write %d reports%s: %s",
+            len(rows),
+            f" ({context})" if context else "",
+            e,
+            exc_info=True,
+        )
+        return False
 
 
 def is_cluster_labeled_with(cluster: Cluster, label: dict) -> bool:

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
@@ -64,20 +64,25 @@ def test_get_candidate_clusters_filters_by_bk_cloud_ids(redis_affinity_module):
     query = MagicMock()
     query.exclude.return_value = query
     query.filter.return_value = query
+    query.values_list.return_value = [1, 2]
 
     with patch.object(redis_affinity_module.Cluster.objects, "filter", return_value=query) as cluster_filter:
-        redis_affinity_module._get_candidate_clusters(config)
+        redis_affinity_module._get_candidate_cluster_ids(config)
 
     cluster_filter.assert_called_once_with(cluster_type__in=["RedisInstance"])
     query.filter.assert_called_once_with(bk_cloud_id__in=[0])
+    query.values_list.assert_called_once_with("id", flat=True)
 
 
 def test_get_candidate_clusters_checks_all_clouds_when_bk_cloud_ids_empty(redis_affinity_module):
     config = redis_affinity_module.RedisAffinityCheckConfig(cluster_types=["RedisInstance"])
     query = MagicMock()
     query.exclude.return_value = query
+    query.values_list.return_value = []
 
     with patch.object(redis_affinity_module.Cluster.objects, "filter", return_value=query):
-        redis_affinity_module._get_candidate_clusters(config)
+        redis_affinity_module._get_candidate_cluster_ids(config)
+
+    query.filter.assert_not_called()
 
     query.filter.assert_not_called()

--- a/dbm-ui/backend/tests/db_report/models/test_redis_report_utils.py
+++ b/dbm-ui/backend/tests/db_report/models/test_redis_report_utils.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+
+import pytest
+
+from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.db_report.models import MetaCheckReport
+from backend.flow.utils.redis.redis_report_utils import RedisReportWriter, _chunked, safe_write_meta_reports
+
+pytestmark = pytest.mark.django_db
+
+
+class _FakeCluster:
+    def __init__(self, cluster_id: int, domain: str):
+        self.id = cluster_id
+        self.immute_domain = domain
+        self.cluster_type = "TendisPredixyRedisCluster"
+        self.bk_biz_id = 1001
+        self.bk_cloud_id = 0
+
+
+def _meta_row(cluster: _FakeCluster, ip: str, state: str, msg: str = "test") -> dict:
+    return {
+        "cluster": cluster,
+        "ip": ip,
+        "port": 30000,
+        "subtype": MetaCheckSubType.EntryInconsistent,
+        "msg": msg,
+        "state": state,
+        "creator": "pytest",
+    }
+
+
+def test_chunked_splits_list():
+    assert list(_chunked(list(range(5)), 2)) == [[0, 1], [2, 3], [4]]
+
+
+def test_bulk_add_mode_preserves_failed_days_per_ip():
+    cluster = _FakeCluster(90001, "redis-meta-bulk-a.db")
+    MetaCheckReport.objects.filter(cluster=cluster.immute_domain).delete()
+
+    writer = RedisReportWriter()
+    rows = [
+        _meta_row(cluster, "1.1.1.1", ReportStateType.ABNORMAL.value),
+        _meta_row(cluster, "1.1.1.2", ReportStateType.ABNORMAL.value),
+    ]
+    writer.write_meta_reports(rows)
+
+    failed_days = {
+        row.ip: row.failed_days for row in MetaCheckReport.objects.filter(cluster=cluster.immute_domain).order_by("ip")
+    }
+    assert failed_days == {"1.1.1.1": 1, "1.1.1.2": 1}
+
+
+def test_bulk_add_mode_increments_duplicate_key_in_same_batch():
+    cluster = _FakeCluster(90002, "redis-meta-bulk-b.db")
+    MetaCheckReport.objects.filter(cluster=cluster.immute_domain).delete()
+
+    writer = RedisReportWriter()
+    writer.write_meta_reports(
+        [
+            _meta_row(cluster, "1.1.1.1", ReportStateType.ABNORMAL.value, msg="first"),
+            _meta_row(cluster, "1.1.1.1", ReportStateType.ABNORMAL.value, msg="second"),
+        ]
+    )
+
+    assert list(
+        MetaCheckReport.objects.filter(cluster=cluster.immute_domain)
+        .order_by("create_at")
+        .values_list("failed_days", flat=True)
+    ) == [1, 2]
+
+
+def test_bulk_add_mode_chunks_large_batches(monkeypatch):
+    cluster = _FakeCluster(90003, "redis-meta-bulk-c.db")
+    MetaCheckReport.objects.filter(cluster=cluster.immute_domain).delete()
+
+    bulk_create_calls = []
+    original_bulk_create = MetaCheckReport.objects.bulk_create
+
+    def _track_bulk_create(objs, *args, **kwargs):
+        bulk_create_calls.append(len(objs))
+        return original_bulk_create(objs, *args, **kwargs)
+
+    monkeypatch.setattr(MetaCheckReport.objects, "bulk_create", _track_bulk_create)
+    monkeypatch.setattr(
+        "backend.flow.utils.redis.redis_report_utils.META_REPORT_WRITE_CHUNK",
+        2,
+    )
+
+    writer = RedisReportWriter()
+    rows = [_meta_row(cluster, f"1.1.1.{idx}", ReportStateType.ABNORMAL.value) for idx in range(5)]
+    writer.write_meta_reports(rows)
+
+    assert bulk_create_calls == [2, 2, 1]
+    assert MetaCheckReport.objects.filter(cluster=cluster.immute_domain).count() == 5
+
+
+def test_safe_write_meta_reports_returns_false_on_db_error():
+    writer = RedisReportWriter()
+    with patch.object(writer, "write_meta_reports", side_effect=RuntimeError("db down")):
+        assert safe_write_meta_reports(writer, [{"cluster": object()}], context="test") is False

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_conf_check.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_conf_check.py
@@ -32,7 +32,7 @@ from backend.flow.plugins.components.collections.redis.conf_check.components imp
     RedisConfCheckBatchService,
     _collapse_conf_check_report_rows,
     _collect_host_conf_data,
-    _run_drs_groups,
+    _run_drs_chunk_slice,
     _run_single_drs_chunk,
     _target_from_info,
     _target_to_info,
@@ -334,8 +334,26 @@ class TestConfCheckReportCollapse:
 
 
 class TestConfCheckDrsChunking:
-    def test_drs_chunk_failure_does_not_drop_other_chunks(self):
-        drs_groups = {(0, "pwd", "INFO REPLICATION"): {"1.1.1.1:30000", "1.1.1.2:30000", "1.1.1.3:30000"}}
+    def test_run_single_drs_chunk_empty_result_records_error(self):
+        with patch(
+            "backend.flow.plugins.components.collections.redis.conf_check.components.DRSApi.redis_rpc",
+            return_value=[{"address": "1.1.1.1:30000", "result": "", "error_msg": "auth failed"}],
+        ):
+            result, errors = _run_single_drs_chunk(
+                (0, 1, "redis_password", "INFO REPLICATION"),
+                ["1.1.1.1:30000"],
+                {1: {"redis_password": "pwd"}},
+                {},
+            )
+        assert result == {}
+        assert errors[(0, "INFO REPLICATION", "1.1.1.1:30000")] == "empty_result: auth failed"
+
+    def test_run_drs_chunk_slice_parallel(self):
+        chunk_slice = [
+            ((0, 1, "redis_password", "INFO REPLICATION"), ["1.1.1.1:30000"]),
+            ((0, 2, "redis_password", "INFO REPLICATION"), ["1.1.1.2:30000"]),
+            ((0, 3, "redis_password", "INFO REPLICATION"), ["1.1.1.3:30000"]),
+        ]
 
         def fake_redis_rpc(payload):
             addresses = payload["addresses"]
@@ -347,30 +365,18 @@ class TestConfCheckDrsChunking:
             "backend.flow.plugins.components.collections.redis.conf_check.components.DRSApi.redis_rpc",
             side_effect=fake_redis_rpc,
         ) as redis_rpc:
-            errors = {}
-            result_map = _run_drs_groups(drs_groups, chunk_size=1, errors_out=errors)
+            password_cache = {
+                1: {"redis_password": "pwd"},
+                2: {"redis_password": "pwd"},
+                3: {"redis_password": "pwd"},
+            }
+            result_map, errors = _run_drs_chunk_slice(chunk_slice, password_cache, {})
 
         assert redis_rpc.call_count == 3
         assert result_map[(0, "INFO REPLICATION", "1.1.1.1:30000")] == "role:master"
         assert result_map[(0, "INFO REPLICATION", "1.1.1.3:30000")] == "role:master"
         assert (0, "INFO REPLICATION", "1.1.1.2:30000") not in result_map
         assert "drs_rpc_error: boom" in errors[(0, "INFO REPLICATION", "1.1.1.2:30000")]
-
-    def test_run_single_drs_chunk_empty_result_records_error(self):
-        with patch(
-            "backend.flow.plugins.components.collections.redis.conf_check.components.DRSApi.redis_rpc",
-            return_value=[{"address": "1.1.1.1:30000", "result": "", "error_msg": "auth failed"}],
-        ):
-            errors = {}
-            result = _run_single_drs_chunk(
-                (0, 1, "redis_password", "INFO REPLICATION"),
-                ["1.1.1.1:30000"],
-                {1: {"redis_password": "pwd"}},
-                {},
-                errors,
-            )
-        assert result == {}
-        assert errors[(0, "INFO REPLICATION", "1.1.1.1:30000")] == "empty_result: auth failed"
 
 
 class TestConfCheckHostCollectionErrors:
@@ -557,8 +563,8 @@ class TestConfCheckBatchPhases:
         assert 99 in data.outputs.pending_jobs
 
     @patch(
-        "backend.flow.plugins.components.collections.redis.conf_check.components._run_single_drs_chunk",
-        return_value={(0, "INFO REPLICATION", "1.1.1.1:30000"): "role:master"},
+        "backend.flow.plugins.components.collections.redis.conf_check.components._run_drs_chunk_slice",
+        return_value=({(0, "INFO REPLICATION", "1.1.1.1:30000"): "role:master"}, {}),
     )
     @patch(
         "backend.flow.plugins.components.collections.redis.conf_check.components._get_password_cache_for_drs",
@@ -568,7 +574,7 @@ class TestConfCheckBatchPhases:
         "backend.flow.plugins.components.collections.redis.conf_check.components._evaluate_and_report",
         return_value=(1, 0),
     )
-    def test_drs_chunks_paced_across_ticks(self, _evaluate, _passwords, _run_chunk):
+    def test_drs_chunks_paced_across_ticks(self, _evaluate, _passwords, _run_slice):
         service = self._make_service()
         queue = [((0, 1, "redis_password", "INFO REPLICATION"), ["1.1.1.1:30000"])] * 3
         data = self._make_data(
@@ -594,7 +600,53 @@ class TestConfCheckBatchPhases:
         assert data.outputs.drs_cursor == 3
         assert data.outputs.phase == PHASE_EVALUATE
         service.finish_schedule.assert_called_once()
-        assert _run_chunk.call_count == 3
+        assert _run_slice.call_count == 3
+
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._run_drs_chunk_slice",
+        return_value=({(0, "INFO REPLICATION", "1.1.1.1:30000"): "role:master"}, {}),
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._get_password_cache_for_drs",
+        return_value=({1: {"redis_password": "pwd"}}, {}),
+    )
+    @patch(
+        "backend.flow.plugins.components.collections.redis.conf_check.components._evaluate_and_report",
+        return_value=(1, 0),
+    )
+    def test_drs_chunks_per_tick_batches_slice(self, _evaluate, _passwords, _run_slice):
+        service = self._make_service()
+        queue = [((0, 1, "redis_password", "INFO REPLICATION"), ["1.1.1.1:30000"])] * 3
+        data = self._make_data(
+            phase=PHASE_RUN_DRS,
+            target_infos=[],
+            poll_count=0,
+            drs_chunk_queue=queue,
+            drs_cursor=0,
+            drs_result_map={},
+            drs_error_map={},
+            host_conf_data={},
+        )
+        data.get_one_of_inputs.side_effect = lambda key: {
+            "kwargs": {
+                "node_name": "test_batch",
+                "candidates_key": "dbm:redis_conf_check:candidates:test",
+                "batch_num": 1,
+                "batch_size": 10,
+                "total_batches": 1,
+                "interval": 1,
+                "max_retries": 3,
+                "drs_chunk_size": 1,
+                "drs_chunks_per_tick": 3,
+            },
+            "global_data": {"created_by": "tester"},
+        }.get(key)
+
+        assert service._schedule(data, {}) is True
+        assert data.outputs.drs_cursor == 3
+        assert data.outputs.phase == PHASE_EVALUATE
+        _run_slice.assert_called_once()
+        assert len(_run_slice.call_args[0][0]) == 3
 
     @patch(
         "backend.flow.plugins.components.collections.redis.conf_check.components.delete_candidates_key",

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_entry_check.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_entry_check.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.flow.plugins.components.collections.redis.redis_entry_check import RedisEntryCheckService
+
+
+@pytest.fixture
+def service():
+    svc = RedisEntryCheckService()
+    svc.log_warning = MagicMock()
+    svc.log_exception = MagicMock()
+    return svc
+
+
+def test_load_batch_clusters_prefetches_ids(service):
+    cluster = SimpleNamespace(id=1)
+    qs = MagicMock()
+    qs.prefetch_related.return_value = [cluster]
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_entry_check.Cluster.objects.filter",
+        return_value=qs,
+    ) as cluster_filter:
+        result = RedisEntryCheckService._load_batch_clusters([1, 2])
+
+    cluster_filter.assert_called_once_with(id__in=[1, 2])
+    qs.prefetch_related.assert_called_once()
+    assert result == {1: cluster}
+
+
+def test_build_entry_report_row_normal(service):
+    cluster = SimpleNamespace(id=1, immute_domain="redis.test.db")
+    row = RedisEntryCheckService._build_entry_report_row(cluster, [])
+    assert row["state"] == ReportStateType.NORMAL
+    assert row["subtype"] == MetaCheckSubType.EntryInconsistent
+
+
+def test_check_single_cluster_returns_report_row_without_db_write(service):
+    cluster = SimpleNamespace(
+        id=1,
+        immute_domain="redis.test.db",
+        cluster_type="TendisPredixyRedisCluster",
+        clusterentry_set=SimpleNamespace(all=lambda: []),
+    )
+    with patch.object(service, "_check_entry_consistency", return_value=None):
+        result = service._check_single_cluster(cluster)
+
+    assert result["report_row"]["state"] == ReportStateType.NORMAL
+    assert result["checked"] == 0
+
+
+def test_schedule_writes_reports_on_main_thread(service):
+    data = MagicMock()
+    data.outputs = {
+        "candidates_key": "key",
+        "batch_size": 2,
+        "current_batch": 0,
+        "total_checked": 0,
+        "total_inconsistent": 0,
+        "total_batches": 1,
+    }
+    cluster = SimpleNamespace(id=1, immute_domain="redis.test.db")
+    service._pop_batch_from_redis = MagicMock(return_value=[1])
+    service._load_batch_clusters = MagicMock(return_value={1: cluster})
+    service._check_single_cluster = MagicMock(
+        return_value={
+            "checked": 1,
+            "inconsistent": 0,
+            "report_row": {
+                "cluster": cluster,
+                "ip": None,
+                "port": None,
+                "subtype": MetaCheckSubType.EntryInconsistent,
+                "msg": "ok",
+                "state": ReportStateType.NORMAL,
+                "creator": "system",
+            },
+        }
+    )
+    service.finish_schedule = MagicMock()
+    service.log_info = MagicMock()
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_entry_check.safe_write_meta_reports",
+        return_value=True,
+    ) as safe_write:
+        service._schedule(data, parent_data=None)
+
+    safe_write.assert_called_once()
+    service._check_single_cluster.assert_called_once_with(cluster)
+
+
+def test_schedule_requeues_batch_when_write_fails(service):
+    data = MagicMock()
+    data.outputs = {
+        "candidates_key": "key",
+        "batch_size": 2,
+        "current_batch": 0,
+        "total_checked": 0,
+        "total_inconsistent": 0,
+        "total_batches": 2,
+    }
+    cluster = SimpleNamespace(id=1, immute_domain="redis.test.db")
+    service._pop_batch_from_redis = MagicMock(return_value=[1, 2])
+    service._load_batch_clusters = MagicMock(return_value={1: cluster})
+    service._check_single_cluster = MagicMock(
+        return_value={
+            "checked": 1,
+            "inconsistent": 0,
+            "report_row": {
+                "cluster": cluster,
+                "ip": None,
+                "port": None,
+                "subtype": MetaCheckSubType.EntryInconsistent,
+                "msg": "ok",
+                "state": ReportStateType.NORMAL,
+                "creator": "system",
+            },
+        }
+    )
+    service._requeue_batch_to_redis = MagicMock()
+    service.log_warning = MagicMock()
+
+    with patch(
+        "backend.flow.plugins.components.collections.redis.redis_entry_check.safe_write_meta_reports",
+        return_value=False,
+    ):
+        service._schedule(data, parent_data=None)
+
+    service._requeue_batch_to_redis.assert_called_once_with("key", [1, 2])
+    assert data.outputs["current_batch"] == 0


### PR DESCRIPTION
## 这条 PR 解决什么

- Redis 元数据检查（孤立实例、亲和性、入口一致性）在集群量大时 DB 连接泄漏、N+1 查询，且单次写入失败易拖垮整轮检查

## 具体改动

- **线程内 Django ORM 泄漏**：entry check 将 `Cluster` prefetch 与 `write_meta_reports` 收口到主线程，worker 仅做 DNS/CLB/Polaris I/O → 消除 `ThreadPoolExecutor` 内 ORM 导致的连接不释放
- **逐条写入放大查询**：新增 `write_meta_reports()` 批量 prefetch + chunked `bulk_create`/`bulk_update`，instance/affinity 按页（300 集群）收集报告后统一落库 → 降低 N+1 与连接持有时间
- **单页写入失败拖垮全量**：新增 `safe_write_meta_reports()`，DB 异常仅记日志并跳过当前页，不中断后续分页 → 定时任务可跑完全部候选集群
- **入口检查队列丢单**：entry check 写入失败时将已 `RPOP` 的 cluster id 按序 `RPUSH` 回 Redis，且不推进 `current_batch` → 下轮 schedule 自动重试
- **亲和性 debug 空域名崩溃**：`debug_check_cluster` 对查无集群提前返回，避免 `IndexError`

## 测试 & 风险

- 单测已覆盖 `write_meta_reports` 批量写入/`failed_days` 递增、chunk 切分、`safe_write_meta_reports` 异常兜底、entry check 主线程写入与失败重入队
- 仅影响 Redis 元数据检查与报告写入链路；`write_meta_report()` 仍可用；亲和性对「应忽略集群」不再产出 unsupported-level 警告属预期行为变化