### PR TITLE
fix(backend): update_dba_notice_group更新告警组时未持久化monitor_duty_rule_id字段 #18807

### DIFF
--- a/dbm-ui/backend/db_monitor/tasks.py
+++ b/dbm-ui/backend/db_monitor/tasks.py
@@ -466,6 +466,6 @@ def update_dba_notice_group(dba_id: int):
             group.receivers = group_receivers
             if not group.details:
                 group.details = {"alert_notice": DEFAULT_ALERT_NOTICE}
-            group.save(update_fields=["name", "receivers", "details"])
+            group.save(update_fields=["name", "receivers", "details", "monitor_group_id", "monitor_duty_rule_id"])
     except Exception as e:
         logger.exception("[local_notice_group] update_or_create notice group error: %s", e)


### PR DESCRIPTION
close #18807

## 问题描述
update_dba_notice_group 定期更新告警组时，调用 group.save(update_fields=["name", "receivers", "details"])，
但 NoticeGroup.save() 内部的 save_monitor_group() 会创建/更新轮值规则并赋值 monitor_duty_rule_id 和 monitor_group_id，
由于这两个字段不在 update_fields 中，导致它们无法持久化到数据库。

## 修复内容
在 update_fields 中补充 monitor_group_id 和 monitor_duty_rule_id 字段，确保 save_monitor_group() 中更新的值能正确写回 DB。

## 测试
- [ ] 单元测试通过
- [ ] 功能验证完成
