### PR TITLE
fix(backend): 修复个人工作台告警事件查询 utcoffset 报错

### DIFF
--- a/dbm-ui/backend/db_monitor/views/event.py
+++ b/dbm-ui/backend/db_monitor/views/event.py
@@ -82,7 +82,10 @@ class AlertView(SystemViewSet):
         # 查询用户管理的告警事件，查出用户管理的业务，添加到查询条件中
         self_manage = params.pop("self_manage")
         self_assist = params.pop("self_assist")
-        dbas = DBAdministrator.objects.filter(users__contains=request.user.username)
+        # 仅取所需字段，避免 SELECT update_at 触发 Django 时区转换（脏 update_at 会导致 utcoffset 报错）
+        dbas = DBAdministrator.objects.filter(users__contains=request.user.username).only(
+            "bk_biz_id", "db_type", "users"
+        )
         biz_cluster_type_conditions = []
         if self_manage:
             # 主负责的业务（第一个 DBA）


### PR DESCRIPTION
closes #18848

## 根因
个人工作台打开调用 `POST /apis/monitor/event/search/` 报 `'str' object has no attribute 'utcoffset'`（500）。`db_monitor/views/event.py:search` 中 `DBAdministrator.objects.filter(...)` 会 SELECT 模型唯一的 `DateTimeField` 字段 `update_at`；当该列存在零值/非法日期（如 `0000-00-00 00:00:00`）时，PyMySQL 无法解析为 datetime、退化返回字符串，Django 4.2 MySQL 后端 `convert_datetimefield_value` 直接对其 `timezone.make_aware` → `is_aware(str)` → `str.utcoffset()` 抛 AttributeError。

## 修复
视图未使用 `update_at`，改为 `.only('bk_biz_id','db_type','users')` 只查所需字段，避免触发对 `update_at` 的时区转换。

## 备注
彻底根治仍建议 DBA 清理 `configuration_dbadministrator` 表中 `update_at` 的零值/非法日期数据。