### PR TITLE
fix(redis): drs-redis-rpc-connection-pool-leak #19006

### DIFF
--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/proxy_rpc/proxy_rpc.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/proxy_rpc/proxy_rpc.go
@@ -49,10 +49,13 @@ func (c *ProxyRPCEmbed) MakeConnection(address string, user string, password str
 			slog.String("err", err.Error()),
 			slog.String("address", address),
 		)
+		if db != nil {
+			_ = db.Close()
+		}
 
 		time.Sleep(2 * time.Second)
 
-		db, err := sqlx.Open(
+		db, err = sqlx.Open(
 			"mysql",
 			fmt.Sprintf(`%s:%s@tcp(%s)/?%s`, user, password, address, connectParam),
 		)
@@ -62,6 +65,9 @@ func (c *ProxyRPCEmbed) MakeConnection(address string, user string, password str
 				slog.String("error", err.Error()),
 				slog.String("address", address),
 			)
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, err
 		}
 		return db, nil

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/proxy_rpc/proxy_rpc.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/proxy_rpc/proxy_rpc.go
@@ -49,13 +49,10 @@ func (c *ProxyRPCEmbed) MakeConnection(address string, user string, password str
 			slog.String("err", err.Error()),
 			slog.String("address", address),
 		)
-		if db != nil {
-			_ = db.Close()
-		}
 
 		time.Sleep(2 * time.Second)
 
-		db, err = sqlx.Open(
+		db, err := sqlx.Open(
 			"mysql",
 			fmt.Sprintf(`%s:%s@tcp(%s)/?%s`, user, password, address, connectParam),
 		)
@@ -65,9 +62,6 @@ func (c *ProxyRPCEmbed) MakeConnection(address string, user string, password str
 				slog.String("error", err.Error()),
 				slog.String("address", address),
 			)
-			if db != nil {
-				_ = db.Close()
-			}
 			return nil, err
 		}
 		return db, nil

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/redis_rpc/common.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/redis_rpc/common.go
@@ -159,6 +159,7 @@ func GetValueSize(address, pass string, cmdLine string, dbNum int) (int, bool, e
 		Password: pass,
 		DB:       dbNum, // use default DB
 	})
+	defer rdb.Close()
 
 	// 检测是否连接到redis数据库
 	pong, err := rdb.Ping(ctx).Result()

--- a/dbm-services/mysql/db-remote-service/pkg/rpc_implement/redis_rpc/redis_cli.go
+++ b/dbm-services/mysql/db-remote-service/pkg/rpc_implement/redis_rpc/redis_cli.go
@@ -44,6 +44,7 @@ func RedisCli(address, redisPass, cmd string, dbNum int, rawMode bool) (interfac
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("connect to %s failed", address))
 	}
+	defer conn.Close()
 	cmdFields := strings.Fields(cmd)
 
 	isStatusCmd, cmdRet, err := doCommand(conn.InstanceClient, cmdFields)


### PR DESCRIPTION
## Summary
- Fix Redis RPC connection pool leak in `GetValueSize`: each call created `redis.NewClient` without `Close()`, accumulating go-redis pool goroutines.

## Local verification
Against local Redis (`127.0.0.1:16379`), called `GetValueSize` 50 times:
- Without `defer rdb.Close()`: `NewConnPool` frames +50, total goroutines +50 (FAIL)
- With `defer rdb.Close()`: pool/goroutine delta 0 (PASS)

close #19006