### PR TITLE
feat(mysql): optimize-mysql-kill-connection-mcp #18991

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/decorators.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/decorators.py
@@ -288,19 +288,15 @@ def _check_callee_plan(callee_mcp_id, request, request_slz, checker):
 
     username = request.user.username
 
-    callee_plan = (
-        McpCalleePlan.objects.select_for_update()
-        .filter(
-            username=username,
-            callee_mcp_id=callee_mcp_id,
-            status=McpCalleePlanStatus.APPROVED,
-            time_window_start__lte=now,
-            time_window_end__gte=now,
-        )
-        .first()
+    callee_plans = McpCalleePlan.objects.select_for_update().filter(
+        username=username,
+        callee_mcp_id=callee_mcp_id,
+        status=McpCalleePlanStatus.APPROVED,
+        time_window_start__lte=now,
+        time_window_end__gte=now,
     )
 
-    if not callee_plan:
+    if not callee_plans.exists():
         raise DBMMcpCalleePlanException(
             msg=f"No approved plan found for `{callee_mcp_id}`. "
             f"Before calling this tool, you MUST first announce your execution plan "
@@ -309,29 +305,43 @@ def _check_callee_plan(callee_mcp_id, request, request_slz, checker):
             f"After the plan is approved, retry this call."
         )
 
-    slz_planned = request_slz(data=callee_plan.params)
-    slz_planned.is_valid(raise_exception=True)
-
     slz_requested = request_slz(data=request.data)
     slz_requested.is_valid(raise_exception=True)
 
-    try:
-        checker(slz_planned, slz_requested)
-    except Exception as e:
-        raise DBMMcpCalleePlanException(
-            msg=f"The parameters in this request do not match those registered in the plan. "
-            f"Detail: {e}. "
-            f"You must call this tool with exactly the same parameters you announced, "
-            f"or create a new plan via `register_callee_plan` with the correct parameters."
-        )
+    # 尝试所有的 username, 时间, mcp id 匹配的计划
+    for callee_plan in callee_plans:
+        slz_planned = request_slz(data=callee_plan.params)
+        try:
+            slz_planned.is_valid(raise_exception=True)
+        except Exception as e:  # noqa
+            logger.info(
+                f"exception: {e}, "
+                f"register param {callee_plan.params} not match to {slz_planned} struct, "
+                f"may be the mcp input definition has changed, try next"
+            )
+            continue
 
-    if callee_plan.current_call_count >= callee_plan.max_call_count:
-        raise DBMMcpCalleePlanException(
-            msg=f"The plan for `{callee_mcp_id}` has reached its maximum call count "
-            f"({callee_plan.current_call_count}/{callee_plan.max_call_count}). "
-            f"To continue, create a new plan by calling `register_callee_plan` again."
-        )
+        try:
+            checker(slz_planned, slz_requested)
+        except Exception as e:  # noqa
+            logger.info(
+                f"exception: {e}, "
+                f"param match check failed, "
+                f"plan param={slz_planned.data}, request param= {slz_requested.data}, try next"
+            )
+            continue
 
-    callee_plan.current_call_count = models.F("current_call_count") + 1
-    callee_plan.save(update_fields=["current_call_count"])
-    callee_plan.refresh_from_db()
+        if callee_plan.current_call_count >= callee_plan.max_call_count:
+            logger.exception("call count check failed, try next")
+            continue
+
+        callee_plan.current_call_count = models.F("current_call_count") + 1
+        callee_plan.save(update_fields=["current_call_count"])
+        callee_plan.refresh_from_db()
+        return
+
+    raise DBMMcpCalleePlanException(
+        msg="The parameters in this request do not match those registered in the plan. "
+        "You must call this tool with exactly the same parameters you announced, "
+        "or create a new plan via `register_callee_plan` with the correct parameters."
+    )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/kill_connection.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/kill_connection.py
@@ -15,4 +15,4 @@ from rest_framework import serializers
 class KillConnectionInputSerializer(serializers.Serializer):
     bk_cloud_id = serializers.IntegerField(help_text=_("云区域 ID"))
     address = serializers.CharField(help_text=_("实例地址, ip:port 格式"))
-    connection_id = serializers.IntegerField(help_text=_("要杀死的连接 ID"))
+    connection_ids = serializers.ListField(child=serializers.IntegerField(help_text="要杀死的连接 id 列表"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_sensitive_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_sensitive_mcp.py
@@ -8,6 +8,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from collections import Counter
+
 from django.utils.translation import gettext as _
 from rest_framework.response import Response
 
@@ -16,7 +18,7 @@ from backend.db_meta.enums import ClusterType, InstanceRole, MachineType, TenDBC
 from backend.db_meta.models import Cluster, Spec
 from backend.dbm_aiagent.mcp_tools.common.auth_parser.base import auth_parse_clusters, auth_parse_instances
 from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
-from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
+from backend.dbm_aiagent.mcp_tools.decorators import logger, mcp_tools_api_decorator
 from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpBaseException
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.kill_connection import KillConnectionInputSerializer
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.modify_cluster_spec import (
@@ -27,6 +29,24 @@ from backend.dbm_aiagent.mcp_tools.mysql.serializers.modify_cluster_spec import 
 )
 from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
 from backend.iam_app.handlers.drf_perm.mcp import McpClusterDetailPermission, McpIsDbaPermission
+
+
+def kill_connection_plan_checker(
+    plan_slz: KillConnectionInputSerializer, requested_slz: KillConnectionInputSerializer
+):
+    plan = plan_slz.validated_data
+    requested = requested_slz.validated_data
+    if (
+        Counter(plan["connection_ids"]) != Counter(requested["connection_ids"])
+        or plan["bk_cloud_id"] != requested["bk_cloud_id"]
+        or plan["address"] != requested["address"]
+    ):
+        raise Exception(
+            f"The request parameters do not match those registered in the plan. "
+            f"plan params: {plan_slz.data}, but received: {requested_slz.data}. "
+            f"You must call this tool with exactly the same parameters you announced, "
+            f"or create a new plan via `register_callee_plan` with the correct parameters."
+        )
 
 
 class MySQLSensitiveMcpViewSet(McpToolsViewSet):
@@ -44,30 +64,35 @@ class MySQLSensitiveMcpViewSet(McpToolsViewSet):
         mcp=[DBMMcpTools.MYSQL_SENSITIVE],
         name_prefix="mysql_sensitive",
         enable_callee_plan=True,
+        callee_plan_checker=kill_connection_plan_checker,
     )
     def kill_connection(self, request, *args, **kwargs):
         bk_cloud_id = self.get_param("bk_cloud_id")
-        connection_id = self.get_param("connection_id")
+        connection_ids = self.get_param("connection_ids", [])
         address = self.get_param("address")
 
-        drs_raw_res = DRSApi.v2_mysql_rpc(
-            params={
-                "bk_cloud_id": bk_cloud_id,
-                "addresses": [address],
-                "cmds": [f"KILL {connection_id}"],
-                "query_timeout": 10,
-            }
-        )
+        if connection_ids:
+            drs_raw_res = DRSApi.v2_mysql_rpc(
+                params={
+                    "bk_cloud_id": bk_cloud_id,
+                    "addresses": [address],
+                    "cmds": [f"KILL {cid}" for cid in connection_ids],
+                    "query_timeout": 60,
+                    "force": True,
+                }
+            )
 
-        address_res = drs_raw_res[0]
-        if address_res["error_msg"]:
-            raise DBMMcpBaseException(msg=address_res["error_msg"])
+            address_res = drs_raw_res[0]
+            if address_res["error_msg"]:
+                logger.info(address_res["error_msg"])
+                # raise DBMMcpBaseException(msg=address_res["error_msg"])
 
-        cmd_res = address_res["cmd_results"][0]
-        if cmd_res["error_msg"]:
-            raise DBMMcpBaseException(msg=cmd_res["error_msg"])
+            cmd_res = address_res["cmd_results"][0]
+            if cmd_res["error_msg"]:
+                logger.info(cmd_res["error_msg"])
+                # raise DBMMcpBaseException(msg=cmd_res["error_msg"])
 
-        return Response({"bk_cloud_id": bk_cloud_id, "address": address, "connection_id": connection_id})
+        return Response({"bk_cloud_id": bk_cloud_id, "address": address, "connection_ids": connection_ids})
 
     @mcp_tools_api_decorator(
         description=str(_("""修改 TenDBHA 集群规格, 只能修改 proxy 和 standby backend""")),


### PR DESCRIPTION
1. mysql-kill-connection 支持一次性批量提交连接id, 只注册一个mcp计划
2. 优化 mcp 计划审计