### PR TITLE
feat(mysql): SQL模拟执行语法检查接口增加bk_biz_id参数传递 #19067

### DIFF
--- a/dbm-ui/backend/db_services/mysql/sql_import/handlers.py
+++ b/dbm-ui/backend/db_services/mysql/sql_import/handlers.py
@@ -153,6 +153,7 @@ class SQLHandler(object):
                 "cluster_type": self.cluster_type,
                 "versions": versions,
                 "execute_objects": execute_objects,
+                "bk_biz_id": self.bk_biz_id,
             }
         )
 


### PR DESCRIPTION
close #19067

## 问题描述
SQL模拟执行的语法检查接口(grammar_check)调用时未传递业务ID(bk_biz_id)参数，导致下游服务无法获取业务上下文信息。

## 修复内容
在 SQLHandler.grammar_check 方法中，向 SQLSimulationApi.grammar_check 的 params 字典添加 bk_biz_id 参数传递。

## 测试
- [x] 代码变更确认
- [ ] 功能验证完成
