### PR TITLE
fix(backend): 修复 TenDBCluster 部分单据 FlowBuilder group 错误归类为 mysql

### DIFF
--- a/dbm-ui/backend/ticket/builders/tendbcluster/tendb_cluster_spider_rebuild.py
+++ b/dbm-ui/backend/ticket/builders/tendbcluster/tendb_cluster_spider_rebuild.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
+from backend.configuration.constants import DBType
 from backend.flow.engine.controller.spider import SpiderController
 from backend.ticket import builders
 from backend.ticket.builders.mysql.base import BaseMySQLHATicketFlowBuilder
@@ -36,6 +37,7 @@ class TendbClusterSpiderRebuildParamBuilder(builders.FlowParamBuilder):
 
 @builders.BuilderFactory.register(TicketType.TENDBCLUSTER_SPIDER_REBUILD)
 class TendbClusterSpiderRebuildFlowBuilder(BaseMySQLHATicketFlowBuilder):
+    group = DBType.TenDBCluster.value
     serializer = TendbClusterSpiderRebuildDetailSerializer
     inner_flow_builder = TendbClusterSpiderRebuildParamBuilder
     inner_flow_name = _("TenDBCluster 接入层原地重建")

--- a/dbm-ui/backend/ticket/builders/tendbcluster/tendb_import_sqlfile.py
+++ b/dbm-ui/backend/ticket/builders/tendbcluster/tendb_import_sqlfile.py
@@ -54,7 +54,8 @@ class TenDBClusterSqlImportFlowParamBuilder(MysqlSqlImportFlowParamBuilder):
 
 
 @builders.BuilderFactory.register(TicketType.TENDBCLUSTER_IMPORT_SQLFILE)
-class TenDBClusterSqlImportFlowBuilder(MysqlSqlImportFlowBuilder, BaseTendbTicketFlowBuilder):
+class TenDBClusterSqlImportFlowBuilder(BaseTendbTicketFlowBuilder, MysqlSqlImportFlowBuilder):
+    group = DBType.TenDBCluster.value
     serializer = TenDBClusterSqlImportDetailSerializer
     # 定义流程所用到的cls，方便继承复用
     itsm_flow_builder = TenDBClusterSqlImportItsmParamBuilder


### PR DESCRIPTION
closes #19098

## 根因
`TenDBClusterSqlImportFlowBuilder(MysqlSqlImportFlowBuilder, BaseTendbTicketFlowBuilder)` 将 MySQL 基类写在父类列表首位且未显式声明 `group`；按 Python C3 MRO，`BaseMySQLTicketFlowBuilder`(group=mysql) 排在 `BaseTendbTicketFlowBuilder`(group=tendbcluster) 之前，导致 `group` 被解析为 `mysql`。`TendbClusterSpiderRebuildFlowBuilder` 单继承 `BaseMySQLHATicketFlowBuilder` 且未覆盖 `group`，存在同类问题。

## 修复
1. `tendb_import_sqlfile.py`：父类顺序调整为 `(BaseTendbTicketFlowBuilder, MysqlSqlImportFlowBuilder)`，并显式声明 `group = DBType.TenDBCluster.value`。
2. `tendb_cluster_spider_rebuild.py`：显式声明 `group = DBType.TenDBCluster.value`（补充 DBType import）。

## 验证
- `TenDBClusterSqlImportFlowBuilder.group == "tendbcluster"`
- `TendbClusterSpiderRebuildFlowBuilder.group == "tendbcluster"`