### PR TITLE
fix(backend): 修复 DBMAgentResourceManager 初始化误用 agent_code/agent_secret 关键字导致 agent 凭证丢失

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/agent/configs/manager.py
+++ b/dbm-ui/backend/dbm_aiagent/agent/configs/manager.py
@@ -47,7 +47,7 @@ class DBMAgentResourceManager(AgentResourceManager):
     def __init__(self, agent_code: str = None, agent_secret: str = None, username: str = ""):
         agent_code = agent_code or settings.AGENT_APP_CODE
         agent_secret = agent_secret or settings.AGENT_APP_SECRET
-        super().__init__(agent_code=agent_code, agent_secret=agent_secret)
+        super().__init__(app_code=agent_code, app_secret=agent_secret)
 
     @classmethod
     def set_backend_mcp_config(cls, agent_config: AgentConfig):


### PR DESCRIPTION
closes #19227

## 根因
`DBMAgentResourceManager.__init__` 调用 `super().__init__(agent_code=..., agent_secret=...)`，但父类 `BaseResourceManager.__init__` 只接受 `app_code` / `app_secret`。错误关键字被 `**kwargs` 吞掉并忽略，`self.app_code` / `self.app_secret` 回退为 DBM 平台的 `settings.APP_CODE` / `SECRET_KEY`，而非 Agent 的 `AGENT_APP_CODE` / `AGENT_APP_SECRET`，导致 `get_agent_code()`、`get_client()`、后台 mcp 鉴权与 access_token 换取均使用错误应用身份。

## 修复
将 `super().__init__` 关键字改为父类正确的 `app_code=agent_code, app_secret=agent_secret`。

## 影响
仅一行改动，使 agent 使用正确的应用凭证；不改变对外行为签名。