### PR TITLE
feat(backend): bkcc-mcp-wrap #19197

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/config.py
+++ b/dbm-ui/backend/dbm_aiagent/config.py
@@ -496,6 +496,19 @@ BK_APIGW_STAGE_MCP_SERVERS = [
         # 自动发现并填充该 MCP 服务器对应的工具
         "tools": [],
     },
+    {
+        "name": "bkcc-wrap",
+        "description": """bkcc api wrap""",
+        # 主动授权 app_code
+        "target_app_codes": [env.APP_CODE, "ai-dbm"],
+        "labels": ["bkcc-wrap"],
+        # 是否启用：1-启用，0-停止
+        "status": 1,
+        # 是否公开
+        "is_public": False,
+        # 自动发现并填充该 MCP 服务器对应的工具
+        "tools": [],
+    },
 ]
 
 __all__ = [

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/check_operator.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/check_operator.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from backend.components import CCApi
+from backend.dbm_aiagent.mcp_tools.exceptions import DBMMcpForbiddenException
+
+
+def check_operator(username: str, bk_host_ids: list[int]):
+    unique_host_ids = list(set(bk_host_ids))
+    kwargs = {
+        "fields": ["bk_host_id"],
+        "host_property_filter": {
+            "condition": "AND",
+            "rules": [
+                {"field": "bk_host_id", "operator": "in", "value": unique_host_ids},
+                {
+                    "condition": "OR",
+                    "rules": [
+                        {"field": "operator", "operator": "equal", "value": username},
+                        {"field": "bk_bak_operator", "operator": "equal", "value": username},
+                    ],
+                },
+            ],
+        },
+    }
+
+    res = CCApi.list_hosts_without_biz(kwargs, use_admin=True)
+    match_host_ids = {ele["bk_host_id"] for ele in res.get("info", []) if ele.get("bk_host_id")}
+    not_match_ids = set(unique_host_ids) - match_host_ids
+    if not_match_ids:
+        raise DBMMcpForbiddenException(msg=f"machines {sorted(not_match_ids)} are not operated by {username}")

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/list_hosts_without_biz.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/list_hosts_without_biz.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from backend.components import CCApi
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.list_hosts_without_biz import CCHostInfoSerializer
+
+
+def list_hosts_without_biz(bk_cloud_id: int, ips: list[str]):
+    kwargs = {
+        "fields": list(CCHostInfoSerializer().fields.keys()),
+        "host_property_filter": {
+            "condition": "AND",
+            "rules": [
+                {"field": "bk_host_innerip", "operator": "in", "value": ips},
+                {"field": "bk_cloud_id", "operator": "equal", "value": bk_cloud_id},
+            ],
+        },
+    }
+
+    res = CCApi.list_hosts_without_biz(kwargs, use_admin=True)
+    return res["info"]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/update_hosts_operator.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/impl/bkcc_wrap/update_hosts_operator.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from backend.components import CCApi
+from backend.dbm_aiagent.mcp_tools.common.impl.bkcc_wrap.check_operator import check_operator
+
+
+def update_hosts_operator(bk_host_ids: list[int], operators: list[str], bak_operators: list[str], username: str):
+    check_operator(username=username, bk_host_ids=bk_host_ids)
+
+    update_infos = []
+    for host_id in bk_host_ids:
+        properties = {}
+        if operators:
+            properties["operator"] = ",".join(operators)
+        if bak_operators:
+            properties["bk_bak_operator"] = ",".join(bak_operators)
+
+        update_infos.append({"properties": properties, "bk_host_id": host_id})
+
+    CCApi.batch_update_host({"update": update_infos}, use_admin=True)

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/find_host_biz_relations.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/find_host_biz_relations.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class FindHostBizRelationsInputSerializer(serializers.Serializer):
+    bk_host_ids = serializers.ListField(child=serializers.IntegerField(), help_text=_("主机 ID"))
+
+
+class HostBizRelationSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    bk_host_id = serializers.IntegerField(help_text=_("主机 ID"))
+    bk_module_id = serializers.IntegerField(help_text=_("模块 ID"))
+    bk_set_id = serializers.IntegerField(help_text=_("集群 ID"))
+    bk_supplier_account = serializers.CharField(help_text=_("开发商账号"))
+
+
+class FindHostBizRelationsOutputSerializer(serializers.Serializer):
+    info = serializers.ListField(child=HostBizRelationSerializer(), help_text=_("主机归属关系列表"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/get_biz_internal_module.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/get_biz_internal_module.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class GetBizInternalModuleInputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+
+
+class BizInternalModuleSerializer(serializers.Serializer):
+    bk_module_id = serializers.IntegerField(help_text=_("模块 ID"))
+    bk_module_name = serializers.CharField(help_text=_("模块名称"))
+    default = serializers.IntegerField(help_text=_("内置模块类型"))
+    host_apply_enabled = serializers.BooleanField(help_text=_("是否启用主机属性自动应用"))
+
+
+class GetBizInternalModuleOutputSerializer(serializers.Serializer):
+    bk_set_id = serializers.IntegerField(help_text=_("集群 ID"))
+    bk_set_name = serializers.CharField(help_text=_("集群名称"))
+    module = serializers.ListField(child=BizInternalModuleSerializer(), help_text=_("内置模块列表"))

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/list_hosts_without_biz.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/list_hosts_without_biz.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class ListHostsWithoutBizInputSerializer(serializers.Serializer):
+    bk_cloud_id = serializers.IntegerField(help_text=_("云区域 ID"))
+    ips = serializers.ListField(child=serializers.CharField(), help_text=_("IP 列表"))
+
+
+class CCHostInfoSerializer(serializers.Serializer):
+    bk_agent_id = serializers.CharField(help_text=_("Agent ID"))
+    bk_bak_operator = serializers.CharField(help_text=_("备份负责人"))
+    bk_cloud_id = serializers.IntegerField(help_text=_("云区域 ID"))
+    bk_cloud_inst_id = serializers.CharField(help_text=_("云实例 ID"))
+    bk_host_id = serializers.IntegerField(help_text=_("主机 ID"))
+    bk_host_innerip = serializers.CharField(help_text=_("内网 IP"))
+    bk_idc_area = serializers.CharField(help_text=_("IDC 区域"))
+    bk_idc_area_id = serializers.IntegerField(help_text=_("IDC 区域 ID"))
+    bk_os_name = serializers.CharField(help_text=_("操作系统"))
+    bk_svr_device_cls_name = serializers.CharField(help_text=_("机型"))
+    idc_city_id = serializers.CharField(help_text=_("城市 ID"))
+    idc_city_name = serializers.CharField(help_text=_("城市"))
+    idc_id = serializers.IntegerField(help_text=_("IDC ID"))
+    idc_name = serializers.CharField(help_text=_("IDC 名称"))
+    net_device_id = serializers.CharField(help_text=_("网络设备 ID"))
+    operator = serializers.CharField(help_text=_("负责人"))
+    rack = serializers.CharField(help_text=_("机架"))
+    rack_id = serializers.CharField(help_text=_("机架 ID"))
+    sub_zone = serializers.CharField(help_text=_("园区"))
+    sub_zone_id = serializers.CharField(help_text=_("园区 ID"))
+
+
+class ListHostsWithoutBizOutputSerializer(serializers.Serializer):
+    info = serializers.ListField(child=CCHostInfoSerializer())

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/transfer_host_across_biz.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/transfer_host_across_biz.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class TransferHostAcrossBizInputSerializer(serializers.Serializer):
+    src_bk_biz_id = serializers.IntegerField(help_text=_("源业务 ID"))
+    dst_bk_biz_id = serializers.IntegerField(help_text=_("目标业务 ID"))
+    bk_host_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        min_length=1,
+        help_text=_("主机 ID 列表"),
+    )
+
+    def validate(self, attrs):
+        if attrs["src_bk_biz_id"] == attrs["dst_bk_biz_id"]:
+            raise serializers.ValidationError(_("src_bk_biz_id 与 dst_bk_biz_id 不能相同"))
+
+        attrs["bk_host_ids"] = list(set(attrs["bk_host_ids"]))
+        return attrs
+
+
+class TransferHostAcrossBizOutputSerializer(serializers.Serializer):
+    src_bk_biz_id = serializers.IntegerField(help_text=_("源业务 ID"))
+    dst_bk_biz_id = serializers.IntegerField(help_text=_("目标业务 ID"))
+    dst_idle_module_id = serializers.IntegerField(help_text=_("目标业务空闲机模块 ID"))
+    bk_host_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        help_text=_("已跨业务转移的主机 ID 列表"),
+    )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/transfer_host_to_idlemodule.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/transfer_host_to_idlemodule.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class TransferHostToIdlemoduleInputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    bk_host_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        min_length=1,
+        help_text=_("主机 ID 列表"),
+    )
+
+    def validate(self, attrs):
+        attrs["bk_host_ids"] = list(set(attrs["bk_host_ids"]))
+        return attrs
+
+
+class TransferHostToIdlemoduleOutputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    bk_host_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        help_text=_("已转移到空闲机模块的主机 ID 列表"),
+    )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/update_hosts_operator.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/serializers/bkcc_wrap/update_hosts_operator.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class UpdateHostsOperatorInputSerializer(serializers.Serializer):
+    bk_host_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        min_length=1,
+        help_text=_("主机 ID 列表"),
+    )
+    operators = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        help_text=_("主负责人列表，对应 CMDB operator 字段"),
+    )
+    bak_operators = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+        help_text=_("备份负责人列表，对应 CMDB bk_bak_operator 字段"),
+    )
+
+    def validate(self, attrs):
+        operators = [s.strip() for s in attrs.get("operators", []) if s.strip()]
+        bak_operators = [s.strip() for s in attrs.get("bak_operators", []) if s.strip()]
+        if not operators and not bak_operators:
+            raise serializers.ValidationError(_("operators 与 bak_operators 不能同时为空"))
+
+        attrs["operators"] = operators
+        attrs["bak_operators"] = bak_operators
+        attrs["bk_host_ids"] = list(set(attrs["bk_host_ids"]))
+        return attrs
+
+
+class UpdateHostsOperatorOutputSerializer(serializers.Serializer):
+    bk_host_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        help_text=_("已更新的主机 ID 列表"),
+    )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/urls.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/urls.py
@@ -23,6 +23,7 @@ from backend.dbm_aiagent.mcp_tools.common.views import (
     TicketOperationMcpToolsViewSet,
 )
 from backend.dbm_aiagent.mcp_tools.common.views.alarm_query import MonitorQueryMcpToolsViewSet
+from backend.dbm_aiagent.mcp_tools.common.views.bkcc_wrap import BKCCWrapMcpToolsViewSet
 from backend.dbm_aiagent.mcp_tools.common.views.mcp_callee_plan import McpCalleePlanMcpToolsViewSet
 
 routers = DefaultRouter(trailing_slash=True)
@@ -39,4 +40,5 @@ routers.register(r"", PromQLQueryMcpToolsViewSet, basename="mcp-promql-query")
 routers.register(r"", McpCalleePlanMcpToolsViewSet, basename="mcp-callee-plan")
 routers.register(r"", AiReportMcpToolsViewSet, basename="mcp-ai-report")
 routers.register(r"", PortraitQueryMcpToolsViewSet, basename="mcp-portrait-query")
+routers.register(r"", BKCCWrapMcpToolsViewSet, basename="mcp-bkcc-wrap")
 urlpatterns = routers.urls

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/README.md
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/README.md
@@ -1,0 +1,227 @@
+# BKCC Wrap MCP 工具
+
+MCP 分组：`bkcc-wrap`
+
+默认权限：`DBManagePermission`
+
+敏感控制指 **Callee Plan**（`enable_callee_plan`）：写操作需先 `register_callee_plan` 登记参数，实际调用时参数必须与 plan 完全一致。
+
+---
+
+## bkcc_wrap_list_hosts_without_biz
+
+| 项 | 说明 |
+|---|---|
+| 描述 | 没有业务信息的主机查询 |
+| 读/写 | 读 |
+| 敏感控制 | 否 |
+
+**入参**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_cloud_id` | int | 是 | 云区域 ID |
+| `ips` | list[str] | 是 | IP 列表 |
+
+**返回**
+
+`info` 为数组，元素字段如下：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `bk_agent_id` | str | Agent ID |
+| `bk_bak_operator` | str | 备份负责人 |
+| `bk_cloud_id` | int | 云区域 ID |
+| `bk_cloud_inst_id` | str | 云实例 ID |
+| `bk_host_id` | int | 主机 ID |
+| `bk_host_innerip` | str | 内网 IP |
+| `bk_idc_area` | str | IDC 区域 |
+| `bk_idc_area_id` | int | IDC 区域 ID |
+| `bk_os_name` | str | 操作系统 |
+| `bk_svr_device_cls_name` | str | 机型 |
+| `idc_city_id` | str | 城市 ID |
+| `idc_city_name` | str | 城市 |
+| `idc_id` | int | IDC ID |
+| `idc_name` | str | IDC 名称 |
+| `net_device_id` | str | 网络设备 ID |
+| `operator` | str | 负责人 |
+| `rack` | str | 机架 |
+| `rack_id` | str | 机架 ID |
+| `sub_zone` | str | 园区 |
+| `sub_zone_id` | str | 园区 ID |
+
+**校验规则**
+
+- `bk_cloud_id`、`ips` 必填
+
+---
+
+## bkcc_wrap_get_biz_internal_module
+
+| 项 | 说明 |
+|---|---|
+| 描述 | 查询业务的空闲机/故障机/待回收模块 |
+| 读/写 | 读 |
+| 敏感控制 | 否 |
+
+**入参**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_biz_id` | int | 是 | 业务 ID |
+
+**返回**
+
+```json
+{
+  "bk_set_id": 143,
+  "bk_set_name": "空闲机池",
+  "module": [
+    {
+      "bk_module_id": 1762,
+      "bk_module_name": "空闲机",
+      "default": 1,
+      "host_apply_enabled": false
+    }
+  ]
+}
+```
+
+**校验规则**
+
+- `bk_biz_id` 必填
+
+---
+
+## bkcc_wrap_find_host_biz_relations
+
+| 项 | 说明 |
+|---|---|
+| 描述 | 查询主机业务关系信息 |
+| 读/写 | 读 |
+| 敏感控制 | 否 |
+
+**入参**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_host_ids` | list[int] | 是 | 主机 ID 列表 |
+
+**返回**
+
+```json
+{
+  "info": [
+    {
+      "bk_biz_id": 100,
+      "bk_host_id": 123,
+      "bk_module_id": 456,
+      "bk_set_id": 789,
+      "bk_supplier_account": "0"
+    }
+  ]
+}
+```
+
+**校验规则**
+
+- `bk_host_ids` 必填
+
+---
+
+## bkcc_wrap_update_hosts_operator
+
+| 项 | 说明 |
+|---|---|
+| 描述 | 修改机器负责人 |
+| 读/写 | 写 |
+| 敏感控制 | **是** |
+
+**入参**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_host_ids` | list[int] | 是 | 主机 ID 列表，至少 1 个 |
+| `operators` | list[str] | 否 | 主负责人，对应 CMDB `operator` |
+| `bak_operators` | list[str] | 否 | 备份负责人，对应 CMDB `bk_bak_operator` |
+
+**返回**
+
+```json
+{
+  "bk_host_ids": [123, 456]
+}
+```
+
+**校验规则**
+
+- 所有主机必须存在于 DBM 纳管池
+- 当前用户必须是每台机器的主负责人或备份负责人
+
+---
+
+## bkcc_wrap_transfer_host_to_idlemodule
+
+| 项 | 说明 |
+|---|---|
+| 描述 | 主机移动到空闲机模块 |
+| 读/写 | 写 |
+| 敏感控制 | **是** |
+
+**入参**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_biz_id` | int | 是 | 业务 ID |
+| `bk_host_ids` | list[int] | 是 | 主机 ID 列表，至少 1 个 |
+
+**返回**
+
+```json
+{
+  "bk_biz_id": 100,
+  "bk_host_ids": [123, 456]
+}
+```
+
+**校验规则**
+
+- 当前用户必须是每台机器的主负责人或备份负责人
+- 主机**不能**在 DBM 纳管池中
+
+---
+
+## bkcc_wrap_transfer_host_across_biz
+
+| 项 | 说明 |
+|---|---|
+| 描述 | 跨业务空闲机转移 |
+| 读/写 | 写 |
+| 敏感控制 | **是** |
+
+**入参**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `src_bk_biz_id` | int | 是 | 源业务 ID |
+| `dst_bk_biz_id` | int | 是 | 目标业务 ID |
+| `bk_host_ids` | list[int] | 是 | 主机 ID 列表，至少 1 个 |
+
+**返回**
+
+```json
+{
+  "src_bk_biz_id": 100,
+  "dst_bk_biz_id": 200,
+  "dst_idle_module_id": 1762,
+  "bk_host_ids": [123, 456]
+}
+```
+
+**校验规则**
+
+- `src_bk_biz_id` 与 `dst_bk_biz_id` 不能相同
+- 当前用户必须是每台机器的主负责人或备份负责人
+- 主机**不能**在 DBM 纳管池中
+- 目标业务须存在空闲机模块（`default == 1` 且 `bk_module_name == "空闲机"`）
+- 源业务侧主机须在空闲机池（由 CMDB API 内置校验）

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/__init__.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from backend.dbm_aiagent.mcp_tools.common.views.bkcc_wrap.viewset import BKCCWrapMcpToolsViewSet
+
+__all__ = ["BKCCWrapMcpToolsViewSet"]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/plan_checkers.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/plan_checkers.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from collections import Counter
+
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.transfer_host_across_biz import (
+    TransferHostAcrossBizInputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.transfer_host_to_idlemodule import (
+    TransferHostToIdlemoduleInputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.update_hosts_operator import (
+    UpdateHostsOperatorInputSerializer,
+)
+
+
+def update_hosts_operator_plan_checker(
+    plan_slz: UpdateHostsOperatorInputSerializer, requested_slz: UpdateHostsOperatorInputSerializer
+):
+    plan = plan_slz.validated_data
+    requested = requested_slz.validated_data
+    if (
+        Counter(plan["bk_host_ids"]) != Counter(requested["bk_host_ids"])
+        or Counter(plan["operators"]) != Counter(requested["operators"])
+        or Counter(plan["bak_operators"]) != Counter(requested["bak_operators"])
+    ):
+        raise Exception(
+            f"The request parameters do not match those registered in the plan. "
+            f"plan params: {plan_slz.data}, but received: {requested_slz.data}. "
+            f"You must call this tool with exactly the same parameters you announced, "
+            f"or create a new plan via `register_callee_plan` with the correct parameters."
+        )
+
+
+def transfer_host_to_idlemodule_plan_checker(
+    plan_slz: TransferHostToIdlemoduleInputSerializer, requested_slz: TransferHostToIdlemoduleInputSerializer
+):
+    plan = plan_slz.validated_data
+    requested = requested_slz.validated_data
+    if plan["bk_biz_id"] != requested["bk_biz_id"] or Counter(plan["bk_host_ids"]) != Counter(
+        requested["bk_host_ids"]
+    ):
+        raise Exception(
+            f"The request parameters do not match those registered in the plan. "
+            f"plan params: {plan_slz.data}, but received: {requested_slz.data}. "
+            f"You must call this tool with exactly the same parameters you announced, "
+            f"or create a new plan via `register_callee_plan` with the correct parameters."
+        )
+
+
+def transfer_host_across_biz_plan_checker(
+    plan_slz: TransferHostAcrossBizInputSerializer, requested_slz: TransferHostAcrossBizInputSerializer
+):
+    plan = plan_slz.validated_data
+    requested = requested_slz.validated_data
+    if (
+        plan["src_bk_biz_id"] != requested["src_bk_biz_id"]
+        or plan["dst_bk_biz_id"] != requested["dst_bk_biz_id"]
+        or Counter(plan["bk_host_ids"]) != Counter(requested["bk_host_ids"])
+    ):
+        raise Exception(
+            f"The request parameters do not match those registered in the plan. "
+            f"plan params: {plan_slz.data}, but received: {requested_slz.data}. "
+            f"You must call this tool with exactly the same parameters you announced, "
+            f"or create a new plan via `register_callee_plan` with the correct parameters."
+        )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/viewset.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/common/views/bkcc_wrap/viewset.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework.response import Response
+
+from backend.components import CCApi
+from backend.db_dirty.models import DirtyMachine
+from backend.dbm_aiagent.mcp_tools.common.impl.bkcc_wrap.check_operator import check_operator
+from backend.dbm_aiagent.mcp_tools.common.impl.bkcc_wrap.list_hosts_without_biz import list_hosts_without_biz
+from backend.dbm_aiagent.mcp_tools.common.impl.bkcc_wrap.update_hosts_operator import update_hosts_operator
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.find_host_biz_relations import (
+    FindHostBizRelationsInputSerializer,
+    FindHostBizRelationsOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.get_biz_internal_module import (
+    GetBizInternalModuleInputSerializer,
+    GetBizInternalModuleOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.list_hosts_without_biz import (
+    ListHostsWithoutBizInputSerializer,
+    ListHostsWithoutBizOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.transfer_host_across_biz import (
+    TransferHostAcrossBizInputSerializer,
+    TransferHostAcrossBizOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.transfer_host_to_idlemodule import (
+    TransferHostToIdlemoduleInputSerializer,
+    TransferHostToIdlemoduleOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.serializers.bkcc_wrap.update_hosts_operator import (
+    UpdateHostsOperatorInputSerializer,
+    UpdateHostsOperatorOutputSerializer,
+)
+from backend.dbm_aiagent.mcp_tools.common.views.bkcc_wrap.plan_checkers import (
+    transfer_host_across_biz_plan_checker,
+    transfer_host_to_idlemodule_plan_checker,
+    update_hosts_operator_plan_checker,
+)
+from backend.dbm_aiagent.mcp_tools.constants import DBMMCPTags, DBMMcpTools
+from backend.dbm_aiagent.mcp_tools.decorators import mcp_tools_api_decorator
+from backend.dbm_aiagent.mcp_tools.exceptions import (
+    DBMMcpBaseException,
+    DBMMcpForbiddenException,
+    DBMMcpUsernameNotFoundException,
+)
+from backend.dbm_aiagent.mcp_tools.views import McpToolsViewSet
+from backend.iam_app.handlers.drf_perm.mcp import McpIsDbaPermission
+
+
+class BKCCWrapMcpToolsViewSet(McpToolsViewSet):
+    default_permission_class = [McpIsDbaPermission()]
+
+    @mcp_tools_api_decorator(
+        description=str(CCApi.list_hosts_without_biz.description),
+        request_slz=ListHostsWithoutBizInputSerializer,
+        response_slz=ListHostsWithoutBizOutputSerializer,
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.BKCC_WRAP],
+        name_prefix="bkcc_wrap",
+        enable=True,
+    )
+    def list_hosts_without_biz(self, request, *args, **kwargs):
+        bk_cloud_id = self.get_param("bk_cloud_id")
+        ips = self.get_param("ips")
+
+        res = list_hosts_without_biz(bk_cloud_id=bk_cloud_id, ips=ips)
+        return Response({"info": res})
+
+    @mcp_tools_api_decorator(
+        description=str(CCApi.get_biz_internal_module.description),
+        request_slz=GetBizInternalModuleInputSerializer,
+        response_slz=GetBizInternalModuleOutputSerializer,
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.BKCC_WRAP],
+        name_prefix="bkcc_wrap",
+        enable=True,
+    )
+    def get_biz_internal_module(self, request, *args, **kwargs):
+        bk_biz_id = self.get_param("bk_biz_id")
+        return Response(CCApi.get_biz_internal_module({"bk_biz_id": bk_biz_id}, use_admin=True))
+
+    @mcp_tools_api_decorator(
+        description=str(CCApi.find_host_biz_relations.description),
+        request_slz=FindHostBizRelationsInputSerializer,
+        response_slz=FindHostBizRelationsOutputSerializer,
+        tags=[DBMMCPTags.READ],
+        mcp=[DBMMcpTools.BKCC_WRAP],
+        name_prefix="bkcc_wrap",
+        enable=True,
+    )
+    def find_host_biz_relations(self, request, *args, **kwargs):
+        """
+        ccapi 的参数用单数名词又是传入 list -_-
+        """
+        bk_host_ids = self.get_param("bk_host_ids")
+        return Response({"info": CCApi.find_host_biz_relations({"bk_host_id": bk_host_ids}, use_admin=True)})
+
+    @mcp_tools_api_decorator(
+        description=_("修改机器负责人"),
+        request_slz=UpdateHostsOperatorInputSerializer,
+        response_slz=UpdateHostsOperatorOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.BKCC_WRAP],
+        name_prefix="bkcc_wrap",
+        enable=True,
+        enable_callee_plan=True,
+        callee_plan_checker=update_hosts_operator_plan_checker,
+    )
+    def update_hosts_operator(self, request, *args, **kwargs):
+        bk_host_ids = self.get_param("bk_host_ids")
+        operators = self.get_param("operators", [])
+        bak_operators = self.get_param("bak_operators", [])
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        dbm_pool_machines = DirtyMachine.objects.filter(bk_host_id__in=bk_host_ids)
+        pool_host_ids = set(dbm_pool_machines.values_list("bk_host_id", flat=True))
+        not_in_pool_host_ids = list(set(bk_host_ids) - pool_host_ids)
+        if not_in_pool_host_ids:
+            raise DBMMcpForbiddenException(msg=f"{not_in_pool_host_ids} not found in DBM pool")
+
+        update_hosts_operator(
+            bk_host_ids=bk_host_ids,
+            operators=operators,
+            bak_operators=bak_operators,
+            username=username,
+        )
+
+        return Response({"bk_host_ids": bk_host_ids})
+
+    @mcp_tools_api_decorator(
+        description=str(CCApi.transfer_host_to_idlemodule.description),
+        request_slz=TransferHostToIdlemoduleInputSerializer,
+        response_slz=TransferHostToIdlemoduleOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.BKCC_WRAP],
+        name_prefix="bkcc_wrap",
+        enable=True,
+        enable_callee_plan=True,
+        callee_plan_checker=transfer_host_to_idlemodule_plan_checker,
+    )
+    def transfer_host_to_idlemodule(self, request, *args, **kwargs):
+        bk_biz_id = self.get_param("bk_biz_id")
+        bk_host_ids = self.get_param("bk_host_ids")
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        check_operator(username=username, bk_host_ids=bk_host_ids)
+
+        dbm_pool_machines = DirtyMachine.objects.filter(bk_host_id__in=bk_host_ids)
+        if dbm_pool_machines.exists():
+            raise DBMMcpForbiddenException(
+                msg=f"{list(dbm_pool_machines.values_list('bk_host_id', flat=True))} found in DBM pool"
+            )
+
+        CCApi.transfer_host_to_idlemodule(
+            {"bk_biz_id": bk_biz_id, "bk_host_id": bk_host_ids}, use_admin=True  # CC API 这里是传入数组, 但是 key 名确实是单数形式
+        )
+
+        return Response({"bk_biz_id": bk_biz_id, "bk_host_ids": bk_host_ids})
+
+    @mcp_tools_api_decorator(
+        description=_("跨业务空闲机转移"),
+        request_slz=TransferHostAcrossBizInputSerializer,
+        response_slz=TransferHostAcrossBizOutputSerializer,
+        tags=[DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.BKCC_WRAP],
+        name_prefix="bkcc_wrap",
+        enable=True,
+        enable_callee_plan=True,
+        callee_plan_checker=transfer_host_across_biz_plan_checker,
+    )
+    def transfer_host_across_biz(self, request, *args, **kwargs):
+        """
+        跨业务转移主机，只能将源业务空闲机池集群中的主机转移到目标业务的空闲机池集群
+        这是 cc api 内置的校验
+        所以这里不需要再校验机器在 src biz 中的拓扑位置
+
+        bk_module_id	int	是	主机要转移到的模块ID，该模块ID必须为下空闲机池set下的模块ID
+        这是 cc api 对目标的内置限制
+        """
+        src_bk_biz_id = self.get_param("src_bk_biz_id")
+        bk_host_ids = self.get_param("bk_host_ids")
+        dst_bk_biz_id = self.get_param("dst_bk_biz_id")
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        check_operator(username=username, bk_host_ids=bk_host_ids)
+
+        dbm_pool_machines = DirtyMachine.objects.filter(bk_host_id__in=bk_host_ids)
+        if dbm_pool_machines.exists():
+            raise DBMMcpForbiddenException(
+                msg=f"{list(dbm_pool_machines.values_list('bk_host_id', flat=True))} found in DBM pool"
+            )
+
+        dst_biz_internal_module = CCApi.get_biz_internal_module({"bk_biz_id": dst_bk_biz_id}, use_admin=True)
+        dst_idle_module_id = None
+        for module in dst_biz_internal_module.get("module") or []:
+            if module.get("default") == 1:
+                dst_idle_module_id = module["bk_module_id"]
+                break
+        if dst_idle_module_id is None:
+            raise DBMMcpBaseException(msg=f"idle module not found in biz {dst_bk_biz_id}")
+
+        CCApi.transfer_host_across_biz(
+            {
+                "src_bk_biz_id": src_bk_biz_id,
+                "bk_host_id": bk_host_ids,
+                "dst_bk_biz_id": dst_bk_biz_id,
+                "bk_module_id": dst_idle_module_id,
+            },
+            use_admin=True,
+        )
+
+        return Response(
+            {
+                "src_bk_biz_id": src_bk_biz_id,
+                "dst_bk_biz_id": dst_bk_biz_id,
+                "dst_idle_module_id": dst_idle_module_id,
+                "bk_host_ids": bk_host_ids,
+            }
+        )

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/constants.py
@@ -59,6 +59,8 @@ class DBMMcpTools(StrStructuredEnum):
     # MARKET
     DBM_PUBLIC_MARKET = EnumField("dbm-public-market", _("DBM公共服务"))
     RESOURCE_POOL = EnumField("resource-pool", "resource-pool")
+    # 3rd platform wrap
+    BKCC_WRAP = EnumField("bkcc-wrap", _("bkcc-wrap"))
 
 
 class DBMMCPTags(StrStructuredEnum):


### PR DESCRIPTION
# BKCC Wrap MCP 工具

MCP 分组：`bkcc-wrap`

默认权限：`DBManagePermission`

敏感控制指 **Callee Plan**（`enable_callee_plan`）：写操作需先 `register_callee_plan` 登记参数，实际调用时参数必须与 plan 完全一致。

---

## bkcc_wrap_list_hosts_without_biz

| 项 | 说明 |
|---|---|
| 描述 | 没有业务信息的主机查询 |
| 读/写 | 读 |
| 敏感控制 | 否 |

**入参**

| 字段 | 类型 | 必填 | 说明 |
|---|---|---|---|
| `bk_cloud_id` | int | 是 | 云区域 ID |
| `ips` | list[str] | 是 | IP 列表 |

**返回**

`info` 为数组，元素字段如下：

| 字段 | 类型 | 说明 |
|---|---|---|
| `bk_agent_id` | str | Agent ID |
| `bk_bak_operator` | str | 备份负责人 |
| `bk_cloud_id` | int | 云区域 ID |
| `bk_cloud_inst_id` | str | 云实例 ID |
| `bk_host_id` | int | 主机 ID |
| `bk_host_innerip` | str | 内网 IP |
| `bk_idc_area` | str | IDC 区域 |
| `bk_idc_area_id` | int | IDC 区域 ID |
| `bk_os_name` | str | 操作系统 |
| `bk_svr_device_cls_name` | str | 机型 |
| `idc_city_id` | str | 城市 ID |
| `idc_city_name` | str | 城市 |
| `idc_id` | int | IDC ID |
| `idc_name` | str | IDC 名称 |
| `net_device_id` | str | 网络设备 ID |
| `operator` | str | 负责人 |
| `rack` | str | 机架 |
| `rack_id` | str | 机架 ID |
| `sub_zone` | str | 园区 |
| `sub_zone_id` | str | 园区 ID |

**校验规则**

- `bk_cloud_id`、`ips` 必填

---

## bkcc_wrap_get_biz_internal_module

| 项 | 说明 |
|---|---|
| 描述 | 查询业务的空闲机/故障机/待回收模块 |
| 读/写 | 读 |
| 敏感控制 | 否 |

**入参**

| 字段 | 类型 | 必填 | 说明 |
|---|---|---|---|
| `bk_biz_id` | int | 是 | 业务 ID |

**返回**

```json
{
  "bk_set_id": 143,
  "bk_set_name": "空闲机池",
  "module": [
    {
      "bk_module_id": 1762,
      "bk_module_name": "空闲机",
      "default": 1,
      "host_apply_enabled": false
    }
  ]
}
```

**校验规则**

- `bk_biz_id` 必填

---

## bkcc_wrap_find_host_biz_relations

| 项 | 说明 |
|---|---|
| 描述 | 查询主机业务关系信息 |
| 读/写 | 读 |
| 敏感控制 | 否 |

**入参**

| 字段 | 类型 | 必填 | 说明 |
|---|---|---|---|
| `bk_host_ids` | list[int] | 是 | 主机 ID 列表 |

**返回**

```json
{
  "info": [
    {
      "bk_biz_id": 100,
      "bk_host_id": 123,
      "bk_module_id": 456,
      "bk_set_id": 789,
      "bk_supplier_account": "0"
    }
  ]
}
```

**校验规则**

- `bk_host_ids` 必填

---

## bkcc_wrap_update_hosts_operator

| 项 | 说明 |
|---|---|
| 描述 | 修改机器负责人 |
| 读/写 | 写 |
| 敏感控制 | **是** |

**入参**

| 字段 | 类型 | 必填 | 说明 |
|---|---|---|---|
| `bk_host_ids` | list[int] | 是 | 主机 ID 列表，至少 1 个 |
| `operators` | list[str] | 否 | 主负责人，对应 CMDB `operator` |
| `bak_operators` | list[str] | 否 | 备份负责人，对应 CMDB `bk_bak_operator` |

**返回**

```json
{
  "bk_host_ids": [123, 456]
}
```

**校验规则**

- 所有主机必须存在于 DBM 纳管池
- 当前用户必须是每台机器的主负责人或备份负责人

---

## bkcc_wrap_transfer_host_to_idlemodule

| 项 | 说明 |
|---|---|
| 描述 | 主机移动到空闲机模块 |
| 读/写 | 写 |
| 敏感控制 | **是** |

**入参**

| 字段 | 类型 | 必填 | 说明 |
|---|---|---|---|
| `bk_biz_id` | int | 是 | 业务 ID |
| `bk_host_ids` | list[int] | 是 | 主机 ID 列表，至少 1 个 |

**返回**

```json
{
  "bk_biz_id": 100,
  "bk_host_ids": [123, 456]
}
```

**校验规则**

- 当前用户必须是每台机器的主负责人或备份负责人
- 主机**不能**在 DBM 纳管池中

---

## bkcc_wrap_transfer_host_across_biz

| 项 | 说明 |
|---|---|
| 描述 | 跨业务空闲机转移 |
| 读/写 | 写 |
| 敏感控制 | **是** |

**入参**

| 字段 | 类型 | 必填 | 说明 |
|---|---|---|---|
| `src_bk_biz_id` | int | 是 | 源业务 ID |
| `dst_bk_biz_id` | int | 是 | 目标业务 ID |
| `bk_host_ids` | list[int] | 是 | 主机 ID 列表，至少 1 个 |

**返回**

```json
{
  "src_bk_biz_id": 100,
  "dst_bk_biz_id": 200,
  "dst_idle_module_id": 1762,
  "bk_host_ids": [123, 456]
}
```

**校验规则**

- `src_bk_biz_id` 与 `dst_bk_biz_id` 不能相同
- 当前用户必须是每台机器的主负责人或备份负责人
- 主机**不能**在 DBM 纳管池中
- 目标业务须存在空闲机模块（`default == 1` 且 `bk_module_name == "空闲机"`）
- 源业务侧主机须在空闲机池（由 CMDB API 内置校验）
