### PR TITLE
fix(mysql): 修改 tmysql 3.3 介质包的 full_version 为 5.7.20.3.3.0 #19383

### DIFF
--- a/dbm-ui/backend/dbm_init/medium/medium.lock
+++ b/dbm-ui/backend/dbm_init/medium/medium.lock
@@ -409,7 +409,7 @@ mysql:
     installation: true
     distribution_name: TMySQL
     version_series: MySQL-5.7
-    full_version: 5.7.20.3.4.3
+    full_version: 5.7.20.3.3.0
     os_type: "Linux"
     os_version:
 - mysql:


### PR DESCRIPTION
close #19383

## 问题描述
`medium.lock` 中 `/install/mysql/mysql-5.7.20-linux-x86_64-tmysql-3.3-gcs.tar.gz` 介质包的 `full_version` 配置有误。

## 修复内容
将该介质包的 `full_version` 由 `5.7.20.3.4.3` 修改为 `5.7.20.3.3.0`。

## 测试
- [ ] 单元测试通过
- [ ] 功能验证完成
