### PR TITLE
feat(redis): 备份批次Tag  #19302

### DIFF
--- a/dbm-services/common/db-event-consumer/pkg/base/model_base.go
+++ b/dbm-services/common/db-event-consumer/pkg/base/model_base.go
@@ -55,7 +55,10 @@ func (b BaseModel) StrictSchema() bool {
 // if exists and has different definition, drop and create
 // if exists and has same definition, do nothing
 func CreateOrUpdateIndex(db *gorm.DB, tableName string, indexName string, columnNames []string, unique bool, overwrite bool) error {
-	indexes, _ := db.Migrator().GetIndexes(tableName)
+	indexes, err := db.Migrator().GetIndexes(tableName)
+	if err != nil {
+		return errors.WithMessagef(err, "get indexes of %s", tableName)
+	}
 	for _, i := range indexes {
 		// same definition: 索引名字相同，unique相同，列相同 --> 不重复添加索引
 		if i.Name() == indexName {

--- a/dbm-services/common/db-event-consumer/pkg/model/redis_backup_result.go
+++ b/dbm-services/common/db-event-consumer/pkg/model/redis_backup_result.go
@@ -9,8 +9,10 @@
 package model
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -22,6 +24,40 @@ import (
 	"dbm-services/common/db-event-consumer/pkg/base"
 	"dbm-services/common/db-event-consumer/pkg/sinker"
 )
+
+type stringOrInt64 int64
+
+func (n *stringOrInt64) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" || len(data) == 0 {
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		if s == "" {
+			*n = 0
+			return nil
+		}
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		*n = stringOrInt64(v)
+		return nil
+	}
+	v, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+	*n = stringOrInt64(v)
+	return nil
+}
+
+func (n stringOrInt64) Value() (driver.Value, error) {
+	return int64(n), nil
+}
 
 /*
 {"report_type":"redis_fullbackup","bk_biz_id":"00001","bk_cloud_id":0,
@@ -52,10 +88,10 @@ type RedisBackupResultModel struct {
 	InstRole     string `json:"role" db:"redis_role" gorm:"column:redis_role;type:varchar(32);NOT NULL"`
 	DbType       string `json:"db_type" db:"redis_type" gorm:"column:redis_type;type:varchar(32);NOT NULL"`
 	// BillId          string `json:"bill_id" db:"bill_id" gorm:"column:bill_id;type:varchar(32);NOT NULL"`
-	BkBizId string `json:"bk_biz_id" db:"bk_biz_id" gorm:"column:bk_biz_id;type:varchar(32);NOT NULL"`
+	BkBizId stringOrInt64 `json:"bk_biz_id" db:"bk_biz_id" gorm:"column:bk_biz_id;type:int;NOT NULL"`
 	// MysqlVersion    string `json:"mysql_version" db:"mysql_version" gorm:"column:mysql_version;type:varchar(120);NOT NULL"`
 
-	BackupTaskID   uint64 `json:"backup_taskid" db:"backup_taskid" gorm:"column:backup_taskid;type:bigint;NOT NULL"`
+	BackupTaskID   string `json:"backup_taskid" db:"backup_taskid" gorm:"column:backup_taskid;type:varchar(128);NOT NULL"`
 	BackupFilesize uint64 `json:"backup_file_size" db:"backup_file_size" gorm:"column:backup_file_size;type:bigint;NOT NULL"`
 	BackupFileName string `json:"backup_file" db:"backup_file" gorm:"column:backup_file;type:varchar(255);NOT NULL"`
 
@@ -139,6 +175,7 @@ func (m *RedisBackupResultModel) mysqlCreate(i interface{}, db *gorm.DB) error {
 		"backup_host",
 		"backup_port",
 		"redis_role",
+		"redis_type",
 		"shard_value",
 		"backup_type",
 		"is_standby",
@@ -169,6 +206,7 @@ func (m *RedisBackupResultModel) mysqlCreate(i interface{}, db *gorm.DB) error {
 			modelObj.BackupHost,
 			modelObj.BackupPort,
 			modelObj.InstRole,
+			modelObj.DbType,
 			modelObj.ShardValue,
 			modelObj.BackupType,
 			modelObj.IsStandby,
@@ -180,7 +218,7 @@ func (m *RedisBackupResultModel) mysqlCreate(i interface{}, db *gorm.DB) error {
 			modelObj.BackupBeginTime.UTC(),
 			modelObj.BackupEndTime.UTC(),
 			modelObj.BackupStatus,
-			modelObj.BkBizId,
+			int64(modelObj.BkBizId),
 			modelObj.ExtraFields,
 			modelObj.EventCreateTimestamp,
 			modelObj.EventReportTimestamp,
@@ -208,19 +246,22 @@ func (m *RedisBackupResultModel) Validate() error {
 	//validationErrors := err.(validator.ValidationErrors)
 }
 
-// func (m *RedisBackupResultModel) UnmarshalJSON(data []byte) error {
-// 	msg := RedisBackupResultMsg{}
-// 	if err := json.Unmarshal(data, &msg); err != nil {
-// 		return err
-// 	}
-// 	if err := copier.Copy(&m, msg); err != nil {
-// 		return err
-// 	}
-
-// 	m.ExtraFields, _ = json.Marshal(msg.ExtraFields)
-// 	// m.BkBizId = strconv.atoi(msg.BkBizId)
-// 	return nil
-// }
+func (m *RedisBackupResultModel) UnmarshalJSON(data []byte) error {
+	type redisBackupResultModel RedisBackupResultModel
+	msg := struct {
+		*redisBackupResultModel
+		BackupFileTag string `json:"backup_file_tag"`
+	}{
+		redisBackupResultModel: (*redisBackupResultModel)(m),
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return err
+	}
+	if m.BackupIdentify == "" {
+		m.BackupIdentify = msg.BackupFileTag
+	}
+	return nil
+}
 
 // type RedisBackupResultMsg struct {
 // 	base.BaseModel `json:",inline"`

--- a/dbm-services/common/db-event-consumer/pkg/model/redis_backup_status.go
+++ b/dbm-services/common/db-event-consumer/pkg/model/redis_backup_status.go
@@ -21,16 +21,17 @@ type RedisBackupStatus struct {
 	// StatusDetail 如果失败，记录失败详情
 	StatusDetail string `json:"status_detail" gorm:"type:text"`
 
-	BackupId   string `json:"backup_task_id" gorm:"type:varchar(60);NOT NULL"`
-	BackupType string `json:"backup_type"  gorm:"type:varchar(32);NOT NULL"`
+	BackupId       string `json:"backup_task_id" gorm:"type:varchar(60);NOT NULL"`
+	BackupType     string `json:"backup_type"  gorm:"type:varchar(32);NOT NULL"`
+	BackupIdentify string `json:"backup_identify" gorm:"type:varchar(255);NOT NULL"`
 
 	ImmuteDomain string `json:"immute_domain" gorm:"type:varchar(255);NOT NULL"`
 	BackupHost   string `json:"backup_host"  gorm:"type:varchar(32);NOT NULL"`
 	BackupPort   int    `json:"backup_port"  gorm:"type:int;NOT NULL"`
 	RedisRole    string `json:"redis_role"  gorm:"type:varchar(32);NOT NULL"`
 
-	ShardValue int    `json:"shard_value"  gorm:"type:int;NOT NULL"`
-	BkBizId    string `json:"bk_biz_id"  gorm:"type:int;NOT NULL"`
+	ShardValue string        `json:"shard_value"  gorm:"type:varchar(255);NOT NULL"`
+	BkBizId    stringOrInt64 `json:"bk_biz_id"  gorm:"type:int;NOT NULL"`
 	// IsFullBackup 是否包含数据的全备
 	IsFullBackup bool `json:"is_full_backup"  gorm:"type:tinyint"`
 }
@@ -71,6 +72,10 @@ func (m RedisBackupStatusModel) MigrateSchema(w base.DSWriter) error {
 		}
 		if err := base.CreateOrUpdateIndex(db, m.TableName(), "idx_host",
 			[]string{"backup_host"}, false, true); err != nil {
+			return err
+		}
+		if err := base.CreateOrUpdateIndex(db, m.TableName(), "idx_backup_identify",
+			[]string{"backup_identify"}, false, true); err != nil {
 			return err
 		}
 		if err := base.CreateOrUpdateIndex(db, m.TableName(), "idx_create_ts",

--- a/dbm-services/common/db-event-consumer/pkg/model/redis_binlog_result.go
+++ b/dbm-services/common/db-event-consumer/pkg/model/redis_binlog_result.go
@@ -9,7 +9,11 @@
 package model
 
 import (
+	"log/slog"
 	"time"
+
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
 
 	"dbm-services/common/db-event-consumer/pkg/base"
 )
@@ -38,16 +42,16 @@ type RedisBinlogFileModel struct {
 
 	BackupType   string `json:"report_type" db:"backup_type" gorm:"column:backup_type;type:varchar(32);NOT NULL"`
 	ImmuteDomain string `json:"domain" db:"immute_domain" gorm:"column:immute_domain;type:varchar(255);NOT NULL;index:uk_cluster,unique,priority:1"`
-	BackupHost   string `json:"server_ip" db:"backup_ip" gorm:"column:backup_ip;type:varchar(32);NOT NULL;index:uk_cluster,unique,priority:2"`
+	BackupHost   string `json:"server_ip" db:"backup_host" gorm:"column:backup_host;type:varchar(32);NOT NULL;index:uk_cluster,unique,priority:2"`
 	BackupPort   int    `json:"server_port" db:"backup_port" gorm:"column:backup_port;type:int;NOT NULL;index:uk_cluster,unique,priority:3"`
 	KvStoreIdx   int    `json:"kvstoreidx" db:"kvstoreidx" gorm:"column:kvstoreidx;type:int;NOT NULL;index:uk_cluster,unique,priority:4"`
 	InstRole     string `json:"role" db:"redis_role" gorm:"column:redis_role;type:varchar(32);NOT NULL"`
 	DbType       string `json:"db_type" db:"redis_type" gorm:"column:redis_type;type:varchar(32);NOT NULL"`
 	// BillId          string `json:"bill_id" db:"bill_id" gorm:"column:bill_id;type:varchar(32);NOT NULL"`
-	BkBizId string `json:"bk_biz_id" db:"bk_biz_id" gorm:"column:bk_biz_id;type:varchar(32);NOT NULL"`
+	BkBizId stringOrInt64 `json:"bk_biz_id" db:"bk_biz_id" gorm:"column:bk_biz_id;type:int;NOT NULL"`
 	// MysqlVersion    string `json:"mysql_version" db:"mysql_version" gorm:"column:mysql_version;type:varchar(120);NOT NULL"`
 
-	BackupTaskID   uint64 `json:"backup_taskid" db:"backup_taskid" gorm:"column:backup_taskid;type:bigint;NOT NULL"`
+	BackupTaskID   string `json:"backup_taskid" db:"backup_taskid" gorm:"column:backup_taskid;type:varchar(128);NOT NULL"`
 	BackupFilesize uint64 `json:"backup_file_size" db:"backup_file_size" gorm:"column:backup_file_size;type:bigint;NOT NULL"`
 	BackupFileName string `json:"backup_file" db:"backup_file" gorm:"column:backup_file;type:varchar(255);NOT NULL"`
 
@@ -56,7 +60,7 @@ type RedisBinlogFileModel struct {
 
 	BackupBeginTime time.Time `json:"start_time" db:"backup_begin_time" gorm:"column:backup_begin_time;type:TIMESTAMP NULL;default:null"`
 	BackupEndTime   time.Time `json:"end_time" db:"backup_end_time" gorm:"column:backup_end_time;type:TIMESTAMP NULL;default:null"`
-	BackupStatus    int       `json:"status,omitempty" db:"backup_status" gorm:"column:backup_status;type:tinyint;NOT NULL"`
+	BackupStatus    string    `json:"status,omitempty" db:"backup_status" gorm:"column:backup_status;type:varchar(32);NOT NULL"`
 }
 
 func (m RedisBinlogFileModel) TableName() string {
@@ -65,5 +69,76 @@ func (m RedisBinlogFileModel) TableName() string {
 
 // UniqueKey is used to handle duplicate record
 func (m RedisBinlogFileModel) UniqueKey() []string {
-	return []string{"backup_ip", "backup_port", "kvstoreidx", "backup_file"}
+	return []string{"backup_host", "backup_port", "kvstoreidx", "backup_file"}
+}
+
+// MigrateSchema 自定义迁移: 处理列名 backup_ip -> backup_host 的历史数据.
+// 老版本 (v<=?) 该列叫 backup_ip, 与 tb_redis_backup_result / tb_mysql_binlog_result
+// 的 backup_host 不一致, 这里统一为 backup_host, 老列存在时通过 CHANGE COLUMN 保留存量数据.
+func (m RedisBinlogFileModel) MigrateSchema(w base.DSWriter) error {
+	slog.Info("run migrate for RedisBinlogFileModel", slog.String("table", m.TableName()))
+	if w.Type() != "mysql" && w.Type() != "mysql_raw" {
+		return w.AutoMigrate(m)
+	}
+	dbWriter, ok := w.(base.GormMigrator)
+	if !ok {
+		return errors.Errorf("writer_type=%s has no gorm db for custom migrate: %s", w.Type(), m.TableName())
+	}
+	db := dbWriter.GormDB()
+
+	// 若历史表存在 backup_ip 列, 先把它重命名为 backup_host, 保留存量数据
+	if db.Migrator().HasTable(m.TableName()) &&
+		db.Migrator().HasColumn(&m, "backup_ip") &&
+		!db.Migrator().HasColumn(&m, "backup_host") {
+		slog.Info("rename column backup_ip -> backup_host",
+			slog.String("table", m.TableName()))
+		if err := db.Exec(
+			"ALTER TABLE `" + m.TableName() + "` " +
+				"CHANGE COLUMN `backup_ip` `backup_host` varchar(32) NOT NULL",
+		).Error; err != nil {
+			return errors.WithMessage(err, "rename backup_ip -> backup_host")
+		}
+		// 老唯一索引里带的是 backup_ip, 需要重建
+		if err := dropIndexIfExists(db, m.TableName(), "uk_cluster"); err != nil {
+			return err
+		}
+	}
+
+	// 历史列 backup_status 曾为 tinyint (数值枚举), 现已改为 varchar(32) (与 dbmon 生产端
+	// models/binlog.go 里 Status string 对齐). AutoMigrate 不会自动改变列类型, 这里显式
+	// MODIFY COLUMN 以确保存量表也升级到 varchar(32); 已经是 varchar 的表执行也是幂等的.
+	if db.Migrator().HasTable(m.TableName()) && db.Migrator().HasColumn(&m, "backup_status") {
+		if err := db.Exec(
+			"ALTER TABLE `" + m.TableName() + "` " +
+				"MODIFY COLUMN `backup_status` varchar(32) NOT NULL",
+		).Error; err != nil {
+			return errors.WithMessage(err, "modify backup_status to varchar(32)")
+		}
+	}
+
+	if err := db.Migrator().AutoMigrate(&m); err != nil {
+		return err
+	}
+
+	if err := base.CreateOrUpdateIndex(db, m.TableName(), "uk_cluster",
+		[]string{"immute_domain", "backup_host", "backup_port", "kvstoreidx"}, true, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func dropIndexIfExists(db *gorm.DB, tableName, indexName string) error {
+	indexes, err := db.Migrator().GetIndexes(tableName)
+	if err != nil {
+		return errors.WithMessagef(err, "get indexes of %s", tableName)
+	}
+	for _, i := range indexes {
+		if i.Name() == indexName {
+			if err := db.Migrator().DropIndex(tableName, indexName); err != nil {
+				return errors.WithMessagef(err, "drop old index %s on %s", indexName, tableName)
+			}
+			return nil
+		}
+	}
+	return nil
 }

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_backup.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_backup.go
@@ -155,8 +155,11 @@ func (job *RedisBackup) Run() (err error) {
 	}
 	bakTasks := make([]*BackupTask, 0, len(job.params.Ports))
 	if job.params.BackupIdentify == "" {
+		// Go time 布局: 15 表示 24 小时制小时 (03 是 12 小时制, 凌晨 3 点与下午 3 点会冲突).
+		// 与 SCHEDULED (redisfullbackup/task.go) 及 Python 侧 (redis_cluster_backup.py 用 %Y%m%d%H) 保持一致,
+		// 避免 identify 里落的小时数具有误导性.
 		job.params.BackupIdentify = fmt.Sprintf("BILL%s-%s",
-			job.runtime.UID, time.Now().Format("2006010203"))
+			job.runtime.UID, time.Now().Format("2006010215"))
 	}
 	for _, port := range job.params.Ports {
 		password, err = myredis.GetRedisPasswdFromConfFile(port)
@@ -209,6 +212,17 @@ func (task *BackupTask) CheckBackupStatus() {
 		return
 	}
 
+	// 记录上一次已上报的 progress 状态, 只在状态发生变化时才重新上报
+	// 避免 120 次探测循环里对同一个 running 状态重复上报, 造成 tb_redis_backup_progress 膨胀
+	lastReported := ""
+	reportIfChanged := func() {
+		if task.Status == lastReported {
+			return
+		}
+		task.reportBackupProgress()
+		lastReported = task.Status
+	}
+
 	// 半个小时还没上传成功则认为失败了
 	for i := 0; i < 120; i++ {
 		// taskStatus>4,上传失败;
@@ -219,6 +233,7 @@ func (task *BackupTask) CheckBackupStatus() {
 		if err != nil {
 			task.Status = consts.BackupStatusFailed
 			task.Message = fmt.Sprintf("备份系统调用失败:%d", i)
+			reportIfChanged()
 			mylog.Logger.Warn(fmt.Sprintf("taskid(%+v) upload error, err:%+v", taskID, err))
 			time.Sleep(time.Second * 10)
 			continue
@@ -226,11 +241,13 @@ func (task *BackupTask) CheckBackupStatus() {
 		if taskStatus > 4 {
 			task.Status = consts.BackupStatusToBakSystemFailed
 			task.Message = "上传备份系统失败"
+			reportIfChanged()
 			mylog.Logger.Error(fmt.Sprintf("上传失败,statusCode:%d,err:%s", taskStatus, statusMsg))
 			break
 		} else if taskStatus < 4 {
 			task.Status = consts.BackupStatusRunning
 			task.Message = fmt.Sprintf("上传备份系统中:%d", i)
+			reportIfChanged()
 			mylog.Logger.Info(fmt.Sprintf("taskid(%+v)上传中.... statusCode:%d", taskID, taskStatus))
 			// 每30s去探测一次
 			time.Sleep(30 * time.Second)
@@ -238,6 +255,7 @@ func (task *BackupTask) CheckBackupStatus() {
 		} else if taskStatus == 4 {
 			task.Status = consts.BackupStatusToBakSysSuccess
 			task.Message = "上传备份系统成功"
+			reportIfChanged()
 			mylog.Logger.Info(fmt.Sprintf("taskid(%+v)上传成功", taskID))
 			break
 		}
@@ -376,6 +394,12 @@ func (task *BackupTask) ToString() string {
 	return string(tmpBytes)
 }
 
+func (task *BackupTask) reportBackupProgress() {
+	if err := dbmonreport.RedisBackupProgressReport(&task.RedisFullbackupHistorySchema, task.reporter); err != nil {
+		mylog.Logger.Error(err.Error())
+	}
+}
+
 // GoFullBakcup 执行备份task,本地备份+上传备份系统
 func (task *BackupTask) GoFullBakcup() {
 	mylog.Logger.Info("redis(%s) begin to backup", task.Addr())
@@ -418,13 +442,14 @@ func (task *BackupTask) GoFullBakcup() {
 	defer flock.Unlock()
 
 	defer func() {
-		if task.Err != nil && task.Status == "" {
+		if task.Err != nil && (task.Status == "" || task.Status == consts.BackupStatusRunning) {
 			task.Message = task.Err.Error()
 			task.Status = consts.BackupStatusFailed
 		}
 		if err := dbmonreport.RedisFullBackupReport(&task.RedisFullbackupHistorySchema, task.reporter); err != nil {
 			mylog.Logger.Error(err.Error())
 		}
+		task.reportBackupProgress()
 		// task.BackupRecordReport(task.reporter)
 	}()
 
@@ -435,6 +460,7 @@ func (task *BackupTask) GoFullBakcup() {
 	if err := dbmonreport.RedisFullBackupReport(&task.RedisFullbackupHistorySchema, task.reporter); err != nil {
 		mylog.Logger.Error(err.Error())
 	}
+	task.reportBackupProgress()
 	// task.BackupRecordReport(task.reporter)
 
 	mylog.Logger.Info(fmt.Sprintf("redis(%s) dbType:%s start backup...", task.Addr(), task.DbType))

--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_reupload_old_backup_records.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_reupload_old_backup_records.go
@@ -284,6 +284,9 @@ func (job *RedisReuploadOldBackupRecords) reupload() (err error) {
 func (job *RedisReuploadOldBackupRecords) setParams(port int, backupDir, backupFile string, backupFileSize int64,
 	upTime time.Time, taskID, shardVal, fileTag string) {
 	if fileTag == consts.RedisFullBackupTAG {
+		// 基于备份文件 upTime 生成稳定的 BackupIdentify, 避免同实例多条全备记录在
+		// tb_redis_backup_result 里被 REPLACE INTO 相互覆盖.
+		backupIdentify := fmt.Sprintf("REUPLOAD-%s", upTime.Format("20060102150405"))
 		job.fullbackupRow.ServerPort = port
 		job.fullbackupRow.BackupDir = backupDir
 		job.fullbackupRow.BackupFile = backupFile
@@ -292,6 +295,7 @@ func (job *RedisReuploadOldBackupRecords) setParams(port int, backupDir, backupF
 		job.fullbackupRow.EndTime = upTime
 		job.fullbackupRow.BackupTaskID = taskID
 		job.fullbackupRow.ShardValue = shardVal
+		job.fullbackupRow.BackupIdentify = backupIdentify
 	} else if fileTag == consts.RedisBinlogTAG {
 		job.binlogRow.ServerPort = port
 		job.binlogRow.BackupDir = backupDir

--- a/dbm-services/redis/db-tools/dbmon/pkg/redisfullbackup/backupjob.go
+++ b/dbm-services/redis/db-tools/dbmon/pkg/redisfullbackup/backupjob.go
@@ -213,9 +213,17 @@ func (job *Job) CheckOldFullbackupStatus(port int) {
 			row.BackupTaskID, job.Err = job.backupClient.Upload(row.BackupFile)
 			if job.Err != nil {
 				row.Message = job.Err.Error()
+				// Upload 报错时也要上报一次 progress, 让 tb_redis_backup_progress 能看到失败流水
+				row.Status = consts.BackupStatusToBakSystemFailed
+				if err := report.RedisBackupProgressReport(&row, job.Reporter); err != nil {
+					mylog.Logger.Error(err.Error())
+				}
 			} else {
 				row.Status = consts.BackupStatusToBakSystemStart
 				row.Message = "上传备份系统中"
+				if err := report.RedisBackupProgressReport(&row, job.Reporter); err != nil {
+					mylog.Logger.Error(err.Error())
+				}
 			}
 			// 更新记录 status 和 message
 			job.Err = job.sqdb.Save(&row).Error
@@ -244,6 +252,9 @@ func (job *Job) CheckOldFullbackupStatus(port int) {
 					if err := report.RedisFullBackupReport(&row, job.Reporter); err != nil {
 						mylog.Logger.Error(err.Error())
 					}
+					if err := report.RedisBackupProgressReport(&row, job.Reporter); err != nil {
+						mylog.Logger.Error(err.Error())
+					}
 					// row.BackupRecordReport(job.Reporter)
 					mylog.Logger.Error(fmt.Sprintf("%s %s", row.BackupFile, row.Message))
 				}
@@ -256,6 +267,9 @@ func (job *Job) CheckOldFullbackupStatus(port int) {
 					row.Status = consts.BackupStatusToBakSysSuccess
 					row.Message = "上传备份系统成功"
 					if err := report.RedisFullBackupReport(&row, job.Reporter); err != nil {
+						mylog.Logger.Error(err.Error())
+					}
+					if err := report.RedisBackupProgressReport(&row, job.Reporter); err != nil {
 						mylog.Logger.Error(err.Error())
 					}
 					// row.BackupRecordReport(job.Reporter)

--- a/dbm-services/redis/db-tools/dbmon/pkg/redisfullbackup/task.go
+++ b/dbm-services/redis/db-tools/dbmon/pkg/redisfullbackup/task.go
@@ -66,16 +66,18 @@ func NewFullBackupTask(bkBizID string, bkCloudID int64, domain, ip string, port 
 	}
 	timeZone, _ := time.Now().Local().Zone()
 	ret.RedisFullbackupHistorySchema = models.RedisFullbackupHistorySchema{
-		ReportType:     consts.RedisFullBackupReportType,
-		BkBizID:        bkBizID,
-		BkCloudID:      bkCloudID,
-		Domain:         domain,
-		ServerIP:       ip,
-		ServerPort:     port,
-		BackupDir:      backupDir,
-		BackupTaskID:   "",
-		BackupMD5:      "",
-		BackupIdentify: fmt.Sprintf("SCHEDULED-%s", time.Now().Format("2006010203")),
+		ReportType:   consts.RedisFullBackupReportType,
+		BkBizID:      bkBizID,
+		BkCloudID:    bkCloudID,
+		Domain:       domain,
+		ServerIP:     ip,
+		ServerPort:   port,
+		BackupDir:    backupDir,
+		BackupTaskID: "",
+		BackupMD5:    "",
+		// Go time 布局: 15 表示 24 小时制小时 (03 是 12 小时制, 凌晨 3 点与下午 3 点会冲突).
+		// 该 identify 表示"这一小时内的这批例行备份", 同集群同一小时内多次触发会归并为一条 result.
+		BackupIdentify: fmt.Sprintf("SCHEDULED-%s", time.Now().Format("2006010215")),
 		BackupTag:      backupFileTag,
 		TimeZone:       timeZone,
 		ShardValue:     shardValue,
@@ -94,6 +96,12 @@ func NewFullBackupTask(bkBizID string, bkCloudID int64, domain, ip string, port 
 func (task *BackupTask) ToString() string {
 	tmpBytes, _ := json.Marshal(task)
 	return string(tmpBytes)
+}
+
+func (task *BackupTask) reportBackupProgress() {
+	if err := report.RedisBackupProgressReport(&task.RedisFullbackupHistorySchema, task.reporter); err != nil {
+		mylog.Logger.Error(err.Error())
+	}
 }
 
 // BakcupToLocal 执行备份task,备份到本地
@@ -147,13 +155,14 @@ func (task *BackupTask) BakcupToLocal() {
 	defer flock.Unlock()
 
 	defer func() {
-		if task.Err != nil && task.Status == "" {
+		if task.Err != nil && (task.Status == "" || task.Status == consts.BackupStatusRunning) {
 			task.Message = task.Err.Error()
 			task.Status = consts.BackupStatusFailed
 		}
 		if err := report.RedisFullBackupReport(&task.RedisFullbackupHistorySchema, task.reporter); err != nil {
 			mylog.Logger.Error(err.Error())
 		}
+		task.reportBackupProgress()
 		// task.BackupRecordReport(task.reporter)
 	}()
 
@@ -165,6 +174,7 @@ func (task *BackupTask) BakcupToLocal() {
 	if err := report.RedisFullBackupReport(&task.RedisFullbackupHistorySchema, task.reporter); err != nil {
 		mylog.Logger.Error(err.Error())
 	}
+	task.reportBackupProgress()
 
 	mylog.Logger.Info(fmt.Sprintf("redis(%s) dbType:%s start backup...", task.Addr(), task.DbType))
 
@@ -515,13 +525,13 @@ func (task *BackupTask) TransferToBackupSystem() {
 	var msg string
 	cliFileInfo, err := os.Stat(consts.COSBackupClient)
 	if err != nil {
-		err = fmt.Errorf("os.stat(%s) failed,err:%v", consts.COSBackupClient, err)
-		mylog.Logger.Error(err.Error())
+		task.Err = fmt.Errorf("os.stat(%s) failed,err:%v", consts.COSBackupClient, err)
+		mylog.Logger.Error(task.Err.Error())
 		return
 	}
 	if !util.IsExecOther(cliFileInfo.Mode().Perm()) {
-		err = fmt.Errorf("%s is unable to execute by other", consts.COSBackupClient)
-		mylog.Logger.Error(err.Error())
+		task.Err = fmt.Errorf("%s is unable to execute by other", consts.COSBackupClient)
+		mylog.Logger.Error(task.Err.Error())
 		return
 	}
 	mylog.Logger.Info(fmt.Sprintf("redis(%s) backupFiles:%+v start upload backupSystem", task.Addr(), task.BackupFile))

--- a/dbm-services/redis/db-tools/dbmon/pkg/report/event.go
+++ b/dbm-services/redis/db-tools/dbmon/pkg/report/event.go
@@ -1,12 +1,30 @@
 package report
 
 import (
+	"dbm-services/redis/db-tools/dbmon/mylog"
 	"dbm-services/redis/db-tools/dbmon/pkg/models"
 	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 )
+
+// parseBkBizID 将字符串形式的 bk_biz_id 解析为 int64,
+// 解析失败时以 warn 级别记录日志并返回 0, 避免脏数据静默落库难以排障.
+func parseBkBizID(eventType, rawBkBizID string) int64 {
+	if rawBkBizID == "" {
+		mylog.Logger.Warn(fmt.Sprintf("event(%s) bk_biz_id is empty, will fallback to 0", eventType))
+		return 0
+	}
+	bkbizID, err := strconv.ParseInt(rawBkBizID, 10, 64)
+	if err != nil {
+		mylog.Logger.Warn(fmt.Sprintf(
+			"event(%s) parse bkBizID:%s 2 int64 failed:%+v, will fallback to 0",
+			eventType, rawBkBizID, err))
+		return 0
+	}
+	return bkbizID
+}
 
 // binlog backup event.
 type RedisBinlogResultEvent models.RedisBinlogHistorySchema
@@ -19,16 +37,17 @@ func (e *RedisBinlogResultEvent) EventType() string {
 	return "redis_binlog_result"
 }
 
+// EventCreateTime 使用 binlog 文件生成时间(StartTime)作为事件时间,
+// 保证同一 binlog 多次状态上报时事件时间稳定,避免与"上报时间"混淆.
 func (e *RedisBinlogResultEvent) EventCreateTime() time.Time {
-	return time.Now()
+	if e.StartTime.IsZero() {
+		return time.Now()
+	}
+	return e.StartTime
 }
 
 func (e *RedisBinlogResultEvent) EventBkBizId() int64 {
-	bkbizID, err := strconv.ParseInt(e.BkBizID, 10, 64)
-	if err != nil {
-		fmt.Printf("parse bkBizID:%s 2 int64 failed:%+v", e.BkBizID)
-	}
-	return bkbizID
+	return parseBkBizID(e.EventType(), e.BkBizID)
 }
 
 // 不强求实现 String, 这里是给下面的错误处理写例子用的
@@ -48,20 +67,80 @@ func (e *RedisFullBackupResultEvent) EventType() string {
 	return "redis_backup_result"
 }
 
+// EventCreateTime 使用备份开始时间(StartTime)作为事件时间,
+// 使同一次备份的多次状态上报共享稳定的 event_create_timestamp.
 func (e *RedisFullBackupResultEvent) EventCreateTime() time.Time {
-	return time.Now()
+	if e.StartTime.IsZero() {
+		return time.Now()
+	}
+	return e.StartTime
 }
 
 func (e *RedisFullBackupResultEvent) EventBkBizId() int64 {
-	bkbizID, err := strconv.ParseInt(e.BkBizID, 10, 64)
-	if err != nil {
-		fmt.Printf("parse bkBizID:%s 2 int64 failed:%+v", e.BkBizID)
-	}
-	return bkbizID
+	return parseBkBizID(e.EventType(), e.BkBizID)
 }
 
 // 不强求实现 String, 这里是给下面的错误处理写例子用的
 func (e *RedisFullBackupResultEvent) String() string {
+	b, _ := json.Marshal(e)
+	return string(b)
+}
+
+type redisBackupProgressPayload struct {
+	Status         string `json:"status"`
+	StatusDetail   string `json:"status_detail"`
+	BackupId       string `json:"backup_task_id"`
+	BackupType     string `json:"backup_type"`
+	BackupIdentify string `json:"backup_identify"`
+	ImmuteDomain   string `json:"immute_domain"`
+	BackupHost     string `json:"backup_host"`
+	BackupPort     int    `json:"backup_port"`
+	RedisRole      string `json:"redis_role"`
+	ShardValue     string `json:"shard_value"`
+	BkBizId        string `json:"bk_biz_id"`
+	IsFullBackup   bool   `json:"is_full_backup"`
+}
+
+// RedisBackupProgressEvent full backup progress event.
+type RedisBackupProgressEvent models.RedisFullbackupHistorySchema
+
+func (e *RedisBackupProgressEvent) ClusterType() string {
+	return getEventReporteClusterType(e.DbType)
+}
+
+func (e *RedisBackupProgressEvent) EventType() string {
+	return "redis_backup_progress"
+}
+
+// EventCreateTime progress 事件以"进度发生时刻"为事件时间(即上报当下),
+// 与 RedisFullBackupResultEvent 用 StartTime 不同, 请注意区分.
+func (e *RedisBackupProgressEvent) EventCreateTime() time.Time {
+	return time.Now()
+}
+
+func (e *RedisBackupProgressEvent) EventBkBizId() int64 {
+	return parseBkBizID(e.EventType(), e.BkBizID)
+}
+
+func (e *RedisBackupProgressEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(redisBackupProgressPayload{
+		Status:         e.Status,
+		StatusDetail:   e.Message,
+		BackupId:       e.BackupTaskID,
+		BackupType:     e.ReportType,
+		BackupIdentify: e.BackupIdentify,
+		ImmuteDomain:   e.Domain,
+		BackupHost:     e.ServerIP,
+		BackupPort:     e.ServerPort,
+		RedisRole:      e.RealRole,
+		ShardValue:     e.ShardValue,
+		BkBizId:        e.BkBizID,
+		IsFullBackup:   true,
+	})
+}
+
+// 不强求实现 String, 这里是给下面的错误处理写例子用的
+func (e *RedisBackupProgressEvent) String() string {
 	b, _ := json.Marshal(e)
 	return string(b)
 }

--- a/dbm-services/redis/db-tools/dbmon/pkg/report/report.go
+++ b/dbm-services/redis/db-tools/dbmon/pkg/report/report.go
@@ -74,3 +74,28 @@ func RedisFullBackupReport(r *models.RedisFullbackupHistorySchema, reporter Repo
 	}
 	return nil
 }
+
+// RedisBackupProgressReport 上报全备进度到 reverse api 2.0 通道.
+// reporter 非空时同时写一份本地 report 文件, 作为 Kafka 不可达时的兜底.
+func RedisBackupProgressReport(r *models.RedisFullbackupHistorySchema, reporter Reporter) error {
+	if reporter != nil {
+		reportRow := RedisFullBackupReportSch{
+			RedisFullbackupHistorySchema: *r,
+			StartTime:                    r.StartTime.Local().Format(time.RFC3339),
+			EndTime:                      r.EndTime.Local().Format(time.RFC3339),
+		}
+		tmpBytes, _ := json.Marshal(reportRow)
+		reporter.AddRecord(string(tmpBytes)+"\n", true)
+	}
+
+	reverseConfig := common.GetResrveAPIConfig()
+	reportCore, err := recore.NewCoreWithAddrsFile(r.BkCloudID, reverseConfig)
+	if err != nil {
+		return fmt.Errorf("report NewCore failed: %s", err.Error())
+	}
+	ev := RedisBackupProgressEvent(*r)
+	if resp, err := reapi.SyncReport(reportCore, &ev); err != nil {
+		return fmt.Errorf("report fullbackup progress failed:%s, resp=%s", err.Error(), string(resp))
+	}
+	return nil
+}

--- a/dbm-ui/backend/db_services/redis/rollback/handlers.py
+++ b/dbm-ui/backend/db_services/redis/rollback/handlers.py
@@ -128,6 +128,191 @@ class DataStructureHandler:
         )
         return backup_logs
 
+    def get_bklog_by_identify(
+        self, backup_identify: str, start_time: datetime = None, end_time: datetime = None
+    ) -> List[Dict]:
+        """
+        通过日志平台按 (cluster_domain, backup_identify) 精确查询"一次备份"产生的全部分片记录.
+        数据量上限	6000 条硬顶
+        重要: backup_identify **不是全局唯一** 的:
+        - Flow 场景 (BILL/FLUSH/FOREVER/DTS-{uid}-{ts}): 一个单据涉及多个集群时,
+          所有集群共用同一个 identify;
+        - 例行备份 (SCHEDULED-{YYYYMMDDHH}): 全业务所有 Redis 集群在同一小时的
+          identify 完全相同;
+        - Reupload (REUPLOAD-{ts}): 同一秒重上报多集群时 identify 相同.
+
+        因此本方法**始终**使用当前实例的 self.cluster.immute_domain 作为过滤条件, identify
+        只在集群维度内定位"一次备份". 调用方无法通过 identify 跨集群查询.
+
+        :param backup_identify: 备份批次标识 (集群内唯一)
+        :param start_time:      查询起始时间; 不传时默认往前推
+                                BACKUP_LOG_ROLLBACK_TIME_RANGE_DAYS 天
+        :param end_time:        查询结束时间; 不传时默认取当前时间
+        :return: 该集群该批次的原始 bklog 记录 (未做格式转换)
+        """
+        if not backup_identify:
+            raise AppBaseException(_("backup_identify 不能为空"))
+
+        if end_time is None:
+            end_time = datetime.now()
+        if start_time is None:
+            start_time = end_time - timedelta(days=BACKUP_LOG_ROLLBACK_TIME_RANGE_DAYS)
+
+        cluster_domain = self.cluster.immute_domain
+        status = "to_backup_system_success"
+        # 语义: 集群维度 (domain) + 批次维度 (backup_identify) + 状态维度 (status) 三元锁定
+        # backup_identify 单独不能定位到"一次备份", 必须与 domain 组合
+        backup_logs = self._get_log_from_bklog(
+            collector="redis_fullbackup_result",
+            start_time1=start_time,
+            end_time1=end_time,
+            query_string=(
+                f"domain: {cluster_domain} AND status: {status} " f'AND backup_identify: "{backup_identify}"'
+            ),
+        )
+        return backup_logs
+
+    def query_backup_logs_by_identify(
+        self, backup_identify: str, start_time: datetime = None, end_time: datetime = None
+    ) -> List[Dict[str, Union[int, Any]]]:
+        """
+        按 (当前集群, backup_identify) 精确聚齐一次备份的所有分片, 并转换为备份系统标准格式.
+
+        与 query_donmain_backup_log 的差异:
+        - query_donmain_backup_log 用 "最近 N 天 + 3 小时时间窗口" 聚批, 精度较低;
+        - 本方法在当前集群下用 backup_identify 精确聚批, 直接对应"一次备份行为",
+          不需要时间窗口.
+
+        注意: backup_identify 不是全局唯一, 必须绑定当前 self.cluster; 若调用方需要跨
+        集群查询同一单据触发的所有备份, 请对每个 cluster 分别 new 一个 handler 后调用本方法.
+
+        :param backup_identify: 备份批次标识
+        :param start_time:      查询起始时间(可选)
+        :param end_time:        查询结束时间(可选)
+        :return: 与 query_donmain_backup_log 相同格式的备份文件列表
+        """
+        backup_logs = self.get_bklog_by_identify(
+            backup_identify=backup_identify, start_time=start_time, end_time=end_time
+        )
+        if not backup_logs:
+            raise AppBaseException(
+                _("无法查找到集群{}下 backup_identify={} 的全备份日志").format(self.cluster.immute_domain, backup_identify)
+            )
+
+        logger.info(
+            _("集群{} 按 backup_identify={} 命中 {} 条备份记录").format(
+                self.cluster.immute_domain, backup_identify, len(backup_logs)
+            )
+        )
+        backup_logs.sort(key=lambda x: x["start_time"])
+
+        # 转换为备份系统标准格式
+        return [self.convert_to_backup_system_format(log) for log in backup_logs]
+
+    def list_backup_identifies(
+        self, start_time: datetime, end_time: datetime, status: str = "to_backup_system_success"
+    ) -> List[Dict[str, Any]]:
+        """
+        枚举当前集群在指定时间范围内出现过的所有 backup_identify, 附带每个批次的聚合元信息.
+        后期可以改成： 查：tb_redis_backup_result 位于 bk_dbm_report 数据库
+        使用场景:
+        - 前端"备份批次列表"下拉框, 让用户按批次选择恢复
+        - 单据结束页面回显"本次单据触发的备份批次"
+        - 运维排查"某天该集群做过哪些备份"
+
+        实现说明:
+        - 复用 _get_log_from_bklog 拉当前集群时间窗内的原始记录, 应用层按 backup_identify
+          分组去重, 与项目现有 set() 去重风格保持一致;
+        - 数据量控制: _get_log_from_bklog size=6000, 单集群 backup_identify 一般是"1天 1~24 批 *
+          N 分片" 量级, 不会触发上限. 若未来上限成为问题, 可再考虑走 ES aggregations.
+
+        :param start_time: 查询起始时间
+        :param end_time:   查询结束时间
+        :param status:     备份状态过滤; 默认只列出"上传备份系统成功"的批次
+        :return: 批次列表, 每个元素形如:
+                 {
+                     "backup_identify": "SCHEDULED-2026073003",
+                     "backup_type":      "SCHEDULED",         # 从 identify 前缀提取
+                     "shard_count":      12,                  # 该批次记录数
+                     "earliest_start":   "2026-07-30T03:00:11+08:00",
+                     "latest_end":       "2026-07-30T03:04:22+08:00",
+                     "total_file_size":  123456789,           # 该批次总大小
+                     "roles":            ["slave"],           # 涉及的实例角色
+                 }
+                 按 earliest_start 倒序 (最新的批次在前).
+        """
+        cluster_domain = self.cluster.immute_domain
+        query_string = f"domain: {cluster_domain}"
+        if status:
+            query_string = f"{query_string} AND status: {status}"
+
+        raw_logs = self._get_log_from_bklog(
+            collector="redis_fullbackup_result",
+            start_time1=start_time,
+            end_time1=end_time,
+            query_string=query_string,
+        )
+        if not raw_logs:
+            logger.info(_("集群{} 在时间范围 {} ~ {} 未发现任何备份批次").format(cluster_domain, start_time, end_time))
+            return []
+
+        # 按 backup_identify 分组聚合
+        buckets: Dict[str, Dict[str, Any]] = {}
+        for log in raw_logs:
+            identify = log.get("backup_identify") or ""
+            if not identify:
+                # 兜底: 未上报 identify 的老记录跳过 (它们无法用于批次维度定位)
+                continue
+
+            bucket = buckets.setdefault(
+                identify,
+                {
+                    "backup_identify": identify,
+                    "backup_type": self._extract_identify_prefix(identify),
+                    "shard_count": 0,
+                    "earliest_start": log["start_time"],
+                    "latest_end": log["end_time"],
+                    "total_file_size": 0,
+                    "roles": set(),
+                },
+            )
+            bucket["shard_count"] += 1
+            bucket["total_file_size"] += int(log.get("backup_file_size") or 0)
+            if log.get("role"):
+                bucket["roles"].add(log["role"])
+            if log["start_time"] < bucket["earliest_start"]:
+                bucket["earliest_start"] = log["start_time"]
+            if log["end_time"] > bucket["latest_end"]:
+                bucket["latest_end"] = log["end_time"]
+
+        # set 转 list 便于 json 序列化, 并按最新时间倒序返回
+        result = []
+        for bucket in buckets.values():
+            bucket["roles"] = sorted(bucket["roles"])
+            result.append(bucket)
+        result.sort(key=lambda x: x["earliest_start"], reverse=True)
+
+        logger.info(_("集群{} 在时间范围 {} ~ {} 发现 {} 个备份批次").format(cluster_domain, start_time, end_time, len(result)))
+        return result
+
+    @staticmethod
+    def _extract_identify_prefix(backup_identify: str) -> str:
+        """
+        从 backup_identify 提取批次类型前缀:
+        - BILL{uid}-{ts}     -> BILL 普通单据备份：
+        - FLUSH{uid}-{ts}    -> FLUSH 清档前备份：
+        - FOREVER{uid}-{ts}  -> FOREVER 集群下架永久备份：实例下架永久备份：
+        - DTS{uid}-{ts}      -> DTS DTS 目标集群清档前备份：
+        - SCHEDULED-{ts}     -> SCHEDULED 周期备份生成格式：
+        - REUPLOAD-{ts}      -> REUPLOAD 迁移DBM备份
+        - 其它未识别格式返回 UNKNOWN
+        """
+        known_prefixes = ("SCHEDULED", "REUPLOAD", "FOREVER", "FLUSH", "BILL", "DTS")
+        for prefix in known_prefixes:
+            if backup_identify.startswith(prefix):
+                return prefix
+        return "UNKNOWN"
+
     def query_donmain_backup_log(self, rollback_time: datetime) -> List[Dict[str, Union[int, Any]]]:
         # 1、通过集群名从日志平台查询集群信息,首先是扩大范围查询到离回档时间点最近的一个备份文件
         end_time = rollback_time

--- a/dbm-ui/backend/flow/utils/redis/redis_proxy_util.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_proxy_util.py
@@ -601,13 +601,13 @@ def get_online_redis_version(ip: str, port: int, bk_cloud_id: int, redis_passwor
     if not resp or len(resp) == 0:
         return ""
     result = resp[0].get("result")
-    version_str = re.search(r"redis_version:(.*)\r?\n", result).group(1)
+    version_str = re.search(r"redis_version:(.*?)\r?\n", result).group(1).strip()
 
     # valkey 兼容 redis 协议，INFO SERVER 中 redis_version 只是兼容版本号(如 7.2.4)，
     # 真实的 valkey 版本需要看 valkey_version 字段，server_name 字段用于区分是否为 valkey
-    server_name_match = re.search(r"server_name:(.*)\r?\n", result)
+    server_name_match = re.search(r"server_name:(.*?)\r?\n", result)
     if server_name_match and server_name_match.group(1).strip().lower() == "valkey":
-        valkey_version_match = re.search(r"valkey_version:(.*)\r?\n", result)
+        valkey_version_match = re.search(r"valkey_version:(.*?)\r?\n", result)
         if valkey_version_match and valkey_version_match.group(1).strip():
             version_str = valkey_version_match.group(1).strip()
         return "valkey-" + version_str

--- a/helm-charts/bk-dbm/values.yaml
+++ b/helm-charts/bk-dbm/values.yaml
@@ -614,6 +614,30 @@ db-event-consumer:
       from_beginning: false
       client_id_suffix: ""
       group_id_suffix: ""
+    - topic: "redis_backup_result"
+      model_table: "tb_redis_backup_result"
+      strict_schema: true
+      skip_migrate_schema: false
+      datasource: "prod_bk_dbm_report"
+      from_beginning: false
+      client_id_suffix: ""
+      group_id_suffix: ""
+    - topic: "redis_binlog_result"
+      model_table: "tb_redis_binlog_result"
+      strict_schema: true
+      skip_migrate_schema: false
+      datasource: "prod_bk_dbm_report"
+      from_beginning: false
+      client_id_suffix: ""
+      group_id_suffix: ""
+    - topic: "redis_backup_progress"
+      model_table: "tb_redis_backup_progress"
+      strict_schema: true
+      skip_migrate_schema: false
+      datasource: "prod_bk_dbm_report"
+      from_beginning: false
+      client_id_suffix: ""
+      group_id_suffix: ""
 
 # reloader
 stakater:


### PR DESCRIPTION
普通单据备份：redis_cluster_backup.py
生成格式：BILL{uid}-{YYYYMMDDHH}
用于 REDIS_BACKUP 单据触发的集群备份。

清档前备份：redis_flush_data.py
生成格式：FLUSH{uid}-{YYYYMMDDHH}
只在 rule["backup"] 为真时下发到备份节点。

集群下架永久备份：redis_cluster_shutdown.py
生成格式：FOREVER{uid}-{YYYYMMDDHH}。

实例下架永久备份：redis_ins_shutdown.py
生成格式：FOREVER{uid}-{YYYYMMDDHH}。

DTS 目标集群清档前备份：redis_dts.py
生成格式：DTS{uid}-{YYYYMMDDHH}。

周期备份生成格式：
SCHEDULED-{YYYYMMDDHH}