### PR TITLE
feat(mcp): 新增 MySQL 集群禁用/删除 MCP 工具并修复工具发现超时

### DIFF
--- a/dbm-services/common/db-mcp-server/internal/tools/discover.go
+++ b/dbm-services/common/db-mcp-server/internal/tools/discover.go
@@ -33,7 +33,7 @@ func discover() ([]*toolsDefinition, error) {
 	}
 
 	httpClient := &http.Client{
-		Timeout: 1 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 
 	resp, err := httpClient.Get(discoveryUrl)

--- a/dbm-services/common/db-mcp-server/internal/tools/load_tools.go
+++ b/dbm-services/common/db-mcp-server/internal/tools/load_tools.go
@@ -2,31 +2,23 @@ package tools
 
 import (
 	"slices"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"dbm-services/common/go-pubpkg/logger"
 )
 
 func LoadTools(s *server.MCPServer) (err error) {
 	var tds []*toolsDefinition
+	// 启动阶段发现失败时重试一次，避免首次拉取工具列表因瞬时抖动失败
 	tds, err = discover()
-	//err = retry.Do(
-	//	func() error {
-	//		tds, err = discover()
-	//		if err != nil {
-	//			return err
-	//		}
-	//		return nil
-	//	},
-	//	retry.Attempts(1),
-	//	retry.Delay(5*time.Second),
-	//	retry.DelayType(retry.FixedDelay),
-	//	retry.OnRetry(
-	//		func(n uint, err error) {
-	//			logger.Warn("retry load tools %d on %s", n, err.Error())
-	//		},
-	//	),
-	//)
+	if err != nil {
+		logger.Warn("load tools first try failed: %s, retry once...", err.Error())
+		time.Sleep(2 * time.Second)
+		tds, err = discover()
+	}
 
 	if err != nil {
 		return err

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/MCP_TOOLS.md
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/MCP_TOOLS.md
@@ -1,0 +1,154 @@
+# MySQL MCP 工具集说明（提单类）
+
+> 来源：`backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py`
+> 命名空间：`mysql_bill`（所有工具均通过 `name_prefix="mysql_bill"` 注册）
+> 权限：`McpTicketToolPermission`，按集群粒度鉴权（`mcp_auth_parser=auth_parse_clusters`）
+> 标签：所有工具均为 `READ` + `WRITE`（提单属于读写操作）
+> MCP 分组：`DBMMcpTools.MYSQL_BILL`（mysql-bill）
+
+## 公共说明
+
+- 所有工具均为**提单类**接口：创建 DBM 单据后返回 `bills` 列表（`bill_id` + `bill_url`），实际执行需用户在 DBM 平台完成单据审批/执行。
+- `bill_url` 链接格式：业务维度单据管理页 `{BK_SAAS_HOST}/{bk_biz_id}/ticket-business-manage/{ticket_id}`（如 `https://dbm.woa.com/5016766/ticket-business-manage/2382071`）。
+- 集群前置校验：接口内通过 `assert_cluster_type` 校验集群类型，不支持的集群类型直接报错，不产生单据。
+- 用户身份：从 `request.user.username` 获取提单人，为空时报错。
+- 输出结构统一为 `SubmitBillOutputSerializer`：
+
+```json
+{
+  "bills": [
+    {"bill_id": 123, "bill_url": "https://dbm.woa.com/#/tickets/detail/123"}
+  ]
+}
+```
+
+## 工具一览
+
+| # | 工具方法（operation_id 后缀） | 用途 | 支持的集群类型 |
+|---|---|---|---|
+| 1 | `submit_bill_mysql_full_backup` | 创建全备单据 | TenDBHA / TenDBCluster |
+| 2 | `submit_bill_mysql_db_table_backup` | 创建库表备单据 | TenDBHA / TenDBCluster |
+| 3 | `submit_bill_mysql_apply_priv` | 创建权限申请单据 | TenDBSingle / TenDBHA / TenDBCluster |
+| 4 | `submit_bill_mysql_standardize` | 创建标准化单据 | TenDBSingle / TenDBHA / TenDBCluster |
+| 5 | `submit_bill_mysql_db_rename` | 创建 DB 重命名单据 | TenDBSingle / TenDBHA / TenDBCluster |
+| 6 | `submit_bill_tdbctl_upgrade` | 创建 TenDBCluster 中控（tdbctl）升级单据 | TenDBCluster |
+| 7 | `submit_bill_proxy_replace` | 创建 TenDBHA proxy 新机替换单据 | TenDBHA |
+| 8 | `submit_bill_backend_slave_replace` | 创建 TenDBHA 存储 slave 新机替换单据 | TenDBHA |
+| 9 | `submit_bill_spider_replace` | 创建 TenDBCluster spider 新机替换单据 | TenDBCluster |
+| 10 | `submit_bill_remote_slave_replace` | 创建 TenDBCluster remote slave 新机替换单据 | TenDBCluster |
+| 11 | `submit_bill_tendbha_master_slave_switch` | 创建 TenDBHA 主从互切单据 | TenDBHA |
+| 12 | `submit_bill_tendbcluster_master_slave_switch` | 创建 TenDBCluster 主从互切单据 | TenDBCluster |
+| 13 | `submit_bill_mysql_construct_rollback` | 创建数据构造到已有集群 / 回档单据 | TenDBHA / TenDBCluster |
+| 14 | `submit_bill_mysql_clone_grants` | 创建 DB 权限克隆流程 | TenDBSingle / TenDBHA / TenDBCluster |
+| 15 | `submit_bill_mysql_disable` | **创建 MySQL 集群禁用单据（新增）** | TenDBSingle / TenDBHA / TenDBCluster |
+| 16 | `submit_bill_mysql_destroy` | **创建 MySQL 集群删除单据（新增，需集群已禁用）** | TenDBSingle / TenDBHA / TenDBCluster |
+
+> operation_id 完整形式：`mysql_bill_` + 上表方法名，如 `mysql_bill_submit_bill_mysql_disable`。
+
+---
+
+## `submit_bill_mysql_disable`：创建 MySQL 集群禁用单据
+
+**用途**：对指定业务下的一个或多个 MySQL 系列集群发起禁用操作，按集群类型自动拆分生成对应禁用单据。
+
+**operation_id**：`mysql_bill_submit_bill_mysql_disable`
+
+**输入字段**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_biz_id` | int | 是 | 业务 ID |
+| `cluster_domains` | string[] | 是 | 集群域名列表（支持多个，可混合不同类型） |
+| `force` | bool | 否（默认 `false`） | 是否强制禁用（对应单据 `force` 字段） |
+
+**输出字段**
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `bills[]` | object[] | 生成的禁用单据列表 |
+| `bills[].bill_id` | int | 单据 ID |
+| `bills[].bill_url` | string | 单据链接 |
+
+**行为约定**
+
+- 按集群类型自动拆分提单，一个请求可能生成多张单据：
+
+| 集群类型 | TicketType | 单据名称 |
+|---|---|---|
+| TenDBHA | `MYSQL_HA_DISABLE` | MySQL 高可用禁用 |
+| TenDBSingle | `MYSQL_SINGLE_DISABLE` | MySQL 单节点禁用 |
+| TenDBCluster | `TENDBCLUSTER_DISABLE` | TenDB Cluster 集群禁用 |
+
+- 所有集群按 `bk_biz_id` + `cluster_domains` 匹配；未找到任何集群时报错，不产生单据。
+- 传入不支持的类型（如 redis / mongodb 集群）时报错，不产生单据。
+- 单据 `details` 结构：`{"cluster_ids": [...], "force": <force>}`，并通过对应 `DetailSerializer`（`MysqlHADisableDetailSerializer` / `MysqlSingleDisableDetailSerializer` / `TendbDisableDetailSerializer`）做集群状态转移等校验。
+
+**调用示例**（`dbm-mcp-cli`）
+
+```bash
+dbm-mcp-cli call bkdbm-mcp-prod-mysql-bill.mysql_bill_submit_bill_mysql_disable \
+  body_param='{"bk_biz_id": 123, "cluster_domains": ["ha1.db.com", "cluster1.db.com"], "force": false}' \
+  --raw-query "禁用集群 ha1.db.com 和 cluster1.db.com"
+```
+
+**注意事项**
+
+- 禁用为高风险写操作，提交后需用户在 DBM 平台审批执行。
+- **集群名前缀限制**：仅允许 `spider.temp` 或 `tmpdb.` 前缀的临时集群禁用，其他域名直接报错，不产生单据。
+- **集群状态限制**：仅允许状态为正常（`normal`）的集群提单禁用，状态异常（`abnormal`）的集群直接报错，不产生单据。
+- `force=false` 时仅对状态可转移的集群生效；`force=true` 会跳过部分状态校验。
+- 一个请求混合多种集群类型时，会按类型生成多张单据，需逐一确认。
+
+---
+
+## `submit_bill_mysql_destroy`：创建 MySQL 集群删除单据
+
+**用途**：对指定业务下**已禁用**的一个或多个 MySQL 系列集群发起删除操作，按集群类型自动拆分生成对应删除单据。
+
+**operation_id**：`mysql_bill_submit_bill_mysql_destroy`
+
+**输入字段**
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bk_biz_id` | int | 是 | 业务 ID |
+| `cluster_domains` | string[] | 是 | 集群域名列表（支持多个，可混合不同类型） |
+| `force` | bool | 否（默认 `false`） | 是否强制删除（对应单据 `force` 字段） |
+
+**输出字段**
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `bills[]` | object[] | 生成的删除单据列表 |
+| `bills[].bill_id` | int | 单据 ID |
+| `bills[].bill_url` | string | 单据链接 |
+
+**行为约定**
+
+- **前置条件：集群必须处于禁用状态（`phase == offline`）才可以提交删除单据**。存在未禁用集群时直接报错，不产生任何单据。状态转移规则：ONLINE(在线) → OFFLINE(禁用) → DESTROY(删除)。
+- 按集群类型自动拆分提单，一个请求可能生成多张单据：
+
+| 集群类型 | TicketType | 单据名称 |
+|---|---|---|
+| TenDBHA | `MYSQL_HA_DESTROY` | MySQL 高可用删除 |
+| TenDBSingle | `MYSQL_SINGLE_DESTROY` | MySQL 单节点删除 |
+| TenDBCluster | `TENDBCLUSTER_DESTROY` | TenDB Cluster 集群销毁 |
+
+- 所有集群按 `bk_biz_id` + `cluster_domains` 匹配；未找到任何集群时报错，不产生单据。
+- 传入不支持的类型（如 redis / mongodb 集群）时报错，不产生单据。
+- 单据 `details` 结构：`{"cluster_ids": [...], "force": <force>}`，并通过对应 `DetailSerializer`（`MysqlHADestroyDetailSerializer` / `MysqlSingleDestroyDetailSerializer` / `TendbDestroyDetailSerializer`）做集群状态转移等二次校验。
+
+**调用示例**（`dbm-mcp-cli`）
+
+```bash
+dbm-mcp-cli call bkdbm-mcp-prod-mysql-bill.mysql_bill_submit_bill_mysql_destroy \
+  body_param='{"bk_biz_id": 123, "cluster_domains": ["ha1.db.com", "cluster1.db.com"], "force": false}' \
+  --raw-query "删除集群 ha1.db.com 和 cluster1.db.com"
+```
+
+**注意事项**
+
+- 删除为高风险写操作，提交后需用户在 DBM 平台审批执行。
+- **集群名前缀限制**：仅允许 `spider.temp` 或 `tmpdb.` 前缀的临时集群删除（与禁用一致），其他域名直接报错，不产生单据。
+- `force` 只影响删除单据内部的状态转移校验，不豁免「必须已禁用」的前置检查；集群未禁用时即使 `force=true` 也会报错。
+- 一个请求混合多种集群类型时，会按类型生成多张单据，需逐一确认。

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/bill_mysql_destroy.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/bill_mysql_destroy.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import re
+from typing import List
+
+from backend import env
+from backend.db_meta.enums import ClusterPhase, ClusterType
+from backend.db_meta.models import Cluster
+from backend.dbm_aiagent.mcp_tools.exceptions import (
+    DBMMcpClusterNotFoundException,
+    DBMMcpForbiddenException,
+    DBMMcpNoneBillSubmittedException,
+    DBMMcpNotSupportClusterTypeException,
+)
+from backend.ticket.builders.mysql.mysql_ha_destroy import MysqlHADestroyDetailSerializer
+from backend.ticket.builders.mysql.mysql_single_destroy import MysqlSingleDestroyDetailSerializer
+from backend.ticket.builders.tendbcluster.tendb_destroy import TendbDestroyDetailSerializer
+from backend.ticket.constants import TicketType
+from backend.ticket.models import Ticket
+
+# 允许删除的临时集群域名命名规范（正则，与禁用保持一致）：
+# 1. tmpdb. + 内容 + .dba.db，如 tmpdb.abc.dba.db
+# 2. spider. + 内容 + -tmp + 8位日期数字 + -，如 spider.abc-tmp20240801-xxx
+ALLOWED_DESTROY_DOMAIN_PATTERNS = [
+    re.compile(r"^tmpdb\..+\.dba\.db$"),
+    re.compile(r"^spider\..+-tmp\d{8}-"),
+]
+# 命名规范的人类可读描述（用于报错提示）
+ALLOWED_DESTROY_DOMAIN_RULES = ["tmpdb.内容.dba.db", "spider.内容-tmpYYYYMMDD-"]
+
+# 集群类型 -> (TicketType, DetailSerializer) 映射，按类型分组提单
+_DESTROY_GROUP_MAP = [
+    (ClusterType.TenDBHA, TicketType.MYSQL_HA_DESTROY, MysqlHADestroyDetailSerializer),
+    (ClusterType.TenDBSingle, TicketType.MYSQL_SINGLE_DESTROY, MysqlSingleDestroyDetailSerializer),
+    (ClusterType.TenDBCluster, TicketType.TENDBCLUSTER_DESTROY, TendbDestroyDetailSerializer),
+]
+
+
+def bill_mysql_destroy(
+    username: str,
+    bk_biz_id: int,
+    cluster_domains: List[str],
+) -> list:
+    """创建 MySQL 集群删除单据，返回业务维度单据链接
+
+    前置条件：集群必须处于禁用状态（phase == ClusterPhase.OFFLINE）才可以提交删除单据。
+
+    返回结构：[{bill_id, bill_url}]，其中 bill_url 为业务单据管理页链接：
+    {BK_SAAS_HOST}/{bk_biz_id}/ticket-business-manage/{ticket_id}
+    """
+    # 空列表显式报错，避免静默返回空结果（LLM 会误以为已提交）
+    if not cluster_domains:
+        raise DBMMcpForbiddenException(msg="cluster_domains 不能为空")
+
+    # 命名规范校验：一次传入的多个集群必须全部符合规范才可提交，否则整体拒绝并返回不符合的集群名
+    invalid_domains = [d for d in cluster_domains if not any(p.match(d) for p in ALLOWED_DESTROY_DOMAIN_PATTERNS)]
+    if invalid_domains:
+        raise DBMMcpForbiddenException(
+            msg="一次提交的集群必须全部符合临时集群命名规范（{}），以下集群不符合：{}".format(
+                " / ".join(ALLOWED_DESTROY_DOMAIN_RULES), ", ".join(invalid_domains)
+            )
+        )
+
+    clusters = Cluster.objects.filter(bk_biz_id=bk_biz_id, immute_domain__in=cluster_domains)
+    # 校验提交的域名是否全部命中集群，防止部分域名被静默丢弃（拼写错误/跨业务/已删除）
+    found_domains = set(clusters.values_list("immute_domain", flat=True))
+    not_found_domains = set(cluster_domains) - found_domains
+    if not_found_domains:
+        raise DBMMcpClusterNotFoundException(
+            msg="以下集群未找到，请检查域名是否正确/是否属于当前业务：{}".format(", ".join(sorted(not_found_domains)))
+        )
+
+    supported_types = [item[0] for item in _DESTROY_GROUP_MAP]
+    unsupported_clusters = clusters.exclude(cluster_type__in=supported_types)
+    if unsupported_clusters.exists():
+        raise DBMMcpNotSupportClusterTypeException(
+            cluster_type=set(unsupported_clusters.values_list("cluster_type", flat=True))
+        )
+
+    # 核心校验：集群状态必须是禁用状态（phase == offline）才可以提交删除单据
+    not_disabled_clusters = clusters.exclude(phase=ClusterPhase.OFFLINE.value)
+    if not_disabled_clusters.exists():
+        raise DBMMcpForbiddenException(
+            msg="集群必须处于禁用状态（offline）才可以提交删除单据，以下集群未禁用：{}".format(
+                ", ".join(not_disabled_clusters.values_list("immute_domain", flat=True))
+            )
+        )
+
+    # 两阶段提单：先完成所有类型的入参校验，全部通过后才创建单据，
+    # 避免「类型 A 已建单、类型 B 校验失败」导致的部分提交（部分成功且未回滚）
+    pending_tickets = []
+    for cluster_type, ticket_type, detail_slz_cls in _DESTROY_GROUP_MAP:
+        type_clusters = clusters.filter(cluster_type=cluster_type)
+        if not type_clusters.exists():
+            continue
+
+        ticket_param = {
+            "ticket_type": ticket_type,
+            "remark": ticket_type,
+            "creator": username,
+            "helpers": [],
+            "bk_biz_id": bk_biz_id,
+            "details": {
+                "cluster_ids": list(type_clusters.values_list("pk", flat=True).distinct()),
+                # 固定非强制删除：不允许外部传入 force，执行侧始终走安全检查
+                "force": False,
+            },
+        }
+
+        slz = detail_slz_cls(data=ticket_param["details"])
+        slz.context["bk_biz_id"] = bk_biz_id
+        slz.context["ticket_type"] = ticket_type
+        slz.is_valid(raise_exception=True)
+        pending_tickets.append(ticket_param)
+
+    res = []
+    for ticket_param in pending_tickets:
+        tk = Ticket.create_ticket(**ticket_param)
+        res.append(
+            {
+                "bill_id": tk.pk,
+                "bill_url": f"{env.BK_SAAS_HOST}/{bk_biz_id}/ticket-business-manage/{tk.pk}",
+            }
+        )
+
+    if not res:
+        raise DBMMcpNoneBillSubmittedException(msg="未生成任何删除单据，请检查集群域名")
+
+    return res

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/bill_mysql_disable.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/bill_mysql_disable.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import re
+from typing import List
+
+from backend import env
+from backend.db_meta.enums import ClusterStatus, ClusterType
+from backend.db_meta.models import Cluster
+from backend.dbm_aiagent.mcp_tools.exceptions import (
+    DBMMcpClusterNotFoundException,
+    DBMMcpForbiddenException,
+    DBMMcpNoneBillSubmittedException,
+    DBMMcpNotSupportClusterTypeException,
+)
+from backend.ticket.builders.mysql.mysql_ha_disable import MysqlHADisableDetailSerializer
+from backend.ticket.builders.mysql.mysql_single_disable import MysqlSingleDisableDetailSerializer
+from backend.ticket.builders.tendbcluster.tendb_disable import TendbDisableDetailSerializer
+from backend.ticket.constants import TicketType
+from backend.ticket.models import Ticket
+
+# 允许禁用的临时集群域名命名规范（正则）：
+# 1. tmpdb. + 内容 + .dba.db，如 tmpdb.abc.dba.db
+# 2. spider. + 内容 + -tmp + 8位日期数字 + -，如 spider.abc-tmp20240801-xxx
+ALLOWED_DISABLE_DOMAIN_PATTERNS = [
+    re.compile(r"^tmpdb\..+\.dba\.db$"),
+    re.compile(r"^spider\..+-tmp\d{8}-"),
+]
+# 命名规范的人类可读描述（用于报错提示）
+ALLOWED_DISABLE_DOMAIN_RULES = ["tmpdb.内容.dba.db", "spider.内容-tmpYYYYMMDD-"]
+
+# 集群类型 -> (TicketType, DetailSerializer) 映射，按类型分组提单
+_DISABLE_GROUP_MAP = [
+    (ClusterType.TenDBHA, TicketType.MYSQL_HA_DISABLE, MysqlHADisableDetailSerializer),
+    (ClusterType.TenDBSingle, TicketType.MYSQL_SINGLE_DISABLE, MysqlSingleDisableDetailSerializer),
+    (ClusterType.TenDBCluster, TicketType.TENDBCLUSTER_DISABLE, TendbDisableDetailSerializer),
+]
+
+
+def bill_mysql_disable(
+    username: str,
+    bk_biz_id: int,
+    cluster_domains: List[str],
+) -> list:
+    """创建 MySQL 集群禁用单据，返回业务维度单据链接
+
+    返回结构：[{bill_id, bill_url}]，其中 bill_url 为业务单据管理页链接：
+    {BK_SAAS_HOST}/{bk_biz_id}/ticket-business-manage/{ticket_id}
+    """
+    # 空列表显式报错，避免静默返回空结果（LLM 会误以为已提交）
+    if not cluster_domains:
+        raise DBMMcpForbiddenException(msg="cluster_domains 不能为空")
+
+    # 命名规范校验：一次传入的多个集群必须全部符合规范才可提交，否则整体拒绝并返回不符合的集群名
+    invalid_domains = [d for d in cluster_domains if not any(p.match(d) for p in ALLOWED_DISABLE_DOMAIN_PATTERNS)]
+    if invalid_domains:
+        raise DBMMcpForbiddenException(
+            msg="一次提交的集群必须全部符合临时集群命名规范（{}），以下集群不符合：{}".format(
+                " / ".join(ALLOWED_DISABLE_DOMAIN_RULES), ", ".join(invalid_domains)
+            )
+        )
+
+    clusters = Cluster.objects.filter(bk_biz_id=bk_biz_id, immute_domain__in=cluster_domains)
+    # 校验提交的域名是否全部命中集群，防止部分域名被静默丢弃（拼写错误/跨业务/已删除）
+    found_domains = set(clusters.values_list("immute_domain", flat=True))
+    not_found_domains = set(cluster_domains) - found_domains
+    if not_found_domains:
+        raise DBMMcpClusterNotFoundException(
+            msg="以下集群未找到，请检查域名是否正确/是否属于当前业务：{}".format(", ".join(sorted(not_found_domains)))
+        )
+
+    supported_types = [item[0] for item in _DISABLE_GROUP_MAP]
+    unsupported_clusters = clusters.exclude(cluster_type__in=supported_types)
+    if unsupported_clusters.exists():
+        raise DBMMcpNotSupportClusterTypeException(
+            cluster_type=set(unsupported_clusters.values_list("cluster_type", flat=True))
+        )
+
+    # 仅允许状态为正常（normal）的集群提单禁用
+    abnormal_clusters = clusters.exclude(status=ClusterStatus.NORMAL.value)
+    if abnormal_clusters.exists():
+        raise DBMMcpForbiddenException(
+            msg="仅允许状态为正常（normal）的集群禁用，以下集群状态异常：{}".format(
+                ", ".join(abnormal_clusters.values_list("immute_domain", flat=True))
+            )
+        )
+
+    # 两阶段提单：先完成所有类型的入参校验，全部通过后才创建单据，
+    # 避免「类型 A 已建单、类型 B 校验失败」导致的部分提交（部分成功且未回滚）
+    pending_tickets = []
+    for cluster_type, ticket_type, detail_slz_cls in _DISABLE_GROUP_MAP:
+        type_clusters = clusters.filter(cluster_type=cluster_type)
+        if not type_clusters.exists():
+            continue
+
+        ticket_param = {
+            "ticket_type": ticket_type,
+            "remark": ticket_type,
+            "creator": username,
+            "helpers": [],
+            "bk_biz_id": bk_biz_id,
+            "details": {
+                "cluster_ids": list(type_clusters.values_list("pk", flat=True).distinct()),
+                # 固定非强制禁用：不允许外部传入 force，执行侧始终走安全检查
+                "force": False,
+            },
+        }
+
+        slz = detail_slz_cls(data=ticket_param["details"])
+        slz.context["bk_biz_id"] = bk_biz_id
+        slz.context["ticket_type"] = ticket_type
+        slz.is_valid(raise_exception=True)
+        pending_tickets.append(ticket_param)
+
+    res = []
+    for ticket_param in pending_tickets:
+        tk = Ticket.create_ticket(**ticket_param)
+        res.append(
+            {
+                "bill_id": tk.pk,
+                "bill_url": f"{env.BK_SAAS_HOST}/{bk_biz_id}/ticket-business-manage/{tk.pk}",
+            }
+        )
+
+    if not res:
+        raise DBMMcpNoneBillSubmittedException(msg="未生成任何禁用单据，请检查集群域名")
+
+    return res

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/mysql_destroy_bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/mysql_destroy_bill.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class SubmitBillMySQLDestroyInputSerializer(serializers.Serializer):
+    # 单次批量提单的集群数量上限，避免超大 IN 查询与巨型单据 details
+    MAX_CLUSTER_DOMAINS = 50
+
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    cluster_domains = serializers.ListField(
+        child=serializers.CharField(),
+        allow_empty=False,
+        help_text=_("集群域名列表（至少一个，最多 {} 个）".format(MAX_CLUSTER_DOMAINS)),
+    )
+
+    def validate_cluster_domains(self, value):
+        if len(value) > self.MAX_CLUSTER_DOMAINS:
+            raise serializers.ValidationError(
+                _("一次最多提交 {} 个集群，当前提交 {} 个").format(self.MAX_CLUSTER_DOMAINS, len(value))
+            )
+        return value

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/mysql_disable_bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/mysql_disable_bill.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class SubmitBillMySQLDisableInputSerializer(serializers.Serializer):
+    # 单次批量提单的集群数量上限，避免超大 IN 查询与巨型单据 details
+    MAX_CLUSTER_DOMAINS = 50
+
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    cluster_domains = serializers.ListField(
+        child=serializers.CharField(),
+        allow_empty=False,
+        help_text=_("集群域名列表（至少一个，最多 {} 个）".format(MAX_CLUSTER_DOMAINS)),
+    )
+
+    def validate_cluster_domains(self, value):
+        if len(value) > self.MAX_CLUSTER_DOMAINS:
+            raise serializers.ValidationError(
+                _("一次最多提交 {} 个集群，当前提交 {} 个").format(self.MAX_CLUSTER_DOMAINS, len(value))
+            )
+        return value

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/views/mysql_bill_mcp.py
@@ -46,6 +46,8 @@ from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_machine_replace.bill_tendbclu
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_machine_replace.bill_tendbha_master_slave_swtich import (
     bill_tendbha_master_slave_switch,
 )
+from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_mysql_destroy import bill_mysql_destroy
+from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_mysql_disable import bill_mysql_disable
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_mysql_standardize import bill_mysql_standardize
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_rename_db import bill_rename_db
 from backend.dbm_aiagent.mcp_tools.mysql.impl.bill_tdbctl_upgrade import bill_tdbctl_upgrade
@@ -63,6 +65,8 @@ from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_db_rename_bill import
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_db_table_backup import (
     SubmitBillMySQLDBTableBackupInputSerializer,
 )
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_destroy_bill import SubmitBillMySQLDestroyInputSerializer
+from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_disable_bill import SubmitBillMySQLDisableInputSerializer
 from backend.dbm_aiagent.mcp_tools.mysql.serializers.mysql_full_backup_bill import (
     SubmitBillMySQLFullBackupInputSerializer,
 )
@@ -566,4 +570,89 @@ class MySQLBillMcpToolsViewSet(McpToolsViewSet):
 
         return Response(
             [{"bill_id": root_id, "bill_url": f"{env.BK_SAAS_HOST}/{m.bk_biz_id}/task-history/detail/{root_id}"}]
+        )
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                """创建 MySQL 集群禁用单据（TenDBHA / TenDBSingle / TenDBCluster）
+参数说明：
+- bk_biz_id: 业务ID（必填）
+- cluster_domains: 集群域名列表（必填，支持多个，可按集群类型自动拆分提单）
+
+使用场景：对指定业务下的一个或多个 MySQL 系列集群发起禁用操作。
+按集群类型分别生成对应禁用单据：TenDBHA → MYSQL_HA_DISABLE，TenDBSingle → MYSQL_SINGLE_DISABLE，TenDBCluster → TENDBCLUSTER_DISABLE。
+"""
+            )
+        ),
+        request_slz=SubmitBillMySQLDisableInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.MYSQL_BILL],
+        name_prefix="mysql_bill",
+    )
+    def submit_bill_mysql_disable(self, request, *args, **kwargs):
+        bk_biz_id = self.get_param("bk_biz_id")
+        cluster_domains = list({d.strip() for d in self.get_param("cluster_domains") if d.strip()})
+
+        assert_cluster_type(
+            Cluster.objects.filter(immute_domain__in=cluster_domains),
+            [ClusterType.TenDBSingle, ClusterType.TenDBHA, ClusterType.TenDBCluster],
+        )
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        return Response(
+            bill_mysql_disable(
+                username=username,
+                bk_biz_id=bk_biz_id,
+                cluster_domains=cluster_domains,
+            )
+        )
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                """创建 MySQL 集群删除单据（TenDBHA / TenDBSingle / TenDBCluster）
+参数说明：
+- bk_biz_id: 业务ID（必填）
+- cluster_domains: 集群域名列表（必填，支持多个，可按集群类型自动拆分提单）
+
+前置条件：集群必须处于禁用状态（phase=offline）才可以提交删除单据，否则直接报错。
+使用场景：对指定业务下已禁用的一个或多个 MySQL 系列集群发起删除操作。
+按集群类型分别生成对应删除单据：TenDBHA → MYSQL_HA_DESTROY，TenDBSingle → MYSQL_SINGLE_DESTROY，TenDBCluster → TENDBCLUSTER_DESTROY。
+"""
+            )
+        ),
+        request_slz=SubmitBillMySQLDestroyInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.MYSQL_BILL],
+        name_prefix="mysql_bill",
+    )
+    def submit_bill_mysql_destroy(self, request, *args, **kwargs):
+        bk_biz_id = self.get_param("bk_biz_id")
+        cluster_domains = list({d.strip() for d in self.get_param("cluster_domains") if d.strip()})
+
+        assert_cluster_type(
+            Cluster.objects.filter(immute_domain__in=cluster_domains),
+            [ClusterType.TenDBSingle, ClusterType.TenDBHA, ClusterType.TenDBCluster],
+        )
+
+        username = request.user.username
+        if not username:
+            raise DBMMcpUsernameNotFoundException()
+
+        return Response(
+            bill_mysql_destroy(
+                username=username,
+                bk_biz_id=bk_biz_id,
+                cluster_domains=cluster_domains,
+            )
         )


### PR DESCRIPTION
## 变更内容
新增 MySQL 集群禁用/删除 MCP 工具，并修复 db-mcp-server 工具发现超时（1s→30s）

## 变更文件
- mysql_bill_mcp.py: 新增 submit_bill_mysql_disable / submit_bill_mysql_destroy 接口
- bill_mysql_disable.py: 禁用业务实现（前缀/类型/状态校验）
- bill_mysql_destroy.py: 删除业务实现
- mysql_disable_bill.py / mysql_destroy_bill.py: 入参序列化器
- MCP_TOOLS.md: 工具文档
- discover.go: HTTP 超时 1s→30s

## 测试
- 本地 DEBUG_MCP 联调验证：提单→落库→页面展示全链路通过