### PR TITLE
fix(backend): 修复webconsole指定角色查询无正常实例时报系统错误

### DIFF
--- a/dbm-ui/backend/db_meta/api/cluster/tendbha/handler.py
+++ b/dbm-ui/backend/db_meta/api/cluster/tendbha/handler.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 from typing import Dict, List
 
 from django.db import transaction
+from django.utils.translation import gettext as _
 
 from backend.configuration.constants import DBType
 from backend.core.encrypt.constants import AsymmetricCipherConfigType
@@ -26,6 +27,7 @@ from backend.db_meta.enums import (
     MachineType,
 )
 from backend.db_meta.enums.extra_process_type import ExtraProcessType
+from backend.db_meta.exceptions import InstanceNotExistException
 from backend.db_meta.models import StorageInstance
 from backend.db_meta.models.extra_process import ExtraProcessInstance
 from backend.db_package.models import Package
@@ -193,6 +195,9 @@ class TenDBHAClusterHandler(ClusterHandler):
             status=InstanceStatus.RUNNING.value,
             phase=InstancePhase.ONLINE.value,
         )
+        if not query_set.exists():
+            raise InstanceNotExistException(_("集群{}不具有该角色「{}」的正常实例").format(self.cluster.name, role))
+
         if role == InstanceRole.BACKEND_SLAVE.value and query_set.filter(is_stand_by=True).exists():
             return query_set.filter(is_stand_by=True).first().ip_port
 

--- a/dbm-ui/backend/db_meta/api/cluster/tendbsingle/handler.py
+++ b/dbm-ui/backend/db_meta/api/cluster/tendbsingle/handler.py
@@ -10,11 +10,13 @@ specific language governing permissions and limitations under the License.
 """
 
 from django.db import transaction
+from django.utils.translation import gettext as _
 
 from backend.configuration.constants import DBType
 from backend.db_meta import api
 from backend.db_meta.api.cluster.base.handler import ClusterHandler
 from backend.db_meta.enums import ClusterType, InstancePhase, InstanceRole, InstanceStatus, MachineType
+from backend.db_meta.exceptions import InstanceNotExistException
 from backend.db_meta.models import StorageInstance
 from backend.db_package.models import Package
 from backend.flow.consts import MediumEnum
@@ -120,6 +122,7 @@ class TenDBSingleClusterHandler(ClusterHandler):
             status=InstanceStatus.RUNNING.value,
             phase=InstancePhase.ONLINE.value,
         )
-        if not query_set:
-            raise ValueError("not online host")
+        if not query_set.exists():
+            raise InstanceNotExistException(_("集群{}不具有该角色「{}」的正常实例").format(self.cluster.name, role))
+
         return query_set.first().ip_port


### PR DESCRIPTION
closes #19452

### 根因

`TenDBHAClusterHandler.get_remote_address` 指定 role 后按 `status=running` + `phase=online` 过滤实例，未判空即取 `query_set.first().ip_port`。当集群不存在该角色的正常实例时 `first()` 返回 None，抛出未捕获的 `AttributeError: 'NoneType' object has no attribute 'ip_port'`，webconsole 接口返回 8700500 系统错误。

### 修复

- `tendbha/handler.py`：查询为空时抛出 `InstanceNotExistException`，与 `TenDBClusterClusterHandler` 的行为保持一致
- `tendbsingle/handler.py`：将 `ValueError("not online host")` 统一为 `InstanceNotExistException`，避免同样被当成系统错误返回 500

### 验证

1. 对不存在正常 backend_slave/backend_master 实例的 TenDBHA 集群执行 webconsole 查询，前端应提示「集群xxx不具有该角色「backend_slave」的正常实例」，而非 8700500 系统错误
2. 对正常的 TenDBHA / TenDBSingle 集群按角色查询，功能无回归