### PR TITLE
fix(backend): 修复集群容量指标为0或负数导致使用率计算除零异常

### DIFF
--- a/dbm-ui/backend/db_monitor/tasks.py
+++ b/dbm-ui/backend/db_monitor/tasks.py
@@ -213,6 +213,15 @@ def query_cap(bk_biz_id, cluster_type, cap_key="used", immute_domains=None):
     return cluster_bytes, extra_info
 
 
+def is_valid_capacity(used, total) -> bool:
+    """校验容量指标是否可用于计算使用率
+    total 为 0(如 redis 未设置 maxmemory)或负数(指标异常上报)时无法作为分母
+    """
+    if used is None or total is None:
+        return False
+    return used >= 0 and total > 0
+
+
 def query_cluster_capacity(bk_biz_id, cluster_type):
     """查询集群容量"""
 
@@ -250,7 +259,12 @@ def query_capacity_for_clusters(bk_biz_id, cluster_type, immute_domains) -> (dic
     used_data, extra_info = query_cap(bk_biz_id, cluster_type, "used", immute_domains)
     total_data, _ = query_cap(bk_biz_id, cluster_type, "total", immute_domains)
     for cluster in immute_domains:
-        if cluster in used_data and cluster in total_data and cluster in extra_info:
+        if (
+            cluster in used_data
+            and cluster in total_data
+            and cluster in extra_info
+            and is_valid_capacity(used_data[cluster], total_data[cluster])
+        ):
             cluster_cap_bytes[cluster]["used"] = used_data[cluster]
             cluster_cap_bytes[cluster]["total"] = total_data[cluster]
             cluster_cap_bytes[cluster]["mount_point"] = extra_info[cluster]["mount_point"]
@@ -372,6 +386,10 @@ def sync_cluster_stat_by_cluster_type(bk_biz_id, cluster_type):
     for cluster, cap in cluster_stats.items():
         # 兼容查不到数据的情况
         if not ("used" in cap and "total" in cap):
+            continue
+        # 跳过容量指标非法的集群，避免单个集群阻断整个业务的容量查询
+        if not is_valid_capacity(cap["used"], cap["total"]):
+            logger.warning("skip invalid capacity for cluster: %s -> %s", cluster, cap)
             continue
         cap["in_use"] = round(cap["used"] * 100.0 / cap["total"], 2)
 


### PR DESCRIPTION
closes #19464

## 根因

`sync_cluster_stat_by_cluster_type` 计算容量使用率时只校验了 `used`/`total` 两个 key 是否存在，未校验分母取值：

```python
cap["in_use"] = round(cap["used"] * 100.0 / cap["total"], 2)
```

RedisInstance 的 `total` 取自监控指标 `redis_config_maxmemory`，Redis 中 `maxmemory=0` 表示不限制内存，是合法配置；线上实际存在 `maxmemory` 上报 `0` 的集群（另有 tendisplus 集群上报 `-3`、`-5` 等负值），于是抛出 `ZeroDivisionError: float division by zero`。

该计算不在函数内 try/except 的覆盖范围内，异常穿透到 DRF 全局异常处理器，使接口 `GET /apis/dbbase/query_cluster_stat/` 被兜底为 8700500 系统错误，该业务下所有同类型集群的容量数据整体不可用；周期任务 `sync_cluster_stat_by_cluster_type` 也因同一行反复失败，导致容量缓存无法刷新。

## 改动

- 新增 `is_valid_capacity`：`total` 必须为正数、`used` 不能为负数，任一为 `None` 视为不合法。
- `sync_cluster_stat_by_cluster_type`：指标不合法时打 warning 日志并 `continue`，跳过该集群的使用率计算，不再影响其余集群。
- `query_capacity_for_clusters`：`used_percent` 计算前一并校验，不合法的集群走既有的 `no_stats` 分支，修掉同一处除零隐患。

## 验证

- 用线上真实指标数据校验：`(used=19805032, total=0)`、`(used=100, total=-3)`、`total=None` 均判定为不合法并跳过；`(used=62897112, total=14414963096)` 正常算出 `0.44`，`used=0` 的新集群正常算出 `0.0`。
- 修复后请求 `GET /apis/dbbase/query_cluster_stat/?bk_biz_id=<业务>&cluster_type=RedisInstance` 应返回 200 且包含其余集群的 `in_use`。