### PR TITLE
feat(mongodb): 按机器内存分档分配 mongod cache，并修复 remove-shard 未分片库 primary 列举 #19442 #19438

### DIFF
--- a/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/remove_shard_from_cluster.go
+++ b/dbm-services/mongodb/db-tools/dbactuator/pkg/atomjobs/atommongodb/remove_shard_from_cluster.go
@@ -248,7 +248,7 @@ func pickTargetShard(allShards []string, removeShards []string, i int) (string, 
 }
 
 func (r *RemoveShardFromCluster) listPrimaryDatabasesOnShards(removeShards []string) ([]databasePrimary, error) {
-	evalScript := `JSON.stringify(db.getSiblingDB("config").databases.find({partitioned:true},{_id:1,primary:1}).toArray())`
+	evalScript := `JSON.stringify(db.getSiblingDB("config").databases.find({},{_id:1,primary:1}).toArray())`
 	stdout, err := r.runMongoEval(evalScript, 60*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("list config.databases fail: %w", err)

--- a/dbm-ui/backend/flow/consts.py
+++ b/dbm-ui/backend/flow/consts.py
@@ -1367,10 +1367,13 @@ class MongoDBClusterRole(StrStructuredEnum):
 
 class MongoDBTotalCache(FloatStructuredEnum):
     """
-    cache占机器内存的百分比
+    cache 占机器内存的百分比（按机器总内存分档）
+    <=4G: 25%, <=16G: 40%, 其它: 50%
     """
 
-    Cache_Percent = EnumField(0.65, _("cache_percent"))
+    Cache_Percent_Small = EnumField(0.25, _("cache_percent_small"))
+    Cache_Percent_Medium = EnumField(0.40, _("cache_percent_medium"))
+    Cache_Percent_Large = EnumField(0.50, _("cache_percent_large"))
 
 
 class MongoDBDomainPrefix(StrStructuredEnum):

--- a/dbm-ui/backend/flow/utils/mongodb/calculate_cluster.py
+++ b/dbm-ui/backend/flow/utils/mongodb/calculate_cluster.py
@@ -25,9 +25,21 @@ from backend.flow.utils.mongodb.mongodb_repo import MongoRepository
 from backend.flow.utils.mongodb.version_utils import resolve_mongodb_flow_db_version
 
 
-def get_cache_size(memory_size: int, cache_percent: float, num: int) -> int:
-    """计算内存大小 gb"""
+def get_cache_percent(memory_size: int) -> float:
+    """按机器总内存(MB)分档计算 mongod cache 占比"""
 
+    memory_gb = memory_size / 1024
+    if memory_gb <= 4:
+        return MongoDBTotalCache.Cache_Percent_Small.value
+    if memory_gb <= 16:
+        return MongoDBTotalCache.Cache_Percent_Medium.value
+    return MongoDBTotalCache.Cache_Percent_Large.value
+
+
+def get_cache_size(memory_size: int, num: int) -> int:
+    """计算 cacheSizeGB。memory_size 单位为 MB。"""
+
+    cache_percent = get_cache_percent(memory_size)
     cache_size = int(memory_size * cache_percent / num / 1024)
     return cache_size if cache_size > 0 else 1
 
@@ -117,7 +129,6 @@ def replicase_calc(payload: dict, payload_clusters: dict, app: str, domain_prefi
     data_disk = "/data1"
     avg_mem_size_gb = get_cache_size(
         memory_size=payload["infos"][0]["mongo_machine_set"][0]["bk_mem"],
-        cache_percent=MongoDBTotalCache.Cache_Percent,
         num=node_replica_count,
     )
     if payload["infos"][0]["mongo_machine_set"][0]["storage_device"].get("/data1"):
@@ -194,12 +205,10 @@ def cluster_calc(payload: dict, payload_clusters: dict, app: str) -> dict:
     # 计算configCacheSizeGB，shardCacheSizeGB，oplogSizeMB
     shard_avg_mem_size_gb = get_cache_size(
         memory_size=payload["nodes"]["mongodb"][0][0]["bk_mem"],
-        cache_percent=MongoDBTotalCache.Cache_Percent,
         num=node_replica_count,
     )
     config_mem_size_gb = get_cache_size(
         memory_size=payload["nodes"]["mongo_config"][0]["bk_mem"],
-        cache_percent=MongoDBTotalCache.Cache_Percent,
         num=1,
     )
     # shard oplogSizeMB
@@ -377,7 +386,6 @@ def calculate_cluster_add_shard(payload: dict) -> dict:
         # shard CacheSizeGB
         shard_avg_mem_size_gb = get_cache_size(
             memory_size=cluster["mongo_add_shards"][0][0]["bk_mem"],
-            cache_percent=MongoDBTotalCache.Cache_Percent,
             num=node_replicaset_count,
         )
 

--- a/dbm-ui/backend/flow/utils/mongodb/mongodb_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mongodb/mongodb_dataclass.py
@@ -40,7 +40,6 @@ from backend.flow.consts import (
     MongoDBInstanceType,
     MongoDBManagerUser,
     MongoDBTask,
-    MongoDBTotalCache,
     MongoDBUserPrivileges,
     MongoInstanceDbmonType,
     MongoOplogSizePercent,
@@ -1531,7 +1530,6 @@ class ActKwargs:
         # 计算cacheSizeGB和oplogSizeMB
         self.replicaset_info["cacheSizeGB"] = get_cache_size(
             memory_size=info["target"]["bk_mem"],
-            cache_percent=MongoDBTotalCache.Cache_Percent.value,
             num=instance_count,
         )
         data_disk = "/data1"
@@ -2580,7 +2578,6 @@ class ActKwargs:
         # 计算cacheSizeGB和oplogSizeMB
         self.replicaset_info["cacheSizeGB"] = get_cache_size(
             memory_size=info["bk_mem"],
-            cache_percent=MongoDBTotalCache.Cache_Percent.value,
             num=instance_num,
         )
         data_disk = "/data1"

--- a/dbm-ui/backend/tests/flow/utils/mongodb/test_calculate_cluster_cache_size.py
+++ b/dbm-ui/backend/tests/flow/utils/mongodb/test_calculate_cluster_cache_size.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""mongod cacheSizeGB 按机器内存分档分配规则测试"""
+
+import pytest
+
+from backend.flow.consts import MongoDBTotalCache
+from backend.flow.utils.mongodb.calculate_cluster import get_cache_percent, get_cache_size
+
+
+@pytest.mark.parametrize(
+    ("memory_mb", "expected_percent"),
+    [
+        (1 * 1024, MongoDBTotalCache.Cache_Percent_Small.value),  # 1G -> 25%
+        (4 * 1024, MongoDBTotalCache.Cache_Percent_Small.value),  # 4G -> 25%
+        (5 * 1024, MongoDBTotalCache.Cache_Percent_Medium.value),  # 5G -> 40%
+        (16 * 1024, MongoDBTotalCache.Cache_Percent_Medium.value),  # 16G -> 40%
+        (17 * 1024, MongoDBTotalCache.Cache_Percent_Large.value),  # 17G -> 50%
+        (32 * 1024, MongoDBTotalCache.Cache_Percent_Large.value),  # 32G -> 50%
+    ],
+)
+def test_get_cache_percent_tiers(memory_mb, expected_percent):
+    assert get_cache_percent(memory_mb) == expected_percent
+
+
+@pytest.mark.parametrize(
+    ("memory_mb", "num", "expected_gb"),
+    [
+        (4 * 1024, 1, 1),  # 4G * 25% = 1G
+        (16 * 1024, 1, 6),  # 16G * 40% = 6.4 -> int 6
+        (32 * 1024, 1, 16),  # 32G * 50% = 16G
+        (32 * 1024, 2, 8),  # 同机 2 实例均分
+        (1 * 1024, 1, 1),  # 1G * 25% = 0.25 -> 下限 1G
+    ],
+)
+def test_get_cache_size(memory_mb, num, expected_gb):
+    assert get_cache_size(memory_size=memory_mb, num=num) == expected_gb


### PR DESCRIPTION
## Summary
- 按机器内存分档计算并分配 mongod cacheSizeGB，移除 dataclass 中硬编码逻辑，并补充单测
- 修复 remove-shard 列举 primary 时漏掉未分片库（unsharded）的问题

## Test plan
- [ ] 验证不同内存规格机器上 cacheSizeGB 分档结果符合预期
- [ ] 跑 `test_calculate_cluster_cache_size` 相关单测
- [ ] 验证 remove-shard 流程能正确列出含未分片库的 primary


Made with [Cursor](https://cursor.com)