### PR TITLE
feat(redis): improve rollback exercise AI failure log evidence and weekly parse #19625

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/weekly_ai_summary.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/weekly_ai_summary.py
@@ -30,7 +30,11 @@ from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.db_report.models.ai_analysis_report import AiAnalysisReport, ResultFormat
 from backend.db_services.redis.autofix.enums import MsgPriority
 from backend.db_services.redis.autofix.message import load_chat_ids_by_priority
-from backend.db_services.redis.rollback.failure_analysis import AI_ANALYSIS_SENTINEL, is_exercise_ai_analysis_enabled
+from backend.db_services.redis.rollback.failure_analysis import (
+    AI_ANALYSIS_END_SENTINEL,
+    AI_ANALYSIS_SENTINEL,
+    is_exercise_ai_analysis_enabled,
+)
 from backend.dbm_aiagent.agent.constants import DBMAgentCode
 
 logger = logging.getLogger("root")
@@ -42,6 +46,9 @@ MAX_WECOM_CONTENT_CHARS = 1024
 CATEGORY_PATTERN = re.compile(r"原因分类\s*[:：]\s*([^\n\r]+)")
 DIAGNOSIS_PATTERN = re.compile(r"诊断\s*[:：]\s*([^\n\r]+)")
 _MAX_CASE_DIAGNOSIS_CHARS = 120
+# Legacy AI blocks (no end sentinel) are short by contract (≤5 content lines);
+# an 8-line window keeps cleanup logs that follow from polluting the parse.
+_LEGACY_AI_BLOCK_MAX_LINES = 8
 
 
 def get_week_window(now: Optional[datetime] = None) -> Tuple[datetime, datetime]:
@@ -69,11 +76,42 @@ def get_previous_week_window(start: datetime, end: datetime) -> Tuple[datetime, 
     return start - delta, start
 
 
-def _parse_failure_category(task_message: str) -> str:
+def _extract_last_ai_block(task_message: str) -> str:
+    """Return the body of the last ``[AI失败分析]`` block, excluding sentinels.
+
+    Prefer an explicit ``[/AI失败分析]`` end marker. For legacy reports without
+    one, take at most ``_LEGACY_AI_BLOCK_MAX_LINES`` lines after the opening
+    sentinel so later cleanup logs cannot pollute category/diagnosis parsing.
+    """
     if not task_message or AI_ANALYSIS_SENTINEL not in task_message:
+        return ""
+
+    start = task_message.rfind(AI_ANALYSIS_SENTINEL)
+    if start < 0:
+        return ""
+
+    after_open = task_message[start + len(AI_ANALYSIS_SENTINEL) :]
+    # Drop the optional timestamp on the sentinel line (" 2026-08-10 14:43:43\n...")
+    if after_open.startswith(" ") or after_open.startswith("\t"):
+        nl = after_open.find("\n")
+        after_open = after_open[nl + 1 :] if nl >= 0 else ""
+    elif after_open.startswith("\n"):
+        after_open = after_open[1:]
+
+    end = after_open.find(AI_ANALYSIS_END_SENTINEL)
+    if end >= 0:
+        return after_open[:end].strip()
+
+    # Legacy: no end sentinel — take a short fixed window.
+    lines = after_open.splitlines()
+    return "\n".join(lines[:_LEGACY_AI_BLOCK_MAX_LINES]).strip()
+
+
+def _parse_failure_category(task_message: str) -> str:
+    block = _extract_last_ai_block(task_message)
+    if not block:
         return _("未分析")
-    # Prefer the last analysis block in case of accidental duplicates.
-    matches = CATEGORY_PATTERN.findall(task_message)
+    matches = CATEGORY_PATTERN.findall(block)
     if not matches:
         return _("未分类")
     return matches[-1].strip() or _("未分类")
@@ -81,9 +119,10 @@ def _parse_failure_category(task_message: str) -> str:
 
 def _parse_failure_diagnosis(task_message: str) -> str:
     """Extract the last AI ``诊断`` line; empty when analysis is missing."""
-    if not task_message or AI_ANALYSIS_SENTINEL not in task_message:
+    block = _extract_last_ai_block(task_message)
+    if not block:
         return ""
-    matches = DIAGNOSIS_PATTERN.findall(task_message)
+    matches = DIAGNOSIS_PATTERN.findall(block)
     if not matches:
         return ""
     return matches[-1].strip()

--- a/dbm-ui/backend/db_services/redis/rollback/failure_analysis.py
+++ b/dbm-ui/backend/db_services/redis/rollback/failure_analysis.py
@@ -25,6 +25,7 @@ logger = logging.getLogger("root")
 
 AI_ANALYSIS_SENTINEL = _("[AI失败分析]")
 AI_ANALYSIS_FAILED_SENTINEL = _("[AI分析失败]")
+AI_ANALYSIS_END_SENTINEL = _("[/AI失败分析]")
 FAILED_NODE_LOGS_SENTINEL = _("[子流程失败节点日志]")
 AI_ANALYSIS_COUNTDOWN_SECONDS = 60
 AI_ANALYSIS_TIMEOUT_SECONDS = 300
@@ -33,15 +34,52 @@ AI_ANALYSIS_TIMEOUT_SECONDS = 300
 FENCE_RE = re.compile(r"^```[^\n]*\n?|\n?```\s*$")
 # task_message embeds the failed-node log block; leave room for timeline + AI block.
 _MAX_TASK_MESSAGE_CHARS = 12000
+_TASK_MESSAGE_HEAD_CHARS = 4000
 _MAX_FLOW_LOG_CHARS = 8000
 # Cap embedded logs so MySQL TEXT stays lean and UI remains readable.
 _MAX_EMBEDDED_LOG_CHARS = 4000
 # Hard caps so we never mirror TaskFlowHandler.get_version_logs (ES size=10000 x2).
 _MAX_BKLOG_HITS = 300
 _BKLOG_TIME_PAD_HOURS = 24
+_ERROR_CONTEXT_LINES = 2
+# ERROR levelnames plus message patterns (actuator often embeds errors in INFO lines).
+_ERROR_LEVELS = frozenset({"ERROR", "CRITICAL", "FATAL"})
+_ERROR_LINE_RE = re.compile(
+    "|".join(
+        [
+            r"Traceback",
+            r"Exception",
+            r"\[error\]",
+            re.escape(_("错误")),
+            re.escape(_("失败")),
+            r"failed",
+            r"Error",
+        ]
+    ),
+    re.I,
+)
+_OMIT_LINES_PREFIX = _("...(省略")
+# Strip wall-clock / epoch timestamps so consecutive heartbeat / retry lines fold.
+_NORMALIZE_TS_RE = re.compile(
+    r"\d{4}[-/]\d{2}[-/]\d{2}[ T]\d{2}:\d{2}:\d{2}"  # 2026-08-10 14:02:52 / 2026/08/10 14:02:52
+    r"|\b\d{13}\b"  # epoch millis in job-status JSON
+)
+_EMBEDDED_TS_RE = re.compile(r"(\d{2}:\d{2}:\d{2})")
+_BKLOG_SORT_DESC = [
+    ["dtEventTimeStamp", "desc"],
+    ["gseIndex", "desc"],
+    ["iterationIndex", "desc"],
+]
 
 # Stages whose failure evidence lives on a child flow (need BKLog fetch at mark time).
 _FLOW_FAILURE_STAGES = (TaskStage.ROLLBACK_FAILED, TaskStage.CLEANUP_FAILED)
+
+
+def _end_sentinel_for(sentinel: str) -> str:
+    """Derive ``[/AI失败分析]`` / ``[/AI分析失败]`` from the opening sentinel."""
+    if sentinel.startswith("[") and not sentinel.startswith("[/"):
+        return "[" + "/" + sentinel[1:]
+    return AI_ANALYSIS_END_SENTINEL
 
 
 def is_exercise_ai_analysis_enabled() -> bool:
@@ -135,11 +173,18 @@ def embed_failed_node_logs(task_message: str, report: Report, stage) -> str:
         return existing
 
 
-def _truncate_text(text: str, max_chars: int) -> str:
-    text = (text or "").strip()
+def _head_tail_truncate(text: str, max_chars: int, head_chars: int = _TASK_MESSAGE_HEAD_CHARS) -> str:
+    """Keep the head (timeline) and tail (embedded child logs); drop the middle."""
+    text = text or ""
     if len(text) <= max_chars:
         return text
-    return text[:max_chars] + "\n...(truncated)"
+    head_chars = max(0, min(head_chars, max_chars))
+    # Leave room for the middle marker itself.
+    marker_budget = 40
+    tail_chars = max(0, max_chars - head_chars - marker_budget)
+    omitted = len(text) - head_chars - tail_chars
+    marker = _("\n...(中间截断 {} 字符)\n").format(omitted)
+    return f"{text[:head_chars]}{marker}{text[-tail_chars:]}" if tail_chars else f"{text[:head_chars]}{marker}"
 
 
 def _find_activity_name(activities: dict, target_node_id: str) -> str:
@@ -155,7 +200,7 @@ def _find_activity_name(activities: dict, target_node_id: str) -> str:
 
 
 def _esquery_search_capped(indices: str, query_string: str, start_time: str, end_time: str, size: int) -> list:
-    """BKLog search with an explicit size cap (TaskFlowHandler hardcodes 10000)."""
+    """BKLog search with an explicit size cap; newest-first so tail errors survive heartbeat floods."""
     from backend.components import BKLogApi
 
     resp = BKLogApi.esquery_search(
@@ -166,13 +211,19 @@ def _esquery_search_capped(indices: str, query_string: str, start_time: str, end
             "query_string": query_string,
             "start": 0,
             "size": size,
+            "sort_list": _BKLOG_SORT_DESC,
         }
     )
     return (resp or {}).get("hits", {}).get("hits", []) or []
 
 
 def _fetch_node_logs_capped(root_id: str, node_id: str, version_id: str, started_at, updated_at) -> list:
-    """Fetch node logs from BKLog with hard hit caps; never dump full ES payloads to logs."""
+    """Fetch node logs from BKLog with hard hit caps; never dump full ES payloads to logs.
+
+    Queries newest-first (desc) so long-running nodes with heartbeat spam still
+    return the trailing error lines within the hit budget; results are reversed
+    back to chronological order before formatting.
+    """
     from datetime import timedelta
 
     from backend.db_services.taskflow.handlers import TaskFlowHandler
@@ -232,7 +283,8 @@ def _fetch_node_logs_capped(root_id: str, node_id: str, version_id: str, started
             )
         )
     except Exception:
-        pass
+        # Desc query already returns newest-first; reverse as a best-effort chrono order.
+        hits = list(reversed(hits))
 
     logs = []
     for hit in hits:
@@ -274,14 +326,246 @@ def _pick_last_abnormal_flow_node(root_id: str):
     return None, ""
 
 
+def _format_log_line(log) -> str:
+    if isinstance(log, dict):
+        level = log.get("levelname") or log.get("level") or ""
+        message = log.get("message") or ""
+        return f"[{level}] {message}".strip() if level else message
+    return str(log)
+
+
+def _normalize_line_for_fold(line: str) -> str:
+    """Strip wall-clock / epoch timestamps so consecutive heartbeat/retry lines match."""
+    return _NORMALIZE_TS_RE.sub("<TS>", line or "")
+
+
+def _extract_last_hhmmss(line: str) -> str:
+    matches = _EMBEDDED_TS_RE.findall(line or "")
+    return matches[-1] if matches else ""
+
+
+def _fold_consecutive_duplicate_lines(lines: list) -> list:
+    """Run-length fold adjacent lines that differ only by timestamps.
+
+    Keeps the first occurrence and appends
+    ``（连续重复 N 次，末次 HH:MM:SS）`` so the AI can see flood duration.
+    """
+    if not lines:
+        return []
+
+    folded = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        key = _normalize_line_for_fold(lines[i])
+        j = i + 1
+        last_line = lines[i]
+        while j < n and _normalize_line_for_fold(lines[j]) == key:
+            last_line = lines[j]
+            j += 1
+        count = j - i
+        if count >= 2:
+            last_ts = _extract_last_hhmmss(last_line)
+            if last_ts:
+                suffix = _("（连续重复 {} 次，末次 {}）").format(count - 1, last_ts)
+            else:
+                suffix = _("（连续重复 {} 次）").format(count - 1)
+            folded.append(f"{lines[i]}{suffix}")
+        else:
+            folded.append(lines[i])
+        i = j
+    return folded
+
+
+def _is_error_line(line: str) -> bool:
+    if not line:
+        return False
+    # Formatted lines start with [LEVEL]; also match message-body patterns.
+    if line.startswith("["):
+        closing = line.find("]")
+        if closing > 1 and line[1:closing].upper() in _ERROR_LEVELS:
+            return True
+    return bool(_ERROR_LINE_RE.search(line))
+
+
+def _merge_index_windows(indices: list, total: int, radius: int = _ERROR_CONTEXT_LINES) -> list:
+    """Merge overlapping [idx-radius, idx+radius] windows into inclusive ranges."""
+    if not indices or total <= 0:
+        return []
+    ranges = []
+    for idx in sorted(indices):
+        start = max(0, idx - radius)
+        end = min(total - 1, idx + radius)
+        if ranges and start <= ranges[-1][1] + 1:
+            ranges[-1] = (ranges[-1][0], max(ranges[-1][1], end))
+        else:
+            ranges.append((start, end))
+    return ranges
+
+
+def _tail_truncate_line(line: str, max_chars: int) -> str:
+    """Keep the useful tail of an oversized line (exception names live at the end).
+
+    Preserves a leading ``[LEVEL]`` tag when present so severity survives truncation.
+    """
+    if max_chars <= 0:
+        # ``line[-0:]`` would return the whole line, not an empty one.
+        return ""
+    if len(line) <= max_chars:
+        return line
+    if max_chars <= 3:
+        return line[-max_chars:]
+
+    prefix = ""
+    body = line
+    if line.startswith("["):
+        closing = line.find("]")
+        if 0 < closing < 20:
+            tag = line[: closing + 1]
+            # Need room for tag + " ..." + at least one body char.
+            if len(tag) + 5 <= max_chars:
+                prefix = tag + " "
+                body = line[closing + 1 :].lstrip()
+                max_chars = max_chars - len(prefix)
+
+    if len(body) <= max_chars:
+        return prefix + body
+    if max_chars <= 3:
+        return prefix + body[-max_chars:]
+    return prefix + "..." + body[-(max_chars - 3) :]
+
+
+def _select_log_lines_for_budget(lines: list, budget: int) -> list:
+    """Pick error windows (tail-first) within ``budget`` chars; fall back to pure tail.
+
+    Returns selected lines in chronological order, with ``...(省略 N 行)`` markers
+    for gaps. Guarantees the last error line (tail-truncated if needed) fits when
+    any error exists.
+    """
+    if not lines or budget <= 0:
+        return []
+
+    # Work on a mutable copy so oversized lines can be tail-truncated in place.
+    lines = list(lines)
+    error_indices = [i for i, line in enumerate(lines) if _is_error_line(line)]
+    if error_indices:
+        kept = _kept_indices_error_windows(lines, error_indices, budget)
+    else:
+        kept = _kept_indices_tail_first(lines, budget)
+
+    ordered = sorted(kept)
+    if not ordered:
+        return []
+    return _render_selected_lines(lines, ordered, set(error_indices), budget)
+
+
+def _kept_indices_tail_first(lines: list, budget: int) -> list:
+    """No-error fallback: keep as many tail lines as fit in ``budget``."""
+    kept = []
+    length = 0
+    for idx in range(len(lines) - 1, -1, -1):
+        remaining = budget - length - (1 if kept else 0)
+        if remaining <= 0:
+            break
+        if len(lines[idx]) > remaining:
+            if not kept:
+                lines[idx] = _tail_truncate_line(lines[idx], remaining)
+                kept.append(idx)
+            break
+        kept.append(idx)
+        length += len(lines[idx]) + (1 if length else 0)
+    return kept
+
+
+def _kept_indices_error_windows(lines: list, error_indices: list, budget: int) -> set:
+    """Keep merged error windows tail-first; the newest error line is always secured."""
+    error_set = set(error_indices)
+    kept: set = set()
+    length = 0
+    for start, end in reversed(_merge_index_windows(error_indices, len(lines))):
+        chunk = range(start, end + 1)
+        extra = 1 if kept else 0
+        chunk_len = sum(len(lines[i]) for i in chunk) + len(chunk) - 1
+        if length + chunk_len + extra <= budget:
+            kept.update(chunk)
+            length += chunk_len + extra
+            continue
+        _keep_partial_window(lines, kept, length, start, end, error_set, budget)
+        break
+    return kept
+
+
+def _keep_partial_window(
+    lines: list, kept: set, length: int, start: int, end: int, error_set: set, budget: int
+) -> None:
+    """Fill a too-big window tail-first, securing its newest error line first.
+
+    Without the upfront reservation, short trailing context lines (err+1, err+2)
+    could consume a tight budget and starve the actual error line out.
+    """
+    last_err = max(i for i in range(start, end + 1) if i in error_set)
+    remaining = budget - length - (1 if kept else 0)
+    if len(lines[last_err]) > remaining:
+        lines[last_err] = _tail_truncate_line(lines[last_err], max(1, remaining))
+    kept.add(last_err)
+    length += len(lines[last_err]) + (1 if length else 0)
+
+    for idx in range(end, start - 1, -1):
+        if idx == last_err:
+            continue
+        remaining = budget - length - 1
+        if remaining <= 0 or len(lines[idx]) > remaining:
+            break
+        kept.add(idx)
+        length += len(lines[idx]) + 1
+
+
+def _render_selected_lines(lines: list, ordered: list, error_set: set, budget: int) -> list:
+    """Render kept indices chronologically, inserting omission markers for gaps."""
+    result = []
+    length = 0
+    prev = None
+
+    if ordered[0] > 0:
+        marker = _("...(省略 {} 行)").format(ordered[0])
+        if len(marker) <= budget:
+            result.append(marker)
+            length = len(marker)
+
+    for idx in ordered:
+        line = lines[idx]
+        if prev is not None and idx > prev + 1:
+            marker = _("...(省略 {} 行)").format(idx - prev - 1)
+            marker_cost = len(marker) + (1 if result else 0)
+            line_cost = len(line) + 1
+            if length + marker_cost + line_cost <= budget:
+                result.append(marker)
+                length += marker_cost
+        cost = len(line) + (1 if result else 0)
+        if length + cost > budget:
+            remaining = budget - length - (1 if result else 0)
+            has_content = any(not x.startswith(_OMIT_LINES_PREFIX) for x in result)
+            # Force-fit error lines; for pure-tail, only force-fit when nothing
+            # useful is kept yet. Otherwise drop the leftover non-error line.
+            if remaining > 0 and (idx in error_set or not has_content):
+                result.append(_tail_truncate_line(line, remaining))
+            break
+        result.append(line)
+        length += cost
+        prev = idx
+
+    return result
+
+
 def get_last_failed_node_logs(root_id: str, max_chars: int = _MAX_FLOW_LOG_CHARS) -> str:
     """Locate the last abnormal node under ``root_id`` and return its logs (capped).
 
     DB: indexed ``FlowNode`` lookup by ``root_id`` (+ optional pipeline tree for
     node name). Never scans unscoped tables.
 
-    Logs: capped BKLog queries (not ``get_version_logs``, which uses size=10000×2
-    and dumps full ES payloads into app logs). Text is truncated to ``max_chars``.
+    Logs: capped BKLog queries (newest-first so heartbeat spam cannot hide the
+    trailing error). Lines are fold-deduped, then error-window selected
+    (tail-first) within ``max_chars``.
     """
     if not root_id:
         return ""
@@ -310,27 +594,15 @@ def get_last_failed_node_logs(root_id: str, max_chars: int = _MAX_FLOW_LOG_CHARS
         updated_at=last_failed.updated_at,
     )
 
-    # Build text incrementally and stop once we exceed max_chars (avoid joining
-    # a huge in-memory list then slicing).
     header = (
         f"failed_node: {node_name} ({node_id}) version={version_id} "
         f"status={getattr(last_failed, 'status', '')} pick={pick_reason}"
     )
-    parts = [header]
-    length = len(header)
-    for log in logs:
-        if isinstance(log, dict):
-            level = log.get("levelname") or log.get("level") or ""
-            message = log.get("message") or ""
-            line = f"[{level}] {message}".strip() if level else message
-        else:
-            line = str(log)
-        if length + 1 + len(line) > max_chars:
-            parts.append("...(truncated)")
-            break
-        parts.append(line)
-        length += 1 + len(line)
-
+    body_budget = max(0, max_chars - len(header) - (1 if max_chars > len(header) else 0))
+    formatted = [_format_log_line(log) for log in logs]
+    folded = _fold_consecutive_duplicate_lines(formatted)
+    selected = _select_log_lines_for_budget(folded, body_budget)
+    parts = [header, *selected]
     return "\n".join(parts).strip()
 
 
@@ -348,8 +620,12 @@ def _append_block_to_report(report: Report, sentinel: str, block: str, elapsed_s
     if sentinel in existing:
         return
 
+    end_sentinel = _end_sentinel_for(sentinel)
     ts = timezone.localtime().strftime("%Y-%m-%d %H:%M:%S")
-    combined = f"{existing.rstrip()}\n{sentinel} {ts}\n{cleaned}".strip()
+    # Blank lines around the block keep it visually distinct even when cleanup
+    # logs are later merged after it.
+    block_text = f"\n{sentinel} {ts}\n{cleaned}\n{end_sentinel}\n"
+    combined = f"{existing.rstrip()}{block_text}".strip()
     report.mark(task_message=combined)
 
 
@@ -412,9 +688,7 @@ def analyze_redis_rollback_exercise_failure(report_id: int) -> None:
 
     # Failed-node logs are already embedded into task_message at mark time
     # (see embed_failed_node_logs); do not re-fetch from BKLog here.
-    task_message = report.task_message or ""
-    if len(task_message) > _MAX_TASK_MESSAGE_CHARS:
-        task_message = task_message[:_MAX_TASK_MESSAGE_CHARS] + "\n...(truncated)"
+    task_message = _head_tail_truncate(report.task_message or "", _MAX_TASK_MESSAGE_CHARS)
 
     instance = ""
     if report.instance_ip:

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_failure_analysis_and_weekly_summary.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_failure_analysis_and_weekly_summary.py
@@ -114,6 +114,41 @@ class TestParseAndCut:
         weekly = _weekly()
         assert weekly._parse_failure_diagnosis("plain failure log") == ""
 
+    def test_parse_ignores_cleanup_logs_after_closed_ai_block(self):
+        weekly = _weekly()
+        msg = (
+            "timeline\n"
+            "[AI失败分析] 2026-08-10 14:43:43\n"
+            "原因分类: 执行器错误\n"
+            "诊断: 模板变量未被渲染\n"
+            "建议: 修复 databases 渲染\n"
+            "AI耗时: 25.5s\n"
+            "[/AI失败分析]\n"
+            "[2026-08-10 14:48:38] [INFO]: Step 1/4: Collecting cleanup targets\n"
+            "诊断: should-not-win\n"
+            "原因分类: 其他\n"
+        )
+        assert weekly._parse_failure_category(msg) == "执行器错误"
+        assert weekly._parse_failure_diagnosis(msg) == "模板变量未被渲染"
+
+    def test_parse_legacy_block_without_end_sentinel_caps_window(self):
+        weekly = _weekly()
+        # Legacy: no [/AI失败分析]. Cleanup lines after the 8-line window must not win.
+        noise = "\n".join([f"cleanup line {i}" for i in range(20)])
+        msg = (
+            "timeline\n"
+            "[AI失败分析] 2026-08-10 14:43:43\n"
+            "原因分类: 执行器错误\n"
+            "诊断: real diagnosis\n"
+            "建议: fix it\n"
+            "AI耗时: 1.0s\n"
+            f"{noise}\n"
+            "原因分类: 其他\n"
+            "诊断: fake from cleanup\n"
+        )
+        assert weekly._parse_failure_category(msg) == "执行器错误"
+        assert weekly._parse_failure_diagnosis(msg) == "real diagnosis"
+
     def test_cut_content_splits_long_message(self):
         weekly = _weekly()
         lines = [f"line-{i}-" + ("x" * 80) for i in range(30)]
@@ -435,10 +470,21 @@ class TestFailureAnalysisEnqueueAndIdempotency(TestCase):
 
         report.refresh_from_db()
         assert failure.AI_ANALYSIS_SENTINEL in report.task_message
+        assert failure.AI_ANALYSIS_END_SENTINEL in report.task_message
         assert "构造流程失败" in report.task_message
+        # Block is visually delimited with blank lines around the sentinels.
+        assert f"\n{failure.AI_ANALYSIS_SENTINEL}" in report.task_message or report.task_message.startswith(
+            failure.AI_ANALYSIS_SENTINEL
+        )
+        assert f"{failure.AI_ANALYSIS_END_SENTINEL}\n" in report.task_message or report.task_message.endswith(
+            failure.AI_ANALYSIS_END_SENTINEL
+        )
         cost_match = re.search(r"AI耗时: (\d+\.\d)s", report.task_message)
         assert cost_match, report.task_message
         assert float(cost_match.group(1)) >= 0.0
+        # AI耗时 stays inside the closed block.
+        end_pos = report.task_message.index(failure.AI_ANALYSIS_END_SENTINEL)
+        assert cost_match.start() < end_pos
         first_msg = report.task_message
         assert mock_ask.call_count == 1
         params = mock_ask.call_args.kwargs["command_params"]
@@ -451,6 +497,24 @@ class TestFailureAnalysisEnqueueAndIdempotency(TestCase):
         assert report.task_message == first_msg
         assert report.task_message.count(failure.AI_ANALYSIS_SENTINEL) == 1
         assert mock_ask.call_count == 1
+
+    @patch("backend.dbm_aiagent.agent.handlers.AgentHandler.ask_agent_with_command")
+    def test_analyze_head_tail_truncates_task_message(self, mock_ask):
+        failure = _failure()
+        head = "HEAD-" + ("A" * 100)
+        middle = "MID-" + ("B" * 15000)
+        tail = "TAIL-" + ("C" * 100) + f"\n{failure.FAILED_NODE_LOGS_SENTINEL} root_id=x\n    [ERROR] boom"
+        report = self._create_failed(task_message=head + middle + tail)
+        mock_ask.return_value = "原因分类: 其他\n诊断: x\n建议: y"
+
+        failure.analyze_redis_rollback_exercise_failure.run(report.id)
+
+        params = mock_ask.call_args.kwargs["command_params"]
+        tm = params["task_message"]
+        assert tm.startswith("HEAD-")
+        assert "中间截断" in tm
+        assert "[ERROR] boom" in tm
+        assert len(tm) <= failure._MAX_TASK_MESSAGE_CHARS + 80  # marker slack
 
     @patch("backend.dbm_aiagent.agent.handlers.AgentHandler.ask_agent_with_command")
     def test_analyze_agent_error_appends_failed_sentinel(self, mock_ask):
@@ -504,7 +568,7 @@ class TestGetLastFailedNodeLogs:
         with patch(f"{FAILURE_MODULE}._pick_last_abnormal_flow_node", return_value=(None, "")):
             assert failure.get_last_failed_node_logs("root-x") == ""
 
-    def test_formats_and_truncates_all_logs(self):
+    def test_formats_and_truncates_preferring_error_tail(self):
         failure = _failure()
         last_failed = SimpleNamespace(
             node_id="n1",
@@ -534,11 +598,145 @@ class TestGetLastFailedNodeLogs:
 
         assert "failed_node: 回档节点 (n1)" in text
         assert "status=REVOKED" in text
-        assert "[INFO] start" in text
-        assert "...(truncated)" in text
-        assert len(text) <= 120 + len("\n...(truncated)")
+        # Tight budget keeps the ERROR (tail-truncated) and may drop the INFO head.
+        assert "[ERROR]" in text
+        assert "..." in text
+        assert len(text) <= 120 + 5  # small slack for join
 
-    def test_es_query_uses_capped_size(self):
+    def test_error_window_keeps_context_and_omits_head(self):
+        failure = _failure()
+        lines = [{"levelname": "INFO", "message": f"noise-{i}"} for i in range(20)]
+        lines.append({"levelname": "INFO", "message": "before-err"})
+        lines.append({"levelname": "ERROR", "message": "real-boom"})
+        lines.append({"levelname": "INFO", "message": "after-err"})
+        last_failed = SimpleNamespace(
+            node_id="n1",
+            version_id="v1",
+            status="FAILED",
+            started_at=timezone.now(),
+            updated_at=timezone.now(),
+        )
+        with patch(
+            f"{FAILURE_MODULE}._pick_last_abnormal_flow_node",
+            return_value=(last_failed, "failed_or_revoked"),
+        ), patch("backend.flow.engine.bamboo.engine.BambooEngine") as mock_engine_cls, patch(
+            f"{FAILURE_MODULE}._fetch_node_logs_capped",
+            return_value=lines,
+        ):
+            mock_engine_cls.return_value.get_pipeline_tree.return_value = {
+                "activities": {"n1": {"name": "回档"}},
+            }
+            text = failure.get_last_failed_node_logs("root-x", max_chars=800)
+
+        assert "[ERROR] real-boom" in text
+        assert "before-err" in text
+        assert "after-err" in text
+        assert "省略" in text
+        assert "noise-0" not in text
+
+    def test_no_error_falls_back_to_tail(self):
+        failure = _failure()
+        lines = [{"levelname": "INFO", "message": f"step-{i}"} for i in range(30)]
+        last_failed = SimpleNamespace(
+            node_id="n1",
+            version_id="v1",
+            status="REVOKED",
+            started_at=timezone.now(),
+            updated_at=timezone.now(),
+        )
+        with patch(
+            f"{FAILURE_MODULE}._pick_last_abnormal_flow_node",
+            return_value=(last_failed, "failed_or_revoked"),
+        ), patch("backend.flow.engine.bamboo.engine.BambooEngine") as mock_engine_cls, patch(
+            f"{FAILURE_MODULE}._fetch_node_logs_capped",
+            return_value=lines,
+        ):
+            mock_engine_cls.return_value.get_pipeline_tree.return_value = {
+                "activities": {"n1": {"name": "回档"}},
+            }
+            text = failure.get_last_failed_node_logs("root-x", max_chars=400)
+
+        assert "step-28" in text or "step-29" in text
+        assert "省略" in text
+        assert "step-0" not in text
+
+    def test_folds_consecutive_heartbeat_and_retry_errors(self):
+        failure = _failure()
+        heartbeats = [{"levelname": "INFO", "message": f"[2026-08-10 14:{i:02d}:00]heartbeat"} for i in range(60)]
+        retries = [
+            {
+                "levelname": "ERROR",
+                "message": (
+                    f"##[error][2026-08-10 14:25:{i:02d} error][dbactuator-1.1.1.1]: "
+                    "NewRedisClient failed :redis new conn fail"
+                ),
+            }
+            for i in range(15)
+        ]
+        last_failed = SimpleNamespace(
+            node_id="n1",
+            version_id="v1",
+            status="FAILED",
+            started_at=timezone.now(),
+            updated_at=timezone.now(),
+        )
+        with patch(
+            f"{FAILURE_MODULE}._pick_last_abnormal_flow_node",
+            return_value=(last_failed, "failed_or_revoked"),
+        ), patch("backend.flow.engine.bamboo.engine.BambooEngine") as mock_engine_cls, patch(
+            f"{FAILURE_MODULE}._fetch_node_logs_capped",
+            return_value=heartbeats + retries,
+        ):
+            mock_engine_cls.return_value.get_pipeline_tree.return_value = {
+                "activities": {"n1": {"name": "回档"}},
+            }
+            text = failure.get_last_failed_node_logs("root-x", max_chars=2000)
+
+        assert text.count("heartbeat") == 1
+        assert "连续重复 59 次" in text
+        assert text.count("NewRedisClient failed") == 1
+        assert "连续重复 14 次" in text
+        assert "末次" in text
+
+    def test_non_consecutive_duplicates_not_folded(self):
+        failure = _failure()
+        lines = [
+            {"levelname": "ERROR", "message": "same-err"},
+            {"levelname": "INFO", "message": "middle"},
+            {"levelname": "ERROR", "message": "same-err"},
+        ]
+        assert failure._fold_consecutive_duplicate_lines([failure._format_log_line(x) for x in lines]) == [
+            "[ERROR] same-err",
+            "[INFO] middle",
+            "[ERROR] same-err",
+        ]
+
+    def test_oversized_line_keeps_tail(self):
+        failure = _failure()
+        assert failure._tail_truncate_line("abcdef", 4) == "...f"
+        assert failure._tail_truncate_line("abcdef", 0) == ""
+        truncated = failure._tail_truncate_line("prefix-" + ("x" * 100) + "-EXCEPTION", 30)
+        assert truncated.startswith("...")
+        assert truncated.endswith("EXCEPTION")
+        leveled = failure._tail_truncate_line("[ERROR] " + ("x" * 100) + "-boom", 25)
+        assert leveled.startswith("[ERROR]")
+        assert "boom" in leveled
+
+    def test_tight_budget_keeps_error_over_trailing_context(self):
+        """Trailing INFO context of the error window must not starve the error line."""
+        failure = _failure()
+        lines = [
+            "[ERROR] " + ("x" * 100) + "-boom",
+            "[INFO] ctx-after-1",
+            "[INFO] ctx-after-2",
+        ]
+        selected = failure._select_log_lines_for_budget(lines, 40)
+        text = "\n".join(selected)
+        assert "[ERROR]" in text
+        assert "boom" in text
+        assert len(text) <= 40
+
+    def test_es_query_uses_capped_size_and_desc_sort(self):
         failure = _failure()
         with patch(f"{FAILURE_MODULE}.BKLogApi", create=True), patch(
             "backend.components.BKLogApi.esquery_search"
@@ -551,7 +749,17 @@ class TestGetLastFailedNodeLogs:
                 end_time="2026-01-02 00:00:00",
                 size=123,
             )
-        assert mock_search.call_args.args[0]["size"] == 123
+        payload = mock_search.call_args.args[0]
+        assert payload["size"] == 123
+        assert payload["sort_list"] == failure._BKLOG_SORT_DESC
+
+    def test_head_tail_truncate_helper(self):
+        failure = _failure()
+        text = "H" * 100 + "M" * 500 + "T" * 100
+        out = failure._head_tail_truncate(text, max_chars=250, head_chars=80)
+        assert out.startswith("H" * 80)
+        assert "中间截断" in out
+        assert out.endswith("T" * 100) or "T" * 50 in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 这条 PR 解决什么

- 回档演练失败日志被心跳/重试刷屏淹没，以及周报解析被 cleanup 日志污染

## 具体改动

- **BKLog 心跳刷屏**：desc 拉取 + 错误窗口优先选取 → 预算内保住尾部真实错误
- **连续重复行**：按时间戳折叠心跳/重试 → AI 能看到洪水时长而不被淹没
- **紧预算丢 ERROR**：部分窗口先锁定最新错误行再填上下文 → 避免 INFO context 挤掉 ERROR
- **C901**：`_select_log_lines_for_budget` 拆成 4 个 helper，复杂度从 24 降到 ≤8
- **周报误分类**：用 `[/AI失败分析]` 闭合块 + 旧报告 8 行窗口 → cleanup 日志不再污染分类/诊断

## 测试 & 风险

- 单测已覆盖错误窗口、无错误尾部回退、心跳折叠、紧预算保 ERROR、周报闭合块解析（143 passed）
- 仅影响回档演练失败分析嵌入日志与周报解析；无对外 API 变更