### PR TITLE
feat(redis): add process-level instance_cpu_usage metric for Redis MCP #19631

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
@@ -539,11 +539,12 @@ METRIC_REGISTRY = {
         "required_dimensions": ["ip"],  # Inner query needs ip dimension for per-IP bucket counts
     },
     # Twemproxy proxy metrics
+    # Host multi-core CPU — same source as redis/predixy cpu_usage (cpu_summary).
     "twemproxy_cpu_usage": {
         "promql_template": (
             "max by ({group_by}) ("
             "max_over_time("
-            "bkmonitor:dbm_system:cpu_detail:usage{{"
+            "bkmonitor:dbm_system:cpu_summary:usage{{"
             "{filters}"
             "}}[{time_window}s]"
             "))"
@@ -553,10 +554,10 @@ METRIC_REGISTRY = {
             "stats": [AggFunction.MIN, AggFunction.MAX, AggFunction.AVG, AggFunction.STDDEV],
         },
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP],
-        "required_dimensions": ["ip"],  # Twemproxy uses cpu_detail which has device dimension
+        "required_dimensions": ["ip"],
     },
     # Per Twemproxy process CPU (%): irate(process_cpu)/100. Distinct from host
-    # twemproxy_cpu_usage (cpu_detail). Outer agg is max across instances.
+    # twemproxy_cpu_usage (cpu_summary). Outer agg is max across instances.
     "twemproxy_instance_cpu_usage": {
         "promql_template": (
             "max by ({group_by}) ("

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/constants.py
@@ -72,7 +72,7 @@ LATENCY_DISTRIBUTION_BUCKETS = [
 TREND_UNIT_BY_METRIC_KEY = {
     # Redis backend metrics
     "redis_cpu_usage": "%/min",
-    "redis_cpu_usage_instance": "core/min",
+    "redis_instance_cpu_usage": "%/min",
     "redis_memory_usage": "%/min",
     "redis_connections": "connections/min",
     "redis_qps": "qps/min",
@@ -92,6 +92,7 @@ TREND_UNIT_BY_METRIC_KEY = {
     "predixy_latency_distribution": "requests/min",
     # Twemproxy proxy metrics
     "twemproxy_cpu_usage": "%/min",
+    "twemproxy_instance_cpu_usage": "%/min",
     "twemproxy_memory_usage": "%/min",
     "twemproxy_connections": "connections/min",
     "twemproxy_qps": "qps/min",
@@ -156,28 +157,24 @@ METRIC_REGISTRY = {
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP],
         "required_dimensions": ["ip"],  # Inner query needs ip dimension for proper aggregation
     },
-    # Instance-level CPU: process-level (Redis exporter) so it can drill down to ip:port.
-    # Value semantics: "CPU cores consumed" = irate(user_seconds) + irate(sys_seconds).
-    # 1.0 == one full core busy. Sum across the group_by so cluster/ip aggregates reflect
-    # total cores burned by all master/slave processes in that scope.
-    "redis_cpu_usage_instance": {
+    # Per Redis process CPU (% of one core): irate(user)+irate(sys). Distinct from host
+    # redis_cpu_usage (dbm_system multi-core). Outer agg is max across instances.
+    "redis_instance_cpu_usage": {
         "promql_template": (
-            "sum by ({group_by}) ("
+            "max by ({group_by}) (("
             "irate("
             "bkmonitor:exporter_dbm_redis_exporter:redis_cpu_user_seconds_total{{"
             "{filters}"
             "}}[{time_window}s]"
-            ")"
-            "+"
+            ") + "
             "irate("
             "bkmonitor:exporter_dbm_redis_exporter:redis_cpu_sys_seconds_total{{"
             "{filters}"
             "}}[{time_window}s]"
-            ")"
-            ")"
+            ")) * 100)"
         ),
         "aggregation": {
-            "overall": AggFunction.SUM,
+            "overall": AggFunction.MAX,
             "stats": [AggFunction.MIN, AggFunction.MAX, AggFunction.AVG, AggFunction.STDDEV],
         },
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.INSTANCE],
@@ -370,6 +367,8 @@ METRIC_REGISTRY = {
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP],
         "required_dimensions": ["ip"],
     },
+    # Predixy has no process-level CPU exporter metric; instance_cpu_usage is unsupported
+    # (callers should use predixy_cpu_usage / MetricType.CPU_USAGE for host multi-core CPU).
     "predixy_memory_usage": {
         "promql_template": (
             "max by ({group_by}) ("
@@ -555,6 +554,24 @@ METRIC_REGISTRY = {
         },
         "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP],
         "required_dimensions": ["ip"],  # Twemproxy uses cpu_detail which has device dimension
+    },
+    # Per Twemproxy process CPU (%): irate(process_cpu)/100. Distinct from host
+    # twemproxy_cpu_usage (cpu_detail). Outer agg is max across instances.
+    "twemproxy_instance_cpu_usage": {
+        "promql_template": (
+            "max by ({group_by}) ("
+            "irate("
+            "bkmonitor:exporter_dbm_twemproxy_exporter:twemproxy_process_cpu{{"
+            "{filters}"
+            "}}[{time_window}s]"
+            ") / 100)"
+        ),
+        "aggregation": {
+            "overall": AggFunction.MAX,
+            "stats": [AggFunction.MIN, AggFunction.MAX, AggFunction.AVG, AggFunction.STDDEV],
+        },
+        "supported_group_by": [MetricsGroupBy.CLUSTER_DOMAIN, MetricsGroupBy.IP, MetricsGroupBy.INSTANCE],
+        "required_dimensions": ["ip", "instance_port"],
     },
     "twemproxy_memory_usage": {
         "promql_template": (

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/enums.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/enums.py
@@ -20,8 +20,10 @@ class MetricType(StrStructuredEnum):
     Used as the suffix of metric key in METRIC_REGISTRY.
     """
 
-    CPU_USAGE = EnumField("cpu_usage", "CPU usage (host / machine level)")
-    CPU_USAGE_INSTANCE = EnumField("cpu_usage_instance", "CPU usage (process / instance level, in cores)")
+    CPU_USAGE = EnumField("cpu_usage", "CPU usage")
+    # Process CPU (% of one core), not host multi-core summary.
+    # Redis: exporter user+sys; Twemproxy: process_cpu. Predixy has no process metric — unsupported.
+    INSTANCE_CPU_USAGE = EnumField("instance_cpu_usage", "Instance CPU usage")
     MEMORY_USAGE = EnumField("memory_usage", "Memory usage")
     CONNECTIONS = EnumField("connections", "Connections")
     QPS = EnumField("qps", "QPS")
@@ -34,12 +36,13 @@ class MetricType(StrStructuredEnum):
 
     @classmethod
     def get_proxy_cluster_api_choices(cls) -> List[Tuple]:
-        """Choices for cluster-level proxy MCP APIs (capacity is backend-only;
-        cpu_usage_instance is currently backend-only since predixy/twemproxy exporters
-        do not expose process-level CPU counters)."""
+        """Choices for cluster-level proxy MCP APIs (capacity is backend-only).
 
-        excluded = {cls.CAPACITY.value, cls.CPU_USAGE_INSTANCE.value}
-        return [c for c in cls.get_choices() if c[0] not in excluded]
+        instance_cpu_usage remains listed for Twemproxy process CPU; Predixy rejects it
+        at query time (no process-level exporter metric) — use cpu_usage instead.
+        """
+
+        return [c for c in cls.get_choices() if c[0] != cls.CAPACITY.value]
 
     @classmethod
     def get_backend_cluster_api_choices(cls) -> List[Tuple]:
@@ -49,8 +52,7 @@ class MetricType(StrStructuredEnum):
 
     @classmethod
     def get_instance_api_choices(cls) -> List[Tuple]:
-        """Choices for instance-scoped MCP APIs (host-level cpu/memory/io/disk unavailable at ip:port scope;
-        cpu_usage_instance is exposed instead for process-level CPU)."""
+        """Choices for instance-scoped MCP APIs (host resource metrics unavailable at ip:port scope)."""
 
         host_level = {cls.CPU_USAGE.value, cls.MEMORY_USAGE.value, cls.IO_USAGE.value, cls.DISK_USAGE.value}
         return [c for c in cls.get_choices() if c[0] not in host_level]

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/enums.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/enums.py
@@ -20,7 +20,7 @@ class MetricType(StrStructuredEnum):
     Used as the suffix of metric key in METRIC_REGISTRY.
     """
 
-    CPU_USAGE = EnumField("cpu_usage", "CPU usage")
+    CPU_USAGE = EnumField("cpu_usage", "CPU usage (host multi-core)")
     # Process CPU (% of one core), not host multi-core summary.
     # Redis: exporter user+sys; Twemproxy: process_cpu. Predixy has no process metric — unsupported.
     INSTANCE_CPU_USAGE = EnumField("instance_cpu_usage", "Instance CPU usage")

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/impl/redis_metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/impl/redis_metrics.py
@@ -20,10 +20,9 @@ from backend.dbm_aiagent.mcp_tools.redis.tools.redis_metrics_svc import RedisMet
 from backend.dbm_aiagent.mcp_tools.redis.utils import calculate_time_range_window
 
 _PROXY_ONLY_METRICS = {MetricType.LATENCY_DISTRIBUTION}
-# CPU_USAGE_INSTANCE is currently only wired up for Redis backend (via Redis exporter's
-# user/sys CPU seconds counters). Predixy/Twemproxy exporters do not expose comparable
-# process-level CPU counters at the moment, so treat it as backend-only.
-_BACKEND_ONLY_METRICS = {MetricType.CAPACITY, MetricType.CPU_USAGE_INSTANCE}
+# CAPACITY is backend-only. instance_cpu_usage works for Redis backend and Twemproxy proxy;
+# Predixy proxy has no process CPU metric and is rejected at metric-key resolve time.
+_BACKEND_ONLY_METRICS = {MetricType.CAPACITY}
 
 
 @dataclass

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_metrics.py
@@ -94,8 +94,10 @@ class RedisMetricsClusterProxyInputSerializer(ClusterDomainsFieldMixin, RedisMet
     metric_type = serializers.ChoiceField(
         choices=MetricType.get_proxy_cluster_api_choices(),
         help_text=_(
-            "Metric to query (proxy nodes; capacity and cpu_usage_instance are not available at proxy). "
-            "[Resource] cpu_usage (machine-level, host CPU %), memory_usage, io_usage, disk_usage. "
+            "Metric to query (proxy nodes; capacity is not available at proxy). "
+            "[Resource] cpu_usage (host), instance_cpu_usage (Twemproxy process CPU only; "
+            "Predixy has no process CPU — use cpu_usage), "
+            "memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
             "[Latency] host_latency, command_latency (broken down per command automatically), "
             "latency_distribution (broken down per latency bucket automatically). "
@@ -117,8 +119,7 @@ class RedisMetricsClusterBackendInputSerializer(ClusterDomainsFieldMixin, RedisM
         choices=MetricType.get_backend_cluster_api_choices(),
         help_text=_(
             "Metric to query (backend nodes; latency_distribution is proxy-only). "
-            "[Resource] cpu_usage (machine-level, host CPU %), "
-            "cpu_usage_instance (process-level, in cores, drill-down to ip:port), "
+            "[Resource] cpu_usage (host multi-core), instance_cpu_usage (per Redis process), "
             "memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
             "[Latency] host_latency, command_latency (broken down per command automatically). "
@@ -154,9 +155,9 @@ class RedisMetricsMachineInputSerializer(RedisMetricsTimeWindowSerializer):
         choices=MetricType.get_choices(),
         help_text=_(
             "Metric to query. Role (proxy vs backend) is resolved from ip; "
-            "latency_distribution is proxy-only; capacity and cpu_usage_instance are backend-only. "
-            "[Resource] cpu_usage (machine-level, host CPU %), "
-            "cpu_usage_instance (process-level, in cores, backend-only), "
+            "latency_distribution is proxy-only, capacity is backend-only. "
+            "[Resource] cpu_usage (host), instance_cpu_usage (Redis/Twemproxy process CPU; "
+            "Predixy proxy unsupported — use cpu_usage), "
             "memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
             "[Latency] host_latency, command_latency (broken down per command automatically), latency_distribution. "
@@ -195,10 +196,11 @@ class RedisMetricsInstanceInputSerializer(RedisMetricsTimeWindowSerializer):
         choices=MetricType.get_instance_api_choices(),
         help_text=_(
             "Metric to query for a single ip:port. "
-            "Machine-level resource metrics (cpu_usage, memory_usage, io_usage, disk_usage) "
-            "are not available at instance scope -- use cpu_usage_instance for per-process CPU (backend-only, in cores). "
+            "Host-level resource metrics (cpu_usage, memory_usage, io_usage, disk_usage) "
+            "are not available at instance scope; use instance_cpu_usage for Redis/Twemproxy "
+            "process CPU (Predixy proxy unsupported — use machine/cluster cpu_usage instead). "
             "latency_distribution is proxy-only; capacity is backend-only. "
-            "[Resource] cpu_usage_instance (process-level, in cores, backend-only). "
+            "[Resource] instance_cpu_usage. "
             "[Throughput] connections, qps. "
             "[Latency] host_latency, command_latency (broken down per command automatically), latency_distribution. "
             "[Capacity] capacity. "

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_metrics.py
@@ -95,7 +95,7 @@ class RedisMetricsClusterProxyInputSerializer(ClusterDomainsFieldMixin, RedisMet
         choices=MetricType.get_proxy_cluster_api_choices(),
         help_text=_(
             "Metric to query (proxy nodes; capacity is not available at proxy). "
-            "[Resource] cpu_usage (host), instance_cpu_usage (Twemproxy process CPU only; "
+            "[Resource] cpu_usage (host multi-core), instance_cpu_usage (Twemproxy process CPU only; "
             "Predixy has no process CPU — use cpu_usage), "
             "memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "
@@ -156,7 +156,7 @@ class RedisMetricsMachineInputSerializer(RedisMetricsTimeWindowSerializer):
         help_text=_(
             "Metric to query. Role (proxy vs backend) is resolved from ip; "
             "latency_distribution is proxy-only, capacity is backend-only. "
-            "[Resource] cpu_usage (host), instance_cpu_usage (Redis/Twemproxy process CPU; "
+            "[Resource] cpu_usage (host multi-core), instance_cpu_usage (Redis/Twemproxy process CPU; "
             "Predixy proxy unsupported — use cpu_usage), "
             "memory_usage, io_usage, disk_usage. "
             "[Throughput] connections, qps. "

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/tools/redis_metrics_svc.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/tools/redis_metrics_svc.py
@@ -34,7 +34,7 @@ from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsGroupBy
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricsInstanceRole as InstanceRole
 from backend.dbm_aiagent.mcp_tools.redis.enums import MetricType
 from backend.dbm_aiagent.mcp_tools.redis.models import InstanceFilter, MetricSeries, MetricsQueryParams
-from backend.dbm_aiagent.mcp_tools.redis.utils import resolve_metric_key
+from backend.dbm_aiagent.mcp_tools.redis.utils import explain_missing_metric_key, resolve_metric_key
 
 logger = logging.getLogger("root")
 
@@ -975,11 +975,12 @@ class RedisMetricsQueryService:
         # Resolve metric key from registry
         metric_key = resolve_metric_key(cluster.cluster_type, metric_type, instance_role)
         if not metric_key:
+            error_msg = explain_missing_metric_key(cluster.cluster_type, metric_type, instance_role)
             logger.error(
-                f"No metric mapping found for cluster_type={cluster.cluster_type}, "
-                f"metric_type={metric_type.value}, instance_role={instance_role.value}"
+                f"{error_msg} (cluster_type={cluster.cluster_type}, "
+                f"metric_type={metric_type.value}, instance_role={instance_role.value})"
             )
-            return None, {"error": "No metric mapping found", "metric_type": metric_type.value}
+            return None, {"error": error_msg, "metric_type": metric_type.value}
 
         metric_config = METRIC_REGISTRY.get(metric_key)
         if not metric_config:

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/utils.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/utils.py
@@ -84,6 +84,24 @@ def resolve_metric_key(
     return metric_key
 
 
+def explain_missing_metric_key(
+    cluster_type: str,
+    metric_type: MetricType,
+    instance_role: InstanceRole,
+) -> str:
+    """Human-readable reason when resolve_metric_key returns None."""
+    if (
+        metric_type == MetricType.INSTANCE_CPU_USAGE
+        and instance_role == InstanceRole.PROXY
+        and is_predixy_proxy_type(cluster_type)
+    ):
+        return (
+            "instance_cpu_usage is not available for Predixy proxy "
+            "(no process-level CPU metric); use cpu_usage for host multi-core CPU instead"
+        )
+    return "No metric mapping found"
+
+
 def calculate_time_range_window(
     max_len_datapoints: int,
     start_time: Optional[datetime] = None,

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/views/metrics.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/views/metrics.py
@@ -111,8 +111,9 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=_(
             "Query time-series metrics for Redis cluster PROXY nodes. "
-            "Applicable metrics: cpu_usage (machine-level), memory_usage, io_usage, disk_usage, connections, qps, "
-            "host_latency, command_latency, latency_distribution (not capacity, not cpu_usage_instance). "
+            "Applicable metrics: cpu_usage, instance_cpu_usage (Twemproxy only; Predixy use cpu_usage), "
+            "memory_usage, io_usage, disk_usage, "
+            "connections, qps, host_latency, command_latency, latency_distribution (not capacity). "
             "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic). "
             "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
@@ -140,8 +141,9 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=_(
             "Query scalar statistics (min/max/avg/p95/cv/trend) for Redis cluster PROXY nodes. "
-            "Applicable metrics: cpu_usage (machine-level), memory_usage, io_usage, disk_usage, connections, qps, "
-            "host_latency, command_latency, latency_distribution (not capacity, not cpu_usage_instance). "
+            "Applicable metrics: cpu_usage, instance_cpu_usage (Twemproxy only; Predixy use cpu_usage), "
+            "memory_usage, io_usage, disk_usage, "
+            "connections, qps, host_latency, command_latency, latency_distribution (not capacity). "
             "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisClusterProxyStatsInputSerializer,
@@ -173,9 +175,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=_(
             "Query time-series metrics for Redis cluster MASTER nodes. "
-            "Applicable metrics: cpu_usage (machine-level), cpu_usage_instance (process-level, in cores), "
-            "memory_usage, io_usage, disk_usage, connections, qps, "
-            "host_latency, command_latency, capacity (not latency_distribution). "
+            "Applicable metrics: cpu_usage, instance_cpu_usage, memory_usage, io_usage, disk_usage, "
+            "connections, qps, host_latency, command_latency, capacity (not latency_distribution). "
             "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic). "
             "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
@@ -203,9 +204,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=_(
             "Query scalar statistics (min/max/avg/p95/cv/trend) for Redis cluster MASTER nodes. "
-            "Applicable metrics: cpu_usage (machine-level), cpu_usage_instance (process-level, in cores), "
-            "memory_usage, io_usage, disk_usage, connections, qps, "
-            "host_latency, command_latency, capacity (not latency_distribution). "
+            "Applicable metrics: cpu_usage, instance_cpu_usage, memory_usage, io_usage, disk_usage, "
+            "connections, qps, host_latency, command_latency, capacity (not latency_distribution). "
             "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisClusterBackendStatsInputSerializer,
@@ -237,9 +237,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=_(
             "Query time-series metrics for Redis cluster SLAVE nodes. "
-            "Applicable metrics: cpu_usage (machine-level), cpu_usage_instance (process-level, in cores), "
-            "memory_usage, io_usage, disk_usage, connections, qps, "
-            "host_latency, command_latency, capacity (not latency_distribution). "
+            "Applicable metrics: cpu_usage, instance_cpu_usage, memory_usage, io_usage, disk_usage, "
+            "connections, qps, host_latency, command_latency, capacity (not latency_distribution). "
             "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic). "
             "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
@@ -267,9 +266,8 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
     @mcp_tools_api_decorator(
         description=_(
             "Query scalar statistics (min/max/avg/p95/cv/trend) for Redis cluster SLAVE nodes. "
-            "Applicable metrics: cpu_usage (machine-level), cpu_usage_instance (process-level, in cores), "
-            "memory_usage, io_usage, disk_usage, connections, qps, "
-            "host_latency, command_latency, capacity (not latency_distribution). "
+            "Applicable metrics: cpu_usage, instance_cpu_usage, memory_usage, io_usage, disk_usage, "
+            "connections, qps, host_latency, command_latency, capacity (not latency_distribution). "
             "group_by: ip, instance, cluster_domain (per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisClusterBackendStatsInputSerializer,
@@ -302,8 +300,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
         description=_(
             "Query time-series metrics for a specific machine (by IP). "
             "Cluster and instance role are auto-resolved. "
-            "All metric types are accepted; latency_distribution is proxy-only; "
-            "capacity and cpu_usage_instance are backend-only. "
+            "All metric types are accepted; latency_distribution is proxy-only, capacity is backend-only. "
             "group_by: ip, instance (not cluster_domain; per-command/bucket/capacity breakdowns are automatic). "
             "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
@@ -333,8 +330,7 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
         description=_(
             "Query scalar statistics (min/max/avg/p95/cv/trend) for a specific machine (by IP). "
             "Cluster and instance role are auto-resolved. "
-            "All metric types are accepted; latency_distribution is proxy-only; "
-            "capacity and cpu_usage_instance are backend-only. "
+            "All metric types are accepted; latency_distribution is proxy-only, capacity is backend-only. "
             "group_by: ip, instance (not cluster_domain; per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisMachineStatsInputSerializer,
@@ -368,10 +364,9 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
         description=_(
             "Query time-series metrics for a specific instance (by IP + port). "
             "Cluster and instance role are auto-resolved. "
-            "Metrics: cpu_usage_instance (process-level CPU in cores, backend-only), "
-            "connections, qps, host_latency, command_latency, latency_distribution (proxy), "
-            "capacity (backend); machine-level resource metrics (cpu_usage/memory_usage/io_usage/disk_usage) "
-            "are not available at instance scope -- use cpu_usage_instance for per-process CPU. "
+            "Metrics: instance_cpu_usage (Redis/Twemproxy; Predixy proxy unsupported), "
+            "connections, qps, host_latency, command_latency, "
+            "latency_distribution (proxy), capacity (backend); not host resource metrics (cpu/memory/io/disk). "
             "group_by: instance (not cluster_domain or ip; per-command/bucket/capacity breakdowns are automatic). "
             "Keep max_len_datapoints<=15 to avoid context length issues."
         ),
@@ -401,10 +396,9 @@ class RedisMetricsMcpToolsViewSet(McpToolsViewSet):
         description=_(
             "Query scalar statistics (min/max/avg/p95/cv/trend) for a specific instance (by IP + port). "
             "Cluster and instance role are auto-resolved. "
-            "Metrics: cpu_usage_instance (process-level CPU in cores, backend-only), "
-            "connections, qps, host_latency, command_latency, latency_distribution (proxy), "
-            "capacity (backend); machine-level resource metrics (cpu_usage/memory_usage/io_usage/disk_usage) "
-            "are not available at instance scope -- use cpu_usage_instance for per-process CPU. "
+            "Metrics: instance_cpu_usage (Redis/Twemproxy; Predixy proxy unsupported), "
+            "connections, qps, host_latency, command_latency, "
+            "latency_distribution (proxy), capacity (backend); not host resource metrics (cpu/memory/io/disk). "
             "group_by: instance (not cluster_domain or ip; per-command/bucket/capacity breakdowns are automatic)."
         ),
         request_slz=RedisInstanceStatsInputSerializer,

--- a/dbm-ui/backend/tests/dbm_aiagent/mcp_tools/redis/test_instance_cpu_usage.py
+++ b/dbm-ui/backend/tests/dbm_aiagent/mcp_tools/redis/test_instance_cpu_usage.py
@@ -127,3 +127,9 @@ class TestProxyInstanceCpuUsagePromQL:
         assert "/ 100" in promql
         assert "max by (cluster_domain,ip,instance_port)" in promql
         assert promql.startswith("label_replace(max by (cluster_domain)")
+
+    def test_host_cpu_usage_uses_cpu_summary_for_all_components(self):
+        for key in ("redis_cpu_usage", "predixy_cpu_usage", "twemproxy_cpu_usage"):
+            promql = METRIC_REGISTRY[key]["promql_template"]
+            assert "cpu_summary:usage" in promql
+            assert "cpu_detail:usage" not in promql

--- a/dbm-ui/backend/tests/dbm_aiagent/mcp_tools/redis/test_instance_cpu_usage.py
+++ b/dbm-ui/backend/tests/dbm_aiagent/mcp_tools/redis/test_instance_cpu_usage.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""Tests for redis/proxy instance_cpu_usage PromQL construction and API choices."""
+import pytest
+
+from backend.db_meta.enums import ClusterType
+from backend.dbm_aiagent.mcp_tools.redis.constants import METRIC_REGISTRY, TREND_UNIT_BY_METRIC_KEY
+from backend.dbm_aiagent.mcp_tools.redis.enums import (
+    MetricsAggregationLevel,
+    MetricsGroupBy,
+    MetricsInstanceRole,
+    MetricType,
+)
+from backend.dbm_aiagent.mcp_tools.redis.models import MetricsQueryParams
+from backend.dbm_aiagent.mcp_tools.redis.tools.redis_metrics_svc import RedisMetricsQueryService
+from backend.dbm_aiagent.mcp_tools.redis.utils import explain_missing_metric_key, resolve_metric_key
+
+
+def _params(
+    metric_key="redis_instance_cpu_usage",
+    group_by=None,
+    aggregation_level=MetricsAggregationLevel.CLUSTER,
+    instance_role=MetricsInstanceRole.MASTER,
+    instance_filters=None,
+):
+    return MetricsQueryParams(
+        cluster_domains=["test.cluster"],
+        metric_type=MetricType.INSTANCE_CPU_USAGE,
+        metric_config=METRIC_REGISTRY[metric_key],
+        aggregation_level=aggregation_level,
+        group_by=group_by,
+        instance_role=instance_role,
+        instance_filters=instance_filters,
+        time_window=60,
+    )
+
+
+@pytest.fixture
+def svc():
+    return RedisMetricsQueryService()
+
+
+class TestInstanceCpuUsageRegistry:
+    def test_registry_and_trend_unit_present(self):
+        for key in ("redis_instance_cpu_usage", "twemproxy_instance_cpu_usage"):
+            assert key in METRIC_REGISTRY
+            assert TREND_UNIT_BY_METRIC_KEY[key] == "%/min"
+        assert "predixy_instance_cpu_usage" not in METRIC_REGISTRY
+        assert "predixy_instance_cpu_usage" not in TREND_UNIT_BY_METRIC_KEY
+
+    @pytest.mark.parametrize(
+        "cluster_type,role,expected",
+        [
+            (ClusterType.TendisTwemproxyRedisInstance.value, MetricsInstanceRole.MASTER, "redis_instance_cpu_usage"),
+            (
+                ClusterType.TendisTwemproxyRedisInstance.value,
+                MetricsInstanceRole.PROXY,
+                "twemproxy_instance_cpu_usage",
+            ),
+            (ClusterType.TendisPredixyRedisCluster.value, MetricsInstanceRole.MASTER, "redis_instance_cpu_usage"),
+        ],
+    )
+    def test_resolve_metric_key(self, cluster_type, role, expected):
+        assert resolve_metric_key(cluster_type, MetricType.INSTANCE_CPU_USAGE, role) == expected
+
+    def test_predixy_proxy_has_no_instance_cpu_mapping(self):
+        assert (
+            resolve_metric_key(
+                ClusterType.TendisPredixyRedisCluster.value,
+                MetricType.INSTANCE_CPU_USAGE,
+                MetricsInstanceRole.PROXY,
+            )
+            is None
+        )
+        msg = explain_missing_metric_key(
+            ClusterType.TendisPredixyRedisCluster.value,
+            MetricType.INSTANCE_CPU_USAGE,
+            MetricsInstanceRole.PROXY,
+        )
+        assert "Predixy" in msg
+        assert "cpu_usage" in msg
+
+    def test_api_choices(self):
+        proxy_values = {c[0] for c in MetricType.get_proxy_cluster_api_choices()}
+        backend_values = {c[0] for c in MetricType.get_backend_cluster_api_choices()}
+        instance_values = {c[0] for c in MetricType.get_instance_api_choices()}
+        assert MetricType.INSTANCE_CPU_USAGE.value in proxy_values
+        assert MetricType.INSTANCE_CPU_USAGE.value in backend_values
+        assert MetricType.INSTANCE_CPU_USAGE.value in instance_values
+        assert MetricType.CPU_USAGE.value not in instance_values
+
+
+class TestRedisInstanceCpuUsagePromQL:
+    def test_uses_exporter_user_and_sys_cpu(self, svc):
+        query_configs, _ = svc._build_queries(_params(group_by=[MetricsGroupBy.CLUSTER_DOMAIN]))
+        promql = query_configs[0]["promql"]
+        assert "redis_cpu_user_seconds_total" in promql
+        assert "redis_cpu_sys_seconds_total" in promql
+        assert "cpu_summary:usage" not in promql
+        assert "* 100" in promql
+
+    def test_inner_requires_instance_dims_outer_max_at_cluster(self, svc):
+        query_configs, _ = svc._build_queries(_params(group_by=[MetricsGroupBy.CLUSTER_DOMAIN]))
+        promql = query_configs[0]["promql"]
+        assert "max by (cluster_domain,ip,instance_port)" in promql
+        assert promql.startswith("label_replace(max by (cluster_domain)")
+
+    def test_machine_level_max_among_instances(self, svc):
+        query_configs, _ = svc._build_queries(
+            _params(group_by=[MetricsGroupBy.IP], aggregation_level=MetricsAggregationLevel.MACHINE)
+        )
+        promql = query_configs[0]["promql"]
+        assert "max by (ip,instance_port)" in promql
+        assert "max by (cluster_domain,ip)" in promql
+
+
+class TestProxyInstanceCpuUsagePromQL:
+    def test_twemproxy_uses_process_cpu(self, svc):
+        query_configs, _ = svc._build_queries(
+            _params(
+                metric_key="twemproxy_instance_cpu_usage",
+                group_by=[MetricsGroupBy.CLUSTER_DOMAIN],
+                instance_role=MetricsInstanceRole.PROXY,
+            )
+        )
+        promql = query_configs[0]["promql"]
+        assert "twemproxy_process_cpu" in promql
+        assert "/ 100" in promql
+        assert "max by (cluster_domain,ip,instance_port)" in promql
+        assert promql.startswith("label_replace(max by (cluster_domain)")


### PR DESCRIPTION
## 这条 PR 解决什么
- Redis MCP 需要在 ip:port 粒度查看进程级 CPU（主机 `cpu_usage` 无法下钻到实例），支撑热点定位与负载倾斜分析；并统一各组件 `cpu_usage` 为主机多核口径

## 具体改动
- **进程级 CPU 指标**：新增 `instance_cpu_usage`（单位 %，跨实例取 max）→ Redis 用 exporter `user+sys`，Twemproxy 用 `process_cpu`，可按 `instance` group_by 下钻
- **与主机 CPU 分工**：`cpu_usage` 统一表示主机多核占用（`cpu_summary`）；`instance_cpu_usage` 表示单进程占用 → Agent/调用方语义清晰
- **Twemproxy 主机 CPU 标准化**：`twemproxy_cpu_usage` 从 `cpu_detail`（单核）改为 `cpu_summary`（多核），与 Redis/Predixy 一致；进程压力改看 `instance_cpu_usage`
- **Predixy 明确不支持**：Predixy 无进程级 CPU 指标时直接返回可读错误，提示改用 `cpu_usage` → 避免假回退导致默认 `group_by=instance` 报错
- **API 文案与单测**：更新 proxy/machine/instance 接口说明，并补充 registry / PromQL / 主机口径一致 / Predixy 拒绝路径单测

## 测试 & 风险
- 单测覆盖 Redis/Twemproxy PromQL、三组件 `cpu_usage` 均为 `cpu_summary`、Predixy proxy 无 mapping 时的错误文案（`test_instance_cpu_usage.py` 11 passed）
- 影响面限 Redis metrics MCP；Twemproxy 的 `cpu_usage` 数值口径从单核变为多核（通常更低），进程级请用 `instance_cpu_usage`；Predixy 调用 `instance_cpu_usage` 会得到明确错误（应改用 `cpu_usage`）