### PR TITLE
feat(redis): add Redis cluster portrait dimensions and ingest hooks #19688

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
@@ -25,6 +25,8 @@ from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_meta.models.city_map import BKSubzone
 from backend.db_meta.models.storage_instance_tuple import StorageInstanceTuple
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 from backend.flow.utils.redis.redis_report_utils import (
     META_CHECK_CLUSTER_PAGE_SIZE,
     RedisReportWriter,
@@ -260,6 +262,11 @@ class RedisAffinityChecker:
                     )
             if page_rows:
                 safe_write_meta_reports(self._writer, page_rows, context="affinity_check page")
+                ingest_abnormal_cluster_rows(
+                    page_rows,
+                    dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+                    prefix="[亲和性]",
+                )
 
     def _check_cluster_affinity(self, cluster: Cluster, dba_cache: Optional[Dict[int, str]] = None) -> List[dict]:
         """

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
@@ -22,6 +22,8 @@ from backend.db_meta.enums import ClusterPhase, ClusterType, InstanceRole, Insta
 from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_meta.models.storage_instance_tuple import StorageInstanceTuple
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 from backend.flow.utils.redis.redis_report_utils import (
     META_CHECK_CLUSTER_PAGE_SIZE,
     RedisReportWriter,
@@ -133,6 +135,14 @@ def check_redis_instance():
 
         if page_rows:
             safe_write_meta_reports(writer, page_rows, context="instance_check page")
+            ingest_abnormal_cluster_rows(
+                page_rows,
+                dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+                prefix_by_subtype={
+                    MetaCheckSubType.AloneInstance.value: "[孤立实例]",
+                    MetaCheckSubType.StatusAbnormal.value: "[实例状态]",
+                },
+            )
 
 
 def _check_single_cluster_instance(cluster: Cluster, creator: str) -> List[dict]:

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
@@ -23,6 +23,8 @@ from backend.constants import IP_PORT_DIVIDER
 from backend.db_meta.enums import ClusterType, InstanceRole
 from backend.db_meta.models import Cluster, StorageInstance, StorageInstanceTuple
 from backend.db_report.enums import RedisBackupCheckSubType, ReportStateType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 from backend.db_services.redis.util import is_tendisplus_instance_type, is_tendisssd_instance_type
 from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
 
@@ -261,6 +263,11 @@ class CheckBinlogBackupTask:
                 )
                 if rows:
                     cluster_state_total[rows[0].state] += 1
+                    ingest_abnormal_cluster_rows(
+                        rows,
+                        dimension=RedisPortraitDimensionCode.RELIABILITY,
+                        prefix="[binlog]",
+                    )
                 for row in rows:
                     batch_ops.append(row)
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_full_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_full_backup.py
@@ -20,6 +20,8 @@ from backend.constants import IP_PORT_DIVIDER
 from backend.db_meta.enums import ClusterType, InstanceRole
 from backend.db_meta.models import Cluster, StorageInstance, StorageInstanceTuple
 from backend.db_report.enums import RedisBackupCheckSubType, ReportStateType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 
 from .bklog_query import DOMAIN_BATCH_SIZE, batch_fetch_backup_logs, find_and_verify_failed_tasks
 from .config import RedisBackupCheckConfig
@@ -137,6 +139,11 @@ class CheckFullBackupTask:
                 rows = self._check_cluster_with_retry(cluster, bklogs, config)
                 if rows:
                     cluster_state_total[rows[0].state] += 1
+                    ingest_abnormal_cluster_rows(
+                        rows,
+                        dimension=RedisPortraitDimensionCode.RELIABILITY,
+                        prefix="[全备]",
+                    )
                 for row in rows:
                     batch_ops.append(row)
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/check_exporter.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/check_exporter.py
@@ -28,6 +28,8 @@ from backend.db_periodic_task.local_tasks.db_meta.constants import UNIFY_QUERY_P
 from backend.db_periodic_task.local_tasks.redis_tasks.report_op import RedisCheckReportBatchOps, RedisClusterReport
 from backend.db_report.enums import ReportStateType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 from backend.db_report.repo.task_record_repo import get_report_day_from_time
 
 logger = logging.getLogger("root")
@@ -189,6 +191,11 @@ class CheckRedisUpMetricTask:
                 rows = self.check_cluster(cluster, report_day)
                 if rows:
                     cluster_state_total[rows[0].state] += 1
+                    ingest_abnormal_cluster_rows(
+                        rows,
+                        dimension=RedisPortraitDimensionCode.CONFIG_HEALTH,
+                        prefix="[exporter]",
+                    )
                 for record in rows:
                     record_batch_ops.append(record)
             record_batch_ops.bulk_create()

--- a/dbm-ui/backend/db_report/portrait/redis_dimensions.py
+++ b/dbm-ui/backend/db_report/portrait/redis_dimensions.py
@@ -5,8 +5,8 @@ Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
 Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at https://opensource.org/licenses/MIT
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
-an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the License.
 
 集群画像 - Redis 类维度契约。
 
@@ -18,7 +18,7 @@ specific language governing permissions and limitations under the License.
 扩展方式：
     1) 在 :class:`RedisPortraitDimensionCode` 里新增一个 ``EnumField`` 成员
     2) 在下方 ``_DESCRIPTIONS`` 里补一条 description（与成员一一对应）
-    3) 巡检 task 里调 ``ingest_summary(db_type=DBType.Redis, dimension=..., ...)``
+    3) 巡检 task 里调 ``ingest_redis_cluster_summary`` 或 ``ingest_summary(db_type=DBType.Redis, ...)``
        —— 首次运行即自动懒注册到 tb_portrait_dimension_registry
 
 边界：
@@ -48,25 +48,22 @@ class RedisPortraitDimensionCode(StrStructuredEnum):
 
         ingest_summary(
             db_type=DBType.Redis,
-            dimension=RedisPortraitDimensionCode.BIG_KEY,
+            dimension=RedisPortraitDimensionCode.RELIABILITY,
             bk_biz_id=100001,
             cluster_domain="a.b.c",
             report_time=datetime.now(),
-            summary="发现 3 个 >10MB 大 Key，TOP1: user_profile:xxx",
-            detail_url="https:/xxx/redis/big-key/detail?xxx",
+            summary="[全备] 缺备：3 个分片昨日无全备记录",
+            detail_url="",
         )
 
     线程安全：是（枚举本身不可变）
     边界：新增成员建议同步补 :data:`_DESCRIPTIONS`；未登记时 description 返回空串
     """
 
-    # 示例占位成员：单下划线前缀表明"仅作模板，非正式业务维度"，
-    # Redis 首个真实巡检维度落地后应删除本行，避免被误引用。
-    REDIS_EXAMPLE = EnumField("redis_example", _("Redis 示例维度（模板占位，勿在业务代码中引用）"))
-    # 后续正式维度新增示例（保留注释形式作为模板）：
-    # BIG_KEY = EnumField("big_key", _("Redis 大 Key 巡检"))
-    # HOT_KEY = EnumField("hot_key", _("Redis 热 Key 巡检"))
-    # CONFIG_CHECK = EnumField("config_check", _("Redis 配置项巡检"))
+    TOPOLOGY_SCALE = EnumField("topology_scale", _("拓扑与规模"))
+    LOAD_CAPACITY = EnumField("load_capacity", _("负载与容量"))
+    RELIABILITY = EnumField("reliability", _("可靠性与数据安全"))
+    CONFIG_HEALTH = EnumField("config_health", _("配置与组件健康"))
 
     @property
     def description(self) -> str:
@@ -79,14 +76,35 @@ class RedisPortraitDimensionCode(StrStructuredEnum):
 
 
 #: Redis 维度描述表：``<枚举成员> -> description 文本``（模块私有，外部通过成员的 .description 属性访问）
-#: 与枚举成员分离维护的原因：
-#:   1) 保持枚举成员定义单行紧凑
-#:   2) description 通常较长；写在 EnumField 里会破坏 StrStructuredEnum (value/label) 二元约定
-#:   3) 便于集中翻译
-
 _DESCRIPTIONS: Dict[RedisPortraitDimensionCode, StrOrPromise] = {
-    # 与枚举成员一一对应，按需登记；示例：
-    RedisPortraitDimensionCode.REDIS_EXAMPLE: _("Redis 示例维度（模板占位，勿在业务代码中引用）"),
-    # RedisPortraitDimensionCode.BIG_KEY: _("..."),
-    # RedisPortraitDimensionCode.HOT_KEY: _("..."),
+    RedisPortraitDimensionCode.TOPOLOGY_SCALE: _(
+        "集群拓扑结构与规模画像。当前态规模（分片 / proxy / 实例数量、规格、版本、region、亲和性）"
+        "由 skill 生成时通过 Redis 元数据 MCP 拉取，落入报告头，不经本维度摘要表。"
+        "本维度摘要只收拓扑完整性巡检：孤立实例、实例状态非 RUNNING、访问入口绑定与元数据不一致、"
+        "主从或 proxy 可用区亲和性违反、同集群规格不一致。"
+        "summary 以 [孤立实例] / [实例状态] / [亲和性] / [入口] 等前缀区分子检查来源；"
+        "时间窗内无摘要代表拓扑完整、无异常。"
+    ),
+    RedisPortraitDimensionCode.LOAD_CAPACITY: _(
+        "集群负载与容量水位。覆盖 CPU / 内存 / 连接数 / QPS / 磁盘 IO 等负载指标的水位与变化趋势，"
+        "内存容量使用率与增长趋势（重点关注 noeviction 策略集群的内存增长风险），"
+        "以及分片间的负载倾斜与数据倾斜。"
+        "一期暂不写入本维度摘要（容量增长 / 负载倾斜 / 数据倾斜巡检源尚未挂载）；"
+        "时间窗内无摘要代表尚无负载与容量巡检数据，不代表已确认健康。"
+        "本维度不由画像 agent 实时拉 metrics。"
+    ),
+    RedisPortraitDimensionCode.RELIABILITY: _(
+        "集群可靠性与数据安全。覆盖全量备份是否按 schedule 覆盖（缺备 / 偏班 / 失败）、"
+        "TendisPlus 与 SSD 集群从库 binlog 连续性、定期回档演练的成败结果与失败阶段。"
+        "summary 以 [全备] / [binlog] / [回档演练] 等前缀区分来源；"
+        "备份类异常才上报，演练类每次结束必报（含成功样本）。"
+        "时间窗内无摘要代表备份正常且无演练记录。"
+    ),
+    RedisPortraitDimensionCode.CONFIG_HEALTH: _(
+        "集群配置与管控组件健康。覆盖存储节点角色与 INFO REPLICATION 实际状态一致性、"
+        "Predixy INFO Servers 异常与磁盘配置文件漂移等配置巡检，"
+        "以及 redis / proxy exporter 的 down / duplicate / redundant / 跨集群指标串扰等监控组件异常。"
+        "summary 以 [配置] / [exporter] 等前缀区分来源；"
+        "异常才上报，时间窗内无摘要代表配置一致、组件健康。"
+    ),
 }

--- a/dbm-ui/backend/db_report/portrait/redis_ingest.py
+++ b/dbm-ui/backend/db_report/portrait/redis_ingest.py
@@ -36,6 +36,8 @@ from backend.db_report.portrait.sdk import PortraitIngestSDK, ingest_summary
 logger = logging.getLogger("root")
 
 MAX_MSGS_PER_SUMMARY = 8
+# 单条消息上限：8 条 + 前缀 + 「等共 N 项」仍远低于 SDK 4000 字符硬顶，避免硬切把尾巴截掉。
+_MAX_MSG_CHARS = 400
 # 与 weekly_ai_summary._extract_last_ai_block 对齐：无结束标记时最多取 8 行。
 _LEGACY_AI_BLOCK_MAX_LINES = 8
 _ROLLBACK_FALLBACK_CHARS = 800
@@ -53,6 +55,15 @@ def _truncate(text: str, limit: int) -> str:
     return text[:limit]
 
 
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _row_get(row: Any, key: str, default: Any = None) -> Any:
     if isinstance(row, dict):
         return row.get(key, default)
@@ -62,10 +73,9 @@ def _row_get(row: Any, key: str, default: Any = None) -> Any:
 def _cluster_identity(row: Any) -> Tuple[str, int]:
     cluster = _row_get(row, "cluster")
     if cluster is not None and hasattr(cluster, "immute_domain"):
-        return cluster.immute_domain, int(cluster.bk_biz_id)
+        return str(cluster.immute_domain or ""), _safe_int(getattr(cluster, "bk_biz_id", None))
     domain = cluster or _row_get(row, "cluster_domain") or ""
-    bk_biz_id = int(_row_get(row, "bk_biz_id") or 0)
-    return str(domain), bk_biz_id
+    return str(domain), _safe_int(_row_get(row, "bk_biz_id"))
 
 
 def _is_normal_state(state: Any) -> bool:
@@ -73,7 +83,7 @@ def _is_normal_state(state: Any) -> bool:
 
 
 def _build_summary(prefix: str, messages: List[str]) -> str:
-    clipped = list(messages)
+    clipped = [_truncate(m, _MAX_MSG_CHARS) for m in messages]
     if len(clipped) > MAX_MSGS_PER_SUMMARY:
         clipped = clipped[:MAX_MSGS_PER_SUMMARY] + [_("等共 {n} 项").format(n=len(messages))]
     return f"{prefix} " + "；".join(clipped)

--- a/dbm-ui/backend/db_report/portrait/redis_ingest.py
+++ b/dbm-ui/backend/db_report/portrait/redis_ingest.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License as distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the License.
+
+Redis 集群画像摘要上报助手。
+
+职责：
+    - 按集群聚合巡检异常消息，带检查项前缀写入画像摘要表
+    - 吞掉 SDK / ORM 异常，绝不阻断巡检主流程
+
+边界：
+    - 只接 daily 巡检源。所有源一天最多产一条摘要，因此不做写入节流；
+      如需接入高频源（一天多次），必须先补节流，否则会压垮画像摘要的信噪比。
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from django.utils import timezone
+from django.utils.translation import gettext as _
+
+from backend.configuration.constants import DBType
+from backend.db_report.enums import ReportStateType
+from backend.db_report.portrait.exceptions import PortraitSDKBaseException
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.sdk import PortraitIngestSDK, ingest_summary
+
+logger = logging.getLogger("root")
+
+MAX_MSGS_PER_SUMMARY = 8
+# 与 weekly_ai_summary._extract_last_ai_block 对齐：无结束标记时最多取 8 行。
+_LEGACY_AI_BLOCK_MAX_LINES = 8
+_ROLLBACK_FALLBACK_CHARS = 800
+
+
+def _enum_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(getattr(value, "value", value))
+
+
+def _truncate(text: str, limit: int) -> str:
+    if not text or len(text) <= limit:
+        return text or ""
+    return text[:limit]
+
+
+def _row_get(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def _cluster_identity(row: Any) -> Tuple[str, int]:
+    cluster = _row_get(row, "cluster")
+    if cluster is not None and hasattr(cluster, "immute_domain"):
+        return cluster.immute_domain, int(cluster.bk_biz_id)
+    domain = cluster or _row_get(row, "cluster_domain") or ""
+    bk_biz_id = int(_row_get(row, "bk_biz_id") or 0)
+    return str(domain), bk_biz_id
+
+
+def _is_normal_state(state: Any) -> bool:
+    return _enum_value(state) == ReportStateType.NORMAL.value
+
+
+def _build_summary(prefix: str, messages: List[str]) -> str:
+    clipped = list(messages)
+    if len(clipped) > MAX_MSGS_PER_SUMMARY:
+        clipped = clipped[:MAX_MSGS_PER_SUMMARY] + [_("等共 {n} 项").format(n=len(messages))]
+    return f"{prefix} " + "；".join(clipped)
+
+
+def ingest_redis_cluster_summary(
+    *,
+    cluster_domain: str,
+    bk_biz_id: int,
+    dimension: RedisPortraitDimensionCode,
+    prefix: str,
+    messages: List[str],
+    detail_url: str = "",
+) -> None:
+    """按集群写入一条画像摘要。无异常消息时不写。失败只记日志，绝不外抛。"""
+    try:
+        if not messages:
+            return
+
+        summary = _build_summary(prefix, [m for m in messages if m])
+        ingest_summary(
+            db_type=DBType.Redis,
+            dimension=dimension,
+            bk_biz_id=bk_biz_id,
+            cluster_domain=cluster_domain,
+            report_time=timezone.now(),
+            summary=_truncate(summary, PortraitIngestSDK.MAX_SUMMARY_CHARS),
+            detail_url=_truncate(detail_url or "", PortraitIngestSDK.MAX_DETAIL_URL_CHARS),
+        )
+    except PortraitSDKBaseException:
+        logger.exception(
+            "redis portrait ingest sdk failed: domain=%s dim=%s prefix=%s",
+            cluster_domain,
+            getattr(dimension, "value", dimension),
+            prefix,
+        )
+    except Exception:  # noqa
+        logger.exception(
+            "redis portrait ingest failed: domain=%s dim=%s prefix=%s",
+            cluster_domain,
+            getattr(dimension, "value", dimension),
+            prefix,
+        )
+
+
+def ingest_abnormal_cluster_rows(
+    rows: Iterable[Any],
+    *,
+    dimension: RedisPortraitDimensionCode,
+    prefix: Optional[str] = None,
+    prefix_by_subtype: Optional[Dict[str, str]] = None,
+    detail_url: str = "",
+) -> None:
+    """把实例级巡检行按集群（及可选 subtype）聚合成画像摘要。"""
+    try:
+        grouped: Dict[Tuple[str, int, str], List[str]] = defaultdict(list)
+        for row in rows:
+            if _is_normal_state(_row_get(row, "state")):
+                continue
+            domain, bk_biz_id = _cluster_identity(row)
+            if not domain or bk_biz_id <= 0:
+                continue
+            item_prefix = prefix
+            if prefix_by_subtype is not None:
+                item_prefix = prefix_by_subtype.get(_enum_value(_row_get(row, "subtype")), "")
+            if not item_prefix:
+                continue
+            msg = _row_get(row, "msg") or ""
+            grouped[(domain, bk_biz_id, item_prefix)].append(str(msg))
+
+        for (domain, bk_biz_id, item_prefix), messages in grouped.items():
+            ingest_redis_cluster_summary(
+                cluster_domain=domain,
+                bk_biz_id=bk_biz_id,
+                dimension=dimension,
+                prefix=item_prefix,
+                messages=messages,
+                detail_url=detail_url,
+            )
+    except Exception:  # noqa
+        logger.exception(
+            "redis portrait aggregate ingest failed: dim=%s prefix=%s",
+            getattr(dimension, "value", dimension),
+            prefix,
+        )
+
+
+def _extract_rollback_ai_conclusion(task_message: str) -> str:
+    """抽出 task_message 里最后一段 [AI失败分析] 结论；没有则返回空串。"""
+    from backend.db_services.redis.rollback.failure_analysis import AI_ANALYSIS_END_SENTINEL, AI_ANALYSIS_SENTINEL
+
+    if not task_message or AI_ANALYSIS_SENTINEL not in task_message:
+        return ""
+
+    start = task_message.rfind(AI_ANALYSIS_SENTINEL)
+    after_open = task_message[start + len(AI_ANALYSIS_SENTINEL) :]
+    if after_open.startswith(" ") or after_open.startswith("\t"):
+        nl = after_open.find("\n")
+        after_open = after_open[nl + 1 :] if nl >= 0 else ""
+    elif after_open.startswith("\n"):
+        after_open = after_open[1:]
+
+    end = after_open.find(AI_ANALYSIS_END_SENTINEL)
+    if end >= 0:
+        block = after_open[:end].strip()
+    else:
+        block = "\n".join(after_open.splitlines()[:_LEGACY_AI_BLOCK_MAX_LINES]).strip()
+    if not block:
+        return ""
+
+    cost_prefix = _("AI耗时")
+    lines = []
+    for raw in block.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(cost_prefix):
+            continue
+        lines.append(line)
+    return "；".join(lines)
+
+
+def _rollback_extra_text(task_message: str) -> str:
+    """优先用 AI 分析结论；没有才截断原始 task_message。"""
+    conclusion = _extract_rollback_ai_conclusion(task_message)
+    if conclusion:
+        return conclusion
+    extra = (task_message or "").strip()
+    if not extra:
+        return ""
+    return _truncate(extra.replace("\n", " "), _ROLLBACK_FALLBACK_CHARS)
+
+
+def ingest_rollback_exercise_portrait(report) -> None:
+    """回档演练终态：每次一行。SKIPPED / BACKUP_INVALID 不报。"""
+    try:
+        from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
+
+        stage = _enum_value(report.task_stage)
+        if stage in {TaskStage.SKIPPED.value, TaskStage.BACKUP_INVALID.value}:
+            return
+        success = stage == TaskStage.DONE.value
+        result_text = _("成功") if success else _("失败")
+        instance = f"{report.instance_ip}:{report.instance_port}" if report.instance_ip else "-"
+        msg = _("实例 {instance} 演练{result}（阶段 {stage}）").format(instance=instance, result=result_text, stage=stage)
+        extra = _rollback_extra_text(report.task_message or "")
+        if extra:
+            msg = f"{msg}；{extra}"
+        ingest_redis_cluster_summary(
+            cluster_domain=report.cluster_domain,
+            bk_biz_id=report.bk_biz_id,
+            dimension=RedisPortraitDimensionCode.RELIABILITY,
+            prefix=_("[回档演练]"),
+            messages=[msg],
+        )
+    except Exception:  # noqa
+        logger.exception(
+            "redis portrait rollback-exercise ingest failed: domain=%s",
+            getattr(report, "cluster_domain", ""),
+        )

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
@@ -28,6 +28,8 @@ from backend.components import DRSApi, JobApi
 from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_report.enums import ReportStateType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 from backend.flow.consts import SUCCESS_LIST
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils.base.payload_handler import DEFAULT_REDIS_PASSWORD_BATCH_SIZE, PayloadHandler
@@ -667,6 +669,11 @@ def _evaluate_and_report(
             )
     collapsed_rows = _collapse_conf_check_report_rows(report_rows)
     writer.write_redis_reports(collapsed_rows)
+    ingest_abnormal_cluster_rows(
+        collapsed_rows,
+        dimension=RedisPortraitDimensionCode.CONFIG_HEALTH,
+        prefix=_("[配置]"),
+    )
     ok_count = sum(1 for row in collapsed_rows if row["state"] == ReportStateType.NORMAL.value)
     abnormal_count = sum(1 for row in collapsed_rows if row["state"] != ReportStateType.NORMAL.value)
     return ok_count, abnormal_count

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
@@ -532,7 +532,7 @@ class RedisEntryCheckService(BaseService):
                     dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
                     prefix=_("[入口]"),
                 )
-            if not write_ok:
+            else:
                 try:
                     self._requeue_batch_to_redis(candidates_key, batch_cluster_ids)
                     self.log_warning(

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
@@ -19,6 +19,8 @@ from pipeline.core.flow.activity import Service
 from backend.db_meta.enums import ClusterEntryType, InstanceInnerRole
 from backend.db_meta.models import Cluster, ClusterEntry
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
 from backend.db_services.redis.util import is_have_proxy
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils import dns_manage
@@ -524,6 +526,12 @@ class RedisEntryCheckService(BaseService):
                 report_rows,
                 context=f"entry_check batch={batch_num} key={candidates_key}",
             )
+            if write_ok:
+                ingest_abnormal_cluster_rows(
+                    report_rows,
+                    dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+                    prefix=_("[入口]"),
+                )
             if not write_ok:
                 try:
                     self._requeue_batch_to_redis(candidates_key, batch_cluster_ids)

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -260,6 +260,10 @@ class RedisExerciseReportUpdateService(RedisLogCapturingService):
             task_message = embed_failed_node_logs(task_message, report, stage)
             report.mark(stage, task_message=task_message)
             self.log_info(_("Report {} marked as {}").format(report_id, stage))
+            if stage in self.TERMINAL_STAGES:
+                from backend.db_report.portrait.redis_ingest import ingest_rollback_exercise_portrait
+
+                ingest_rollback_exercise_portrait(report)
         except Exception as e:
             self.log_error(_("Failed to update report {}: {}").format(report_id, str(e)))
 
@@ -1396,6 +1400,9 @@ done
         merged_msg = embed_failed_node_logs(merged_msg, report, TaskStage.CLEANUP_FAILED)
         report.mark(TaskStage.CLEANUP_FAILED, task_message=merged_msg)
         self.log_info(_("Report {} marked CLEANUP_FAILED by best-effort cleanup").format(report_id))
+        from backend.db_report.portrait.redis_ingest import ingest_rollback_exercise_portrait
+
+        ingest_rollback_exercise_portrait(report)
 
 
 class RedisExerciseBestEffortCleanupComponent(Component):

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
@@ -85,4 +85,56 @@ def test_get_candidate_clusters_checks_all_clouds_when_bk_cloud_ids_empty(redis_
 
     query.filter.assert_not_called()
 
-    query.filter.assert_not_called()
+
+def test_check_all_clusters_ingests_portrait_and_survives_ingest_failure(redis_affinity_module):
+    config = redis_affinity_module.RedisAffinityCheckConfig(enabled=True, cluster_types=["RedisInstance"])
+    cluster = SimpleNamespace(id=1, immute_domain="a.redis.db", bk_biz_id=1001)
+    warning_row = {
+        "cluster": cluster,
+        "state": redis_affinity_module.ReportStateType.WARNING,
+        "msg": "affinity warning",
+        "subtype": redis_affinity_module.MetaCheckSubType.AffinityViolation,
+    }
+
+    with patch.object(redis_affinity_module, "RedisReportWriter"):
+        checker = redis_affinity_module.RedisAffinityChecker(config)
+
+    with patch.object(redis_affinity_module.BKSubzone, "get_subzone_map", return_value={}), patch.object(
+        redis_affinity_module, "delete_old_meta_check_reports"
+    ), patch.object(redis_affinity_module, "_get_candidate_cluster_ids", return_value=[1]), patch.object(
+        redis_affinity_module, "_fetch_affinity_ignore_cluster_ids", return_value=set()
+    ), patch.object(
+        redis_affinity_module, "_load_affinity_clusters_page", return_value=[cluster]
+    ), patch.object(
+        checker, "_should_ignore_cluster", return_value=False
+    ), patch.object(
+        checker, "_check_cluster_affinity", return_value=[warning_row]
+    ), patch.object(
+        redis_affinity_module, "safe_write_meta_reports"
+    ) as write_mock, patch.object(
+        redis_affinity_module, "ingest_abnormal_cluster_rows"
+    ) as ingest:
+        checker.check_all_clusters()
+
+    write_mock.assert_called_once()
+    ingest.assert_called_once()
+    assert ingest.call_args.kwargs["prefix"] == "[亲和性]"
+    assert ingest.call_args.kwargs["dimension"] == redis_affinity_module.RedisPortraitDimensionCode.TOPOLOGY_SCALE
+
+    with patch.object(redis_affinity_module.BKSubzone, "get_subzone_map", return_value={}), patch.object(
+        redis_affinity_module, "delete_old_meta_check_reports"
+    ), patch.object(redis_affinity_module, "_get_candidate_cluster_ids", return_value=[1]), patch.object(
+        redis_affinity_module, "_fetch_affinity_ignore_cluster_ids", return_value=set()
+    ), patch.object(
+        redis_affinity_module, "_load_affinity_clusters_page", return_value=[cluster]
+    ), patch.object(
+        checker, "_should_ignore_cluster", return_value=False
+    ), patch.object(
+        checker, "_check_cluster_affinity", return_value=[warning_row]
+    ), patch.object(
+        redis_affinity_module, "safe_write_meta_reports"
+    ), patch(
+        "backend.db_report.portrait.redis_ingest.ingest_summary",
+        side_effect=RuntimeError("portrait boom"),
+    ):
+        checker.check_all_clusters()

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_full_backup.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_full_backup.py
@@ -623,3 +623,43 @@ def test_collect_instance_pairs_recently_switched(mock_config):
     assert len(slaves) == 1
     assert "3.3.3.2:30000" in switched
     assert switched["3.3.3.2:30000"] == 6
+
+
+def test_start_ingests_portrait_and_survives_ingest_failure():
+    from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+
+    task = _task()
+    cluster = _make_cluster()
+    row = SimpleNamespace(
+        state=_state().ABNORMAL.value,
+        cluster=cluster.immute_domain,
+        bk_biz_id=cluster.bk_biz_id,
+        msg="missing backup",
+    )
+    cfg = _config()
+    patches = [
+        patch(
+            "backend.db_periodic_task.local_tasks.redis_backup.check_full_backup.RedisBackupCheckConfig.from_settings",
+            return_value=cfg,
+        ),
+        patch("backend.db_periodic_task.local_tasks.redis_backup.check_full_backup.RedisBackupCheckBatchOps"),
+        patch.object(task, "_get_cluster_ids", return_value=[1]),
+        patch.object(task, "_get_cluster_queryset", return_value=[cluster]),
+        patch(_PATCH_FETCH, return_value={cluster.immute_domain: []}),
+        patch.object(task, "_check_cluster_with_retry", return_value=[row]),
+    ]
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patch(
+        "backend.db_periodic_task.local_tasks.redis_backup.check_full_backup.ingest_abnormal_cluster_rows"
+    ) as ingest:
+        task.start()
+
+    ingest.assert_called_once()
+    assert ingest.call_args.kwargs["prefix"] == "[全备]"
+    assert ingest.call_args.kwargs["dimension"] == RedisPortraitDimensionCode.RELIABILITY
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patch(
+        "backend.db_report.portrait.redis_ingest.ingest_summary",
+        side_effect=RuntimeError("portrait boom"),
+    ):
+        task.start()

--- a/dbm-ui/backend/tests/db_report/portrait/test_redis_ingest.py
+++ b/dbm-ui/backend/tests/db_report/portrait/test_redis_ingest.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from backend.configuration.constants import DBType
+from backend.db_report.enums import RedisRollbackExerciseTaskStage as TaskStage
+from backend.db_report.enums import ReportStateType
+from backend.db_report.portrait.exceptions import PortraitSDKBaseException
+from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
+from backend.db_report.portrait.sdk import PortraitIngestSDK
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def redis_ingest():
+    from backend.db_report.portrait import redis_ingest as mod
+
+    return mod
+
+
+def _kwargs(redis_ingest, **overrides):
+    params = dict(
+        cluster_domain="a.redis.db",
+        bk_biz_id=1001,
+        dimension=RedisPortraitDimensionCode.RELIABILITY,
+        prefix="[全备]",
+        messages=["缺备：3 个分片昨日无全备记录"],
+    )
+    params.update(overrides)
+    return params
+
+
+def test_prefix_join(redis_ingest):
+    with patch.object(redis_ingest, "ingest_summary") as ingest:
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest, messages=["缺备 A", "缺备 B"]))
+    assert ingest.call_args.kwargs["summary"] == "[全备] 缺备 A；缺备 B"
+    assert ingest.call_args.kwargs["db_type"] == DBType.Redis
+    assert ingest.call_args.kwargs["dimension"] == RedisPortraitDimensionCode.RELIABILITY
+
+
+def test_truncates_summary_and_detail_url(redis_ingest):
+    with patch.object(redis_ingest, "ingest_summary") as ingest:
+        redis_ingest.ingest_redis_cluster_summary(
+            **_kwargs(
+                redis_ingest,
+                messages=["x" * 5000],
+                detail_url="u" * 2000,
+            )
+        )
+    kwargs = ingest.call_args.kwargs
+    assert len(kwargs["summary"]) == PortraitIngestSDK.MAX_SUMMARY_CHARS
+    assert len(kwargs["detail_url"]) == PortraitIngestSDK.MAX_DETAIL_URL_CHARS
+
+
+def test_sdk_exception_not_raised(redis_ingest):
+    with patch.object(redis_ingest, "ingest_summary", side_effect=PortraitSDKBaseException("portrait boom")):
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest))
+
+
+def test_bare_exception_not_raised(redis_ingest):
+    with patch.object(redis_ingest, "ingest_summary", side_effect=RuntimeError("orm boom")):
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest))
+
+
+def test_skips_empty_messages(redis_ingest):
+    with patch.object(redis_ingest, "ingest_summary") as ingest:
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest, messages=[]))
+    ingest.assert_not_called()
+
+
+def test_always_writes_abnormal(redis_ingest):
+    """只接 daily 源，不做节流：每次有异常都写，重复调用重复写。"""
+    with patch.object(redis_ingest, "ingest_summary") as ingest:
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest))
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest))
+    assert ingest.call_count == 2
+
+
+def test_ingest_abnormal_rows_groups_and_skips_normal(redis_ingest):
+    cluster = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
+    rows = [
+        {"cluster": cluster, "state": ReportStateType.NORMAL, "msg": "ok", "subtype": "alone_instance"},
+        {"cluster": cluster, "state": ReportStateType.ABNORMAL, "msg": "lonely master", "subtype": "alone_instance"},
+        {"cluster": cluster, "state": ReportStateType.WARNING, "msg": "not running", "subtype": "status_abnormal"},
+    ]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_abnormal_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+            prefix_by_subtype={"alone_instance": "[孤立实例]", "status_abnormal": "[实例状态]"},
+        )
+    assert ingest.call_count == 2
+    prefixes = {call.kwargs["prefix"] for call in ingest.call_args_list}
+    assert prefixes == {"[孤立实例]", "[实例状态]"}
+
+
+def test_rollback_skips_skipped_and_backup_invalid(redis_ingest):
+    report = SimpleNamespace(
+        task_stage=TaskStage.SKIPPED.value,
+        instance_ip="1.1.1.1",
+        instance_port=30000,
+        task_message="",
+        cluster_domain="a.redis.db",
+        bk_biz_id=1001,
+    )
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_rollback_exercise_portrait(report)
+        report.task_stage = TaskStage.BACKUP_INVALID.value
+        redis_ingest.ingest_rollback_exercise_portrait(report)
+    ingest.assert_not_called()
+
+
+def test_rollback_writes_terminal_success(redis_ingest):
+    report = SimpleNamespace(
+        task_stage=TaskStage.DONE.value,
+        instance_ip="1.1.1.1",
+        instance_port=30000,
+        task_message="ok",
+        cluster_domain="a.redis.db",
+        bk_biz_id=1001,
+    )
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_rollback_exercise_portrait(report)
+    ingest.assert_called_once()
+    assert ingest.call_args.kwargs["prefix"] == "[回档演练]"
+    assert "成功" in ingest.call_args.kwargs["messages"][0]
+
+
+def test_rollback_prefers_ai_conclusion_over_truncated_logs(redis_ingest):
+    from backend.db_services.redis.rollback.failure_analysis import AI_ANALYSIS_END_SENTINEL, AI_ANALYSIS_SENTINEL
+
+    noisy = "Child pipeline failed\n" + ("ERR " * 200)
+    report = SimpleNamespace(
+        task_stage=TaskStage.ROLLBACK_FAILED.value,
+        instance_ip="1.1.1.1",
+        instance_port=30000,
+        task_message=(
+            f"{noisy}\n{AI_ANALYSIS_SENTINEL} 2026-08-13 13:00:00\n"
+            "原因分类: 构造流程失败\n诊断: 子流程 boom\n建议: 查看 child-root-1\n"
+            "AI耗时: 1.2s\n"
+            f"{AI_ANALYSIS_END_SENTINEL}\n"
+        ),
+        cluster_domain="a.redis.db",
+        bk_biz_id=1001,
+    )
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_rollback_exercise_portrait(report)
+    extra = ingest.call_args.kwargs["messages"][0]
+    assert "原因分类: 构造流程失败" in extra
+    assert "诊断: 子流程 boom" in extra
+    assert "建议: 查看 child-root-1" in extra
+    assert "Child pipeline failed" not in extra
+    assert "AI耗时" not in extra
+    assert "ERR " not in extra
+
+
+def test_rollback_falls_back_to_truncated_task_message(redis_ingest):
+    report = SimpleNamespace(
+        task_stage=TaskStage.ROLLBACK_FAILED.value,
+        instance_ip="1.1.1.1",
+        instance_port=30000,
+        task_message="line1\n" + ("x" * 2000),
+        cluster_domain="a.redis.db",
+        bk_biz_id=1001,
+    )
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_rollback_exercise_portrait(report)
+    extra = ingest.call_args.kwargs["messages"][0]
+    raw_extra = extra.split("；", 1)[1]
+    assert raw_extra.startswith("line1 ")
+    assert len(raw_extra) == redis_ingest._ROLLBACK_FALLBACK_CHARS
+    assert "x" * 2000 not in extra
+
+
+def test_rollback_ai_analysis_failed_falls_back_to_logs(redis_ingest):
+    from backend.db_services.redis.rollback.failure_analysis import AI_ANALYSIS_FAILED_SENTINEL
+
+    report = SimpleNamespace(
+        task_stage=TaskStage.ROLLBACK_FAILED.value,
+        instance_ip="1.1.1.1",
+        instance_port=30000,
+        task_message=f"Child pipeline failed\n{AI_ANALYSIS_FAILED_SENTINEL} t\n诊断: 智能体调用失败",
+        cluster_domain="a.redis.db",
+        bk_biz_id=1001,
+    )
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_rollback_exercise_portrait(report)
+    extra = ingest.call_args.kwargs["messages"][0]
+    assert "Child pipeline failed" in extra

--- a/dbm-ui/backend/tests/db_report/portrait/test_redis_ingest.py
+++ b/dbm-ui/backend/tests/db_report/portrait/test_redis_ingest.py
@@ -60,8 +60,19 @@ def test_truncates_summary_and_detail_url(redis_ingest):
             )
         )
     kwargs = ingest.call_args.kwargs
-    assert len(kwargs["summary"]) == PortraitIngestSDK.MAX_SUMMARY_CHARS
+    assert kwargs["summary"] == "[全备] " + "x" * redis_ingest._MAX_MSG_CHARS
     assert len(kwargs["detail_url"]) == PortraitIngestSDK.MAX_DETAIL_URL_CHARS
+
+
+def test_build_summary_keeps_count_tail_when_msgs_are_long(redis_ingest):
+    msgs = ["x" * 1000] * 10
+    with patch.object(redis_ingest, "ingest_summary") as ingest:
+        redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest, messages=msgs))
+    summary = ingest.call_args.kwargs["summary"]
+    assert summary.startswith("[全备] ")
+    assert summary.endswith("等共 10 项")
+    assert "x" * 1000 not in summary
+    assert len(summary) <= PortraitIngestSDK.MAX_SUMMARY_CHARS
 
 
 def test_sdk_exception_not_raised(redis_ingest):
@@ -86,6 +97,24 @@ def test_always_writes_abnormal(redis_ingest):
         redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest))
         redis_ingest.ingest_redis_cluster_summary(**_kwargs(redis_ingest))
     assert ingest.call_count == 2
+
+
+def test_dirty_cluster_identity_skips_row_not_batch(redis_ingest):
+    good = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
+    dirty = SimpleNamespace(immute_domain="b.redis.db", bk_biz_id=None)
+    rows = [
+        {"cluster": dirty, "state": ReportStateType.ABNORMAL, "msg": "bad biz", "subtype": "alone_instance"},
+        {"cluster": good, "state": ReportStateType.ABNORMAL, "msg": "lonely master", "subtype": "alone_instance"},
+    ]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_abnormal_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+            prefix="[孤立实例]",
+        )
+    ingest.assert_called_once()
+    assert ingest.call_args.kwargs["cluster_domain"] == "a.redis.db"
+    assert ingest.call_args.kwargs["messages"] == ["lonely master"]
 
 
 def test_ingest_abnormal_rows_groups_and_skips_normal(redis_ingest):


### PR DESCRIPTION
新增 Redis 集群画像维度数据注入。

## 具体改动

- **维度契约**：`topology_scale` / `load_capacity` / `reliability` / `config_health` 写清摘要前缀与空窗语义 → 拓扑完整性走维度表，当前态规模由 skill 实时拉 MCP，不经摘要表
- **按集群聚合上报**：`ingest_abnormal_cluster_rows` 跳过 NORMAL 行，按 `(集群, 前缀)` 聚合后写入摘要 → 画像只读维度表，前缀区分 `[孤立实例]` / `[实例状态]` / `[亲和性]` / `[入口]` / `[全备]` / `[binlog]` / `[配置]` / `[exporter]`
- **回档演练终态**：`SKIPPED` / `BACKUP_INVALID` 不报；失败优先抽 `[AI失败分析]` 结论，没有才截断 `task_message` → 摘要可读，不含流水日志
- **失败不阻断巡检**：SDK / ORM 异常只记日志、绝不外抛 → 画像挂了不影响原巡检落库
- **只接 daily 源**：不接 dbmon 心跳、不做 `daily_flip` 节流 → 同一检查项一天最多一条，不产 `[xxx] 已恢复` 翻转行；`load_capacity` 一期无摘要源

## 测试 & 风险

- 单测已覆盖前缀拼接、超长截断、空消息跳过、NORMAL 行过滤、回档 SKIPPED/成功/AI 结论优先/截断兜底，以及亲和性 / 全备巡检 ingest 被调用且失败不抛
- 仅 Redis 画像写侧；原巡检落库路径不变；无 API breaking change
