### PR TITLE
feat(mongodb): 节点角色状态排序、分片拓扑汇总与申请节点数 #19729

### DIFF
--- a/dbm-ui/backend/db_meta/api/cluster/base/graph.py
+++ b/dbm-ui/backend/db_meta/api/cluster/base/graph.py
@@ -29,6 +29,7 @@ class Node:
     node_type: str
     # url: str
     status: str
+    instance_state: str = ""
 
     @staticmethod
     def generate_node_id(ins: Union[StorageInstance, ProxyInstance, ClusterEntry]) -> str:
@@ -85,6 +86,18 @@ class Node:
         else:
             return ins.cluster.status
 
+    @staticmethod
+    def generate_mongo_instance_state(ins: Union[StorageInstance, ProxyInstance, ClusterEntry]) -> str:
+        """Mongo 副本集运行时状态（PRIMARY/SECONDARY/...）；其它类型为空"""
+        if not isinstance(ins, StorageInstance):
+            return ""
+        from django.core.exceptions import ObjectDoesNotExist
+
+        try:
+            return ins.mongodbstorageinstanceext.state or ""
+        except ObjectDoesNotExist:
+            return ""
+
     def __init__(
         self,
         ins: Union[StorageInstance, ProxyInstance, ClusterEntry],
@@ -92,11 +105,13 @@ class Node:
         node_type: str = None,
         # url: str = None,
         status: str = None,
+        instance_state: str = None,
     ):
         self.node_id = node_id or Node.generate_node_id(ins)
         self.node_type = node_type or Node.generate_node_type(ins)
         # self.url = url or Node.generate_url(ins)
         self.status = status or Node.generate_status(ins)
+        self.instance_state = instance_state if instance_state is not None else Node.generate_mongo_instance_state(ins)
         super(Node, self).__init__()
 
 

--- a/dbm-ui/backend/db_meta/api/cluster/mongocluster/detail.py
+++ b/dbm-ui/backend/db_meta/api/cluster/mongocluster/detail.py
@@ -10,30 +10,42 @@ specific language governing permissions and limitations under the License.
 """
 
 import operator
+from collections import defaultdict
 from functools import reduce
-from typing import List
+from typing import Dict, List
 
 from django.db.models import Q
 from django.utils.translation import gettext as _
 
-from backend.db_meta.api.cluster.base.graph import Graphic, Group, LineLabel
+from backend.db_meta.api.cluster.base.graph import Graphic, Group, LineLabel, Node
 from backend.db_meta.enums import AccessLayer, MachineType, MachineTypeInstanceRoleMap
-from backend.db_meta.models import Cluster
-from backend.db_services.mongodb.resources.query import MongoDBListRetrieveResource
+from backend.db_meta.models import Cluster, StorageInstance
+from backend.db_services.mongodb.resources.query import MongoDBListRetrieveResource, mongo_shard_name_sort_key
+
+# 拓扑图分片组 id（前端可按此加宽）
+MONGODB_SHARDS_GROUP_ID = "mongodb_shards"
+
+
+def _add_shard_summary_nodes(graph: Graphic, shard_group: Group, shard_to_insts: Dict[str, List[StorageInstance]]):
+    """每个分片一行：分片名 / ip:port,ip:port,...（不展示单实例状态噪音）"""
+    for shard_name in sorted(shard_to_insts.keys(), key=mongo_shard_name_sort_key):
+        members = sorted(shard_to_insts[shard_name], key=lambda i: (i.machine.ip, i.port))
+        if not members:
+            continue
+        addrs = ["{}:{}".format(m.machine.ip, m.port) for m in members]
+        node_id = "{} / {}".format(shard_name, ",".join(addrs))
+        node = Node(members[0], node_id=node_id, instance_state="")
+        if node in graph.nodes:
+            continue
+        shard_group.add_child(node)
+        graph.nodes.append(node)
 
 
 def scan_cluster(cluster: Cluster) -> Graphic:
     """
-    绘制Mongo Sharded Cluster 的拓扑结构图
-    mongos                             Shard-1:Primary Shard-1:Secondary  Shard-1:Backup
-    mongos                             Shard-2:Primary Shard-2:Secondary  Shard-2:Backup
-    mongos                             Shard-3:Primary Shard-3:Secondary  Shard-3:Backup
-    mongos           configServer      Shard-4:Primary Shard-4:Secondary  Shard-4:Backup
-    mongos           configServer      Shard-5:Primary Shard-5:Secondary  Shard-5:Backup
-    mongos           configServer      Shard-6:Primary Shard-6:Secondary  Shard-6:Backup
-    mongos                             Shard-7:Primary Shard-7:Secondary  Shard-7:Backup
-    mongos                             Shard-8:Primary Shard-8:Secondary  Shard-8:Backup
-    mongos                             Shard-9:Primary Shard-9:Secondary  Shard-9:Backup
+    绘制 Mongo Sharded Cluster 拓扑：
+    访问入口 → Mongos → ConfigServer
+                      → 共 N 分片（每行：shard / addrlist）
     """
     graph = Graphic(node_id=Graphic.generate_graphic_id(cluster))
 
@@ -54,23 +66,28 @@ def scan_cluster(cluster: Cluster) -> Graphic:
         group_name=_("ConfigServer 节点"),
     )
 
-    # 获取各个分片的节点组
+    # 分片合并为一组：共 N 分片，每行 shard / addrlist
     inst_filter = Q(
-        reduce(operator.or_, [Q(instance_role=role) for role in MachineTypeInstanceRoleMap[MachineType.MONOG_CONFIG]]),
+        reduce(operator.or_, [Q(instance_role=role) for role in MachineTypeInstanceRoleMap[MachineType.MONGODB]]),
         cluster=cluster,
         machine_type=MachineType.MONGODB,
     )
     insts, inst_id__shard = MongoDBListRetrieveResource.query_storage_shard(inst_filter)
 
-    shard_groups: List[str] = []
+    shard_to_insts: Dict[str, List[StorageInstance]] = defaultdict(list)
     for inst in insts:
-        shard_group_name = _("分片{} 节点").format(inst_id__shard[inst.id])
-        shard_group = graph.get_or_create_group(group_id=shard_group_name, group_name=shard_group_name)
-        graph.add_node(ins=inst, to_group=shard_group)
-        # mongos -----> 各个shard，关系为：访问
-        if shard_group_name not in shard_groups:
-            graph.add_line(source=mongos_group, target=shard_group, label=LineLabel.Access)
-            shard_groups.append(shard_group_name)
+        shard_name = inst_id__shard.get(inst.id) or ""
+        if not shard_name:
+            continue
+        shard_to_insts[shard_name].append(inst)
+
+    if shard_to_insts and mongos_group:
+        shard_group = graph.get_or_create_group(
+            group_id=MONGODB_SHARDS_GROUP_ID,
+            group_name=_("共{}分片").format(len(shard_to_insts)),
+        )
+        _add_shard_summary_nodes(graph, shard_group, shard_to_insts)
+        graph.add_line(source=mongos_group, target=shard_group, label=LineLabel.Access)
 
     # 获得访问入口节点组
     for proxy_instance in cluster.proxyinstance_set.prefetch_related("bind_entry").all():

--- a/dbm-ui/backend/db_meta/api/cluster/mongorepset/detail.py
+++ b/dbm-ui/backend/db_meta/api/cluster/mongorepset/detail.py
@@ -12,7 +12,7 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext as _
 
 from backend.db_meta.api.cluster.base.graph import Graphic, LineLabel
-from backend.db_meta.enums import InstanceRole, MachineType
+from backend.db_meta.enums import InstanceRole, MachineType, MachineTypeInstanceRoleMap
 from backend.db_meta.models import Cluster
 
 
@@ -23,32 +23,29 @@ def scan_cluster(cluster: Cluster) -> Graphic:
     """
     graph = Graphic(node_id=Graphic.generate_graphic_id(cluster))
 
-    # 获得primary节点访问组
-    m1_inst, m1_primary_group = graph.add_instance_nodes_with_machine_type(
-        cluster=cluster, roles=InstanceRole.MONGO_M1, machine_type=MachineType.MONGODB, group_name=_("M1 Primary 节点")
+    # M1 节点组（元数据角色；运行时 PRIMARY 等状态由 instance_state 展示）
+    m1_inst, m1_group = graph.add_instance_nodes_with_machine_type(
+        cluster=cluster, roles=InstanceRole.MONGO_M1, machine_type=MachineType.MONGODB, group_name=_("M1 节点")
     )
 
-    # 获得secondary节点访问组
+    # secondary 角色节点组（m2…m10），角色列表复用 MachineTypeInstanceRoleMap
     secondary_roles = [
-        InstanceRole.MONGO_M2,
-        InstanceRole.MONGO_M3,
-        InstanceRole.MONGO_M4,
-        InstanceRole.MONGO_M5,
-        InstanceRole.MONGO_M6,
-        InstanceRole.MONGO_M7,
-        InstanceRole.MONGO_M8,
-        InstanceRole.MONGO_M9,
-        InstanceRole.MONGO_M10,
+        role
+        for role in MachineTypeInstanceRoleMap[MachineType.MONGODB]
+        if role not in (InstanceRole.MONGO_M1, InstanceRole.MONGO_BACKUP)
     ]
     for role in secondary_roles:
         _dummy, secondary_group = graph.add_instance_nodes_with_machine_type(
-            cluster=cluster, roles=role, machine_type=MachineType.MONGODB, group_name=_("{} 节点".format(role))
+            cluster=cluster,
+            roles=role,
+            machine_type=MachineType.MONGODB,
+            group_name=_("{} 节点").format(role.value),
         )
-        # m1 primary ----> secondary
+        # m1 ----> secondary
         if secondary_group:
-            graph.add_line(source=m1_primary_group, target=secondary_group, label=LineLabel.Rep)
+            graph.add_line(source=m1_group, target=secondary_group, label=LineLabel.Rep)
 
-    # 获得backup节点访问组
+    # Backup 节点组
     __, backup_group = graph.add_instance_nodes_with_machine_type(
         cluster=cluster, roles=InstanceRole.MONGO_BACKUP, machine_type=MachineType.MONGODB, group_name=_("Backup 节点")
     )
@@ -57,9 +54,9 @@ def scan_cluster(cluster: Cluster) -> Graphic:
     entry = m1_inst.first().bind_entry.first()
     __, entry_group = graph.add_node(entry)
 
-    # 访问入口 ----> m1 primary
-    graph.add_line(source=entry_group, target=m1_primary_group, label=LineLabel.Bind)
-    # m1 primary ----> backup
-    graph.add_line(source=m1_primary_group, target=backup_group, label=LineLabel.Rep)
+    # 访问入口 ----> m1
+    graph.add_line(source=entry_group, target=m1_group, label=LineLabel.Bind)
+    # m1 ----> backup
+    graph.add_line(source=m1_group, target=backup_group, label=LineLabel.Rep)
 
     return graph

--- a/dbm-ui/backend/db_services/mongodb/resources/query.py
+++ b/dbm-ui/backend/db_services/mongodb/resources/query.py
@@ -9,16 +9,31 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import logging
+import re
 from typing import Any, Callable, Dict, List, Tuple
 
-from django.db.models import CharField, ExpressionWrapper, F, Prefetch, Q, QuerySet, Value
-from django.db.models.functions import Concat
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import (
+    Case,
+    CharField,
+    ExpressionWrapper,
+    F,
+    IntegerField,
+    Min,
+    Prefetch,
+    Q,
+    QuerySet,
+    Value,
+    When,
+)
+from django.db.models.functions import Coalesce, Concat
 from django.utils.translation import gettext_lazy as _
 
-from backend.db_meta.enums import ClusterEntryType, ClusterType, InstanceRole, MachineType
+from backend.db_meta.enums import ClusterEntryType, ClusterType, InstanceRole, MachineType, MachineTypeInstanceRoleMap
 from backend.db_meta.models import (
     AppCache,
     ClusterEntry,
+    Machine,
     MongoDBStorageInstanceExt,
     NosqlStorageSetDtl,
     StorageInstanceTuple,
@@ -34,12 +49,58 @@ from backend.db_services.dbbase.resources.query import (
 from backend.db_services.dbbase.resources.query_base import build_empty_and_in_q, build_q_for_domain_by_mongo_instance
 from backend.db_services.dbbase.resources.register import register_resource_decorator
 from backend.db_services.dbresource.handlers import MongoDBShardSpecFilter
+from backend.db_services.ipchooser.handlers.host_handler import HostHandler
 from backend.flow.utils.mongodb.version_utils import get_cluster_live_instance_version
 from backend.ticket.constants import TicketType
 from backend.ticket.models import InstanceOperateRecord
 from backend.utils.time import datetime2str
 
 logger = logging.getLogger("root")
+
+# 集群列表/详情节点展示顺序：m1 → m2…m10 → backup（与 MachineTypeInstanceRoleMap 一致）
+_MONGO_DISPLAY_ROLE_ORDER = [role.value for role in MachineTypeInstanceRoleMap[MachineType.MONGODB]]
+_MONGO_DISPLAY_ROLE_INDEX = {role: idx for idx, role in enumerate(_MONGO_DISPLAY_ROLE_ORDER)}
+
+# 实例/主机列表机型顺序：mongos → config → mongodb
+_MONGO_MACHINE_TYPE_ORDER = [
+    MachineType.MONGOS.value,
+    MachineType.MONOG_CONFIG.value,
+    MachineType.MONGODB.value,
+]
+# 默认排序字段（未传 ordering 时）：集群 → 机型 → 分片 → 角色 → IP → 端口
+_MONGO_INSTANCE_DEFAULT_ORDER = (
+    "cluster__id",
+    "_machine_type_order",
+    "shard",
+    "_role_order",
+    "machine__ip",
+    "port",
+)
+_MONGO_MACHINE_DEFAULT_ORDER = ("_machine_type_order", "_role_order", "ip", "bk_host_id")
+
+
+def mongo_shard_name_sort_key(shard_name: str):
+    """分片名按尾号自然序（s1 < s2 < s10），避免字典序 s1、s10、s11…"""
+    match = re.search(r"(\d+)$", shard_name or "")
+    if match:
+        return (0, int(match.group(1)), shard_name or "")
+    return (1, 0, shard_name or "")
+
+
+def _mongo_machine_type_order_case(field_name: str = "machine_type") -> Case:
+    return Case(
+        *[When(**{field_name: mt}, then=Value(idx)) for idx, mt in enumerate(_MONGO_MACHINE_TYPE_ORDER)],
+        default=Value(9),
+        output_field=IntegerField(),
+    )
+
+
+def _mongo_role_order_case(field_name: str = "instance_role") -> Case:
+    return Case(
+        *[When(**{field_name: role}, then=Value(idx)) for idx, role in enumerate(_MONGO_DISPLAY_ROLE_ORDER)],
+        default=Value(999),
+        output_field=IntegerField(),
+    )
 
 
 class MongoDBExportQueryResourceMixin(CommonExportQueryResourceMixin):
@@ -176,6 +237,8 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
         @param limit: 分页限制
         @param offset: 分页起始
         """
+        # 预取运行时状态，供列表/详情节点字段 mongodb_state 使用
+        storage_queryset = storage_queryset.select_related("mongodbstorageinstanceext")
         storage_instance_queryset = StorageInstance.objects.prefetch_related(
             Prefetch(
                 "as_ejector",
@@ -188,7 +251,7 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
         cluster_queryset = cluster_queryset.prefetch_related(
             Prefetch(
                 "storageinstance_set",
-                queryset=storage_instance_queryset.select_related("machine"),
+                queryset=storage_instance_queryset.select_related("machine", "mongodbstorageinstanceext"),
                 to_attr="storage_instances",
             ),
             Prefetch(
@@ -208,6 +271,38 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
             **kwargs,
         )
 
+    @staticmethod
+    def _get_storage_mongodb_state(storage: StorageInstance):
+        """读取巡检写入的运行时状态；无扩展记录时返回 None"""
+        try:
+            return storage.mongodbstorageinstanceext.state
+        except ObjectDoesNotExist:
+            return None
+
+    @classmethod
+    def _to_mongo_storage_node_desc(cls, storage: StorageInstance, seg_range: str = "", with_seg_range: bool = False):
+        """storage 节点描述：simple_desc + 元数据角色 + 运行时状态（可选分片名）"""
+        desc = {
+            **storage.simple_desc,
+            "instance_role": storage.instance_role,
+            "mongodb_state": cls._get_storage_mongodb_state(storage),
+        }
+        if with_seg_range and seg_range:
+            desc["seg_range"] = seg_range
+        return desc
+
+    @classmethod
+    def _sort_mongo_storages(cls, storages: List[StorageInstance], ip_port_to_seg: Dict[str, str]):
+        """按分片名（自然序）→ 角色(m1…backup) → ip → port 排序"""
+
+        def sort_key(storage: StorageInstance):
+            ip_port = f"{storage.machine.ip}:{storage.port}"
+            seg = ip_port_to_seg.get(ip_port, "")
+            role_idx = _MONGO_DISPLAY_ROLE_INDEX.get(storage.instance_role, 999)
+            return (mongo_shard_name_sort_key(seg), role_idx, storage.machine.ip, storage.port)
+
+        return sorted(storages, key=sort_key)
+
     @classmethod
     def _to_cluster_representation(
         cls,
@@ -225,19 +320,66 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
     ) -> Dict[str, Any]:
         """将集群对象转为可序列化的 dict 结构"""
         mongodb_insts = [m for m in cluster.storages if m.machine.machine_type == MachineType.MONGODB]
+        mongo_config_insts = [m for m in cluster.storages if m.machine.machine_type == MachineType.MONOG_CONFIG]
 
-        # 获取mongos/mongodb/mongo_config的角色信息
-        mongodb = [m.simple_desc for m in mongodb_insts]
-        mongo_config = [m.simple_desc for m in cluster.storages if m.machine.machine_type == MachineType.MONOG_CONFIG]
-        mongos = [
-            {
-                **m.simple_desc,
-                "bk_sub_zone_id": m.machine.bk_sub_zone_id,
-                "bk_sub_zone": m.machine.bk_sub_zone,
-                "bk_city": cluster.region,
-            }
-            for m in cluster.proxies
+        machine_list = [
+            (storage_set_dtl.seg_range, f"{storage_set_dtl.instance.machine.ip}:{storage_set_dtl.instance.port}")
+            for storage_set_dtl in cluster.storage_set_dtl
         ]
+
+        machine_map = {}
+        for group_name, machine_ip_port in machine_list:
+            if not machine_map.get(group_name):
+                machine_map[group_name] = [machine_ip_port]
+            else:
+                machine_map[group_name].append(machine_ip_port)
+
+        master_slave_map = {}
+        for instance in cluster.storage_instances:
+            for instance_tuple in instance.instance_tuples:
+                key = f"{instance.machine.ip}:{instance.port}"
+                item = f"{instance_tuple.receiver.machine.ip}:{instance_tuple.receiver.port}"
+                if not master_slave_map.get(key):
+                    master_slave_map[key] = [item]
+                else:
+                    master_slave_map[key].append(item)
+
+        for k, v in master_slave_map.items():
+            for group_name, ip_port_list in machine_map.items():
+                if k in ip_port_list:
+                    machine_map[group_name].extend(v)
+
+        # ip:port → seg_range，用于 ShardSvr 排序与字段
+        ip_port_to_seg: Dict[str, str] = {}
+        for group_name, ip_port_list in machine_map.items():
+            for ip_port in ip_port_list:
+                ip_port_to_seg[ip_port] = group_name
+
+        is_sharded = cluster.cluster_type == ClusterType.MongoShardedCluster
+        mongodb_insts = cls._sort_mongo_storages(mongodb_insts, ip_port_to_seg)
+        mongo_config_insts = cls._sort_mongo_storages(mongo_config_insts, {})
+
+        mongodb = [
+            cls._to_mongo_storage_node_desc(
+                m,
+                seg_range=ip_port_to_seg.get(f"{m.machine.ip}:{m.port}", ""),
+                with_seg_range=is_sharded,
+            )
+            for m in mongodb_insts
+        ]
+        mongo_config = [cls._to_mongo_storage_node_desc(m) for m in mongo_config_insts]
+        mongos = sorted(
+            [
+                {
+                    **m.simple_desc,
+                    "bk_sub_zone_id": m.machine.bk_sub_zone_id,
+                    "bk_sub_zone": m.machine.bk_sub_zone,
+                    "bk_city": cluster.region,
+                }
+                for m in cluster.proxies
+            ],
+            key=lambda node: (node["ip"], node["port"]),
+        )
 
         # 获取mongodb的分片数和单分片实例数
         if cluster.cluster_type == ClusterType.MongoReplicaSet:
@@ -269,33 +411,6 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
             machine_pair=mongodb_machine_pair,
         )
         shard_spec = MongoDBShardSpecFilter.get_shard_spec(mongodb_spec, shard_num)
-
-        machine_list = [
-            (storage_set_dtl.seg_range, f"{storage_set_dtl.instance.machine.ip}:{storage_set_dtl.instance.port}")
-            for storage_set_dtl in cluster.storage_set_dtl
-        ]
-
-        machine_map = {}
-        for group_name, machine_ip_port in machine_list:
-            if not machine_map.get(group_name):
-                machine_map[group_name] = [machine_ip_port]
-            else:
-                machine_map[group_name].append(machine_ip_port)
-
-        master_slave_map = {}
-        for instance in cluster.storage_instances:
-            for instance_tuple in instance.instance_tuples:
-                key = f"{instance.machine.ip}:{instance.port}"
-                item = f"{instance_tuple.receiver.machine.ip}:{instance_tuple.receiver.port}"
-                if not master_slave_map.get(key):
-                    master_slave_map[key] = [item]
-                else:
-                    master_slave_map[key].append(item)
-
-        for k, v in master_slave_map.items():
-            for group_name, ip_port_list in machine_map.items():
-                if k in ip_port_list:
-                    machine_map[group_name].extend(v)
 
         cluster_extra_info = {
             "machine_instance_num": machine_instance_num,
@@ -348,6 +463,14 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
         return super().update_instance_ext_info(resource_list)
 
     @classmethod
+    def _mongo_instance_order_by(cls, query_params: Dict[str, str]) -> Tuple[str, ...]:
+        """实例列表排序：显式 ordering 优先，否则按机型/分片/角色稳定排序"""
+        ordering = (query_params.get("ordering") or "").strip()
+        if ordering:
+            return tuple(part.strip() for part in ordering.split(",") if part.strip())
+        return _MONGO_INSTANCE_DEFAULT_ORDER
+
+    @classmethod
     def _filter_instance_qs(cls, query_filters: Q, query_params: Dict[str, str]) -> QuerySet:
         """获取过滤的queryset"""
         fields = [
@@ -375,7 +498,10 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
             "machine__bk_svr_device_cls_name",
             "shard",
             "bind_entry__entry",
+            "_machine_type_order",
+            "_role_order",
         ]
+        order_by = cls._mongo_instance_order_by(query_params)
 
         # 过滤实例域名
         if "domain" in query_params:
@@ -391,6 +517,8 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
                     ),
                     output_field=CharField(),
                 ),
+                _machine_type_order=_mongo_machine_type_order_case("machine__machine_type"),
+                _role_order=_mongo_role_order_case("instance_role"),
             )
             .select_related("machine")
             .prefetch_related(
@@ -399,23 +527,103 @@ class MongoDBListRetrieveResource(query.ListRetrieveResource, MongoDBExportQuery
             .filter(query_filters)
         )
         if query_params.get("shard"):
-            return storage_instance.filter(shard__in=query_params["shard"].split(",")).distinct().values(*fields)
+            return (
+                storage_instance.filter(shard__in=query_params["shard"].split(","))
+                .distinct()
+                .values(*fields)
+                .order_by(*order_by)
+            )
+
+        mongodb_state = query_params.get("mongodb_state", "")
+        if mongodb_state:
+            # 根据副本集状态字段过滤（需在 values 前过滤）
+            mongo_state_filters = (build_empty_and_in_q("mongodbstorageinstanceext__state", mongodb_state),)
+            return storage_instance.filter(*mongo_state_filters).distinct().values(*fields).order_by(*order_by)
+
         storage_instance = storage_instance.values(*fields)
         proxy_instance = (
-            ProxyInstance.objects.annotate(role=F("access_layer"), shard=Value(""))
+            ProxyInstance.objects.annotate(
+                role=F("access_layer"),
+                shard=Value(""),
+                _machine_type_order=_mongo_machine_type_order_case("machine__machine_type"),
+                _role_order=Value(0, output_field=IntegerField()),
+            )
             .select_related("machine")
             .prefetch_related("cluster")
             .filter(query_filters & Q(bind_entry__cluster_entry_type=ClusterEntryType.DNS.value))  # 过滤实例域名
             .values(*fields)
         )
-        mongodb_state = query_params.get("mongodb_state", "")
-        ordering = query_params.get("ordering", "-create_at")
-        if mongodb_state:
-            # 根据副本集状态字段过滤
-            mongo_state_filters = (build_empty_and_in_q("mongodbstorageinstanceext__state", mongodb_state),)
-            return storage_instance.filter(*mongo_state_filters).distinct().order_by(ordering)
 
-        return storage_instance.union(proxy_instance).order_by(ordering)
+        return storage_instance.union(proxy_instance).order_by(*order_by)
+
+    @classmethod
+    def _filter_machine_hook(
+        cls,
+        bk_biz_id,
+        machine_queryset: QuerySet,
+        limit: int,
+        offset: int,
+        **kwargs,
+    ) -> ResourceList:
+        """主机列表按机型 → 角色(m1…backup) → IP 排序（替代默认 -create_at）"""
+        machine_queryset = machine_queryset.annotate(
+            _machine_type_order=_mongo_machine_type_order_case("machine_type"),
+            _role_order=Coalesce(
+                Min(_mongo_role_order_case("storageinstance__instance_role")),
+                Case(
+                    When(machine_type=MachineType.MONGOS.value, then=Value(0)),
+                    default=Value(999),
+                    output_field=IntegerField(),
+                ),
+            ),
+        ).order_by(*_MONGO_MACHINE_DEFAULT_ORDER)
+
+        count = machine_queryset.count()
+        limit = count if limit == -1 else limit
+        if count == 0:
+            return ResourceList(count=0, data=[])
+
+        machine_queryset = machine_queryset[offset : limit + offset].prefetch_related(
+            "storageinstance_set__cluster", "proxyinstance_set__cluster"
+        )
+
+        bk_host_ids = list(machine_queryset.values_list("bk_host_id", flat=True))
+        host_id_info_map = {host["host_id"]: host for host in HostHandler.check([], [], [], bk_host_ids)}
+
+        machine_infos: List[Dict[str, Any]] = []
+        for machine in machine_queryset:
+            machine_infos.append(cls._to_machine_representation(machine, host_id_info_map, **kwargs))
+
+        return ResourceList(count=count, data=machine_infos)
+
+    @classmethod
+    def _get_machine_extra_info(cls, machine: Machine) -> dict:
+        """关联实例按角色排序，instance_role 取排序后首个"""
+        storages = list(machine.storageinstance_set.all())
+        proxies = list(machine.proxyinstance_set.all())
+
+        if storages:
+            sorted_storages = cls._sort_mongo_storages(storages, {})
+            instances = [inst.simple_desc for inst in sorted_storages]
+            instance_role = sorted_storages[0].instance_role
+        elif proxies:
+            sorted_proxies = sorted(proxies, key=lambda inst: (inst.machine.ip, inst.port))
+            instances = [inst.simple_desc for inst in sorted_proxies]
+            instance_role = sorted_proxies[0].access_layer
+        else:
+            instances, instance_role = [], ""
+
+        related_clusters_map: Dict[int, List[Dict]] = {}
+        for inst in [*storages, *proxies]:
+            cluster = inst.cluster.first()
+            if cluster:
+                related_clusters_map[cluster.id] = cluster.to_dict()
+
+        return {
+            "instance_role": instance_role,
+            "related_instances": instances,
+            "related_clusters": related_clusters_map.values(),
+        }
 
     @classmethod
     def _filter_instance_hook(cls, bk_biz_id, query_params, instances, **kwargs):

--- a/dbm-ui/backend/tests/db_services/mongodb/resources/test_query.py
+++ b/dbm-ui/backend/tests/db_services/mongodb/resources/test_query.py
@@ -212,6 +212,18 @@ class TestMongoDBListRetrieveResource:
         assert "shard_node_count" in cluster_info
         assert cluster_info["shard_num"] == 1  # 副本集分片数为1
 
+        # 节点带角色/状态字段，且按 m1 → m2 → … → backup 排序
+        assert cluster_info["mongodb"]
+        for node in cluster_info["mongodb"]:
+            assert "instance_role" in node
+            assert "mongodb_state" in node
+            assert "seg_range" not in node  # 副本集不带分片名
+        role_order = [node["instance_role"] for node in cluster_info["mongodb"]]
+        from backend.db_services.mongodb.resources.query import _MONGO_DISPLAY_ROLE_INDEX
+
+        role_indexes = [_MONGO_DISPLAY_ROLE_INDEX.get(role, 999) for role in role_order]
+        assert role_indexes == sorted(role_indexes)
+
     @patch("backend.db_services.ipchooser.query.resource.ResourceQueryHelper.search_cc_cloud")
     @patch("backend.db_meta.models.AppCache.objects.get")
     def test_to_cluster_representation_sharded(
@@ -288,6 +300,43 @@ class TestMongoDBListRetrieveResource:
         assert "seg_range" in cluster_info
         assert cluster_info["shard_num"] > 1  # 分片集群分片数大于1
 
+        # ShardSvr：角色/状态/分片名；按 seg_range → 角色排序
+        assert cluster_info["mongodb"]
+        for node in cluster_info["mongodb"]:
+            assert "instance_role" in node
+            assert "mongodb_state" in node
+            assert node.get("seg_range")
+        from backend.db_services.mongodb.resources.query import (
+            _MONGO_DISPLAY_ROLE_INDEX,
+            mongo_shard_name_sort_key,
+        )
+
+        shard_keys = [
+            (
+                mongo_shard_name_sort_key(node["seg_range"]),
+                _MONGO_DISPLAY_ROLE_INDEX.get(node["instance_role"], 999),
+                node["ip"],
+                node["port"],
+            )
+            for node in cluster_info["mongodb"]
+        ]
+        assert shard_keys == sorted(shard_keys)
+
+        # ConfigSvr：角色有序
+        if cluster_info["mongo_config"]:
+            for node in cluster_info["mongo_config"]:
+                assert "instance_role" in node
+                assert "mongodb_state" in node
+            config_indexes = [
+                _MONGO_DISPLAY_ROLE_INDEX.get(node["instance_role"], 999) for node in cluster_info["mongo_config"]
+            ]
+            assert config_indexes == sorted(config_indexes)
+
+        # Mongos：按 ip → port 排序
+        if cluster_info["mongos"]:
+            mongos_keys = [(node["ip"], node["port"]) for node in cluster_info["mongos"]]
+            assert mongos_keys == sorted(mongos_keys)
+
     def test_list_instances_with_cluster_type_filter(self, mongodb_replicaset_cluster):
         """测试按集群类型过滤实例"""
         cluster = mongodb_replicaset_cluster
@@ -322,16 +371,43 @@ class TestMongoDBListRetrieveResource:
         # 验证返回的是QuerySet
         assert instances is not None
 
+    def test_filter_instance_qs_default_role_order(self, mongodb_replicaset_cluster):
+        """实例列表默认按 m1 → … → backup 排序"""
+        from backend.db_services.mongodb.resources.query import _MONGO_DISPLAY_ROLE_INDEX
+
+        cluster = mongodb_replicaset_cluster
+        query_filters = Q(cluster__id=cluster.id)
+        rows = list(MongoDBListRetrieveResource._filter_instance_qs(query_filters, {}))
+        roles = [row["role"] for row in rows]
+        indexes = [_MONGO_DISPLAY_ROLE_INDEX.get(role, 999) for role in roles]
+        assert indexes == sorted(indexes)
+
     def test_filter_instance_qs_storage_and_proxy(self, mongodb_sharded_cluster):
-        """测试过滤实例查询集 - 同时包含存储和代理实例"""
+        """测试过滤实例查询集 - 同时包含存储和代理实例；默认 mongos → config → shard 角色序"""
+        from backend.db_services.mongodb.resources.query import (
+            _MONGO_DISPLAY_ROLE_INDEX,
+            _MONGO_MACHINE_TYPE_ORDER,
+        )
+
         cluster = mongodb_sharded_cluster
         query_filters = Q(cluster__id=cluster.id)
         query_params = {}
 
-        instances = MongoDBListRetrieveResource._filter_instance_qs(query_filters, query_params)
+        rows = list(MongoDBListRetrieveResource._filter_instance_qs(query_filters, query_params))
+        assert rows
 
-        # 验证返回包含实例信息
-        assert instances is not None
+        machine_type_index = {mt: idx for idx, mt in enumerate(_MONGO_MACHINE_TYPE_ORDER)}
+        sort_keys = [
+            (
+                machine_type_index.get(row["machine__machine_type"], 9),
+                row.get("shard") or "",
+                _MONGO_DISPLAY_ROLE_INDEX.get(row["role"], 0 if row["machine__machine_type"] == "mongos" else 999),
+                row["machine__ip"],
+                row["port"],
+            )
+            for row in rows
+        ]
+        assert sort_keys == sorted(sort_keys)
 
     def test_to_instance_representation(self, mongodb_replicaset_cluster):
         """测试实例信息转换"""

--- a/dbm-ui/backend/ticket/builders/mongodb/mongo_shard_apply.py
+++ b/dbm-ui/backend/ticket/builders/mongodb/mongo_shard_apply.py
@@ -146,7 +146,10 @@ class MongoShardedClusterResourceParamBuilder(BaseMongoDBOperateResourceParamBui
         )
 
         resource_spec = self.ticket_data["resource_spec"]
-        self.format_mongo_resource_spec(resource_spec, self.ticket_data["shard_machine_group"])
+        # 每组 shardsvr 成员数 = mongodb.count / shard_machine_group（勿用默认 3 覆盖用户填写）
+        shard_machine_group = self.ticket_data["shard_machine_group"]
+        shardsvr_members = resource_spec["mongodb"]["count"] // shard_machine_group
+        self.format_mongo_resource_spec(resource_spec, shard_machine_group, shard_count=shardsvr_members)
 
     def post_callback(self):
         with self.next_flow_manager() as next_flow:


### PR DESCRIPTION
## Summary
- Mongo 集群/实例/主机列表默认按角色语义排序，并返回 `instance_role` / `mongodb_state` / `seg_range`
- 拓扑 Node 增加 `instance_state`；分片拓扑合并为「共 N 分片」每行 `shard / addrlist`
- 副本集拓扑组名改为 M1/M2/Backup；SHARD_APPLY 按用户填写的节点数申请（不再强制 3）

## Test plan
- [ ] 副本集/分片集群列表与详情接口字段与排序符合预期
- [ ] 分片拓扑图展示「共 N 分片」汇总行
- [ ] `MONGODB_SHARD_APPLY` 填 mongodb.count=4 时实际申请 4 台 shardsvr
- [ ] 相关单测通过

close #19729


Made with [Cursor](https://cursor.com)