### PR TITLE
fix(redis): keep exercise ticket running on scene preserve #19870

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/task.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup_rollback/task.py
@@ -62,7 +62,7 @@ EXPECTED_CLEANUP_CHILD_BY_STATUS = {
 
 REASON_MISSING_CLEANUP = "missing_cleanup_child"
 REASON_NON_TERMINAL_TIMEOUT = "non_terminal_timeout"
-# SCENE_PRESERVED: wait for DBA skip+cleanup; do not flag as missing_cleanup
+# SCENE_PRESERVED: wait for DBA confirmation and cleanup; do not flag as missing_cleanup
 REASON_SCENE_PRESERVED = "scene_preserved"
 
 
@@ -251,7 +251,7 @@ def collect_redis_rollback_exercise_ticket_anomalies(
                     bk_biz_id=ticket.bk_biz_id,
                     status=ticket.status,
                     reason=REASON_SCENE_PRESERVED,
-                    detail=_("现场保留待排查，需人工在页面跳过后清理"),
+                    detail=_("现场保留待排查，需完成人工确认后清理"),
                     update_at=ticket.update_at,
                     create_at=ticket.create_at,
                     url=ticket.url,
@@ -400,7 +400,7 @@ def repair_stuck_redis_rollback_exercise():
     overdue_cutoff = now - timedelta(seconds=polling_timeout)
     long_overdue_cutoff = now - timedelta(seconds=polling_timeout * 3)
 
-    # SCENE_PRESERVED is omitted on purpose: never auto-wakeup; DBA skip on the page.
+    # SCENE_PRESERVED is omitted on purpose: never auto-wakeup; DBA confirmation is required.
     # Wakeup also guards FAILED runner nodes.
     reports = list(
         Report.objects.filter(

--- a/dbm-ui/backend/db_report/enums/redis_rollback_exercise_task_stage.py
+++ b/dbm-ui/backend/db_report/enums/redis_rollback_exercise_task_stage.py
@@ -46,6 +46,6 @@ FAILED_STAGES = [
     RedisRollbackExerciseTaskStage.RESOURCE_APPLI_FAILED,
     RedisRollbackExerciseTaskStage.ROLLBACK_FAILED,
     RedisRollbackExerciseTaskStage.CLEANUP_FAILED,
-    # Count as failed: weights the cluster now; DBA skip later marks a terminal failure
+    # Count as failed: weights the cluster now; DBA confirmation later marks a terminal failure
     RedisRollbackExerciseTaskStage.SCENE_PRESERVED,
 ]

--- a/dbm-ui/backend/db_report/models/redis_rollback_exercise_report.py
+++ b/dbm-ui/backend/db_report/models/redis_rollback_exercise_report.py
@@ -180,7 +180,7 @@ class RedisRollbackExerciseReport(BaseReportABS):
 
                 case TaskStage.SCENE_PRESERVED:
                     # Scene still open: do not set task_end_time.
-                    # DBA skip later marks ROLLBACK_FAILED/CLEANUP_FAILED and fills it.
+                    # DBA confirmation later marks ROLLBACK_FAILED/CLEANUP_FAILED and fills it.
                     self.recover_end_time = timezone.now()
                     self.state = ReportStateType.ABNORMAL
                     update_fields.extend(["recover_end_time", "state"])

--- a/dbm-ui/backend/db_services/redis/rollback/config.py
+++ b/dbm-ui/backend/db_services/redis/rollback/config.py
@@ -73,8 +73,8 @@ class RedisRollbackExerciseConfig:
     not_exercised_days_threshold: int = 180  # Days threshold for "not exercised" status
 
     # Error handling
-    # False (default): on child failure/timeout, stop and keep the scene
-    # (temp instances and child pipelines stay) until DBA skips the node; then mark failed and clean up.
+    # False (default): on child failure/timeout, keep the scene and wait at a manual
+    # confirmation node; the ticket remains RUNNING so sibling branches can continue.
     # True: legacy behavior — continue and clean up immediately.
     error_ignorable: bool = False
     # Alarm-shield duration (minutes) while the scene is preserved, so temp instances stay quiet.

--- a/dbm-ui/backend/db_services/redis/rollback/failure_analysis.py
+++ b/dbm-ui/backend/db_services/redis/rollback/failure_analysis.py
@@ -101,7 +101,7 @@ def enqueue_exercise_failure_analysis(report_id: int, countdown: int = AI_ANALYS
     Safe to call from ``Report.mark()``: never raises. No-ops when AI analysis is
     disabled, the report is missing / not in a failed stage, or a successful AI
     analysis block has already been appended (e.g. enqueued at SCENE_PRESERVED and
-    later marked terminal again after the DBA skips the failed node).
+    later marked terminal again after the DBA completes the confirmation node).
     """
     if not is_exercise_ai_analysis_enabled() or not report_id:
         return False

--- a/dbm-ui/backend/flow/engine/bamboo/scene/common/get_file_list.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/common/get_file_list.py
@@ -287,7 +287,7 @@ class GetFileList(object):
             f"{env.BKREPO_PROJECT}/{env.BKREPO_BUCKET}/{redis_tool_pkg.path}",
             f"{env.BKREPO_PROJECT}/{env.BKREPO_BUCKET}/{bkdbmon_pkg.path}",
         ]
-        if db_version.startswith("Redis-"):
+        if db_version.startswith(("Redis-", "Valkey-")):
             # 如果是 cache Redis,则下发 redis modules 介质
             redismodules_pkg = Package.get_latest_package(
                 version=MediumEnum.Latest, pkg_type=MediumEnum.RedisModules, db_type=DBType.Redis

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure.py
@@ -126,7 +126,7 @@ class RedisDataStructureFlow(object):
         for info in self.data["infos"]:
             sub_pipelines_multi_cluster.append(self.build_cluster_data_structure(info))
         redis_pipeline_all.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines_multi_cluster)
-        redis_pipeline_all.run_pipeline()
+        return redis_pipeline_all.run_pipeline()
 
     def build_cluster_data_structure(self, info: dict):
         """Build a SubProcess for a single cluster's data-structure steps.

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_task_delete.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_data_structure_task_delete.py
@@ -103,7 +103,7 @@ class RedisDataStructureTaskDeleteFlow(object):
         for info in self.data["infos"]:
             sub_pipelines_multi_cluster.append(self.build_cluster_task_delete(info))
         redis_pipeline_all.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines_multi_cluster)
-        redis_pipeline_all.run_pipeline()
+        return redis_pipeline_all.run_pipeline()
 
     def build_cluster_task_delete(self, info: dict, tasks_info: dict = None):
         """Build a SubProcess for a single cluster's cleanup/delete steps.

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_rollback_exercise.py
@@ -22,6 +22,7 @@ from backend.db_report.models import RedisRollbackExerciseReport as Report
 from backend.flow.consts import DEFAULT_REDIS_START_PORT
 from backend.flow.engine.bamboo.scene.common.builder import Builder, Conditions, SubBuilder
 from backend.flow.plugins.components.collections.common.disable_alarm_shield import DisableAlarmShieldComponent
+from backend.flow.plugins.components.collections.common.pause import PauseComponent
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
     RedisExerciseBestEffortCleanupComponent,
     RedisExerciseFlowRunnerComponent,
@@ -64,8 +65,8 @@ class RedisRollbackExerciseFlow(object):
                     "drill_config": {
                         "polling_interval": 10,
                         "polling_timeout": 3600,
-                        # False (default): stop and preserve scene on child failure/timeout;
-                        # DBA skip then marks failed and cleans up. True: continue and clean up immediately.
+                        # False (default): preserve the scene and wait at a manual confirmation node.
+                        # True: continue and clean up immediately.
                         "error_ignorable": False,
                         "preserve_scene_shield_minutes": 4320,  # Alarm-shield minutes while the scene is preserved
                     },
@@ -191,13 +192,13 @@ class RedisRollbackExerciseFlow(object):
           - success  -> report_succeeded -> task_delete -> report_done
           - failure  -> report_rollback_failed
 
-        With ``error_ignorable=False`` (preserve mode, default) a failed/timed-out
-        child pipeline makes the runner node FAILED and stops the flow with the
-        scene preserved (report marked SCENE_PRESERVED); after the DBA clicks
-        'skip' on the failed node, the gateway branches on ``rollback_code=1`` to
-        mark the rollback failed, then the main pipeline's best-effort cleanup
-        runs. With ``error_ignorable=True`` the sub-flow never hard-fails and
-        cleanup runs immediately.
+        With ``error_ignorable=False`` (preserve mode, default), a failed/timed-out
+        child pipeline completes the runner with a failure output and pauses only
+        that branch at a manual confirmation node. The parent ticket stays RUNNING,
+        so sibling branches can continue launching child pipelines. After the DBA
+        confirms, the branch marks the failure and the main pipeline's best-effort
+        cleanup runs. With ``error_ignorable=True`` there is no pause and cleanup
+        runs immediately.
         """
         cluster_id = info["cluster_id"]
         instance_ip = info["instance_ip"]
@@ -295,19 +296,20 @@ class RedisRollbackExerciseFlow(object):
           - delete success    -> report_done
           - delete failure    -> no-op (best-effort cleanup reconciles)
 
-        ``error_ignorable=False`` (preserve mode, default) makes the runner node
-        FAILED when its child pipeline fails or times out: the flow stops with the
-        scene preserved (report marked SCENE_PRESERVED, child pipeline not revoked).
-        After the DBA clicks 'skip' on the failed node, the gateway branches on
-        ``rollback_code=1`` / ``delete_code=1`` to mark the failure, and the main
-        pipeline's best-effort cleanup (which first revokes leftover child flows) runs.
-        ``error_ignorable=True`` keeps the legacy behavior: the runner always returns
-        True, failures are expressed only through the gateway branch, and cleanup
-        runs immediately.
+        ``error_ignorable=False`` (preserve mode, default) keeps a failed/timed-out
+        child pipeline for inspection, marks the report SCENE_PRESERVED, and routes
+        ``rollback_code=1`` / ``delete_code=1`` to a manual confirmation node. The
+        runner itself finishes normally, so the ticket stays RUNNING and sibling
+        branches are not blocked. After confirmation, the branch marks the failure
+        and the main pipeline's best-effort cleanup first revokes leftover child
+        flows before removing temporary instances.
+        ``error_ignorable=True`` keeps the legacy behavior without manual
+        confirmation and proceeds to cleanup immediately.
 
-        In preserve mode both runner nodes are also ``retryable=False`` (skip only);
-        the runner service additionally revokes any previous non-terminal child
-        pipeline as a force-retry safety net before submitting a new one.
+        Both runner nodes are ``retryable=False`` because child failures are handled
+        as business outcomes. The runner service additionally revokes any previous
+        non-terminal child pipeline as a force-retry safety net before submitting a
+        new one in preserve mode.
         """
         rollback_runner_act = sub_flow.add_act(
             act_name=_("回档流程"),
@@ -377,17 +379,36 @@ class RedisRollbackExerciseFlow(object):
             extend=False,
         )
 
-        delete_failure_act = success_branch.add_act(
-            act_name=_("标记清理失败 (最佳尝试清理兜底)"),
-            act_component_code=RedisExerciseReportUpdateComponent.code,
-            kwargs={
-                "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
-                "report_id": report_id,
-                "info_index": info_index,
-                "stage": TaskStage.CLEANUP_FAILED,
-            },
-            extend=False,
-        )
+        if error_ignorable:
+            delete_failure_act = success_branch.add_act(
+                act_name=_("标记清理失败 (最佳尝试清理兜底)"),
+                act_component_code=RedisExerciseReportUpdateComponent.code,
+                kwargs={
+                    "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
+                    "report_id": report_id,
+                    "info_index": info_index,
+                    "stage": TaskStage.CLEANUP_FAILED,
+                },
+                extend=False,
+            )
+        else:
+            delete_failure_branch = SubBuilder(root_id=self.root_id, data=success_branch.data)
+            delete_failure_branch.add_act(
+                act_name=_("现场保留：确认清理失败并执行兜底清理"),
+                act_component_code=PauseComponent.code,
+                kwargs={"description": _("排查清理失败现场后，确认继续执行兜底清理")},
+            )
+            delete_failure_branch.add_act(
+                act_name=_("标记清理失败 (最佳尝试清理兜底)"),
+                act_component_code=RedisExerciseReportUpdateComponent.code,
+                kwargs={
+                    "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
+                    "report_id": report_id,
+                    "info_index": info_index,
+                    "stage": TaskStage.CLEANUP_FAILED,
+                },
+            )
+            delete_failure_act = delete_failure_branch.build_sub_process(sub_name=_("清理失败现场确认"))
 
         success_branch.add_conditional_subs(
             source_act=delete_runner_act,
@@ -401,18 +422,37 @@ class RedisRollbackExerciseFlow(object):
 
         success_sub = success_branch.build_sub_process(sub_name=_("回档成功处理"))
 
-        # ---- Failure branch: mark rollback failed ----
-        rollback_failure_act = sub_flow.add_act(
-            act_name=_("标记回档失败"),
-            act_component_code=RedisExerciseReportUpdateComponent.code,
-            kwargs={
-                "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
-                "report_id": report_id,
-                "info_index": info_index,
-                "stage": TaskStage.ROLLBACK_FAILED,
-            },
-            extend=False,
-        )
+        # ---- Failure branch: optionally hold the scene, then mark rollback failed ----
+        if error_ignorable:
+            rollback_failure_act = sub_flow.add_act(
+                act_name=_("标记回档失败"),
+                act_component_code=RedisExerciseReportUpdateComponent.code,
+                kwargs={
+                    "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
+                    "report_id": report_id,
+                    "info_index": info_index,
+                    "stage": TaskStage.ROLLBACK_FAILED,
+                },
+                extend=False,
+            )
+        else:
+            rollback_failure_branch = SubBuilder(root_id=self.root_id, data=sub_flow.data)
+            rollback_failure_branch.add_act(
+                act_name=_("现场保留：确认回档失败并清理"),
+                act_component_code=PauseComponent.code,
+                kwargs={"description": _("排查回档失败现场后，确认标记失败并清理临时实例")},
+            )
+            rollback_failure_branch.add_act(
+                act_name=_("标记回档失败"),
+                act_component_code=RedisExerciseReportUpdateComponent.code,
+                kwargs={
+                    "set_trans_data_dataclass": RedisRollbackExerciseContext.__name__,
+                    "report_id": report_id,
+                    "info_index": info_index,
+                    "stage": TaskStage.ROLLBACK_FAILED,
+                },
+            )
+            rollback_failure_act = rollback_failure_branch.build_sub_process(sub_name=_("回档失败现场确认"))
 
         # ---- Conditional gateway on rollback result ----
         sub_flow.add_conditional_subs(

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_rollback_exercise.py
@@ -317,11 +317,14 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
         setattr(data.outputs, output_var, code)
 
     def _finish_by_child_state(self, data, child_root_id: str, child_state):
-        """Tri-state; callers must propagate the return value:
+        """Handle child state and return whether the runner can complete:
 
-        - True: child finished; schedule completed (finish_schedule already called).
-        - False: terminal preserve — return False so the engine marks this node FAILED and stops.
-        - None: child still running; keep polling.
+        - True: child reached a terminal state; schedule completed.
+        - None: child is still running; keep polling.
+
+        A child failure is a business outcome, not a runner failure. Preserve mode
+        records the scene and lets the following pause node hold this branch for
+        manual confirmation, keeping the parent ticket RUNNING.
         """
         if child_state == StateType.FINISHED:
             self.log_info(_("Child pipeline {} finished successfully").format(child_root_id))
@@ -331,17 +334,19 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
 
         if child_state in (StateType.FAILED, StateType.REVOKED):
             if data.get_one_of_outputs("preserve_scene_on_failure"):
-                # Preserve: do not revoke the child or clean up. Node stays FAILED until DBA skips,
-                # then the gateway marks failure and cleanup runs.
+                # Preserve the child and complete this runner normally. The failure
+                # output routes the branch to a manual-confirmation pause node.
                 self.log_error(
                     _(
                         "Child pipeline {} ended with status {}, scene preserved for manual inspection. "
-                        "Please investigate and click 'skip' on this node to mark the rollback failed and clean up."
+                        "Please investigate and complete the following confirmation node to mark the failure "
+                        "and clean up."
                     ).format(child_root_id, child_state)
                 )
                 self._set_result(data, 1)
                 self._preserve_scene(data, child_root_id)
-                return False
+                self.finish_schedule()
+                return True
 
             self.log_error(_("Child pipeline {} ended with status {}").format(child_root_id, child_state))
             # FAILED means the pipeline errored out but sibling/pending nodes may still be running.
@@ -358,7 +363,8 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
         """Mark this runner's report as SCENE_PRESERVED.
 
         Embed child failure-node logs before mark so task_message keeps evidence.
-        Mark failures are logged only; the node still stays FAILED.
+        Mark failures are logged only; the runner still completes so the
+        following pause node can preserve the scene without failing the ticket.
         """
         kwargs = data.get_one_of_inputs("kwargs") or {}
         report_id = kwargs.get("report_id")
@@ -502,9 +508,17 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
 
         try:
             flow_instance = flow_class(root_id=child_root_id, data=copy.deepcopy(flow_data))
-            getattr(flow_instance, method_name)()
+            launch_result = getattr(flow_instance, method_name)()
         except Exception as e:
             self.log_error(_("Failed to run {} (root_id={}): {}").format(flow_identifier, child_root_id, e))
+            self._set_result(data, 1)
+            self.finish_schedule()
+            return True
+
+        if launch_result is False:
+            self.log_error(
+                _("Child pipeline {} ({}) was rejected before submission").format(child_root_id, flow_identifier)
+            )
             self._set_result(data, 1)
             self.finish_schedule()
             return True
@@ -571,17 +585,19 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
 
         if elapsed > polling_timeout:
             if data.get_one_of_outputs("preserve_scene_on_failure"):
-                # Preserve: do not revoke — the hung child *is* the scene. Node stays FAILED until DBA skip.
+                # Preserve: do not revoke — the hung child is the scene. Complete
+                # the runner and let the following pause node hold the branch.
                 self.log_error(
                     _(
                         "Child pipeline {} timed out after {:.0f}s, still running and scene preserved for manual "
-                        "inspection. Please investigate and click 'skip' on this node to mark the rollback failed "
-                        "and clean up."
+                        "inspection. Please investigate and complete the following confirmation node to mark "
+                        "the failure and clean up."
                     ).format(child_root_id, elapsed)
                 )
                 self._set_result(data, 1)
                 self._preserve_scene(data, child_root_id)
-                return False
+                self.finish_schedule()
+                return True
             self.log_error(_("Child pipeline {} timed out after {:.0f}s").format(child_root_id, elapsed))
             self._terminate_child_pipeline(child_root_id)
             self._set_result(data, 1)
@@ -594,7 +610,7 @@ class RedisExerciseFlowRunnerService(RedisLogCapturingService):
             return True
 
         outcome = self._finish_by_child_state(data, child_root_id, flow_tree.status)
-        # None (still running) -> keep polling (True); True/False pass through (False fails the node).
+        # None (still running) -> keep polling; terminal states finish the runner.
         return True if outcome is None else outcome
 
 

--- a/dbm-ui/backend/flow/signal/README_redis_rollback_exercise.md
+++ b/dbm-ui/backend/flow/signal/README_redis_rollback_exercise.md
@@ -51,35 +51,35 @@
 - 若子流程已终态，复用同一个 `wakeup_redis_rollback_runner_by_child(...)` 进行修复
 - 若超过 `3 * polling_timeout` 仍异常，输出告警日志用于可观测性
 
-## 现场保留与页面跳过
+## 现场保留与人工确认
 
 当 `drill_config.error_ignorable=False`（默认）时，回档演练进入**现场保留模式**：
 
-- 回档/清理子流程 FAILED 或超时后，runner 节点进入 `FAILED` 并停住整个流程；
+- 回档/清理子流程 FAILED 或超时后，runner 以业务失败结果正常结束，并进入对应分支的人工确认节点；
 - **不撤销子流程、不清理现场**：临时机器/实例/子流程全部保留，供人工排查；
 - 报告标为「现场保留待排查」（`SCENE_PRESERVED`，属失败阶段集合），并嵌入子流程失败节点日志；
-- 演练单据转 `FAILED` 并发送失败通知。
+- 演练单据保持 `RUNNING`，其他并行分支可继续派生和执行子流程。
 
 ### DBA 操作步骤
 
 1. 查看失败 runner 节点的日志（页面或报告 `task_message` 中已嵌入子流程失败节点日志）；
 2. 登录临时机排查现场（保留期间告警屏蔽已放大到 `preserve_scene_shield_minutes`，默认 72h）；
-3. 排查完成后在页面点「跳过」该失败节点；
+3. 排查完成后处理「现场保留」人工确认待办；
 4. 流程自动沿条件网关（`rollback_code=1`/`delete_code=1`）标记「回档失败/清理失败」，报告由 `SCENE_PRESERVED` 更新为失败终态（演练最终以失败落库）；
 5. 汇聚后主流程执行「最佳尝试清理」：先 revoke 残留子流程（含树状态 FAILED 但仍有兄弟节点运行的情况），再清理临时实例，单据转 SUCCEEDED 后回收主机。
 
 ### 护栏（自动机制不触碰保留中单据）
 
-- `wakeup_redis_rollback_runner_by_child` 只唤醒仍在运行（RUNNING/CREATED/READY）的 runner 节点，FAILED 节点直接返回并清陈旧缓存；
+- `wakeup_redis_rollback_runner_by_child` 只唤醒仍在运行（RUNNING/CREATED/READY）的 runner 节点；runner 完成后直接返回并清陈旧缓存；
 - `repair_stuck_redis_rollback_exercise` 的过滤集合不含 `SCENE_PRESERVED`，保留中报告永不自动唤醒；
-- 异常巡检对保留中单据报 `scene_preserved` reason（“现场保留待排查，需人工在页面跳过后清理”），不误报 `missing_cleanup_child`；
+- 异常巡检对保留中单据报 `scene_preserved` reason（“现场保留待排查，需完成人工确认后清理”），不误报 `missing_cleanup_child`；
 - `REDIS_ROLLBACK_EXERCISE` 单据超时配置全为 `-1`（无超时自动终止/提醒），`auto_clear_expire_flow` 不会触碰现场保留中的演练单据。
 
 ### 已知取舍
 
-- 保留模式下停住的 runner 节点 `retryable=False`，页面只提供「跳过」；有强制重试权限仍可绕过，但 runner 会在提交新子流程前 revoke report 上遗留的非终态旧子流程，避免孤儿现场；
-- 停住期间单据为 FAILED 且属于运行态集合，持续占用集群互斥，跳过并清理后才释放；
-- 不做超时自动跳过，现场一直保留到人工处理；注意 `clean_bamboo_engine_expired_data`（默认关闭、360 天）按创建时间清理流程数据且不判断终态，现场保留不应跨越数月。
+- runner 节点 `retryable=False`，子流程失败作为业务结果流向人工确认；强制重试时 runner 仍会在提交新子流程前 revoke report 上遗留的非终态旧子流程，避免孤儿现场；
+- 停住期间单据保持 RUNNING，持续占用集群互斥，确认并清理后才释放；
+- 不做超时自动确认，现场一直保留到人工处理；注意 `clean_bamboo_engine_expired_data`（默认关闭、360 天）按创建时间清理流程数据且不判断终态，现场保留不应跨越数月。
 
 ## 触发链路（简版）
 

--- a/dbm-ui/backend/flow/signal/redis_rollback_exercise_handler.py
+++ b/dbm-ui/backend/flow/signal/redis_rollback_exercise_handler.py
@@ -113,8 +113,8 @@ def wakeup_redis_rollback_runner_by_child(child_root_id: str, child_state: str, 
         f"runner_node_id={runner_node_id}, cached={'yes' if cached else 'no'}"
     )
 
-    # Preserve guard: only wake runners that are still active. Cache hits would otherwise
-    # blindly callback FAILED (scene preserved) / FINISHED / REVOKED nodes. Skip is DBA-driven.
+    # Preserve guard: only wake runners that are still active. After a runner records
+    # SCENE_PRESERVED it finishes normally and the separate confirmation node is DBA-driven.
     runner_alive = FlowNode.objects.filter(
         root_id=parent_root_id,
         node_id=runner_node_id,

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup_rollback/test_redis_rollback_exercise.py
@@ -354,7 +354,7 @@ class TestReportStateMapping(TestCase):
         assert TaskStage.SCENE_PRESERVED in REDIS_ROLLBACK_EXER_FAILED_STAGES
 
     def test_mark_scene_preserved_then_rollback_failed_transition(self):
-        """SCENE_PRESERVED does not set task_end_time; DBA skip can overwrite to a terminal failure."""
+        """SCENE_PRESERVED stays open until DBA confirmation marks a terminal failure."""
         report = Report.objects.create(**self.common_kwargs)
 
         report.mark(TaskStage.SCENE_PRESERVED, task_message="scene held")

--- a/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
+++ b/dbm-ui/backend/tests/flow/components/collections/redis/test_redis_rollback_exercise_runner.py
@@ -113,9 +113,9 @@ def _mock_preserved_report():
 
 
 def _assert_scene_preserved(result, data, service, mock_revoke, report):
-    assert result is False
+    assert result is True
     assert data.outputs.rollback_code == 1
-    service.finish_schedule.assert_not_called()
+    service.finish_schedule.assert_called_once()
     mock_revoke.assert_not_called()
     report.mark.assert_called_once()
     assert report.mark.call_args.args[0] == TaskStage.SCENE_PRESERVED
@@ -287,6 +287,24 @@ def test_execute_flow_launch_exception_sets_code_1():
     assert result is True
     assert data.outputs.rollback_code == 1
     service.finish_schedule.assert_called_once()
+
+
+def test_execute_rejected_child_launch_sets_code_1_without_recording_fake_child():
+    service, data = _execute()
+
+    with patch(f"{RUNNER_MOD}.generate_root_id", return_value=CHILD_ROOT_ID), patch(
+        f"{RUNNER_MOD}.RedisDataStructureFlow.redis_data_structure_flow", return_value=False
+    ), patch(f"{RUNNER_MOD}.Report.objects.filter") as mock_report_filter, patch(
+        f"{RUNNER_MOD}.cache.set"
+    ) as mock_cache_set:
+        result = service._execute_inner_captured(data, parent_data=None)
+
+    assert result is True
+    assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
+    mock_report_filter.assert_not_called()
+    mock_cache_set.assert_not_called()
+    assert not hasattr(data.outputs, "child_root_id")
 
 
 # ==================== Best-effort cleanup guards ====================
@@ -507,7 +525,7 @@ def test_cleanup_script_removes_only_allowlisted_work_dirs():
 @patch(f"{RUNNER_MOD}.Report.objects.get")
 @patch(f"{RUNNER_MOD}.BambooEngine.revoke_pipeline")
 @patch(f"{RUNNER_MOD}.FlowTree.objects.get")
-def test_failed_preserve_marks_scene_and_returns_false(
+def test_failed_preserve_marks_scene_and_finishes_runner(
     mock_flowtree_get, mock_revoke, mock_report_get, _mock_embed, child_state, via
 ):
     mock_flowtree_get.return_value = SimpleNamespace(status=child_state)
@@ -527,7 +545,7 @@ def test_failed_preserve_marks_scene_and_returns_false(
 @patch(EMBED_PATCH, return_value=_EMBEDDED_LOGS)
 @patch(f"{RUNNER_MOD}.Report.objects.get")
 @patch(f"{RUNNER_MOD}.BambooEngine.revoke_pipeline", return_value=_OK_REVOKE)
-def test_timeout_preserve_does_not_revoke_and_returns_false(mock_revoke, mock_report_get, _mock_embed):
+def test_timeout_preserve_does_not_revoke_and_finishes_runner(mock_revoke, mock_report_get, _mock_embed):
     report = _mock_preserved_report()
     mock_report_get.return_value = report
     service = _make_runner()
@@ -539,15 +557,16 @@ def test_timeout_preserve_does_not_revoke_and_returns_false(mock_revoke, mock_re
 
 @patch(f"{RUNNER_MOD}.Report.objects.get")
 @patch(f"{RUNNER_MOD}.BambooEngine.revoke_pipeline")
-def test_callback_failed_preserve_report_missing_still_returns_false(mock_revoke, mock_report_get):
+def test_callback_failed_preserve_report_missing_still_finishes_runner(mock_revoke, mock_report_get):
     mock_report_get.side_effect = RedisRollbackExerciseReport.DoesNotExist
     service = _make_runner()
     data = _build_schedule_data(preserve=True)
 
     result = _schedule(service, data, child_state=StateType.FAILED)
 
-    assert result is False
+    assert result is True
     assert data.outputs.rollback_code == 1
+    service.finish_schedule.assert_called_once()
 
 
 @patch(EMBED_PATCH)

--- a/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
+++ b/dbm-ui/backend/tests/flow/engine/bamboo/scene/redis/test_redis_rollback_exercise.py
@@ -11,6 +11,7 @@ from backend.flow.engine.bamboo.scene.redis.revoke.redis_rollback_exercise_revok
     RedisRollbackExerciseRevokeFlow,
 )
 from backend.flow.engine.controller.redis import RedisController
+from backend.flow.plugins.components.collections.common.pause import PauseComponent
 from backend.flow.plugins.components.collections.redis.redis_rollback_exercise import (
     RedisExerciseBestEffortCleanupComponent,
     RedisExerciseBestEffortCleanupService,
@@ -156,13 +157,15 @@ def _build_sub_flow_with_config(drill_config: dict):
 
 
 @pytest.mark.parametrize(
-    "drill_config, error_ignorable, preserve, shield_duration, shield_name_contains",
+    "drill_config, error_ignorable, preserve, pause_count, shield_duration, shield_name_contains",
     [
-        pytest.param({}, False, True, max(3600, 4320 * 60), "4320.0 mins", id="preserve"),
-        pytest.param({"error_ignorable": True}, True, False, 3600, None, id="ignorable"),
+        pytest.param({}, False, True, 2, max(3600, 4320 * 60), "4320.0 mins", id="preserve"),
+        pytest.param({"error_ignorable": True}, True, False, 0, 3600, None, id="ignorable"),
     ],
 )
-def test_build_runner_flow_kwargs(drill_config, error_ignorable, preserve, shield_duration, shield_name_contains):
+def test_build_runner_flow_kwargs(
+    drill_config, error_ignorable, preserve, pause_count, shield_duration, shield_name_contains
+):
     acts = _build_sub_flow_with_config(drill_config)
 
     runner_acts = [a for a in acts if a["act_component_code"] == RedisExerciseFlowRunnerComponent.code]
@@ -171,6 +174,9 @@ def test_build_runner_flow_kwargs(drill_config, error_ignorable, preserve, shiel
         assert act["extra"]["error_ignorable"] is error_ignorable
         assert act["extra"]["retryable"] is False
         assert act["kwargs"]["preserve_scene_on_failure"] is preserve
+
+    pause_acts = [a for a in acts if a["act_component_code"] == PauseComponent.code]
+    assert len(pause_acts) == pause_count
 
     shield_act = next(a for a in acts if a["act_component_code"] == RedisRollbackExerciseAlarmShieldComponent.code)
     assert shield_act["kwargs"]["duration_seconds"] == shield_duration


### PR DESCRIPTION
完善回档演练现场保留：单据被标 `FAILED`，兄弟分支无法派生子流程，清理节点卡在“已提交但无 FlowTree”

## 具体改动
解决的问题：
- **单据失败阻断派生**：子流程 FAILED/超时后 runner 正常结束并输出 `rollback_code/delete_code=1`，单据保持 `RUNNING` → 其他并行分支可继续提交子流程
- **失败即清 vs 现场保留**：`error_ignorable=False` 时失败分支走 `PauseComponent` 人工确认，确认后再标失败并兜底清理；`True` 仍立即清理
- **假子流程卡住 runner**：`run_pipeline()` 返回 `False` 时不再记 child root_id / 打 submitted → 避免幽灵 `dcbc50209c6611` 轮询到超时
- **操作入口变化**：DBA 处理「现场保留」待办，不再对 FAILED runner 点跳过

## 测试 & 风险

- 单测已覆盖 preserve 完成 runner、超时不 revoke、启动被拒不记假 child、失败分支挂 2 个 Pause
- 仅影响 Redis 回档演练保留模式；`error_ignorable=True` 行为不变；无 API breaking change；已保留中的 FAILED 单据需按旧方式跳过，新单据才走人工确认