### PR TITLE
feat(redis): ingest daily portrait summaries including healthy checks #19877

### DIFF
--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_affinity.py
@@ -26,7 +26,7 @@ from backend.db_meta.models.city_map import BKSubzone
 from backend.db_meta.models.storage_instance_tuple import StorageInstanceTuple
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 from backend.flow.utils.redis.redis_report_utils import (
     META_CHECK_CLUSTER_PAGE_SIZE,
     RedisReportWriter,
@@ -262,7 +262,7 @@ class RedisAffinityChecker:
                     )
             if page_rows:
                 safe_write_meta_reports(self._writer, page_rows, context="affinity_check page")
-                ingest_abnormal_cluster_rows(
+                ingest_daily_cluster_rows(
                     page_rows,
                     dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
                     prefix="[亲和性]",

--- a/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/check_instance.py
@@ -23,7 +23,7 @@ from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_meta.models.storage_instance_tuple import StorageInstanceTuple
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 from backend.flow.utils.redis.redis_report_utils import (
     META_CHECK_CLUSTER_PAGE_SIZE,
     RedisReportWriter,
@@ -43,6 +43,12 @@ IGNORE_TICKET_TYPES = [
     TicketType.REDIS_DESTROY.value,
     TicketType.REDIS_INSTANCE_DESTROY.value,
 ]
+
+# 本检查写入画像摘要的 subtype → 前缀。新增 subtype 必须同步补这里，否则会落到 [未映射]。
+INSTANCE_CHECK_PREFIX_BY_SUBTYPE = {
+    MetaCheckSubType.AloneInstance.value: "[孤立实例]",
+    MetaCheckSubType.StatusAbnormal.value: "[实例状态]",
+}
 
 
 def _storage_prefetch_qs():
@@ -135,13 +141,10 @@ def check_redis_instance():
 
         if page_rows:
             safe_write_meta_reports(writer, page_rows, context="instance_check page")
-            ingest_abnormal_cluster_rows(
+            ingest_daily_cluster_rows(
                 page_rows,
                 dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
-                prefix_by_subtype={
-                    MetaCheckSubType.AloneInstance.value: "[孤立实例]",
-                    MetaCheckSubType.StatusAbnormal.value: "[实例状态]",
-                },
+                prefix_by_subtype=INSTANCE_CHECK_PREFIX_BY_SUBTYPE,
             )
 
 

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_binlog_backup.py
@@ -24,7 +24,7 @@ from backend.db_meta.enums import ClusterType, InstanceRole
 from backend.db_meta.models import Cluster, StorageInstance, StorageInstanceTuple
 from backend.db_report.enums import RedisBackupCheckSubType, ReportStateType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 from backend.db_services.redis.util import is_tendisplus_instance_type, is_tendisssd_instance_type
 from backend.flow.consts import DEFAULT_DB_MODULE_ID, ConfigTypeEnum
 
@@ -263,7 +263,7 @@ class CheckBinlogBackupTask:
                 )
                 if rows:
                     cluster_state_total[rows[0].state] += 1
-                    ingest_abnormal_cluster_rows(
+                    ingest_daily_cluster_rows(
                         rows,
                         dimension=RedisPortraitDimensionCode.RELIABILITY,
                         prefix="[binlog]",

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_full_backup.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_backup/check_full_backup.py
@@ -21,7 +21,7 @@ from backend.db_meta.enums import ClusterType, InstanceRole
 from backend.db_meta.models import Cluster, StorageInstance, StorageInstanceTuple
 from backend.db_report.enums import RedisBackupCheckSubType, ReportStateType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 
 from .bklog_query import DOMAIN_BATCH_SIZE, batch_fetch_backup_logs, find_and_verify_failed_tasks
 from .config import RedisBackupCheckConfig
@@ -139,7 +139,7 @@ class CheckFullBackupTask:
                 rows = self._check_cluster_with_retry(cluster, bklogs, config)
                 if rows:
                     cluster_state_total[rows[0].state] += 1
-                    ingest_abnormal_cluster_rows(
+                    ingest_daily_cluster_rows(
                         rows,
                         dimension=RedisPortraitDimensionCode.RELIABILITY,
                         prefix="[全备]",

--- a/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/check_exporter.py
+++ b/dbm-ui/backend/db_periodic_task/local_tasks/redis_tasks/check_exporter.py
@@ -29,7 +29,7 @@ from backend.db_periodic_task.local_tasks.redis_tasks.report_op import RedisChec
 from backend.db_report.enums import ReportStateType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 from backend.db_report.repo.task_record_repo import get_report_day_from_time
 
 logger = logging.getLogger("root")
@@ -191,7 +191,7 @@ class CheckRedisUpMetricTask:
                 rows = self.check_cluster(cluster, report_day)
                 if rows:
                     cluster_state_total[rows[0].state] += 1
-                    ingest_abnormal_cluster_rows(
+                    ingest_daily_cluster_rows(
                         rows,
                         dimension=RedisPortraitDimensionCode.CONFIG_HEALTH,
                         prefix="[exporter]",

--- a/dbm-ui/backend/db_report/portrait/redis_dimensions.py
+++ b/dbm-ui/backend/db_report/portrait/redis_dimensions.py
@@ -83,7 +83,9 @@ _DESCRIPTIONS: Dict[RedisPortraitDimensionCode, StrOrPromise] = {
         "本维度摘要只收拓扑完整性巡检：孤立实例、实例状态非 RUNNING、访问入口绑定与元数据不一致、"
         "主从或 proxy 可用区亲和性违反、同集群规格不一致。"
         "summary 以 [孤立实例] / [实例状态] / [亲和性] / [入口] 等前缀区分子检查来源；"
-        "时间窗内无摘要代表拓扑完整、无异常。"
+        "每个子检查每天注入一条，正常也上报（正常态摘要形如 '[亲和性] 正常'）；"
+        "若出现 [未映射] 前缀，代表巡检行的 subtype 未配置检查项前缀，属于接入缺陷，不代表健康、也不代表巡检未执行；"
+        "时间窗内某子检查无摘要代表当天巡检未执行或未覆盖该集群，不代表健康。"
     ),
     RedisPortraitDimensionCode.LOAD_CAPACITY: _(
         "集群负载与容量水位。覆盖 CPU / 内存 / 连接数 / QPS / 磁盘 IO 等负载指标的水位与变化趋势，"
@@ -97,14 +99,16 @@ _DESCRIPTIONS: Dict[RedisPortraitDimensionCode, StrOrPromise] = {
         "集群可靠性与数据安全。覆盖全量备份是否按 schedule 覆盖（缺备 / 偏班 / 失败）、"
         "TendisPlus 与 SSD 集群从库 binlog 连续性、定期回档演练的成败结果与失败阶段。"
         "summary 以 [全备] / [binlog] / [回档演练] 等前缀区分来源；"
-        "备份类异常才上报，演练类每次结束必报（含成功样本）。"
-        "时间窗内无摘要代表备份正常且无演练记录。"
+        "备份类每天注入一条，正常也上报（正常态摘要形如 '[全备] 正常'）；"
+        "演练类为事件驱动，每次演练结束必报（含成功样本），不保证每天都有。"
+        "时间窗内 [全备] / [binlog] 无摘要代表当天备份巡检未执行或未覆盖该集群，不代表健康。"
     ),
     RedisPortraitDimensionCode.CONFIG_HEALTH: _(
         "集群配置与管控组件健康。覆盖存储节点角色与 INFO REPLICATION 实际状态一致性、"
         "Predixy INFO Servers 异常与磁盘配置文件漂移等配置巡检，"
         "以及 redis / proxy exporter 的 down / duplicate / redundant / 跨集群指标串扰等监控组件异常。"
         "summary 以 [配置] / [exporter] 等前缀区分来源；"
-        "异常才上报，时间窗内无摘要代表配置一致、组件健康。"
+        "每个子检查每天注入一条，正常也上报（正常态摘要形如 '[exporter] 正常'）；"
+        "时间窗内某子检查无摘要代表当天巡检未执行或未覆盖该集群，不代表健康。"
     ),
 }

--- a/dbm-ui/backend/db_report/portrait/redis_ingest.py
+++ b/dbm-ui/backend/db_report/portrait/redis_ingest.py
@@ -11,18 +11,26 @@ the specific language governing permissions and limitations under the License.
 Redis 集群画像摘要上报助手。
 
 职责：
-    - 按集群聚合巡检异常消息，带检查项前缀写入画像摘要表
+    - 按集群聚合巡检消息，带检查项前缀写入画像摘要表
     - 吞掉 SDK / ORM 异常，绝不阻断巡检主流程
 
+注入策略（每日注入）：
+    - 每个 (集群, 子检查前缀) 每天产一条摘要，**正常态也写**：
+      组内存在告警/异常行时只写这些行的消息；全部正常时写一条固定的正常文案，
+      避免把 N 条实例级 "ok" 拼进摘要。
+    - 因此「时间窗内无摘要」的语义是「当天巡检未执行或未覆盖该集群」，
+      不再是「健康」。消费侧口径见 redis_dimensions._DESCRIPTIONS 与
+      redis-portrait-generator skill 的判读规则。
+
 边界：
-    - 只接 daily 巡检源。所有源一天最多产一条摘要，因此不做写入节流；
-      如需接入高频源（一天多次），必须先补节流，否则会压垮画像摘要的信噪比。
+    - 只接 daily 巡检源，一天一条，因此不做写入节流；如需接入高频源（一天多次），
+      必须先补节流，否则会压垮画像摘要的信噪比。
+    - 本表纯追加、无当天去重：巡检任务重跑会在同一天留下重复行（已知取舍）。
 """
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -35,6 +43,8 @@ from backend.db_report.portrait.sdk import PortraitIngestSDK, ingest_summary
 
 logger = logging.getLogger("root")
 
+# prefix_by_subtype miss 时的兜底前缀：写入维度摘要，避免静默跳过被消费侧判成巡检缺口。
+UNMAPPED_SUBTYPE_PREFIX = _("[未映射]")
 MAX_MSGS_PER_SUMMARY = 8
 # 单条消息上限：8 条 + 前缀 + 「等共 N 项」仍远低于 SDK 4000 字符硬顶，避免硬切把尾巴截掉。
 _MAX_MSG_CHARS = 400
@@ -98,7 +108,7 @@ def ingest_redis_cluster_summary(
     messages: List[str],
     detail_url: str = "",
 ) -> None:
-    """按集群写入一条画像摘要。无异常消息时不写。失败只记日志，绝不外抛。"""
+    """按集群写入一条画像摘要。messages 为空时不写。失败只记日志，绝不外抛。"""
     try:
         if not messages:
             return
@@ -129,7 +139,7 @@ def ingest_redis_cluster_summary(
         )
 
 
-def ingest_abnormal_cluster_rows(
+def ingest_daily_cluster_rows(
     rows: Iterable[Any],
     *,
     dimension: RedisPortraitDimensionCode,
@@ -137,22 +147,50 @@ def ingest_abnormal_cluster_rows(
     prefix_by_subtype: Optional[Dict[str, str]] = None,
     detail_url: str = "",
 ) -> None:
-    """把实例级巡检行按集群（及可选 subtype）聚合成画像摘要。"""
+    """把实例级巡检行按集群（及可选 subtype）聚合成每日画像摘要。
+
+    每个 (集群, 子检查前缀) 产一条：组内有告警/异常行时只写这些行的消息，
+    全部正常时写一条固定的正常文案。正常行只用来占位分组，其 msg（通常是 "ok"）不入摘要。
+
+    prefix_by_subtype 未命中时不静默丢弃：打 warning，并以 [未映射] 前缀写入摘要（含 subtype），
+    避免消费侧把漏配误判成巡检缺口或健康。
+    """
     try:
-        grouped: Dict[Tuple[str, int, str], List[str]] = defaultdict(list)
+        # 用普通 dict 而非 set 收集分组，保证写入顺序与巡检行顺序一致，便于排查
+        grouped: Dict[Tuple[str, int, str], List[str]] = {}
+        warned_unmapped: Set[Tuple[str, str]] = set()
         for row in rows:
-            if _is_normal_state(_row_get(row, "state")):
-                continue
             domain, bk_biz_id = _cluster_identity(row)
             if not domain or bk_biz_id <= 0:
                 continue
+            subtype = _enum_value(_row_get(row, "subtype"))
             item_prefix = prefix
+            unmapped = False
             if prefix_by_subtype is not None:
-                item_prefix = prefix_by_subtype.get(_enum_value(_row_get(row, "subtype")), "")
+                item_prefix = prefix_by_subtype.get(subtype, "")
+                if not item_prefix:
+                    unmapped = True
+                    item_prefix = UNMAPPED_SUBTYPE_PREFIX
+                    warn_key = (domain, subtype)
+                    if warn_key not in warned_unmapped:
+                        warned_unmapped.add(warn_key)
+                        logger.warning(
+                            "redis portrait ingest unmapped subtype: domain=%s subtype=%s dim=%s",
+                            domain,
+                            subtype or "-",
+                            getattr(dimension, "value", dimension),
+                        )
             if not item_prefix:
                 continue
-            msg = _row_get(row, "msg") or ""
-            grouped[(domain, bk_biz_id, item_prefix)].append(str(msg))
+            messages = grouped.setdefault((domain, bk_biz_id, item_prefix), [])
+            if unmapped:
+                warn_msg = _("subtype={subtype} 未配置检查项前缀").format(subtype=subtype or "-")
+                if warn_msg not in messages:
+                    messages.append(warn_msg)
+            if _is_normal_state(_row_get(row, "state")):
+                continue
+            # 异常行 msg 为空时补占位，避免被下面的正常态兜底误判成「正常」
+            messages.append(str(_row_get(row, "msg") or "") or _("异常（无详情）"))
 
         for (domain, bk_biz_id, item_prefix), messages in grouped.items():
             ingest_redis_cluster_summary(
@@ -160,7 +198,7 @@ def ingest_abnormal_cluster_rows(
                 bk_biz_id=bk_biz_id,
                 dimension=dimension,
                 prefix=item_prefix,
-                messages=messages,
+                messages=messages or [_("正常")],
                 detail_url=detail_url,
             )
     except Exception:  # noqa

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/conf_check/components.py
@@ -29,7 +29,7 @@ from backend.db_meta.models import Cluster, ProxyInstance, StorageInstance
 from backend.db_report.enums import ReportStateType
 from backend.db_report.enums.redis_sub_type import RedisCheckSubType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 from backend.flow.consts import SUCCESS_LIST
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils.base.payload_handler import DEFAULT_REDIS_PASSWORD_BATCH_SIZE, PayloadHandler
@@ -669,7 +669,7 @@ def _evaluate_and_report(
             )
     collapsed_rows = _collapse_conf_check_report_rows(report_rows)
     writer.write_redis_reports(collapsed_rows)
-    ingest_abnormal_cluster_rows(
+    ingest_daily_cluster_rows(
         collapsed_rows,
         dimension=RedisPortraitDimensionCode.CONFIG_HEALTH,
         prefix=_("[配置]"),

--- a/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/redis/redis_entry_check.py
@@ -20,7 +20,7 @@ from backend.db_meta.enums import ClusterEntryType, InstanceInnerRole
 from backend.db_meta.models import Cluster, ClusterEntry
 from backend.db_report.enums import MetaCheckSubType, ReportStateType
 from backend.db_report.portrait.redis_dimensions import RedisPortraitDimensionCode
-from backend.db_report.portrait.redis_ingest import ingest_abnormal_cluster_rows
+from backend.db_report.portrait.redis_ingest import ingest_daily_cluster_rows
 from backend.db_services.redis.util import is_have_proxy
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils import dns_manage
@@ -527,7 +527,7 @@ class RedisEntryCheckService(BaseService):
                 context=f"entry_check batch={batch_num} key={candidates_key}",
             )
             if write_ok:
-                ingest_abnormal_cluster_rows(
+                ingest_daily_cluster_rows(
                     report_rows,
                     dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
                     prefix=_("[入口]"),

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_affinity.py
@@ -112,7 +112,7 @@ def test_check_all_clusters_ingests_portrait_and_survives_ingest_failure(redis_a
     ), patch.object(
         redis_affinity_module, "safe_write_meta_reports"
     ) as write_mock, patch.object(
-        redis_affinity_module, "ingest_abnormal_cluster_rows"
+        redis_affinity_module, "ingest_daily_cluster_rows"
     ) as ingest:
         checker.check_all_clusters()
 

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_instance.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/db_meta/db_meta_check/redis_cluster_check/test_check_instance.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from backend.db_meta.enums import ClusterType, InstanceRole, InstanceStatus
+from backend.db_report.enums import MetaCheckSubType
+
+
+@pytest.fixture(scope="module")
+def redis_instance_check_module(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        return importlib.import_module(
+            "backend.db_periodic_task.local_tasks.db_meta.db_meta_check.redis_cluster_check.check_instance"
+        )
+
+
+def _enum_value(value):
+    return str(getattr(value, "value", value))
+
+
+def _machine(ip: str, machine_type: str = "tendiscache"):
+    return SimpleNamespace(ip=ip, machine_type=machine_type)
+
+
+def _storage(*, ip: str, port: int, role: str, status=InstanceStatus.RUNNING):
+    inst = SimpleNamespace(
+        instance_role=role,
+        status=status,
+        machine=_machine(ip),
+        port=port,
+        machine_type="tendiscache",
+        ip_port=f"{ip}:{port}",
+        as_ejector=SimpleNamespace(all=lambda: []),
+        as_receiver=SimpleNamespace(all=lambda: []),
+    )
+    return inst
+
+
+def _proxy(*, ip: str, port: int = 50000, status=InstanceStatus.RUNNING):
+    return SimpleNamespace(
+        status=status,
+        machine=_machine(ip, "twemproxy"),
+        port=port,
+        machine_type="twemproxy",
+        ip_port=f"{ip}:{port}",
+    )
+
+
+def _link_master_slave(master, slave):
+    master.as_ejector = SimpleNamespace(all=lambda: [SimpleNamespace(receiver=slave)])
+    slave.as_receiver = SimpleNamespace(all=lambda: [SimpleNamespace(ejector=master)])
+
+
+def _cluster(*, cluster_type: str, proxies, storages, domain="a.redis.db"):
+    return SimpleNamespace(
+        cluster_type=cluster_type,
+        immute_domain=domain,
+        bk_biz_id=1001,
+        proxyinstance_set=SimpleNamespace(all=lambda: list(proxies)),
+        storageinstance_set=SimpleNamespace(all=lambda: list(storages)),
+        tags=SimpleNamespace(all=lambda: []),
+    )
+
+
+def _healthy_redis_instance():
+    master = _storage(ip="1.1.1.1", port=30000, role=InstanceRole.REDIS_MASTER.value)
+    slave = _storage(ip="1.1.1.9", port=30000, role=InstanceRole.REDIS_SLAVE.value)
+    _link_master_slave(master, slave)
+    return _cluster(
+        cluster_type=ClusterType.TendisRedisInstance.value,
+        proxies=[],
+        storages=[master, slave],
+        domain="ok.redis.db",
+    )
+
+
+def _broken_twemproxy_cluster():
+    master = _storage(
+        ip="1.1.1.1",
+        port=30000,
+        role=InstanceRole.REDIS_MASTER.value,
+        status=InstanceStatus.UNAVAILABLE,
+    )
+    return _cluster(
+        cluster_type=ClusterType.TendisTwemproxyRedisInstance.value,
+        proxies=[_proxy(ip="2.2.2.2", status=InstanceStatus.UNAVAILABLE)],
+        storages=[master],
+        domain="bad.redis.db",
+    )
+
+
+def test_instance_check_emitted_subtypes_are_mapped(redis_instance_check_module):
+    """本检查发出的 subtype 必须 ⊆ INSTANCE_CHECK_PREFIX_BY_SUBTYPE，避免正常行被 ingest 丢成巡检缺口。"""
+    mod = redis_instance_check_module
+    rows = []
+    rows.extend(mod._check_single_cluster_instance(_healthy_redis_instance(), "admin"))
+    rows.extend(mod._check_single_cluster_instance(_broken_twemproxy_cluster(), "admin"))
+
+    emitted = {_enum_value(row["subtype"]) for row in rows}
+    mapped = set(mod.INSTANCE_CHECK_PREFIX_BY_SUBTYPE)
+    assert emitted
+    assert emitted <= mapped
+    assert mapped == {
+        MetaCheckSubType.AloneInstance.value,
+        MetaCheckSubType.StatusAbnormal.value,
+    }

--- a/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_full_backup.py
+++ b/dbm-ui/backend/tests/db_periodic_task/local_tasks/redis_backup/test_check_full_backup.py
@@ -650,7 +650,7 @@ def test_start_ingests_portrait_and_survives_ingest_failure():
     ]
 
     with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patch(
-        "backend.db_periodic_task.local_tasks.redis_backup.check_full_backup.ingest_abnormal_cluster_rows"
+        "backend.db_periodic_task.local_tasks.redis_backup.check_full_backup.ingest_daily_cluster_rows"
     ) as ingest:
         task.start()
 

--- a/dbm-ui/backend/tests/db_report/portrait/test_redis_ingest.py
+++ b/dbm-ui/backend/tests/db_report/portrait/test_redis_ingest.py
@@ -107,7 +107,7 @@ def test_dirty_cluster_identity_skips_row_not_batch(redis_ingest):
         {"cluster": good, "state": ReportStateType.ABNORMAL, "msg": "lonely master", "subtype": "alone_instance"},
     ]
     with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
-        redis_ingest.ingest_abnormal_cluster_rows(
+        redis_ingest.ingest_daily_cluster_rows(
             rows,
             dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
             prefix="[孤立实例]",
@@ -117,7 +117,7 @@ def test_dirty_cluster_identity_skips_row_not_batch(redis_ingest):
     assert ingest.call_args.kwargs["messages"] == ["lonely master"]
 
 
-def test_ingest_abnormal_rows_groups_and_skips_normal(redis_ingest):
+def test_ingest_daily_rows_groups_by_subtype(redis_ingest):
     cluster = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
     rows = [
         {"cluster": cluster, "state": ReportStateType.NORMAL, "msg": "ok", "subtype": "alone_instance"},
@@ -125,14 +125,98 @@ def test_ingest_abnormal_rows_groups_and_skips_normal(redis_ingest):
         {"cluster": cluster, "state": ReportStateType.WARNING, "msg": "not running", "subtype": "status_abnormal"},
     ]
     with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
-        redis_ingest.ingest_abnormal_cluster_rows(
+        redis_ingest.ingest_daily_cluster_rows(
             rows,
             dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
             prefix_by_subtype={"alone_instance": "[孤立实例]", "status_abnormal": "[实例状态]"},
         )
     assert ingest.call_count == 2
-    prefixes = {call.kwargs["prefix"] for call in ingest.call_args_list}
-    assert prefixes == {"[孤立实例]", "[实例状态]"}
+    by_prefix = {call.kwargs["prefix"]: call.kwargs["messages"] for call in ingest.call_args_list}
+    # 同组内有异常行时，正常行的 "ok" 不入摘要
+    assert by_prefix == {"[孤立实例]": ["lonely master"], "[实例状态]": ["not running"]}
+
+
+def test_ingest_daily_rows_writes_normal_summary_when_all_pass(redis_ingest):
+    """每日注入：全部正常也写一条，且坍缩成固定文案而非拼 N 条实例级 ok。"""
+    cluster = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
+    rows = [{"cluster": cluster, "state": ReportStateType.NORMAL, "msg": "ok"} for _ in range(50)]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_daily_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.RELIABILITY,
+            prefix="[全备]",
+        )
+    ingest.assert_called_once()
+    assert ingest.call_args.kwargs["messages"] == ["正常"]
+
+
+def test_ingest_daily_rows_normal_cluster_does_not_borrow_abnormal_of_another(redis_ingest):
+    healthy = SimpleNamespace(immute_domain="ok.redis.db", bk_biz_id=1001)
+    broken = SimpleNamespace(immute_domain="bad.redis.db", bk_biz_id=1001)
+    rows = [
+        {"cluster": healthy, "state": ReportStateType.NORMAL, "msg": "ok"},
+        {"cluster": broken, "state": ReportStateType.ABNORMAL, "msg": "missing backup"},
+    ]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_daily_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.RELIABILITY,
+            prefix="[全备]",
+        )
+    by_domain = {call.kwargs["cluster_domain"]: call.kwargs["messages"] for call in ingest.call_args_list}
+    assert by_domain == {"ok.redis.db": ["正常"], "bad.redis.db": ["missing backup"]}
+
+
+def test_ingest_daily_rows_empty_abnormal_msg_not_reported_as_normal(redis_ingest):
+    cluster = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
+    rows = [{"cluster": cluster, "state": ReportStateType.ABNORMAL, "msg": ""}]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_daily_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.RELIABILITY,
+            prefix="[全备]",
+        )
+    assert ingest.call_args.kwargs["messages"] == ["异常（无详情）"]
+
+
+def test_ingest_daily_rows_unmapped_subtype_writes_warning_summary(redis_ingest):
+    """prefix_by_subtype miss：打 warning，并以 [未映射] 写入摘要，不静默跳过。"""
+    cluster = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
+    rows = [
+        {"cluster": cluster, "state": ReportStateType.NORMAL, "msg": "ok", "subtype": "unmapped"},
+        {"cluster": cluster, "state": ReportStateType.ABNORMAL, "msg": "lonely master", "subtype": "unmapped"},
+        {"cluster": cluster, "state": ReportStateType.ABNORMAL, "msg": "real issue", "subtype": "alone_instance"},
+    ]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest, patch.object(
+        redis_ingest.logger, "warning"
+    ) as warn:
+        redis_ingest.ingest_daily_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+            prefix_by_subtype={"alone_instance": "[孤立实例]"},
+        )
+    by_prefix = {call.kwargs["prefix"]: call.kwargs["messages"] for call in ingest.call_args_list}
+    assert by_prefix == {
+        redis_ingest.UNMAPPED_SUBTYPE_PREFIX: ["subtype=unmapped 未配置检查项前缀", "lonely master"],
+        "[孤立实例]": ["real issue"],
+    }
+    warn.assert_called_once()
+    assert warn.call_args.args[1:] == ("a.redis.db", "unmapped", "topology_scale")
+
+
+def test_ingest_daily_rows_unmapped_normal_is_not_reported_as_healthy(redis_ingest):
+    """未映射的正常行不得兜底成「正常」，否则消费侧会把漏配当健康。"""
+    cluster = SimpleNamespace(immute_domain="a.redis.db", bk_biz_id=1001)
+    rows = [{"cluster": cluster, "state": ReportStateType.NORMAL, "msg": "ok", "subtype": "unmapped"}]
+    with patch.object(redis_ingest, "ingest_redis_cluster_summary") as ingest:
+        redis_ingest.ingest_daily_cluster_rows(
+            rows,
+            dimension=RedisPortraitDimensionCode.TOPOLOGY_SCALE,
+            prefix_by_subtype={"alone_instance": "[孤立实例]"},
+        )
+    ingest.assert_called_once()
+    assert ingest.call_args.kwargs["prefix"] == redis_ingest.UNMAPPED_SUBTYPE_PREFIX
+    assert ingest.call_args.kwargs["messages"] == ["subtype=unmapped 未配置检查项前缀"]
 
 
 def test_rollback_skips_skipped_and_backup_invalid(redis_ingest):


### PR DESCRIPTION
Redis 画像摘要从「异常才上报」改为按子检查每日注入，正常集群也有当天证据，「无摘要」不再被误判为健康

## 具体改动

- `ingest_abnormal_cluster_rows` 改为 `ingest_daily_cluster_rows`，正常行也进分组 → 每个 (集群, 子检查前缀) 每天写一条，空窗语义变为「当天未巡检 / 未覆盖」
- 组内全 NORMAL 时坍缩成固定文案 `_("正常")`，不把 N 条实例级 `ok` 拼进摘要；有异常则只写异常消息
- 异常行 `msg` 为空时补 `_("异常（无详情）")`，避免落入正常兜底
- 全备 / binlog / 亲和性 / 实例 / 入口 / 配置 / exporter 全部切到新函数；`load_capacity` 本次不挂
- `topology_scale` / `reliability` / `config_health` 的 description 改为「正常也上报，无摘要 = 巡检缺口」；注册表需另跑一次性回刷脚本，SDK 不会自动覆盖已注册文案
- 摘要表纯追加，同一天任务重跑会留下重复行（已知取舍）

## 测试 & 风险

- 单测已覆盖按 subtype 分组、全正常坍缩、健康/异常集群隔离、空异常 msg 占位、无前缀行跳过，以及亲和性/全备调用点改名
- 仅影响 Redis 画像写侧与维度描述；摘要表日增量上升（约 8 行/天/集群）；线上 description 在跑回刷脚本前仍是旧口径，Agent 可能同时看到矛盾语义，需手动刷新