### PR TITLE
perf(redis): check repl link before sleeping in backup precheck #19945

### DIFF
--- a/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_backup.go
+++ b/dbm-services/redis/db-tools/dbactuator/pkg/atomjobs/atomredis/redis_backup.go
@@ -560,34 +560,35 @@ func (task *BackupTask) newConnect() {
 
 // PreCheckReplLink 主从关系链检查
 func (task *BackupTask) PreCheckReplLink() {
-	maxCheckMinute := 10
-	for i := 0; i < maxCheckMinute*2; i++ {
-		mylog.Logger.Info("PreCheckReplLink %d begin...", i)
-
-		// 每30秒 check 一次
+	const checkInterval = 30 * time.Second
+	maxCheckTimes := 20 // 最多检查 10 分钟
+	for i := 0; i < maxCheckTimes; i++ {
+		mylog.Logger.Info("PreCheckReplLink redis(%s) check %d begin...", task.Addr(), i)
 		task.Err = nil
-		time.Sleep(30 * time.Second)
 		masterIp, masterPort, linkStatus, selfRole, err := task.Cli.GetMasterData()
 		if err != nil {
 			task.Err = err
-			continue
+			mylog.Logger.Warn("PreCheckReplLink redis(%s) GetMasterData fail,err:%v", task.Addr(), err)
+		} else {
+			mylog.Logger.Info("myself:%s, master:%s:%s, linkStatus:%s", task.Addr(), masterIp, masterPort, linkStatus)
+			// 如果是master，那么直接在master上执行备份逻辑。场景：清档前备份
+			if selfRole == consts.RedisMasterRole {
+				mylog.Logger.Warn("redis(%s) role is master, sure backup in master?", task.Addr())
+				break
+			}
+			if linkStatus == consts.MasterLinkStatusUP {
+				break
+			}
+			task.Err = fmt.Errorf("master_ip: %s, master_port: %s, link_status: %s. check repl status failed, don't backup",
+				masterIp, masterPort, linkStatus)
 		}
-
-		mylog.Logger.Info("myself:%s, master:%s:%s, linkStatus:%s", task.Addr(), masterIp, masterPort, linkStatus)
-		// 如果是master，那么直接在master上执行备份逻辑。场景：清档前备份
-		if selfRole == consts.RedisMasterRole {
-			mylog.Logger.Warn("my role is master, sure backup in master?")
+		if i == maxCheckTimes-1 {
 			break
 		}
-		if linkStatus != consts.MasterLinkStatusUP {
-			task.Err = fmt.Errorf("master_ip: %s, master_port: %s, link_status: %s. check repl status failed, don't backup", masterIp, masterPort, linkStatus)
-			continue
-		}
-		// 走到这里，说明master_link_status is up
-		break
+		mylog.Logger.Info("PreCheckReplLink redis(%s) not ready, sleep %s then retry", task.Addr(), checkInterval)
+		time.Sleep(checkInterval)
 	}
-	mylog.Logger.Info("PreCheckReplLink end...")
-	return
+	mylog.Logger.Info("PreCheckReplLink redis(%s) end...", task.Addr())
 }
 
 // PrecheckDisk 磁盘检查


### PR DESCRIPTION
Redis 备份 `PreCheckReplLink` 原先无论 link 是否已 up 都先 sleep 30s，healthy slave 被无谓拖慢

## 具体改动

- **先查后 sleep**：立刻查 `INFO replication`，link 已 up 或角色为 master 则直接退出 → healthy 实例少等约 30s
- **失败再轮询**：link 未就绪或 `GetMasterData` 失败才 sleep 30s 重试，最多 20 次（约 10 分钟）→ 超时窗口与原来一致
- **末次不再空等**：最后一轮失败直接带着 `task.Err` 返回，不再多 sleep 30s
- **日志带实例地址**：check/retry/end 日志补 `redis(%s)`，方便单机多实例对照

## 测试 & 风险

- 无单测；行为仍是「成功退出 / 超时退出」两路，未改判定条件（master 可备、slave 需 `master_link_status=up`）
- 仅影响 dbactuator Redis 备份原子任务的前置检查；无 API 变更；link 已 up 时备份会更快启动