### PR TITLE
feat(mongodb): dbtablesize 对齐看板契约并提升慢日志 durationMillis #20151 #20140

### DIFF
--- a/dbm-services/mongodb/db-tools/dbmon/cmd/dbtablesizejob/dbtablesize_job.go
+++ b/dbm-services/mongodb/db-tools/dbmon/cmd/dbtablesizejob/dbtablesize_job.go
@@ -2,10 +2,13 @@
 package dbtablesizejob
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,12 +27,15 @@ import (
 
 const (
 	reportType            = "dbtablesize"
+	aggLevelShard         = "shard"
 	connectTimeout        = 30 * time.Second
 	defaultTimeoutSeconds = int64(300)
 	// reportSavedDays report 文件本地保留天数
 	reportSavedDays = 2
 	// skipHeartbeatMaxBytes test.dbmon_heartbeat 小于该大小时不上报
 	skipHeartbeatMaxBytes = int64(1024 * 1024)
+	// lastBucketFileName 已完成 report_bucket 落盘文件名
+	lastBucketFileName = "dbtablesize.last_bucket"
 
 	// MetricCollectSuccess 采集是否成功：1 成功，0 失败/关闭
 	MetricCollectSuccess = "mongo_dbtablesize_collect_success"
@@ -41,7 +47,16 @@ var (
 	globDbTableSizeJob  *Job
 	dbTableSizeOnce     sync.Once
 	cleanReportLastTime int64
+	shanghaiLoc         *time.Location
 )
+
+func init() {
+	var err error
+	shanghaiLoc, err = time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		shanghaiLoc = time.FixedZone("CST", 8*3600)
+	}
+}
 
 // Job 库表数据量采集
 type Job struct {
@@ -49,13 +64,14 @@ type Job struct {
 }
 
 // GetJob 获取库表数据量采集任务单例
-func GetJob(conf *config.DbMonConfig, logger *zap.Logger, jobName string) *Job {
+func GetJob(conf *config.DbMonConfig, logger *zap.Logger, jobName, workDir string) *Job {
 	dbTableSizeOnce.Do(func() {
 		globDbTableSizeJob = &Job{
 			BaseJob: basejob.BaseJob{
-				Name:   jobName,
-				Conf:   conf,
-				Logger: logger.With(zap.String("job", jobName)),
+				Name:    jobName,
+				Conf:    conf,
+				Logger:  logger.With(zap.String("job", jobName)),
+				WorkDir: workDir,
 			},
 		}
 	})
@@ -87,15 +103,8 @@ type SizeRecord struct {
 	Count         int64   `json:"count"`
 	AvgObjSize    float64 `json:"avg_obj_size"`
 	ReportTime    string  `json:"report_time"`
-}
-
-type dbStatsResult struct {
-	DataSize    int64   `bson:"dataSize"`
-	StorageSize int64   `bson:"storageSize"`
-	IndexSize   int64   `bson:"indexSize"`
-	Objects     int64   `bson:"objects"`
-	AvgObjSize  float64 `bson:"avgObjSize"`
-	OK          int     `bson:"ok"`
+	ReportBucket  string  `json:"report_bucket"`
+	AggLevel      string  `json:"agg_level"`
 }
 
 type collStatsResult struct {
@@ -113,7 +122,43 @@ var skipDBs = map[string]struct{}{
 	"config": {},
 }
 
-// Run 仅在 backup 节点执行
+// reportBucket 计算 Asia/Shanghai 下对齐到 10 分钟的 yyyymmddhhmm
+func reportBucket(t time.Time) string {
+	local := t.In(shanghaiLoc)
+	floored := time.Date(
+		local.Year(), local.Month(), local.Day(),
+		local.Hour(), local.Minute()-local.Minute()%10, 0, 0, shanghaiLoc)
+	return floored.Format("200601021504")
+}
+
+func (job *Job) lastBucketPath() string {
+	dir := job.WorkDir
+	if dir == "" {
+		dir = "."
+	}
+	return filepath.Join(dir, lastBucketFileName)
+}
+
+func readCompletedBucket(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func writeCompletedBucket(path, bucket string) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(bucket+"\n"), 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// Run 仅在 backup 节点执行；每分钟唤醒，按 report_bucket 门禁同槽可补跑
 func (job *Job) Run() {
 	job.LoopTimes++
 	job.Logger.Info("start", zap.Uint64("loopTimes", job.LoopTimes))
@@ -125,11 +170,23 @@ func (job *Job) Run() {
 	}
 
 	now := time.Now()
+	bucket := reportBucket(now)
+	completed, err := readCompletedBucket(job.lastBucketPath())
+	if err != nil {
+		job.Logger.Warn("read completed bucket failed", zap.Error(err))
+	} else if completed == bucket {
+		job.Logger.Debug("skip, report_bucket already completed",
+			zap.String("report_bucket", bucket))
+		return
+	}
+
 	if now.Unix()-cleanReportLastTime > 24*3600 {
 		job.cleanReport(now, reportSavedDays)
 		cleanReportLastTime = now.Unix()
 	}
 
+	allOK := true
+	attempted := false
 	for i := range job.MyConf.Servers {
 		svr := &job.MyConf.Servers[i]
 		if !isBackupRole(svr.MetaRole) {
@@ -139,13 +196,14 @@ func (job *Job) Run() {
 		}
 		enable, err := config.ClusterConfig.GetOne(svr, config.SegmentDBTableSize, config.KeyEnable)
 		if err != nil {
-			job.Logger.Warn("get dbtablesize.enable failed, use default true",
+			allOK = false
+			job.Logger.Warn("get dbtablesize.enable failed, skip and retry later",
 				zap.String("instance", svr.Addr()), zap.Error(err))
-			enable = config.ValueTrue
+			continue
 		}
 		if enable == config.ValueFalse {
 			job.Logger.Info("dbtablesize disabled", zap.String("instance", svr.Addr()))
-			job.reportCollectStatus(svr, false, 0, 0)
+			job.reportCollectStatus(svr, false, 0, 0, bucket)
 			continue
 		}
 		if config.IsAlarmShield(svr, "skip dbtablesize because Shielded", job.Logger) {
@@ -163,22 +221,36 @@ func (job *Job) Run() {
 				zap.String("instance", svr.Addr()), zap.Int64("timeout", timeoutSeconds))
 			timeoutSeconds = defaultTimeoutSeconds
 		}
+		attempted = true
 		start := time.Now()
-		err = job.runOneServer(svr, time.Duration(timeoutSeconds)*time.Second)
+		err = job.runOneServer(svr, time.Duration(timeoutSeconds)*time.Second, bucket)
 		duration := time.Since(start).Seconds()
 		success := float64(0)
 		if err != nil {
+			allOK = false
 			job.Logger.Warn("dbtablesize failed",
 				zap.String("instance", svr.Addr()), zap.Error(err))
 		} else {
 			success = 1
 		}
-		job.reportCollectStatus(svr, true, success, duration)
+		job.reportCollectStatus(svr, true, success, duration, bucket)
+	}
+
+	// 无可采集目标（无 backup / 全关 / 全屏蔽）或全部成功时落盘，避免同槽反复空跑或成功后重启重跑
+	if allOK {
+		if err := writeCompletedBucket(job.lastBucketPath(), bucket); err != nil {
+			job.Logger.Warn("write completed bucket failed",
+				zap.String("report_bucket", bucket), zap.Error(err))
+		} else {
+			job.Logger.Info("mark report_bucket completed",
+				zap.String("report_bucket", bucket), zap.Bool("attempted", attempted))
+		}
 	}
 }
 
 // reportCollectStatus 上报采集状态指标；发送失败仅记日志，不影响采集结果
-func (job *Job) reportCollectStatus(svr *config.ConfServerItem, enabled bool, success, durationSeconds float64) {
+func (job *Job) reportCollectStatus(svr *config.ConfServerItem, enabled bool,
+	success, durationSeconds float64, bucket string) {
 	enabledLabel := config.ValueFalse
 	if enabled {
 		enabledLabel = config.ValueTrue
@@ -192,7 +264,9 @@ func (job *Job) reportCollectStatus(svr *config.ConfServerItem, enabled bool, su
 			zap.String("instance", svr.Addr()), zap.Error(err))
 		return
 	}
-	msgH.SetLabel("enabled", enabledLabel).SetLabel("port", port)
+	msgH.SetLabel("enabled", enabledLabel).
+		SetLabel("port", port).
+		SetLabel("report_bucket", bucket)
 	if err = msgH.SendTimeSeriesMsg(beat.MetricConfig.DataID, beat.MetricConfig.Token,
 		svr.IP, MetricCollectSuccess, success, job.Logger); err != nil {
 		job.Logger.Warn("report collect success metric failed",
@@ -205,7 +279,9 @@ func (job *Job) reportCollectStatus(svr *config.ConfServerItem, enabled bool, su
 			zap.String("instance", svr.Addr()), zap.Error(err))
 		return
 	}
-	msgH2.SetLabel("enabled", enabledLabel).SetLabel("port", port)
+	msgH2.SetLabel("enabled", enabledLabel).
+		SetLabel("port", port).
+		SetLabel("report_bucket", bucket)
 	if err = msgH2.SendTimeSeriesMsg(beat.MetricConfig.DataID, beat.MetricConfig.Token,
 		svr.IP, MetricCollectDurationSeconds, durationSeconds, job.Logger); err != nil {
 		job.Logger.Warn("report collect duration metric failed",
@@ -249,14 +325,17 @@ func (job *Job) cleanReport(nowTime time.Time, savedDays int) {
 	}
 }
 
-func (job *Job) runOneServer(svr *config.ConfServerItem, timeout time.Duration) error {
-	logger := job.Logger.With(zap.String("instance", svr.Addr()))
+func (job *Job) runOneServer(svr *config.ConfServerItem, timeout time.Duration, bucket string) error {
+	logger := job.Logger.With(zap.String("instance", svr.Addr()), zap.String("report_bucket", bucket))
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	reportFile, _, _ := consts.GetMongoReportPath(reportType)
 	if err := report.PrepareReportPath(reportFile); err != nil {
 		return fmt.Errorf("prepare report path: %w", err)
+	}
+	if err := purgeInstanceBucketRecords(reportFile, svr.Addr(), bucket); err != nil {
+		return fmt.Errorf("purge stale report records: %w", err)
 	}
 
 	client, err := mymongo.ConnectWithDirect(
@@ -275,7 +354,7 @@ func (job *Job) runOneServer(svr *config.ConfServerItem, timeout time.Duration) 
 		return fmt.Errorf("listDatabases: %w", err)
 	}
 
-	reportTime := time.Now().Local().Format(time.RFC3339)
+	reportTime := time.Now().In(shanghaiLoc).Format(time.RFC3339)
 	written := 0
 	failed := 0
 	var firstErr error
@@ -286,7 +365,7 @@ func (job *Job) runOneServer(svr *config.ConfServerItem, timeout time.Duration) 
 		if _, skip := skipDBs[dbName]; skip {
 			continue
 		}
-		n, err := job.collectAndWriteDB(ctx, client, svr, dbName, reportFile, reportTime, logger)
+		n, err := job.collectAndWriteDB(ctx, client, svr, dbName, reportFile, reportTime, bucket, logger)
 		if err != nil {
 			if ctx.Err() != nil {
 				return fmt.Errorf("collect timeout after %s: %w", timeout, ctx.Err())
@@ -315,26 +394,14 @@ func (job *Job) collectAndWriteDB(
 	ctx context.Context,
 	client *mongo.Client,
 	svr *config.ConfServerItem,
-	dbName, reportFile, reportTime string,
+	dbName, reportFile, reportTime, bucket string,
 	logger *zap.Logger,
 ) (int, error) {
-	var dbStats dbStatsResult
-	if err := client.Database(dbName).RunCommand(ctx, bson.D{{Key: "dbStats", Value: 1}}).
-		Decode(&dbStats); err != nil {
-		return 0, fmt.Errorf("dbStats: %w", err)
-	}
-	written := 0
-	dbRec := newSizeRecord(svr, dbName, "", dbStats.DataSize, dbStats.StorageSize,
-		dbStats.IndexSize, dbStats.Objects, dbStats.AvgObjSize, reportTime)
-	if err := report.AppendObjectToFile(reportFile, dbRec); err != nil {
-		return 0, fmt.Errorf("write db record: %w", err)
-	}
-	written++
-
 	colls, err := client.Database(dbName).ListCollectionNames(ctx, bson.D{})
 	if err != nil {
-		return written, fmt.Errorf("listCollections: %w", err)
+		return 0, fmt.Errorf("listCollections: %w", err)
 	}
+	written := 0
 	for _, coll := range colls {
 		if err := ctx.Err(); err != nil {
 			return written, err
@@ -356,7 +423,7 @@ func (job *Job) collectAndWriteDB(
 			continue
 		}
 		rec := newSizeRecord(svr, dbName, coll, collStats.Size, collStats.StorageSize,
-			collStats.TotalIndexSize, collStats.Count, collStats.AvgObjSize, reportTime)
+			collStats.TotalIndexSize, collStats.Count, collStats.AvgObjSize, reportTime, bucket)
 		if err := report.AppendObjectToFile(reportFile, rec); err != nil {
 			logger.Warn("write collection record failed",
 				zap.String("db", dbName), zap.String("collection", coll), zap.Error(err))
@@ -365,6 +432,55 @@ func (job *Job) collectAndWriteDB(
 		written++
 	}
 	return written, nil
+}
+
+type reportRecordKey struct {
+	Instance     string `json:"instance"`
+	ReportBucket string `json:"report_bucket"`
+}
+
+// purgeInstanceBucketRecords 同槽重试前移除该实例当前 bucket 的旧行，避免 Append 重复
+func purgeInstanceBucketRecords(reportFile, instance, bucket string) error {
+	f, err := os.Open(reportFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	var kept []byte
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec reportRecordKey
+		if err := json.Unmarshal(line, &rec); err != nil {
+			kept = append(kept, line...)
+			kept = append(kept, '\n')
+			continue
+		}
+		if rec.Instance == instance && rec.ReportBucket == bucket {
+			continue
+		}
+		kept = append(kept, line...)
+		kept = append(kept, '\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if len(kept) == 0 {
+		return os.Truncate(reportFile, 0)
+	}
+	tmp := reportFile + ".purge.tmp"
+	if err := os.WriteFile(tmp, kept, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, reportFile)
 }
 
 // shouldSkipCollection 忽略小于 1MB 的 test.dbmon_heartbeat
@@ -377,7 +493,7 @@ func newSizeRecord(
 	dbName, collection string,
 	dataSize, storageSize, indexSize, count int64,
 	avgObjSize float64,
-	reportTime string,
+	reportTime, bucket string,
 ) SizeRecord {
 	return SizeRecord{
 		BkCloudID:     svr.BkCloudID,
@@ -402,5 +518,7 @@ func newSizeRecord(
 		Count:         count,
 		AvgObjSize:    avgObjSize,
 		ReportTime:    reportTime,
+		ReportBucket:  bucket,
+		AggLevel:      aggLevelShard,
 	}
 }

--- a/dbm-services/mongodb/db-tools/dbmon/cmd/dbtablesizejob/dbtablesize_job_test.go
+++ b/dbm-services/mongodb/db-tools/dbmon/cmd/dbtablesizejob/dbtablesize_job_test.go
@@ -1,6 +1,14 @@
 package dbtablesizejob
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"dbm-services/mongodb/db-tools/dbmon/config"
+)
 
 func TestShouldSkipCollection(t *testing.T) {
 	cases := []struct {
@@ -25,5 +33,180 @@ func TestShouldSkipCollection(t *testing.T) {
 					c.db, c.coll, c.dataSize, got, c.wantSkip)
 			}
 		})
+	}
+}
+
+func TestReportBucket(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string // RFC3339 in +08:00
+		want string
+	}{
+		{name: "1756_to_1750", in: "2026-08-31T17:56:45+08:00", want: "202608311750"},
+		{name: "1800_to_1800", in: "2026-08-31T18:00:00+08:00", want: "202608311800"},
+		{name: "1700_to_1700", in: "2026-08-31T17:00:01+08:00", want: "202608311700"},
+		{name: "1709_to_1700", in: "2026-08-31T17:09:59+08:00", want: "202608311700"},
+		{name: "2359_to_2350", in: "2026-08-31T23:59:00+08:00", want: "202608312350"},
+		{name: "cross_day_0001", in: "2026-09-01T00:01:00+08:00", want: "202609010000"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tm, err := time.Parse(time.RFC3339, c.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := reportBucket(tm)
+			if got != c.want {
+				t.Fatalf("reportBucket(%s)=%s, want %s", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCompletedBucketPersist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, lastBucketFileName)
+
+	got, err := readCompletedBucket(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("empty file want \"\", got %q", got)
+	}
+
+	bucket := "202608311700"
+	if err := writeCompletedBucket(path, bucket); err != nil {
+		t.Fatal(err)
+	}
+	got, err = readCompletedBucket(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != bucket {
+		t.Fatalf("read=%q, want %q", got, bucket)
+	}
+
+	// rewrite
+	bucket2 := "202608311710"
+	if err := writeCompletedBucket(path, bucket2); err != nil {
+		t.Fatal(err)
+	}
+	got, err = readCompletedBucket(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != bucket2 {
+		t.Fatalf("read=%q, want %q", got, bucket2)
+	}
+
+	// no leftover tmp
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("tmp file should not exist, err=%v", err)
+	}
+}
+
+func TestPurgeInstanceBucketRecords(t *testing.T) {
+	dir := t.TempDir()
+	reportFile := filepath.Join(dir, "dbtablesize-20260901.log")
+	lines := []string{
+		`{"instance":"1.1.1.1:27017","report_bucket":"202608311700","db":"a","collection":"c1"}`,
+		`{"instance":"1.1.1.1:27017","report_bucket":"202608311710","db":"a","collection":"c1"}`,
+		`{"instance":"2.2.2.2:27017","report_bucket":"202608311700","db":"b","collection":"c2"}`,
+	}
+	if err := os.WriteFile(reportFile, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := purgeInstanceBucketRecords(reportFile, "1.1.1.1:27017", "202608311700"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(reportFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := strings.Join([]string{
+		`{"instance":"1.1.1.1:27017","report_bucket":"202608311710","db":"a","collection":"c1"}`,
+		`{"instance":"2.2.2.2:27017","report_bucket":"202608311700","db":"b","collection":"c2"}`,
+	}, "\n")
+	if got != want {
+		t.Fatalf("purge result:\n%s\nwant:\n%s", got, want)
+	}
+
+	// purge all matching rows leaves empty file
+	if err := purgeInstanceBucketRecords(reportFile, "2.2.2.2:27017", "202608311700"); err != nil {
+		t.Fatal(err)
+	}
+	if err := purgeInstanceBucketRecords(reportFile, "1.1.1.1:27017", "202608311710"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(reportFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("expected empty report file, size=%d", info.Size())
+	}
+}
+
+func TestNewSizeRecordAggLevelAndBucket(t *testing.T) {
+	svr := &config.ConfServerItem{}
+	svr.ClusterName = "c1"
+	svr.SetName = "c1-s1"
+	svr.IP = "1.1.1.1"
+	svr.Port = 27017
+	rec := newSizeRecord(svr, "db1", "coll1", 1, 2, 3, 4, 5.5, "2026-08-31T17:01:00+08:00", "202608311700")
+	if rec.AggLevel != aggLevelShard {
+		t.Fatalf("agg_level=%q, want %q", rec.AggLevel, aggLevelShard)
+	}
+	if rec.ReportBucket != "202608311700" {
+		t.Fatalf("report_bucket=%q", rec.ReportBucket)
+	}
+	if rec.Collection == "" {
+		t.Fatal("collection must be non-empty for shard collection rows")
+	}
+}
+
+// TestBucketGate documents Run() skip rule: completed bucket matches current → skip;
+// incomplete (empty / other bucket) → allow retry any minute in the same 10-min window.
+func TestBucketGate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, lastBucketFileName)
+	bucket1700 := "202608311700"
+
+	t1700, _ := time.Parse(time.RFC3339, "2026-08-31T17:00:00+08:00")
+	t1705, _ := time.Parse(time.RFC3339, "2026-08-31T17:05:30+08:00")
+	t1710, _ := time.Parse(time.RFC3339, "2026-08-31T17:10:00+08:00")
+
+	// not completed → any minute in window may run
+	for _, tm := range []time.Time{t1700, t1705} {
+		completed, err := readCompletedBucket(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cur := reportBucket(tm)
+		if completed == cur {
+			t.Fatalf("should allow run at %s before complete", tm)
+		}
+		if cur != bucket1700 {
+			t.Fatalf("bucket=%s, want %s", cur, bucket1700)
+		}
+	}
+
+	if err := writeCompletedBucket(path, bucket1700); err != nil {
+		t.Fatal(err)
+	}
+	// after complete (incl. "restart" re-read) → skip rest of window
+	completed, err := readCompletedBucket(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if completed != reportBucket(t1705) {
+		t.Fatalf("should skip at 17:05 after complete")
+	}
+	// next bucket may run
+	if completed == reportBucket(t1710) {
+		t.Fatalf("should not skip new bucket 17:10")
 	}
 }

--- a/dbm-services/mongodb/db-tools/dbmon/cmd/root.go
+++ b/dbm-services/mongodb/db-tools/dbmon/cmd/root.go
@@ -177,7 +177,7 @@ func main(cmd *cobra.Command, args []string) {
 	job4 := logparserjob.GetJob(dbmonConf, mylog.Logger, "logparser", osCtx, &rootWg)
 	job5 := dstatjob.GetJob(dbmonConf, mylog.Logger, "dstat", workDir)
 	job6 := datadirjob.GetJob(dbmonConf, mylog.Logger, "datadir")
-	job7 := dbtablesizejob.GetJob(dbmonConf, mylog.Logger, "dbtablesize")
+	job7 := dbtablesizejob.GetJob(dbmonConf, mylog.Logger, "dbtablesize", workDir)
 	for _, row := range []struct {
 		job  cron.Job
 		cron string
@@ -189,7 +189,7 @@ func main(cmd *cobra.Command, args []string) {
 		{job: job4, cron: "@every 1m", name: job4.Name},
 		{job: job5, cron: "@every 2m", name: job5.Name}, // dstat 任务间隔为2分钟
 		{job: job6, cron: "@every 5m", name: job6.Name},
-		{job: job7, cron: "@every 10m", name: job7.Name},
+		{job: job7, cron: "@every 1m", name: job7.Name}, // 内部按 report_bucket 门禁，同槽可补跑
 	} {
 		if entryID, err := c.AddJob(row.cron,
 			cron.NewChain(cron.SkipIfStillRunning(mylog.AdapterLog)).Then(row.job)); err == nil {

--- a/dbm-services/mongodb/db-tools/dbmon/config/cluster_config.go
+++ b/dbm-services/mongodb/db-tools/dbmon/config/cluster_config.go
@@ -115,7 +115,7 @@ func GetAllClusterConfigRows() []ClusterConfigItem {
 		{Segment: SegmentAlarm, Key: ShieldEndTimeKey, Value: ""},              // 屏蔽结束时间，为空为0都表示永久屏蔽
 		{Segment: SegmentParseLog, Key: KeyEnable, Value: ValueTrue},           // 是否开启日志解析
 		{Segment: SegmentParseLog, Key: KeyMaxRecordPerSecond, Value: "10000"}, // 每秒解析的最大日志数
-		{Segment: SegmentDBTableSize, Key: KeyEnable, Value: ValueTrue},        // 是否开启库表容量采集
+		{Segment: SegmentDBTableSize, Key: KeyEnable, Value: ValueFalse},       // 是否开启库表容量采集，默认关闭
 		{Segment: SegmentDBTableSize, Key: KeyTimeout, Value: "300"},           // 单实例采集超时时间，单位秒
 		// mongo.log.* 文件最大时间，超过这个时间就删除 2592000 = 30天
 		{Segment: SegmentLog, Key: KeyMaxTime, Value: "2592000"},

--- a/dbm-services/mongodb/db-tools/dbmon/pkg/mongologparser/mongologparse_test.go
+++ b/dbm-services/mongodb/db-tools/dbmon/pkg/mongologparser/mongologparse_test.go
@@ -81,6 +81,39 @@ func TestParseV3Log(t *testing.T) {
 
 }
 
+func TestParseV3DurationMillis(t *testing.T) {
+	line := []byte(`{"t":{"$date":"2024-04-29T18:04:28.239+08:00"},"s":"I",  "c":"COMMAND",  "id":51803,   "ctx":"conn15148443","msg":"Slow query","attr":{"type":"query","ns":"game.tradesellorders","command":{"find":"tradesellorders","filter":{"aid":{"$oid":"5fd8d1a8b4396631a4bbc6b0"}},"$db":"game"},"nShards":64,"cursorExhausted":true,"numYields":0,"nreturned":0,"reslen":249,"durationMillis":105}}`)
+	p, err := GetParser(line)
+	if err != nil {
+		t.Fatalf("GetParser: %v", err)
+	}
+	msg, err := p.Parse(line)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if msg.DurationMillis != 105 {
+		t.Fatalf("DurationMillis = %d, want 105", msg.DurationMillis)
+	}
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got["durationMillis"] != float64(105) {
+		t.Fatalf("json durationMillis = %v, want 105", got["durationMillis"])
+	}
+	attr, ok := got["attr"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("attr missing or not object: %v", got["attr"])
+	}
+	if attr["durationMillis"] != float64(105) {
+		t.Fatalf("attr.durationMillis = %v, want 105", attr["durationMillis"])
+	}
+}
+
 func TestParseV1Log(t *testing.T) {
 	// test cases
 	in := []byte(`Fri Apr 12 04:16:54.496 [conn9818835] getmore xxxx.xxxxxx query: { query: {}, $snapshot: true } cursorid:7678192233559697393 ntoreturn:0 exhaust:1 keyUpdates:0 numYields: 5 locks(micros) r:344667 nreturned:22 reslen:4255713 260ms`)

--- a/dbm-services/mongodb/db-tools/dbmon/pkg/mongologparser/v2.go
+++ b/dbm-services/mongodb/db-tools/dbmon/pkg/mongologparser/v2.go
@@ -69,6 +69,7 @@ func (m *MongoLogMsg) ParseMore() (err error) {
 			m.ParseOk = 1
 			m.Attr = attr
 			m.Id = LogTypeSlowlog
+			m.copyDurationMillisFromAttr()
 		} else {
 			m.ParseOk = 0
 			m.Attr = &SlowlogAttr{

--- a/dbm-services/mongodb/db-tools/dbmon/pkg/mongologparser/v3.go
+++ b/dbm-services/mongodb/db-tools/dbmon/pkg/mongologparser/v3.go
@@ -41,7 +41,11 @@ func ParseV3Mongolog(data []byte) (*MongoLogMsg, []byte, error) {
 		if row.Id == LogTypeSlowlog {
 			attr := row.Attr.(map[string]interface{})
 			// 将不确定的字段转换为string: command
+			// durationMillis 保持原值，兼容 attr.durationMillis 查询
 			for k, v := range attr {
+				if k == "durationMillis" {
+					continue
+				}
 				switch v.(type) {
 				case string, float64, bool, int:
 					continue
@@ -56,6 +60,9 @@ func ParseV3Mongolog(data []byte) (*MongoLogMsg, []byte, error) {
 			attr := row.Attr.(map[string]interface{})
 			// 将不确定的字段转换为string: command
 			for k, v := range attr {
+				if k == "durationMillis" {
+					continue
+				}
 				switch v.(type) {
 				case string, float64, bool, int:
 					continue
@@ -66,12 +73,69 @@ func ParseV3Mongolog(data []byte) (*MongoLogMsg, []byte, error) {
 			}
 			row.Attr = attr
 		}
+		row.copyDurationMillisFromAttr()
 
 	default:
 		log.Warnf("unmarshal Attr failed: unknown type %T", row.Attr)
 	}
 
 	return &row, attrStr, err
+}
+
+func (m *MongoLogMsg) copyDurationMillisFromAttr() {
+	if m == nil || m.Attr == nil {
+		return
+	}
+	switch attr := m.Attr.(type) {
+	case map[string]interface{}:
+		v, ok := attr["durationMillis"]
+		if !ok || v == nil {
+			return
+		}
+		n, ok := parseDurationMillis(v)
+		if ok {
+			m.DurationMillis = n
+		}
+	case *SlowlogAttr:
+		if attr != nil && attr.DurationMillis != 0 {
+			m.DurationMillis = attr.DurationMillis
+		}
+	case SlowlogAttr:
+		if attr.DurationMillis != 0 {
+			m.DurationMillis = attr.DurationMillis
+		}
+	}
+}
+
+func parseDurationMillis(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	case string:
+		n = strings.TrimSpace(strings.TrimSuffix(n, "ms"))
+		if n == "" {
+			return 0, false
+		}
+		i, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	default:
+		return 0, false
+	}
 }
 
 // MongoLogMsg is a struct to hold the parsed log message
@@ -82,14 +146,15 @@ type MongoLogMsg struct {
 	T          *struct {
 		DateTime primitive.DateTime `json:"$date"`
 	} `json:"t,omitempty"` // timestamp
-	DateTime primitive.DateTime `json:"dt"`
-	S        string             `json:"s"` // severity
-	C        string             `json:"c"` // component
-	Id       int64              `json:"id"`
-	Ctx      string             `json:"ctx"`
-	Msg      string             `json:"msg"`
-	Attr     interface{}        `json:"attr,omitempty"`
-	Line     struct {
+	DateTime       primitive.DateTime `json:"dt"`
+	S              string             `json:"s"` // severity
+	C              string             `json:"c"` // component
+	Id             int64              `json:"id"`
+	Ctx            string             `json:"ctx"`
+	Msg            string             `json:"msg"`
+	Attr           interface{}        `json:"attr,omitempty"`
+	DurationMillis int64              `json:"durationMillis,omitempty"`
+	Line           struct {
 		Num      int       `json:"num"`
 		OffSet   int64     `json:"offset"`
 		TimeDiff int64     `json:"timeDiff"` // ms Line.Time - dt (ms)
@@ -119,7 +184,7 @@ type SlowlogAttr struct {
 	Protocol        string      `json:"protocol,omitempty"`
 	Locks           string      `json:"locks,omitempty"`
 	Storage         *string     `json:"storage,omitempty"`
-	DurationMillis  int         `json:"durationMillis"`
+	DurationMillis  int64       `json:"durationMillis"`
 }
 
 // Component
@@ -141,7 +206,7 @@ func (attr *SlowlogAttr) SetProp(key string, value string) (bool, error) {
 	switch key {
 	case "ms", "durationMillis":
 		value = strings.TrimSuffix(value, "ms")
-		attr.DurationMillis, err = strconv.Atoi(value)
+		attr.DurationMillis, err = strconv.ParseInt(value, 10, 64)
 	case "numYields":
 		v, err = strconv.Atoi(value)
 		attr.NumYields = &v


### PR DESCRIPTION
## Summary
- dbtablesize：`report_bucket` / `agg_level=shard`，停报空 collection 库级行；cron `@every 1m` + 同桶落盘去重；`enable` 默认 false
- mongologparser：将 `attr.durationMillis` 提升为根字段 `durationMillis`（含 #20140，可替代既有 PR #20141）

## Test plan
- [ ] `go test ./cmd/dbtablesizejob/ ./pkg/mongologparser/`（dbmon）
- [ ] 显式 `dbtablesize.enable=true` 后确认 report JSON 含 `report_bucket` / `agg_level=shard`
- [ ] 慢日志上报含根字段 `durationMillis`