### PR TITLE
feat(redis): redis/mongo接入clb时，域名直接指向clb #20127

### DIFF
--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/config/fullbackup.json
@@ -32,6 +32,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "1",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-6.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-6.json
@@ -657,7 +657,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-7.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-7.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-70.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-70.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-74.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Redis-74.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Valkey-8.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Valkey-8.json
@@ -801,7 +801,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Valkey-9.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyRedisCluster/dbconf/Valkey-9.json
@@ -993,7 +993,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusCluster/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusCluster/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusCluster/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusCluster/config/fullbackup.json
@@ -16,6 +16,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "2",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusInstance/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusInstance/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusInstance/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/PredixyTendisplusInstance/config/fullbackup.json
@@ -16,6 +16,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "2",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/config/fullbackup.json
@@ -32,6 +32,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "1",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-6.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-6.json
@@ -657,7 +657,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-7.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-7.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-70.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-70.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-74.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Redis-74.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Valkey-8.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Valkey-8.json
@@ -801,7 +801,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Valkey-9.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/RedisInstance/dbconf/Valkey-9.json
@@ -993,7 +993,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/config/fullbackup.json
@@ -32,6 +32,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "2",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-6.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-6.json
@@ -689,7 +689,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-7.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-7.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-70.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-70.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-74.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Redis-74.json
@@ -769,7 +769,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Valkey-8.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Valkey-8.json
@@ -801,7 +801,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Valkey-9.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyRedisInstance/dbconf/Valkey-9.json
@@ -993,7 +993,7 @@
   },
   {
     "conf_name": "io-threads",
-    "value_default": "2",
+    "value_default": "1",
     "value_allowed": "[1,100]",
     "value_type": "INT",
     "value_type_sub": "RANGE",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyTendisSSDInstance/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyTendisSSDInstance/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/TwemproxyTendisSSDInstance/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/TwemproxyTendisSSDInstance/config/fullbackup.json
@@ -16,6 +16,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "1",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/components/dbconfig/migrations/rediscomm/config/binlogbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/rediscomm/config/binlogbackup.json
@@ -1,5 +1,21 @@
 [
   {
+    "conf_name": "binlog_backup_tag",
+    "value_default": "REDIS_BINLOG",
+    "value_allowed": "REDIS_BINLOG|INCREMENT_BACKUP_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "cron",
     "value_default": "@every 10m",
     "value_allowed": "",

--- a/dbm-ui/backend/components/dbconfig/migrations/rediscomm/config/fullbackup.json
+++ b/dbm-ui/backend/components/dbconfig/migrations/rediscomm/config/fullbackup.json
@@ -16,6 +16,22 @@
     "since_version": ""
   },
   {
+    "conf_name": "full_backup_tag",
+    "value_default": "REDIS_FULL",
+    "value_allowed": "REDIS_FULL|REDIS_FULL_7D",
+    "value_type": "STRING",
+    "value_type_sub": "ENUM",
+    "conf_name_lc": "",
+    "description": "",
+    "need_restart": 0,
+    "flag_readonly": 0,
+    "flag_visible": 1,
+    "flag_status": 1,
+    "flag_locked": 0,
+    "flag_encrypt": 0,
+    "since_version": ""
+  },
+  {
     "conf_name": "old_file_left_day",
     "value_default": "1",
     "value_allowed": "[0,365]",

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/impl/redis_bill_impl.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/impl/redis_bill_impl.py
@@ -16,12 +16,14 @@ from itertools import chain
 
 from django.utils.translation import gettext_lazy as _
 
+from backend.components import DBConfigApi
+from backend.components.dbconfig.constants import FormatType, LevelName
 from backend.configuration.constants import DBPrivSecurityType
 from backend.configuration.handlers.password import DBPasswordHandler
 from backend.db_meta.enums import InstanceRole
 from backend.db_meta.enums.cluster_type import ClusterType
 from backend.db_meta.models import AppCache, Cluster, Spec, StorageInstanceTuple
-from backend.flow.consts import ClusterRoleEnum, RedisCapacityUpdateType
+from backend.flow.consts import DEFAULT_DB_MODULE_ID, ClusterRoleEnum, ConfigTypeEnum, RedisCapacityUpdateType
 from backend.flow.utils.base.payload_handler import PayloadHandler
 from backend.ticket.builders.common.base import IpSource
 from backend.ticket.constants import SwitchConfirmType, TicketType
@@ -168,6 +170,172 @@ def redis_cluster_apply(request, bk_biz_id, cluster_domain, new_cluster_name, ke
                 },
             },
         },
+    }
+    tk = Ticket.create_ticket(**ticket_param)
+    return {"bill_id": tk.pk, "bill_url": tk.url}
+
+
+# 主从克隆申请：参照已有主从，克隆申请一个新的redis主从
+REDIS_INS_APPLY_SUPPORTED_TYPES = [ClusterType.TendisRedisInstance]
+
+
+def _get_redis_databases(cluster: Cluster) -> int:
+    """读取源 redis 主从集群配置里的 databases（db 数量），读不到时回退到默认 16"""
+    try:
+        resp = DBConfigApi.query_conf_item(
+            params={
+                "bk_biz_id": str(cluster.bk_biz_id),
+                "level_name": LevelName.CLUSTER.value,
+                "level_value": cluster.immute_domain,
+                "level_info": {"module": str(DEFAULT_DB_MODULE_ID)},
+                "conf_file": cluster.major_version,
+                "conf_type": ConfigTypeEnum.DBConf.value,
+                "namespace": cluster.cluster_type,
+                "format": FormatType.MAP.value,
+            }
+        )
+        return int(resp.get("content", {}).get("databases", 16))
+    except Exception:  # noqa: BLE001
+        return 16
+
+
+def redis_ins_apply(
+    request,
+    bk_biz_id,
+    cluster_domain,
+    new_cluster_name,
+    spec_id=None,
+    keep_source_password=False,
+    master_ip=None,
+):
+    """
+    参照已有主从，克隆申请一个新的redis主从（TendisRedisInstance, REDIS_INS_APPLY）
+
+    新集群的单据参数（db_version/port/容灾级别/城市/db数量）与克隆目标实例保持一致。
+    @param spec_id: 全新机器部署（资源池）时使用的机器规格id；当传入 master_ip 走追加部署模式时本参数忽略
+    @param keep_source_password: 新集群的redis密码是否与源集群保持一致，默认 False（生成新随机密码）；
+                                 设置为 True 时将复用源集群的redis密码；若源集群无redis密码则回退到生成新随机密码
+    @param master_ip: 可选，cluster_domain集群下某个已有master的IP。传入时走"追加部署"（append_apply），
+                      在该master及其对应slave所在的主机对上追加部署新的redis主从实例，不占用新机器；
+                      不传时默认使用资源池全新机器部署
+    """
+    cluster_obj = Cluster.objects.get(bk_biz_id=bk_biz_id, immute_domain=cluster_domain)
+    if cluster_obj.cluster_type not in REDIS_INS_APPLY_SUPPORTED_TYPES:
+        return {
+            "error": "集群类型{}暂不支持通过该工具克隆申请主从，仅支持: {}".format(
+                cluster_obj.cluster_type, [t.value for t in REDIS_INS_APPLY_SUPPORTED_TYPES]
+            )
+        }
+
+    if Cluster.objects.filter(
+        bk_biz_id=bk_biz_id, cluster_type=cluster_obj.cluster_type, name=new_cluster_name
+    ).exists():
+        return {"error": "新集群名{}已存在，请更换".format(new_cluster_name)}
+
+    master_ins_list = list(
+        cluster_obj.storageinstance_set.select_related("machine").filter(instance_role=InstanceRole.REDIS_MASTER.value)
+    )
+    if not master_ins_list:
+        return {"error": "集群{}未找到master实例，无法获取部署参数".format(cluster_domain)}
+
+    db_app_abbr = AppCache.get_app_attr(bk_biz_id, "db_app_abbr") or str(bk_biz_id)
+    city_code = cluster_obj.region
+    disaster_tolerance_level = cluster_obj.disaster_tolerance_level
+
+    # redis访问密码：若指定与源集群保持一致则复用源集群redis密码，否则随机生成
+    if keep_source_password:
+        source_pwd_map = PayloadHandler.redis_get_cluster_password(cluster=cluster_obj)
+        redis_pwd = source_pwd_map.get("redis_password", "")
+        if not redis_pwd:
+            redis_pwd = DBPasswordHandler.get_random_password(security_type=DBPrivSecurityType.REDIS_PASSWORD)
+    else:
+        redis_pwd = DBPasswordHandler.get_random_password(security_type=DBPrivSecurityType.REDIS_PASSWORD)
+
+    # 克隆目标实例的 db 数量，保持与源集群一致
+    databases = _get_redis_databases(cluster_obj)
+
+    # 新集群的单据参数与源集群保持一致
+    details = {
+        "bk_cloud_id": cluster_obj.bk_cloud_id,
+        "city_code": city_code,
+        "cluster_type": cluster_obj.cluster_type,
+        "db_app_abbr": db_app_abbr,
+        "disaster_tolerance_level": disaster_tolerance_level,
+        "redis_pwd": redis_pwd,
+        "append_apply": False,
+    }
+
+    if master_ip:
+        # 追加部署模式：master_ip 必须是 cluster_domain 现有的某个master，
+        # 在其与对应slave所在的主机对上追加部署新的redis主从实例（不占用新机器）
+        master_ip_map = {ins.machine.ip: ins for ins in master_ins_list}
+        master_ins = master_ip_map.get(master_ip)
+        if not master_ins:
+            return {
+                "error": "master_ip {} 不属于集群{}的master实例，请从以下master中选择一个: {}".format(
+                    master_ip, cluster_domain, list(master_ip_map.keys())
+                )
+            }
+        slave_tuple = (
+            StorageInstanceTuple.objects.select_related("receiver__machine").filter(ejector=master_ins).first()
+        )
+        if not slave_tuple:
+            return {"error": "未找到master {} 对应的slave实例，无法追加部署".format(master_ip)}
+        slave_machine = slave_tuple.receiver.machine
+        master_machine = master_ins.machine
+
+        backend_group = {
+            "master": {
+                "ip": master_machine.ip,
+                "bk_cloud_id": master_machine.bk_cloud_id,
+                "bk_host_id": master_machine.bk_host_id,
+            },
+            "slave": {
+                "ip": slave_machine.ip,
+                "bk_cloud_id": slave_machine.bk_cloud_id,
+                "bk_host_id": slave_machine.bk_host_id,
+            },
+        }
+        details.update(
+            ip_source=IpSource.MANUAL_INPUT.value,
+            append_apply=True,
+            infos=[{"cluster_name": new_cluster_name, "databases": databases, "backend_group": backend_group}],
+        )
+    else:
+        # 默认：资源池全新机器部署，port/db_version 仅资源池模式需要（追加部署由master实例反推，无需指定）
+        if not spec_id:
+            return {"error": "全新机器部署模式需要传入 spec_id（机器规格id）"}
+        backend_spec = Spec.objects.get(spec_id=spec_id)
+        details.update(
+            ip_source=IpSource.RESOURCE_POOL.value,
+            port=cluster_obj.access_port,
+            db_version=cluster_obj.major_version,
+            infos=[{"cluster_name": new_cluster_name, "databases": databases}],
+            resource_spec={
+                "backend_group": {
+                    "count": 1,
+                    "spec_id": spec_id,
+                    "cpu": backend_spec.cpu,
+                    "mem": backend_spec.mem,
+                    "qps": backend_spec.qps,
+                    "capacity": backend_spec.capacity,
+                    "spec_name": backend_spec.spec_name,
+                    "storage_spec": backend_spec.storage_spec,
+                    "affinity": disaster_tolerance_level,
+                    "labels": [],
+                    "label_names": [],
+                    "location_spec": {"city": city_code, "sub_zone_ids": []},
+                }
+            },
+        )
+
+    ticket_param = {
+        "bk_biz_id": bk_biz_id,
+        "creator": request.user.username,
+        "helpers": [],
+        "remark": "mcp redis ins apply(clone from {}) ticket".format(cluster_domain),
+        "ticket_type": TicketType.REDIS_INS_APPLY,
+        "details": details,
     }
     tk = Ticket.create_ticket(**ticket_param)
     return {"bill_id": tk.pk, "bill_url": tk.url}

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_bill.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/serializers/redis_bill.py
@@ -34,6 +34,30 @@ class SubmitBillRedisClusterApplyInputSerializer(serializers.Serializer):
     )
 
 
+class SubmitBillRedisInsApplyInputSerializer(serializers.Serializer):
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 id, bk_biz_id"))
+    cluster_domain = serializers.CharField(help_text=_("参照部署参数的已有主从集群域名，格式为xx.xx.xx.db"))
+    new_cluster_name = serializers.CharField(help_text=_("新集群名（英文数字及连字符，不能与已有集群重名）"))
+    spec_id = serializers.IntegerField(
+        help_text=_("全新机器部署（资源池）时使用的机器规格id；当传入 master_ip 走追加部署模式时本参数忽略"),
+        required=False,
+        default=None,
+    )
+    keep_source_password = serializers.BooleanField(
+        help_text=_("新集群密码是否与源集群保持一致，默认 False（生成新随机密码）"),
+        default=False,
+        required=False,
+    )
+    master_ip = serializers.IPAddressField(
+        help_text=_(
+            "可选，指定cluster_domain集群下某个已有master的IP，在其所在主机对（该master及其对应slave）上" "追加部署新的redis主从实例（不占用新机器）；不传时默认使用资源池全新机器部署"
+        ),
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+
+
 class SubmitBillRedisFullBackupInputSerializer(SubmitBillRedisBaseInputSerializer):
     backup_type = serializers.ChoiceField(
         choices=RedisBackupEnum.get_choices(), default=RedisBackupEnum.NORMAL_BACKUP, help_text=_("备份类型")

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/views/redis_bill_mcp.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/redis/views/redis_bill_mcp.py
@@ -22,6 +22,7 @@ from backend.dbm_aiagent.mcp_tools.redis.impl.redis_bill_impl import (
     redis_full_backup,
     redis_general_scale_down,
     redis_hotkey_analysis,
+    redis_ins_apply,
     redis_load_modules,
     redis_master_slave_switch,
     redis_memory_analysis,
@@ -42,6 +43,7 @@ from backend.dbm_aiagent.mcp_tools.redis.serializers.redis_bill import (
     SubmitBillRedisExtractKeyInputSerializer,
     SubmitBillRedisFlushDBInputSerializer,
     SubmitBillRedisFullBackupInputSerializer,
+    SubmitBillRedisInsApplyInputSerializer,
     SubmitBillRedisKeyStatInputSerializer,
     SubmitBillRedisLoadModulesInputSerializer,
     SubmitBillRedisMasterSlaveSwitchInputSerializer,
@@ -91,6 +93,35 @@ class RedisBillMcpToolsViewSet(McpToolsViewSet):
 
         return Response(
             redis_cluster_apply(request, bk_biz_id, cluster_domain, new_cluster_name, keep_source_password)
+        )
+
+    @mcp_tools_api_decorator(
+        description=str(
+            _(
+                """参照已有主从的部署参数（版本、规格、容灾级别、城市、db数量等），克隆申请一个新的redis主从（TendisRedisInstance）；"""
+                """机器来源默认资源池全新机器，可选指定cluster_domain下某个master的IP，在其所在主机对上追加部署"""
+            )
+        ),
+        request_slz=SubmitBillRedisInsApplyInputSerializer,
+        response_slz=SubmitBillOutputSerializer,
+        permission_classes=[McpTicketToolPermission],
+        mcp_auth_parser=auth_parse_clusters,
+        tags=[DBMMCPTags.READ, DBMMCPTags.WRITE],
+        mcp=[DBMMcpTools.REDIS_BILL],
+        name_prefix="redis_bill",
+    )
+    def submit_bill_redis_ins_apply(self, request, *args, **kwargs):
+        bk_biz_id = self.get_param("bk_biz_id")
+        cluster_domain = self.get_param("cluster_domain")
+        new_cluster_name = self.get_param("new_cluster_name")
+        spec_id = self.get_param("spec_id", None)
+        keep_source_password = self.get_param("keep_source_password", False)
+        master_ip = self.get_param("master_ip", None)
+
+        return Response(
+            redis_ins_apply(
+                request, bk_biz_id, cluster_domain, new_cluster_name, spec_id, keep_source_password, master_ip
+            )
         )
 
     @mcp_tools_api_decorator(

--- a/dbm-ui/backend/flow/engine/bamboo/scene/name_service/name_service.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/name_service/name_service.py
@@ -62,6 +62,13 @@ class NameServiceFlow(object):
             act_component_code=ExecNameServiceOperationComponent.code,
             kwargs=asdict(self.kwargs),
         )
+        # 将集群主域名指向clb ip，使集群访问流量经过clb，与"申请clb"串成一条流程
+        self.kwargs.name_service_operation_type = "domain_bind_clb_ip"
+        pipeline.add_act(
+            act_name=_("主域名绑定clb ip"),
+            act_component_code=ExecNameServiceOperationComponent.code,
+            kwargs=asdict(self.kwargs),
+        )
 
         # 运行流程
         pipeline.run_pipeline()

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_predixy_cluster_apply_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_predixy_cluster_apply_flow.py
@@ -306,19 +306,21 @@ class TendisPlusApplyFlow(object):
             }
         )
 
-        dns_kwargs = DnsKwargs(
-            dns_op_type=DnsOpType.CREATE,
-            add_domain_name=self.data["domain_name"],
-            dns_op_exec_port=self.data["proxy_port"],
-        )
-        act_kwargs.exec_ip = proxy_ips
-        acts_list.append(
-            {
-                "act_name": _("proxy注册域名"),
-                "act_component_code": RedisDnsManageComponent.code,
-                "kwargs": {**asdict(act_kwargs), **asdict(dns_kwargs)},
-            }
-        )
+        # 申请了clb时，主域名会由clb子流程绑定到clb ip（domain_bind_clb_ip），不再将主域名注册到proxy ip
+        if not self.data.get("apply_clb", False):
+            dns_kwargs = DnsKwargs(
+                dns_op_type=DnsOpType.CREATE,
+                add_domain_name=self.data["domain_name"],
+                dns_op_exec_port=self.data["proxy_port"],
+            )
+            act_kwargs.exec_ip = proxy_ips
+            acts_list.append(
+                {
+                    "act_name": _("proxy注册域名"),
+                    "act_component_code": RedisDnsManageComponent.code,
+                    "kwargs": {**asdict(act_kwargs), **asdict(dns_kwargs)},
+                }
+            )
         redis_pipeline.add_parallel_acts(acts_list=acts_list)
 
         # dbmon后置安装

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_predixy_tendisplus_ins_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_predixy_tendisplus_ins_flow.py
@@ -314,20 +314,21 @@ class PredixyTendisPlusInsApplyFlow(object):
             }
         )
 
-        # proxy域名注册
-        dns_kwargs = DnsKwargs(
-            dns_op_type=DnsOpType.CREATE,
-            add_domain_name=self.data["domain_name"],
-            dns_op_exec_port=self.data["proxy_port"],
-        )
-        act_kwargs.exec_ip = proxy_ips
-        acts_list.append(
-            {
-                "act_name": _("proxy注册域名"),
-                "act_component_code": RedisDnsManageComponent.code,
-                "kwargs": {**asdict(act_kwargs), **asdict(dns_kwargs)},
-            }
-        )
+        # 申请了clb时，主域名会由clb子流程绑定到clb ip（domain_bind_clb_ip），不再将主域名注册到proxy ip
+        if not self.data.get("apply_clb", False):
+            dns_kwargs = DnsKwargs(
+                dns_op_type=DnsOpType.CREATE,
+                add_domain_name=self.data["domain_name"],
+                dns_op_exec_port=self.data["proxy_port"],
+            )
+            act_kwargs.exec_ip = proxy_ips
+            acts_list.append(
+                {
+                    "act_name": _("proxy注册域名"),
+                    "act_component_code": RedisDnsManageComponent.code,
+                    "kwargs": {**asdict(act_kwargs), **asdict(dns_kwargs)},
+                }
+            )
         redis_pipeline.add_parallel_acts(acts_list=acts_list)
 
         # 步骤8：后置安装dbmon监控

--- a/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_twemproxy_cluster_apply_flow.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/redis/redis_twemproxy_cluster_apply_flow.py
@@ -332,20 +332,21 @@ class RedisClusterApplyFlow(object):
             }
         )
 
-        # 添加域名
-        dns_kwargs = DnsKwargs(
-            dns_op_type=DnsOpType.CREATE,
-            add_domain_name=self.data["domain_name"],
-            dns_op_exec_port=self.data["proxy_port"],
-        )
-        act_kwargs.exec_ip = proxy_ips
-        acts_list.append(
-            {
-                "act_name": _("proxy注册域名"),
-                "act_component_code": RedisDnsManageComponent.code,
-                "kwargs": {**asdict(act_kwargs), **asdict(dns_kwargs)},
-            }
-        )
+        # 申请了clb时，主域名会由clb子流程绑定到clb ip（domain_bind_clb_ip），不再将主域名注册到proxy ip
+        if not self.data.get("apply_clb", False):
+            dns_kwargs = DnsKwargs(
+                dns_op_type=DnsOpType.CREATE,
+                add_domain_name=self.data["domain_name"],
+                dns_op_exec_port=self.data["proxy_port"],
+            )
+            act_kwargs.exec_ip = proxy_ips
+            acts_list.append(
+                {
+                    "act_name": _("proxy注册域名"),
+                    "act_component_code": RedisDnsManageComponent.code,
+                    "kwargs": {**asdict(act_kwargs), **asdict(dns_kwargs)},
+                }
+            )
         redis_pipeline.add_parallel_acts(acts_list=acts_list)
 
         # dbmon后置安装

--- a/dbm-ui/backend/flow/utils/redis/redis_util.py
+++ b/dbm-ui/backend/flow/utils/redis/redis_util.py
@@ -82,6 +82,13 @@ def build_clb_polaris_apply_subs(
             act_component_code=ExecNameServiceOperationComponent.code,
             kwargs=asdict(ns_kwargs),
         )
+        # 将集群主域名指向clb ip，使集群访问流量经过clb；与"创建clb"串成一条子流程
+        ns_kwargs.name_service_operation_type = "domain_bind_clb_ip"
+        clb_sub_pipeline.add_act(
+            act_name=_("主域名绑定clb ip"),
+            act_component_code=ExecNameServiceOperationComponent.code,
+            kwargs=asdict(ns_kwargs),
+        )
         sub_processes.append(clb_sub_pipeline.build_sub_process(sub_name=_("创建clb")))
 
     if apply_polaris:


### PR DESCRIPTION
1、redis/mongo 申请clb的时候，域名直接指向clb
2、redis 主从实例克隆mcp
3、配置服务修改，io-threads默认值为1
4、配置服务增加，全备、增备备份时长tag