### PR TITLE
refactor(other): drop prefix from dispatch prometheus names #20199

### DIFF
--- a/dbm-ui/backend/bk_dataview/prometheus/dispatch_metrics.py
+++ b/dbm-ui/backend/bk_dataview/prometheus/dispatch_metrics.py
@@ -70,17 +70,17 @@ OUTCOME_WHITELIST = frozenset(
 LATENCY_STAGE_WHITELIST = frozenset({"queue_wait_seconds", "execution_seconds", "pump_seconds"})
 
 _LIVE_GAUGES = (
-    ("dbm_dispatch_pending", "pending"),
-    ("dbm_dispatch_pending_ready", "pending_ready"),
-    ("dbm_dispatch_pending_delayed", "pending_delayed"),
-    ("dbm_dispatch_reserved", "reserved"),
-    ("dbm_dispatch_max_admitted_jobs", "max_admitted_jobs"),
-    ("dbm_dispatch_max_reserved", "max_reserved"),
-    ("dbm_dispatch_budget", "budget"),
-    ("dbm_dispatch_congestion_window", "congestion_window"),
-    ("dbm_dispatch_pump_paused", "pump_paused"),
-    ("dbm_dispatch_producer_paused", "producer_paused"),
-    ("dbm_dispatch_reserved_saturated", "reserved_saturated"),
+    ("dispatch_pending", "pending"),
+    ("dispatch_pending_ready", "pending_ready"),
+    ("dispatch_pending_delayed", "pending_delayed"),
+    ("dispatch_reserved", "reserved"),
+    ("dispatch_max_admitted_jobs", "max_admitted_jobs"),
+    ("dispatch_max_reserved", "max_reserved"),
+    ("dispatch_budget", "budget"),
+    ("dispatch_congestion_window", "congestion_window"),
+    ("dispatch_pump_paused", "pump_paused"),
+    ("dispatch_producer_paused", "producer_paused"),
+    ("dispatch_reserved_saturated", "reserved_saturated"),
 )
 
 
@@ -93,7 +93,7 @@ class DispatchMetricsCollector:
     def describe(self):
         families = [
             GaugeMetricFamily(
-                "dbm_dispatch_collector_health",
+                "dispatch_collector_health",
                 "Dispatch collector health (one-hot over a fixed status set).",
                 labels=["status"],
             )
@@ -103,47 +103,47 @@ class DispatchMetricsCollector:
         families.extend(
             [
                 CounterMetricFamily(
-                    "dbm_dispatch_events",
+                    "dispatch_events",
                     "Cumulative dispatch events per namespace.",
                     labels=["namespace", "event"],
                 ),
                 HistogramMetricFamily(
-                    "dbm_dispatch_latency_seconds",
+                    "dispatch_latency_seconds",
                     "Cumulative dispatch latency histogram per stage.",
                     labels=["namespace", "stage"],
                 ),
                 GaugeMetricFamily(
-                    "dbm_dispatch_task_pending",
+                    "dispatch_task_pending",
                     "Pending work items per dispatch task.",
                     labels=["namespace", "task_key"],
                 ),
                 GaugeMetricFamily(
-                    "dbm_dispatch_task_reserved",
+                    "dispatch_task_reserved",
                     "Reserved work items per dispatch task.",
                     labels=["namespace", "task_key"],
                 ),
                 CounterMetricFamily(
-                    "dbm_dispatch_task_outcome",
+                    "dispatch_task_outcome",
                     "Cumulative outcomes per dispatch task.",
                     labels=["namespace", "task_key", "outcome"],
                 ),
                 GaugeMetricFamily(
-                    "dbm_dispatch_report_partial",
+                    "dispatch_report_partial",
                     "Dispatch data completeness per namespace (1 = incomplete).",
                     labels=["namespace"],
                 ),
                 GaugeMetricFamily(
-                    "dbm_dispatch_refresh_timestamp_seconds",
+                    "dispatch_refresh_timestamp_seconds",
                     "Unix timestamp of the latest cumulative snapshot.",
                     labels=[],
                 ),
                 GaugeMetricFamily(
-                    "dbm_dispatch_publisher_heartbeat_timestamp_seconds",
+                    "dispatch_publisher_heartbeat_timestamp_seconds",
                     "Unix timestamp of the last publisher lock acquisition.",
                     labels=[],
                 ),
                 GaugeMetricFamily(
-                    "dbm_dispatch_metrics_started_at_timestamp_seconds",
+                    "dispatch_metrics_started_at_timestamp_seconds",
                     "Unix timestamp when the current namespace metric generation started.",
                     labels=["namespace"],
                 ),
@@ -178,7 +178,7 @@ class DispatchMetricsCollector:
 
     def collect(self):
         health = GaugeMetricFamily(
-            "dbm_dispatch_collector_health",
+            "dispatch_collector_health",
             "Dispatch collector health (one-hot over a fixed status set).",
             labels=["status"],
         )
@@ -232,7 +232,7 @@ class DispatchMetricsCollector:
 
     def _events_family(self, payload: dict) -> CounterMetricFamily:
         family = CounterMetricFamily(
-            "dbm_dispatch_events",
+            "dispatch_events",
             "Cumulative dispatch events per namespace.",
             labels=["namespace", "event"],
         )
@@ -245,7 +245,7 @@ class DispatchMetricsCollector:
 
     def _latency_family(self, payload: dict) -> HistogramMetricFamily:
         family = HistogramMetricFamily(
-            "dbm_dispatch_latency_seconds",
+            "dispatch_latency_seconds",
             "Cumulative dispatch latency histogram per stage.",
             labels=["namespace", "stage"],
         )
@@ -271,17 +271,17 @@ class DispatchMetricsCollector:
 
     def _task_families(self, payload: dict) -> list:
         pending_family = GaugeMetricFamily(
-            "dbm_dispatch_task_pending",
+            "dispatch_task_pending",
             "Pending work items per dispatch task.",
             labels=["namespace", "task_key"],
         )
         reserved_family = GaugeMetricFamily(
-            "dbm_dispatch_task_reserved",
+            "dispatch_task_reserved",
             "Reserved work items per dispatch task.",
             labels=["namespace", "task_key"],
         )
         outcome_family = CounterMetricFamily(
-            "dbm_dispatch_task_outcome",
+            "dispatch_task_outcome",
             "Cumulative outcomes per dispatch task.",
             labels=["namespace", "task_key", "outcome"],
         )
@@ -299,7 +299,7 @@ class DispatchMetricsCollector:
 
     def _partial_family(self, payload: dict) -> GaugeMetricFamily:
         family = GaugeMetricFamily(
-            "dbm_dispatch_report_partial",
+            "dispatch_report_partial",
             "Dispatch data completeness per namespace (1 = incomplete).",
             labels=["namespace"],
         )
@@ -312,7 +312,7 @@ class DispatchMetricsCollector:
 
     def _refresh_family(self, payload: dict) -> GaugeMetricFamily:
         family = GaugeMetricFamily(
-            "dbm_dispatch_refresh_timestamp_seconds",
+            "dispatch_refresh_timestamp_seconds",
             "Unix timestamp of the latest cumulative snapshot.",
             labels=[],
         )
@@ -323,7 +323,7 @@ class DispatchMetricsCollector:
 
     def _heartbeat_family(self) -> GaugeMetricFamily:
         family = GaugeMetricFamily(
-            "dbm_dispatch_publisher_heartbeat_timestamp_seconds",
+            "dispatch_publisher_heartbeat_timestamp_seconds",
             "Unix timestamp of the last publisher lock acquisition.",
             labels=[],
         )
@@ -337,7 +337,7 @@ class DispatchMetricsCollector:
 
     def _started_at_family(self, payload: dict) -> GaugeMetricFamily:
         family = GaugeMetricFamily(
-            "dbm_dispatch_metrics_started_at_timestamp_seconds",
+            "dispatch_metrics_started_at_timestamp_seconds",
             "Unix timestamp when the current namespace metric generation started.",
             labels=["namespace"],
         )

--- a/dbm-ui/backend/tests/bk_dataview/prometheus/test_dispatch_metrics.py
+++ b/dbm-ui/backend/tests/bk_dataview/prometheus/test_dispatch_metrics.py
@@ -83,7 +83,7 @@ def _by_name(families):
 
 
 def _health_status(families):
-    health = _by_name(families).get("dbm_dispatch_collector_health")
+    health = _by_name(families).get("dispatch_collector_health")
     if health is None:
         return None
     for sample in health.samples:
@@ -96,12 +96,12 @@ class TestDispatchMetricsCollector:
     def test_describe_lists_metric_names_without_redis(self):
         collector = DispatchMetricsCollector(client=InMemoryRedis(raises=True))
         names = {family.name for family in collector.describe()}
-        assert "dbm_dispatch_collector_health" in names
-        assert "dbm_dispatch_pending" in names
-        assert "dbm_dispatch_events" in names
-        assert "dbm_dispatch_latency_seconds" in names
-        assert "dbm_dispatch_task_outcome" in names
-        assert "dbm_dispatch_metrics_started_at_timestamp_seconds" in names
+        assert "dispatch_collector_health" in names
+        assert "dispatch_pending" in names
+        assert "dispatch_events" in names
+        assert "dispatch_latency_seconds" in names
+        assert "dispatch_task_outcome" in names
+        assert "dispatch_metrics_started_at_timestamp_seconds" in names
         assert all(not family.samples for family in collector.describe())
 
     def test_generates_counters_histogram_and_live_samples(self):
@@ -110,20 +110,20 @@ class TestDispatchMetricsCollector:
 
         assert _health_status(families) == "ok"
         by_name = _by_name(families)
-        pending = list(by_name["dbm_dispatch_pending"].samples)
+        pending = list(by_name["dispatch_pending"].samples)
         assert pending[0].labels == {"namespace": "ai"}
         assert pending[0].value == 10.0
 
-        event_samples = list(by_name["dbm_dispatch_events"].samples)
+        event_samples = list(by_name["dispatch_events"].samples)
         assert any(
-            sample.name == "dbm_dispatch_events_total"
+            sample.name == "dispatch_events_total"
             and sample.labels == {"namespace": "ai", "event": "published"}
             and sample.value == 100.0
             for sample in event_samples
         )
         assert all(sample.labels["event"] != "bogus_event" for sample in event_samples)
 
-        histogram_samples = list(by_name["dbm_dispatch_latency_seconds"].samples)
+        histogram_samples = list(by_name["dispatch_latency_seconds"].samples)
         buckets = [sample for sample in histogram_samples if sample.name.endswith("_bucket")]
         assert [(sample.labels["le"], sample.value) for sample in buckets] == [
             ("0.1", 2.0),
@@ -133,13 +133,13 @@ class TestDispatchMetricsCollector:
         assert any(sample.name.endswith("_count") and sample.value == 10.0 for sample in histogram_samples)
         assert any(sample.name.endswith("_sum") and sample.value == 4.2 for sample in histogram_samples)
 
-        outcomes = list(by_name["dbm_dispatch_task_outcome"].samples)
-        assert any(sample.name == "dbm_dispatch_task_outcome_total" and sample.value == 30 for sample in outcomes)
+        outcomes = list(by_name["dispatch_task_outcome"].samples)
+        assert any(sample.name == "dispatch_task_outcome_total" and sample.value == 30 for sample in outcomes)
         assert all(sample.labels["outcome"] != "bogus_outcome" for sample in outcomes)
 
-        started = list(by_name["dbm_dispatch_metrics_started_at_timestamp_seconds"].samples)
+        started = list(by_name["dispatch_metrics_started_at_timestamp_seconds"].samples)
         assert started[0].value == 1000.0
-        partial = list(by_name["dbm_dispatch_report_partial"].samples)
+        partial = list(by_name["dispatch_report_partial"].samples)
         assert partial[0].labels == {"namespace": "ai"}
         assert partial[0].value == 0
 
@@ -155,15 +155,15 @@ class TestDispatchMetricsCollector:
         )
         records = reporter.generate_report_data()["data"]
         names = {next(iter(record["metrics"])) for record in records}
-        assert "dbm_dispatch_events_total" in names
-        assert "dbm_dispatch_task_outcome_total" in names
-        assert "dbm_dispatch_latency_seconds_bucket" in names
-        assert "dbm_dispatch_latency_seconds_count" in names
-        assert "dbm_dispatch_latency_seconds_sum" in names
+        assert "dispatch_events_total" in names
+        assert "dispatch_task_outcome_total" in names
+        assert "dispatch_latency_seconds_bucket" in names
+        assert "dispatch_latency_seconds_count" in names
+        assert "dispatch_latency_seconds_sum" in names
         bucket = next(
             record
             for record in records
-            if "dbm_dispatch_latency_seconds_bucket" in record["metrics"] and record["dimension"].get("le") == "+Inf"
+            if "dispatch_latency_seconds_bucket" in record["metrics"] and record["dimension"].get("le") == "+Inf"
         )
         assert bucket["dimension"] == {"le": "+Inf", "namespace": "ai", "stage": "execution"}
 
@@ -172,18 +172,18 @@ class TestDispatchMetricsCollector:
         reset = DispatchMetricsCollector(
             client=InMemoryRedis({KEY_LATEST: json.dumps(_payload(started_at=2000.0, published=3))})
         )
-        first_events = _by_name(first._build_families(_payload(published=100)))["dbm_dispatch_events"].samples
+        first_events = _by_name(first._build_families(_payload(published=100)))["dispatch_events"].samples
         reset_families = _by_name(reset._build_families(_payload(started_at=2000.0, published=3)))
-        reset_events = reset_families["dbm_dispatch_events"].samples
+        reset_events = reset_families["dispatch_events"].samples
         assert first_events[0].value == 100
         assert reset_events[0].value == 3
-        assert reset_families["dbm_dispatch_metrics_started_at_timestamp_seconds"].samples[0].value == 2000
+        assert reset_families["dispatch_metrics_started_at_timestamp_seconds"].samples[0].value == 2000
 
     def test_heartbeat_emits_stored_epoch(self):
         now = time.time()
         client = InMemoryRedis({KEY_LATEST: json.dumps(_payload()), KEY_HEARTBEAT: str(now)})
         families = _collect(DispatchMetricsCollector(client=client))
-        heartbeat = _by_name(families)["dbm_dispatch_publisher_heartbeat_timestamp_seconds"].samples
+        heartbeat = _by_name(families)["dispatch_publisher_heartbeat_timestamp_seconds"].samples
         assert heartbeat[0].value == now
 
     def test_lease_holder_only_emits_data(self):


### PR DESCRIPTION
- **指标名重复前缀**：Prometheus family 从 `dbm_dispatch_*` 改为 `dispatch_*`（如 `dispatch_budget`、`dispatch_events`
- **采集/payload 不变**：Redis key、schema v2 字段、publisher 逻辑未改 → 只换导出名字，不换数据源