### PR TITLE
feat(mysql): mysql-temp-account-use-dbpriv #20207

### DIFF
--- a/dbm-services/mysql/db-priv/handler/v2/add_mysql_temp_account.go
+++ b/dbm-services/mysql/db-priv/handler/v2/add_mysql_temp_account.go
@@ -1,0 +1,53 @@
+package v2
+
+import (
+	"dbm-services/common/go-pubpkg/errno"
+	"dbm-services/mysql/priv-service/handler"
+	"dbm-services/mysql/priv-service/service/v2/add_mysql_temp_account"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func AddMySQLTempAccount(c *gin.Context) {
+	slog.Info("AddMySQLTempAccount")
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		slog.Error("ioutil.ReadAll", err)
+		handler.SendResponse(c, errno.ErrBind, err)
+		return
+	}
+
+	var input add_mysql_temp_account.Param
+	if err := json.Unmarshal(body, &input); err != nil {
+		slog.Error("json.Unmarshal", err)
+		handler.SendResponse(c, errno.ErrBind, err)
+		return
+	}
+
+	report, err := add_mysql_temp_account.AddMySQLTempAccount(&input)
+	slog.Error("report", slog.Any("report", report), slog.Any("err", err))
+	if report != nil || err != nil {
+		rbody := gin.H{
+			"code": 0,
+			"msg":  "",
+			"data": nil,
+		}
+		if report != nil {
+			rbody["data"] = report
+		}
+		if err != nil {
+			rbody["msg"] = err.Error()
+		}
+		c.JSON(
+			http.StatusOK, rbody,
+		)
+	} else {
+		c.JSON(http.StatusOK, gin.H{})
+	}
+	return
+}

--- a/dbm-services/mysql/db-priv/handler/v2/init.go
+++ b/dbm-services/mysql/db-priv/handler/v2/init.go
@@ -10,5 +10,6 @@ func Routes() []*gin.RouteInfo {
 	return []*gin.RouteInfo{
 		{Method: http.MethodPost, Path: "add_priv", HandlerFunc: AddPriv},
 		{Method: http.MethodPost, Path: "clone_instance_priv", HandlerFunc: CloneInstancePriv},
+		{Method: http.MethodPost, Path: "add_mysql_temp_account", HandlerFunc: AddMySQLTempAccount},
 	}
 }

--- a/dbm-services/mysql/db-priv/service/v2/add_mysql_temp_account/init.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_mysql_temp_account/init.go
@@ -1,0 +1,84 @@
+package add_mysql_temp_account
+
+import (
+	"crypto/sha1"
+	"dbm-services/mysql/priv-service/service"
+	"dbm-services/mysql/priv-service/service/v2/add_priv"
+	"fmt"
+	"strings"
+)
+
+type Param struct {
+	RootId    string   `json:"root_id"`
+	Addresses []string `json:"addresses"`
+	BkCloudId int64    `json:"bk_cloud_id"`
+}
+
+func AddMySQLTempAccount(param *Param) (report map[string][]string, err error) {
+	username := fmt.Sprintf("J_%s", param.RootId)
+	password := password(param.RootId)
+	oldPassword := oldPassword(param.RootId)
+
+	accessHosts := []string{"%", "localhost"}
+
+	dummyAddPrivParam := add_priv.PrivTaskPara{
+		PrivTaskPara: &service.PrivTaskPara{
+			User: username,
+		},
+	}
+
+	report, err = dummyAddPrivParam.AddOnMySQL(
+		accessHosts,
+		map[int64][]string{param.BkCloudId: param.Addresses},
+		map[string][]string{"*": []string{"ALL PRIVILEGES"}},
+		password,
+		oldPassword,
+		true,
+		true,
+	)
+	return report, err
+}
+
+// Password 复刻 MySQL 4.1+ 的 PASSWORD() 函数
+// 算法：'*' + UPPER(HEX(SHA1(SHA1(password))))
+// 返回长度固定 41 字符（1 个 '*' + 40 个十六进制字符）
+// 空字符串输入返回空字符串（与 MySQL 行为一致）
+func password(password string) string {
+	if password == "" {
+		return ""
+	}
+	first := sha1.Sum([]byte(password))
+	second := sha1.Sum(first[:])
+	return "*" + strings.ToUpper(fmt.Sprintf("%x", second))
+}
+
+// OldPassword 复刻 MySQL 4.1 之前的 OLD_PASSWORD() 函数
+// 算法：私有的 nr/nr2 双 hash，输出 16 字符十六进制小写
+// 空字符串输入返回空字符串
+func oldPassword(password string) string {
+	if password == "" {
+		return ""
+	}
+
+	var nr uint32 = 1345345333
+	var add uint32 = 7
+	var nr2 uint32 = 0x12345671
+
+	for i := 0; i < len(password); i++ {
+		c := password[i]
+		// 跳过空格和 tab（MySQL 官方实现有这个逻辑）
+		if c == ' ' || c == '\t' {
+			continue
+		}
+		tmp := uint32(c)
+		nr ^= (((nr & 63) + add) * tmp) + (nr << 8)
+		nr2 += (nr2 << 8) ^ nr
+		add += tmp
+	}
+
+	// 取低 31 位（清掉符号位）
+	result1 := nr & ((uint32(1) << 31) - 1)
+	result2 := nr2 & ((uint32(1) << 31) - 1)
+
+	return fmt.Sprintf("%08x%08x", result1, result2)
+}

--- a/dbm-services/mysql/db-priv/service/v2/add_priv/add_on_mysql.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/add_on_mysql.go
@@ -6,6 +6,7 @@ import (
 	"dbm-services/mysql/priv-service/service/v2/internal/drs"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -28,40 +29,68 @@ type versionRelatedInfo struct {
 	AuthColName  string
 }
 
-//const (
-//	productSpider = "spider"
-//	productMySQL  = "mysql"
-//)
-
-func (c *PrivTaskPara) addOnMySQL(
+func (c *PrivTaskPara) AddOnMySQL(
 	clientIps []string, workingInstances map[int64][]string,
 	dbScopePrivs map[string][]string,
 	longPSW string,
 	shortPSW string,
+	withGrantOption bool,
+	skipError bool,
 ) (reports map[string][]string, err error) {
 	reports = make(map[string][]string)
 
 	// 版本相关信息 (密码列、CREATE USER 语法界等) 顶层探一次, 下面 check / grant 都从这里读
 	versionInfosByCloud := make(map[int64]map[string]versionRelatedInfo, len(workingInstances))
 	for bkCloudId, addrs := range workingInstances {
-		infos, err := queryVersionInfo(bkCloudId, addrs)
+		infos, versionReports, err := queryVersionInfo(bkCloudId, addrs)
 		if err != nil {
 			return nil, err
 		}
+
+		if len(versionReports) > 0 {
+			for k, v := range versionReports {
+				if _, ok := reports[k]; !ok {
+					reports[k] = []string{}
+				}
+				reports[k] = append(reports[k], v...)
+				workingInstances[bkCloudId] = slices.DeleteFunc(
+					addrs, func(s string) bool {
+						return s == k
+					},
+				)
+			}
+		}
+
 		versionInfosByCloud[bkCloudId] = infos
+	}
+	if len(reports) > 0 && !skipError {
+		return reports, nil
 	}
 
 	// Go 侧预检. 有报告说明发现冲突, 直接返回, 不再走 dba_grant 里存储过程的检查
 	// existingUsers: addr -> clientIp set, 已存在的用户不再生成建用户语句
-	checkReports, existingUsers, err := c.check(clientIps, workingInstances, versionInfosByCloud, dbScopePrivs, longPSW, shortPSW)
+	checkReports, existingUsers, err := c.check(
+		clientIps, workingInstances, versionInfosByCloud, dbScopePrivs, longPSW, shortPSW,
+	)
 	if err != nil {
 		return nil, err
 	}
 	if len(checkReports) > 0 {
-		return checkReports, nil
+		for k, v := range checkReports {
+			if _, ok := reports[k]; !ok {
+				reports[k] = []string{}
+			}
+			reports[k] = append(reports[k], v...)
+		}
+	}
+	if len(reports) > 0 && !skipError {
+		return reports, nil
 	}
 
-	if err := c.grant(clientIps, workingInstances, versionInfosByCloud, dbScopePrivs, longPSW, existingUsers, reports); err != nil {
+	if err := c.grant(
+		clientIps, workingInstances, versionInfosByCloud, dbScopePrivs, longPSW, existingUsers, reports,
+		withGrantOption,
+	); err != nil {
 		return nil, err
 	}
 	slog.Info(
@@ -328,7 +357,7 @@ func (c *PrivTaskPara) check(
 //	MySQL >= 5.7          -> authentication_string
 //
 // 任一 addr 探测报错(网络/RPC/SQL 执行/结果为空/版本不支持)直接返回错误, 不吞
-func queryVersionInfo(bkCloudId int64, addrs []string) (map[string]versionRelatedInfo, error) {
+func queryVersionInfo(bkCloudId int64, addrs []string) (map[string]versionRelatedInfo, map[string][]string, error) {
 	query := `SELECT
 		@@version AS raw_version,
 		CASE WHEN @@version LIKE '%tspider%' THEN 'spider' ELSE 'mysql' END AS product,
@@ -346,20 +375,36 @@ func queryVersionInfo(bkCloudId int64, addrs []string) (map[string]versionRelate
 
 	res, err := drs.RPCMySQL(bkCloudId, addrs, []string{query}, false, 600)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ret := make(map[string]versionRelatedInfo, len(addrs))
+	reports := make(map[string][]string)
 	for _, r := range res {
 		if r.ErrorMsg != "" {
-			return nil, errors.Errorf("query version info on %s: %s", r.Address, r.ErrorMsg)
+			if _, ok := reports[r.Address]; !ok {
+				reports[r.Address] = make([]string, 0)
+			}
+			reports[r.Address] = append(reports[r.Address], r.ErrorMsg)
+			continue
+			//return nil, errors.Errorf("query version info on %s: %s", r.Address, r.ErrorMsg)
 		}
 		cr := r.CmdResults[0]
 		if cr.ErrorMsg != "" {
-			return nil, errors.Errorf("query version info on %s: %s", r.Address, cr.ErrorMsg)
+			if _, ok := reports[r.Address]; !ok {
+				reports[r.Address] = make([]string, 0)
+			}
+			reports[r.Address] = append(reports[r.Address], cr.ErrorMsg)
+			continue
+			//return nil, errors.Errorf("query version info on %s: %s", r.Address, cr.ErrorMsg)
 		}
 		if len(cr.TableData) == 0 {
-			return nil, errors.Errorf("query version info on %s: empty result", r.Address)
+			if _, ok := reports[r.Address]; !ok {
+				reports[r.Address] = make([]string, 0)
+			}
+			reports[r.Address] = append(reports[r.Address], "query version info empty result")
+			continue
+			//return nil, errors.Errorf("query version info on %s: empty result", r.Address)
 		}
 		row := cr.TableData[0]
 
@@ -367,7 +412,12 @@ func queryVersionInfo(bkCloudId int64, addrs []string) (map[string]versionRelate
 		product, _ := row["product"].(string)
 		col, _ := row["auth_col_name"].(string)
 		if col == "" {
-			return nil, errors.Errorf("not support spider version on %s: %s", r.Address, raw)
+			if _, ok := reports[r.Address]; !ok {
+				reports[r.Address] = make([]string, 0)
+			}
+			reports[r.Address] = append(reports[r.Address], fmt.Sprintf("not support version: %s", raw))
+			continue
+			//return nil, errors.Errorf("not support spider version on %s: %s", r.Address, raw)
 		}
 		vintStr, _ := row["version_as_int"].(string)
 		vint, _ := strconv.ParseInt(vintStr, 10, 64)
@@ -378,7 +428,7 @@ func queryVersionInfo(bkCloudId int64, addrs []string) (map[string]versionRelate
 			AuthColName:  col,
 		}
 	}
-	return ret, nil
+	return ret, reports, nil
 }
 
 // checkPsw 密码一致性检查 + 收集已存在的 user@host
@@ -554,6 +604,7 @@ func (c *PrivTaskPara) grant(
 	longPSW string,
 	existingUsers map[string]map[string]bool,
 	reports map[string][]string,
+	withGrantOption bool,
 ) error {
 	for bkCloudId := range workingInstances {
 		infos := versionInfosByCloud[bkCloudId]
@@ -569,7 +620,9 @@ func (c *PrivTaskPara) grant(
 
 		// >= 5.7: CREATE USER IF NOT EXISTS
 		if len(createUserAddrs) > 0 {
-			sqls := buildGrantSQLs(c.User, clientIps, dbScopePrivs, longPSW, true, existingUsers, createUserAddrs)
+			sqls := buildGrantSQLs(
+				c.User, clientIps, dbScopePrivs, longPSW, true, existingUsers, createUserAddrs, withGrantOption,
+			)
 			if err := runGrant(bkCloudId, createUserAddrs, sqls, reports); err != nil {
 				return err
 			}
@@ -577,7 +630,9 @@ func (c *PrivTaskPara) grant(
 
 		// < 5.7: GRANT USAGE ... IDENTIFIED BY PASSWORD
 		if len(grantUsageAddrs) > 0 {
-			sqls := buildGrantSQLs(c.User, clientIps, dbScopePrivs, longPSW, false, existingUsers, grantUsageAddrs)
+			sqls := buildGrantSQLs(
+				c.User, clientIps, dbScopePrivs, longPSW, false, existingUsers, grantUsageAddrs, withGrantOption,
+			)
 			if err := runGrant(bkCloudId, grantUsageAddrs, sqls, reports); err != nil {
 				return err
 			}
@@ -598,7 +653,7 @@ func (c *PrivTaskPara) grant(
 // dbScopePrivs 的 key "*" -> ON *.*, 其它 -> ON `dbname`.*
 func buildGrantSQLs(
 	user string, clientIps []string, dbScopePrivs map[string][]string, longPSW string, useCreateUser bool,
-	existingUsers map[string]map[string]bool, addrs []string,
+	existingUsers map[string]map[string]bool, addrs []string, withGrantOption bool,
 ) []string {
 	sqls := []string{"SET SESSION sql_log_bin = 0"}
 
@@ -634,12 +689,14 @@ func buildGrantSQLs(
 			onClause = fmt.Sprintf("`%s`.*", db)
 		}
 		for _, ip := range clientIps {
-			sqls = append(
-				sqls, fmt.Sprintf(
-					`GRANT %s ON %s TO '%s'@'%s'`,
-					privStr, onClause, user, ip,
-				),
+			sql := fmt.Sprintf(
+				`GRANT %s ON %s TO '%s'@'%s'`,
+				privStr, onClause, user, ip,
 			)
+			if withGrantOption {
+				sql += " WITH GRANT OPTION"
+			}
+			sqls = append(sqls, sql)
 		}
 	}
 
@@ -663,7 +720,7 @@ func needCreateUser(ip string, existingUsers map[string]map[string]bool, addrs [
 func runGrant(bkCloudId int64, addrs []string, sqls []string, reports map[string][]string) error {
 	slog.Info("grant", slog.Any("addrs", addrs), slog.Any("sqls", sqls))
 
-	res, err := drs.RPCMySQL(bkCloudId, addrs, sqls, true, 600)
+	res, err := drs.RPCMySQL(bkCloudId, addrs, append([]string{"set tc_admin = 0"}, sqls...), true, 600)
 	if err != nil {
 		return err
 	}
@@ -674,7 +731,9 @@ func runGrant(bkCloudId int64, addrs []string, sqls []string, reports map[string
 			continue
 		}
 		for _, cr := range r.CmdResults {
-			if cr.ErrorMsg != "" {
+			// set tc_admin = 0 是强制注入的
+			// 所以忽略掉这个变量不存在的错误
+			if cr.ErrorMsg != "" && cr.Cmd == "set tc_admin = 0" && !strings.Contains(cr.ErrorMsg, "Error 1193") {
 				reports[r.Address] = append(
 					reports[r.Address],
 					fmt.Sprintf("%s: %s", cr.Cmd, cr.ErrorMsg),

--- a/dbm-services/mysql/db-priv/service/v2/add_priv/add_priv.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/add_priv.go
@@ -183,7 +183,7 @@ func (c *PrivTaskPara) AddPriv(jsonPara, ticket string) (err error) {
 
 				// err 是调用函数出错, 直接报错返回
 				// reports 是实施授权的报告
-				reports, err := c.addOnMySQL(clientIps, workingMySQLInstances, dbScopePrivs, longPSW, shortPSW)
+				reports, err := c.AddOnMySQL(clientIps, workingMySQLInstances, dbScopePrivs, longPSW, shortPSW, false, false)
 				//reports, err := c.addOnMySQL(clientIps, workingMySQLInstances, accountAndRuleDetails, &accountPSW)
 				if err != nil {
 					slog.Error("add priv", slog.String("err", err.Error()))

--- a/dbm-services/mysql/db-priv/service/v2/add_priv/fetch_target_dbmeta_info.go
+++ b/dbm-services/mysql/db-priv/service/v2/add_priv/fetch_target_dbmeta_info.go
@@ -48,9 +48,5 @@ func (c *PrivTaskPara) fetchTargetDBMetaInfo() ([]*service.Instance, error) {
 		)
 		return nil, err
 	}
-	//slog.Info(
-	//	"fetch target detail",
-	//	slog.String("res", fmt.Sprintf("%+v", res)),
-	//)
 	return res, nil
 }

--- a/dbm-services/mysql/db-priv/service/v2/internal/drs/export_func.go
+++ b/dbm-services/mysql/db-priv/service/v2/internal/drs/export_func.go
@@ -11,6 +11,7 @@ func RPCMySQL(
 			Force:        force,
 			QueryTimeout: timeout,
 			BkCloudId:    bkCloudId,
+			SkipSetNames: true,
 		},
 	)
 }
@@ -26,6 +27,7 @@ func RPCProxyAdmin(
 			Force:        force,
 			QueryTimeout: timeout,
 			BkCloudId:    bkCloudId,
+			SkipSetNames: true,
 		},
 	)
 }

--- a/dbm-services/mysql/db-priv/service/v2/internal/drs/rpc.go
+++ b/dbm-services/mysql/db-priv/service/v2/internal/drs/rpc.go
@@ -40,6 +40,7 @@ type drsRequest struct {
 	*/
 	QueryTimeout int64 `form:"query_timeout" json:"query_timeout" url:"query_timeout"` // sql执行超时时间
 	BkCloudId    int64 `form:"bk_cloud_id" json:"bk_cloud_id" url:"bk_cloud_id"`       // mysql服务所在的云域
+	SkipSetNames bool  `form:"skip_set_names" json:"skip_set_names" url:"skip_set_names"`
 }
 
 /*

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/checkable_tables.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/checkable_tables.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -22,6 +23,17 @@ type checksumTableFilter struct {
 	includeTableRegex *regexp.Regexp
 	hasIncludeDb      bool
 	hasIncludeTable   bool
+}
+
+func (f *checksumTableFilter) String() string {
+	return fmt.Sprintf(
+		"ignoreDbs=%v, includeDbs=%v, ignoreDbRegex=%v, includeDbRegex=%v, "+
+			"ignoreTablesAll=%v, ignoreTablesByDb=%v, includeTablesAll=%v, includeTablesByDb=%v, "+
+			"ignoreTableRegex=%v, includeTableRegex=%v, hasIncludeDb=%v, hasIncludeTable=%v",
+		f.ignoreDbs, f.includeDbs, f.ignoreDbRegex, f.includeDbRegex,
+		f.ignoreTablesAll, f.ignoreTablesByDb, f.includeTablesAll, f.includeTablesByDb,
+		f.ignoreTableRegex, f.includeTableRegex, f.hasIncludeDb, f.hasIncludeTable,
+	)
 }
 
 func newChecksumTableFilter(filter config.Filter) (*checksumTableFilter, error) {
@@ -74,6 +86,7 @@ func newChecksumTableFilter(filter config.Filter) (*checksumTableFilter, error) 
 		f.hasIncludeTable = true
 	}
 
+	slog.Info("new checksum table filter created", slog.String("filter", f.String()), slog.Any("config", filter))
 	return f, nil
 }
 
@@ -180,7 +193,9 @@ func (r *Checker) hasCheckableTables() (bool, error) {
 			slog.Error("scan checkable tables", slog.String("error", err.Error()))
 			return false, err
 		}
+		slog.Info("base table found", slog.String("db", db), slog.String("tbl", tbl))
 		if filter.isCheckable(db, tbl) {
+			slog.Info("checkable table found", slog.String("db", db), slog.String("tbl", tbl))
 			return true, nil
 		}
 	}

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/move_result.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/move_result.go
@@ -39,7 +39,28 @@ func (r *Checker) moveResult() error {
 
 	columnsStr := strings.Join(columns, ",")
 	// 为了兼容 flashback, 这里拼上库前缀
-	_, err = r.conn.ExecContext(
+	// 这里拿个新的conn, 因为有可能过了很久, 原来的 r.conn 已经失效了
+	conn, err := r.db.Connx(context.Background())
+	if err != nil {
+		slog.Info("fetch connection", slog.String("error", err.Error()))
+		return err
+	}
+	_, err = conn.ExecContext(
+		context.Background(), `SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;`,
+	)
+	if err != nil {
+		slog.Error("set transaction isolation level", slog.String("error", err.Error()))
+		return err
+	}
+	_, err = conn.ExecContext(context.Background(), `SET BINLOG_FORMAT = 'STATEMENT'`)
+	if err != nil {
+		slog.Error(
+			"set binlog format to statement", slog.String("error", err.Error()),
+		)
+		return err
+	}
+
+	_, err = conn.ExecContext(
 		context.Background(),
 		fmt.Sprintf(
 			`REPLACE INTO %s.%s (%s) SELECT %s FROM %s.%s WHERE ts >= ? AND master_ip = ? AND master_port = ?`,

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/run_command.go
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pkg/checker/run_command.go
@@ -23,6 +23,8 @@ var dailyStr = "_dba_fake_daily"
 // var demandStartStr = "_dba_fake_demand_start"
 var demandEndStr = "_dba_fake_demand_end"
 
+var enableFlagStr = "_dba_enable_flag"
+
 // EmptySummaryError 表示校验摘要为空的错误，用于 RetryIf 判断是否需要重试
 // 当 pt-table-checksum 执行完成但没有返回校验摘要时，返回此错误触发重试
 type EmptySummaryError struct {
@@ -106,6 +108,13 @@ func (r *Checker) preRunGeneral() error {
 		slog.Info("run checksum disabled")
 		return nil
 	}
+
+	err = r.writeFakeResult(enableFlagStr, enableFlagStr, false)
+	if err != nil {
+		slog.Error("run checksum write enable flag", slog.String("error", err.Error()))
+		return err
+	}
+
 	_, err = r.conn.ExecContext(
 		context.Background(),
 		fmt.Sprintf("DELETE FROM `%s`.`%s` WHERE ts < NOW() - INTERVAL 10 DAY", r.resultDB, r.resultHistoryTable),
@@ -122,6 +131,7 @@ func (r *Checker) runGeneral() error {
 		return err
 	}
 	if !hasTables {
+		r.startTS = time.Now()
 		slog.Info("no checkable tables, skip pt-table-checksum")
 		return nil
 	}

--- a/dbm-ui/backend/components/mysql_priv_manager/client.py
+++ b/dbm-ui/backend/components/mysql_priv_manager/client.py
@@ -97,6 +97,9 @@ class _DBPrivManagerApi(BaseApi):
             url="/priv/v2/add_priv",
             description=_("添加授权 v2"),
         )
+        self.add_mysql_temp_account_v2 = self.generate_data_api(
+            method="POST", url="priv/v2/add_mysql_temp_account", description=_("添加 mysql 临时账号 v2")
+        )
         self.get_online_rules = self.generate_data_api(
             method="POST",
             url="/priv/get_online_rules",

--- a/dbm-ui/backend/db_meta/models/cluster.py
+++ b/dbm-ui/backend/db_meta/models/cluster.py
@@ -342,7 +342,7 @@ class Cluster(AuditedModel):
             role = TenDBClusterSpiderRole.SPIDER_MASTER
             return self.proxyinstance_set.filter(tendbclusterspiderext__spider_role=role).first().port
 
-    def tendbcluster_ctl_primary_address(self, v2=False) -> str:
+    def tendbcluster_ctl_primary_address(self, v2=True) -> str:
         """
         查询并返回 tendbcluster 的中控 primary
         集群类型不是 TenDBCluster 时会抛出异常
@@ -366,6 +366,7 @@ class Cluster(AuditedModel):
                             "cmds": ["tdbctl get primary"],
                             "force": False,
                             "bk_cloud_id": self.bk_cloud_id,
+                            "skip_set_names": True,
                         }
                     )
                 else:
@@ -444,7 +445,7 @@ class Cluster(AuditedModel):
         return machines
 
     @classmethod
-    def get_cluster_id__primary_address_map(cls, cluster_ids: List[int], v2=False) -> Dict[int, str]:
+    def get_cluster_id__primary_address_map(cls, cluster_ids: List[int], v2=True) -> Dict[int, str]:
         """
         通过集群id列表批量
         查询并返回 tendbcluster 的中控 primary
@@ -484,6 +485,7 @@ class Cluster(AuditedModel):
                             "cmds": ["tdbctl get primary"],
                             "force": False,
                             "bk_cloud_id": bk_cloud_id,
+                            "skip_set_names": True,
                         }
                     )
                 else:

--- a/dbm-ui/backend/flow/plugins/components/collections/common/create_random_job_user.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/create_random_job_user.py
@@ -7,23 +7,20 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-import hashlib
 import logging
 
 from django.utils.translation import gettext as _
 from pipeline.component_framework.component import Component
 
-from backend.components import DBPrivManagerApi, DRSApi
+from backend.components import DBPrivManagerApi
 from backend.db_meta.enums import InstanceStatus
 from backend.db_meta.exceptions import ClusterNotExistException
 from backend.db_meta.models import Cluster
-from backend.flow.consts import PrivRole
 from backend.flow.plugins.components.collections.common.base_service import BaseService
 from backend.flow.utils.mysql.common.random_job_with_ticket_map import (
     TICKET_TYPE_SENSITIVE_LIST,
     get_instance_with_random_job,
 )
-from backend.flow.utils.mysql.get_mysql_sys_user import generate_mysql_tmp_user
 from backend.ticket.constants import TicketType
 
 logger = logging.getLogger("flow")
@@ -35,142 +32,12 @@ class AddTempUserForClusterService(BaseService):
     单据是以集群维度来添加，如果单据涉及到集群，应该统一添加账号密码，以便后续操作方便
     """
 
-    @staticmethod
-    def mysql_pwd(pwd) -> str:
-        """
-        MySQL 4.1+ 的PASSWORD函数实现(SHA1双重哈希)
-        @param pwd: 密码字符串
-        """
-        if isinstance(pwd, str):
-            pwd = pwd.encode("utf-8")
-
-        # 第一次SHA1哈希
-        hash1 = hashlib.sha1(pwd).digest()
-        # 第二次SHA1哈希
-        hash2 = hashlib.sha1(hash1).hexdigest()
-
-        # 添加MySQL的'*'前缀
-        return "*" + hash2.upper()
-
-    def __add_account_for_privilege_api(
-        self, bk_biz_id, bk_cloud_id, job_root_id, created_by, failed_instance, priv_role
-    ) -> bool:
-        """
-        添加临时账号的内置方法
-        通过privilege api去添加临时账号
-        这里用于出现“infodba_schema.dba_grant does not exist”类型异常的重试方式
-        @param bk_biz_id: 业务id
-        @param bk_cloud_id: 云区域id
-        @param job_root_id: flow id
-        @param created_by: 申请者
-        @param failed_instance: 添加失败的实例，字符串格式"ip:port"
-        @param priv_role: 添加失败的实例的授权角色，对应PrivRole类型
-        """
-        param = {
-            "bk_cloud_id": bk_cloud_id,
-            "bk_biz_id": int(bk_biz_id),
-            "operator": created_by,
-            "user": generate_mysql_tmp_user(job_root_id),
-            "psw": job_root_id,
-            "hosts": ["localhost", failed_instance.split(":")[0]],
-            "dbname": "%",
-            "dml_ddl_priv": "",
-            "global_priv": "all privileges",
-            "address": failed_instance,
-            "role": priv_role,
-        }
-        try:
-            DBPrivManagerApi.add_priv_without_account_rule(param)
-            self.log_info(_("在[{}]重试创建添加账号成功").format(param["address"]))
-        except Exception as e:  # pylint: disable=broad-except
-            self.log_error(_("[{}]重试添加用户接口异常，相关信息: {}").format(param["address"], e))
-            return False
-
-        return True
-
-    def __add_account_for_drs(self, cluster: Cluster, instance_list: list, user: str, pwd: str) -> (list, list):
-        """
-        添加临时账号的内置方法
-        通过访问drs_api去调用存储过程dba_grant, 以此来添加临时账号
-        @param cluster: 集群信息实例
-        @param instance_list: 待授权实例列表，每个列表格式{"instance":"ip:port"...}
-        @param user: 待添加账号
-        @param pwd: 待添加密码
-        """
-        # 定义not_running状态的表
-        not_running_status_instances = []
-        # 定义传输参数列表
-        payloads = []
-        for i in instance_list:
-            payloads.append(
-                {
-                    "addresses": [i["instance"]],
-                    "cmds": self.__create_add_priv_cmds(i, user, pwd),
-                    "bk_cloud_id": cluster.bk_cloud_id,
-                }
-            )
-            if i["cmdb_status"] != InstanceStatus.RUNNING:
-                not_running_status_instances.append(i["instance"])
-
-        # 调用批量接口执行
-        resp = DRSApi.mysql_complex_rpc(
-            {
-                "payloads": payloads,
-                "bk_cloud_id": cluster.bk_cloud_id,
-            }
-        )
-        return resp, not_running_status_instances
-
-    @staticmethod
-    def __create_add_priv_cmds(instance: dict, user: str, pwd_hash: str) -> list:
-        """
-        拼接临时账号的授权的
-        通过dba_grant存储授权，提高授权效率
-        每个临时账号给本地ip和localhost生成账号，同时给ALL PRIVILEGES和GRANT OPTION权限
-        @param instance: 待授权实例，格式{"instance":"ip:port"...}
-        @param user: 待添加账号
-        @param pwd_hash: 密文
-        """
-        if instance["priv_role"] == PrivRole.TDBCTL.value:
-            # 这里做差异化处理，如果是中控节点，拼接专属的授权语句
-            #
-            # 会话级开关说明（与 drop_random_job_user.py 中删除语句对称）：
-            #   1) set tc_admin = 0
-            #      让本次会话按"单机 MySQL"模式在中控（TDBCTL/Spider）节点上执行，
-            #      不再通过 TDBCTL 路由层广播到后端 remote 集群，
-            #      同时规避集群模式下的隐式一致性检查导致 CREATE USER / GRANT 失败。
-            #   2) set session sql_log_bin = 0
-            #      关闭本会话 binlog 记录，避免临时账号的创建/授权语句写入本机 binlog，
-            #      从而流入下游 slave 或备份工具，产生"账号漂移"风险。
-            #      注意：tc_admin=0 只影响 TDBCTL 路由，不影响本机 binlog 是否落盘，
-            #            因此 sql_log_bin=0 是必需的，二者职责正交、不可省略。
-            #   3) 最后 set session sql_log_bin = 1 恢复默认，避免连接被复用时污染后续语句。
-            return [
-                "set tc_admin = 0;",
-                "set session sql_log_bin = 0 ;",
-                f"""CREATE USER IF NOT EXISTS '{user}'@'localhost'
-                IDENTIFIED WITH mysql_native_password AS '{pwd_hash}';""",
-                f"""CREATE USER IF NOT EXISTS '{user}'@'{instance["instance"].split(":")[0]}'
-                IDENTIFIED WITH mysql_native_password AS '{pwd_hash}';""",
-                f"GRANT ALL PRIVILEGES ON *.* TO '{user}'@'localhost' WITH GRANT OPTION;",
-                f"""GRANT ALL PRIVILEGES ON *.* TO '{user}'@'{instance["instance"].split(":")[0]}'
-                WITH GRANT OPTION;""",
-                "set session sql_log_bin = 1 ;",
-            ]
-
-        return [
-            f"""CALL infodba_schema.dba_grant('{user}', 'localhost,{instance["instance"].split(":")[0]}',
-                        '*', '{pwd_hash}', '', '', 'all privileges') ;""",
-            f"""GRANT ALL PRIVILEGES ON *.* TO '{user}'@'{instance["instance"].split(":")[0]}' WITH GRANT OPTION""",
-            f"""GRANT ALL PRIVILEGES ON *.* TO '{user}'@'localhost' WITH GRANT OPTION""",
-        ]
-
-    def create_temp_user_for_cluster(
-        self, cluster: Cluster, user: str, pwd: str, ticket_type: TicketType, job_root_id: str
-    ) -> bool:
+    def create_temp_user_for_cluster(self, cluster: Cluster, ticket_type: TicketType, job_root_id: str) -> bool:
         """
         按照集群维度并发处理实例授权逻辑
-        通过mysql_complex_rpc并发接口，拼接授权密码，异常达到并发效果，提高效率
+        unavailable 实例会尽力而为
+        因为有时候会对故障 slave (其实还活着) 做原地重建
+
         @param cluster: 集群信息实例
         @param user: 待添加账号
         @param pwd: 密码
@@ -186,31 +53,30 @@ class AddTempUserForClusterService(BaseService):
         # 标记位
         is_add_success = True
 
-        # 按照集群维度，并发提交权限添加
-        resp, not_running_status_instances = self.__add_account_for_drs(
-            cluster=cluster, instance_list=instance_list, user=user, pwd=pwd
+        raw_resp = DBPrivManagerApi.add_mysql_temp_account_v2(
+            {
+                "bk_cloud_id": cluster.bk_cloud_id,
+                "addresses": [i["instance"] for i in instance_list],
+                "root_id": job_root_id,
+            }
         )
+        self.log_info(raw_resp)
+
+        not_running_status_instances = [
+            i["instance"] for i in instance_list if i["cmdb_status"] != InstanceStatus.RUNNING
+        ]
+
+        resp = []
+        for i in instance_list:
+            address = i["instance"]
+            errors = raw_resp.get(address, [])
+            resp.append({"address": address, "error_msg": ". ".join(errors)})
 
         # 遍历判断每个实例的授权结果
         for result in resp:
             if result["error_msg"]:
                 # 出现执行异常，判断实例状态以及自定义表
                 self.log_error(_("在[{}]创建临时添加账号失败:[{}]").format(result["address"], result["error_msg"]))
-                # 如果出现异常，通过privilege api接口重新尝试加一次
-                self.log_info("retry via privilege_api ...")
-                if self.__add_account_for_privilege_api(
-                    bk_biz_id=cluster.bk_biz_id,
-                    bk_cloud_id=cluster.bk_cloud_id,
-                    failed_instance=result["address"],
-                    priv_role=[item["priv_role"] for item in instance_list if item["instance"] == result["address"]][
-                        0
-                    ],
-                    created_by=job_root_id,
-                    job_root_id=job_root_id,
-                ):
-                    # 重试成功跳过
-                    self.log_info("retry successful")
-                    continue
 
                 if result["address"] in not_running_status_instances and ticket_type not in TICKET_TYPE_SENSITIVE_LIST:
                     # 如果是非running状态，默认标记warning信息，但不作异常处理
@@ -219,17 +85,14 @@ class AddTempUserForClusterService(BaseService):
                     # 如果实例是running状态，应该记录错误，并且返回异常
                     # 如果实例非running状态，且单据类型加入敏感队列，则需要记录错误，并且返回异常
                     is_add_success = False
-                continue
-            self.log_info(_("在[{}]创建临时添加账号成功").format(result["address"]))
+            else:
+                self.log_info(_("在[{}]创建临时添加账号成功").format(result["address"]))
 
         return is_add_success
 
     def _execute(self, data, parent_data, callback=None) -> bool:
         kwargs = data.get_one_of_inputs("kwargs")
         global_data = data.get_one_of_inputs("global_data")
-
-        # 根据mysql4.1+的password函数算法加密
-        pwd_hash = self.mysql_pwd(global_data["job_root_id"])
 
         err_num = 0
         for cluster_id in kwargs["cluster_ids"]:
@@ -242,8 +105,6 @@ class AddTempUserForClusterService(BaseService):
                 )
             if not self.create_temp_user_for_cluster(
                 cluster=cluster,
-                user=generate_mysql_tmp_user(global_data["job_root_id"]),
-                pwd=pwd_hash,
                 ticket_type=global_data.get("ticket_type", "test"),
                 job_root_id=global_data["job_root_id"],
             ):

--- a/dbm-ui/backend/flow/plugins/components/collections/common/drop_random_job_user.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/drop_random_job_user.py
@@ -8,21 +8,16 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-
 import logging
 
 from django.utils.translation import gettext as _
 from pipeline.component_framework.component import Component
 
 from backend.components import DRSApi
-from backend.db_meta.enums import InstanceStatus
 from backend.db_meta.exceptions import ClusterNotExistException
 from backend.db_meta.models import Cluster
 from backend.flow.plugins.components.collections.common.base_service import BaseService
-from backend.flow.utils.mysql.common.random_job_with_ticket_map import (
-    TICKET_TYPE_SENSITIVE_LIST,
-    get_instance_with_random_job,
-)
+from backend.flow.utils.mysql.common.random_job_with_ticket_map import get_instance_with_random_job
 from backend.flow.utils.mysql.get_mysql_sys_user import generate_mysql_tmp_user
 from backend.ticket.constants import TicketType
 
@@ -41,52 +36,29 @@ class DropTempUserForClusterService(BaseService):
         """
         # 拼接临时用户的名称
         user = generate_mysql_tmp_user(root_id)
-        is_drop_success = True
-        # 删除localhost和 local_ip用户
-        payloads = []
-        not_running_status_instances = []
         instance_list = get_instance_with_random_job(cluster=cluster, ticket_type=ticket_type)
+
         if not instance_list:
             self.log_error(_("当前集群没有查询到需要删临时账号的实例：集群域名：{}, 单据类型：{}".format(cluster.immute_domain, ticket_type)))
             return False
 
-        for instance in instance_list:
-            # 会话级开关说明（与 create_random_job_user.py 中授权语句对称）：
-            #   1) set session sql_log_bin = 0
-            #      关闭本会话 binlog 记录，避免临时账号的 drop 语句写入本机 binlog，
-            #      从而流入下游 slave 或备份工具，产生"账号漂移"风险。
-            #      注意：tc_admin=0 只影响 TDBCTL 路由，不影响本机 binlog 是否落盘，
-            #            因此 sql_log_bin=0 是必需的，二者职责正交、不可省略。
-            #   2) set tc_admin = 0
-            #      仅对中控（TDBCTL/Spider）节点生效：让本次会话按"单机 MySQL"模式执行，
-            #      不再通过 TDBCTL 路由层广播到后端 remote 集群，
-            #      同时规避集群模式下的隐式一致性检查导致 drop user 失败。
-            #      对普通 MySQL/Proxy 实例本条命令不生效；配合 force=true 兜底，非中控实例即使不识别该参数也不会中断整体流程。
-            #   3) 最后 set session sql_log_bin = 1 恢复默认，避免连接被复用时污染后续语句。
-            cmd = [
-                "set session sql_log_bin = 0 ;",
-                "set tc_admin = 0;",
-                f"drop user `{user}`@`localhost`;",
-                f"drop user `{user}`@`{instance['instance'].split(':')[0]}`;",
-                "set session sql_log_bin = 1 ;",
-            ]
-            # 最后统一打开binlog, 避免复用异常
-            payloads.append(
-                {
-                    "addresses": [instance["instance"]],
-                    "cmds": cmd,
-                    "force": True,  # 中间出错也要执行下去，保证重新打开binlog
-                    "bk_cloud_id": cluster.bk_cloud_id,
-                }
-            )
-            # 收集非running状态的实例信息
-            if instance["cmdb_status"] != InstanceStatus.RUNNING:
-                not_running_status_instances.append(instance["instance"])
+        # ''@'' 的形式是MySQL官方推荐的, 用单引号
+        cmds = [
+            "set session sql_log_bin = 0 ;",
+            "set tc_admin = 0;",
+            f"drop user '{user}'@localhost;",
+            f"drop user '{user}'@'%';",
+            "set session sql_log_bin = 1 ;",
+        ]
 
-        resp = DRSApi.mysql_complex_rpc(
+        resp = DRSApi.v2_mysql_rpc(
             {
-                "payloads": payloads,
                 "bk_cloud_id": cluster.bk_cloud_id,
+                "addresses": [i["instance"] for i in instance_list],
+                "cmds": cmds,
+                "query_timeout": 600,
+                "force": True,
+                "skip_set_names": True,
             }
         )
         for result in resp:
@@ -95,28 +67,12 @@ class DropTempUserForClusterService(BaseService):
                 self.log_error(
                     f"The result [drop user `{user}`] in {result['address']} error is: [{result['error_msg']}]"
                 )
-                # 如果实例是running状态，应该记录错误，并且返回异常
-                # 如果实例非running状态，且单据类型加入敏感队列，则需要记录错误，并且返回异常
-                if result["address"] in not_running_status_instances and ticket_type not in TICKET_TYPE_SENSITIVE_LIST:
-                    # 如果是非running状态，标记warning信息，但不作异常处理
-                    self.log_warning(f"[{result['address']} is not running in dbm ,ignore]")
-
-                is_drop_success = False
                 continue
 
-            # 如果drop user 过程中出现异常，先打印，但不报错，这里只是为打印命令异常的内容。
-            # 一般情况基本都是账号不存在才有异常。
             if result["cmd_results"]:
-                err_list = [i["error_msg"] for i in result["cmd_results"] if i["error_msg"]]
-                if err_list:
-                    error_log = "\n".join(err_list)
-                    self.log_warning(f"The result [drop user `{user}`] in {result['address']} error is: [{error_log}]")
-
-            self.log_info(f"The result [drop user `{user}`] in {result['address']} is [success]")
-
-        if not is_drop_success:
-            self.log_error(f"drop user error in cluster [{cluster.immute_domain}]")
-            return False
+                for cr in result["cmd_results"][1:]:
+                    if cr["error_msg"]:
+                        self.log_error(cr["error_msg"])
 
         self.log_info(f"drop user finish in cluster [{cluster.immute_domain}]")
         return True


### PR DESCRIPTION
1. mysql 临时账号改用 dbpriv 创建
2. 优化 dbpriv 的错误返回
3. dbpriv rpc call 增加 skip set names = True
4. dbm get primary 增加 skip set names = True
5. 修复 mysql-table-checksum 连接失效