### PR TITLE
fix(mongodb): MongoDB OS用户配置统一使用 cloudid 0 #20265

### DIFF
--- a/dbm-ui/backend/flow/utils/mongodb/mongodb_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mongodb/mongodb_dataclass.py
@@ -29,6 +29,7 @@ from backend.db_meta.models import Cluster
 from backend.db_package.models import Package
 from backend.flow.consts import (
     DEFAULT_DB_MODULE_ID,
+    DEFAULT_INSTANCE,
     ConfigFileEnum,
     ConfigTypeEnum,
     ExecuteShellScriptUser,
@@ -526,10 +527,13 @@ class ActKwargs:
 
         # 获取os配置
         self.get_mongodb_os_conf()
-        # 获取os密码
+        # OS 用户配置与 Redis/MySQL 一致：各云区域统一读取 cloudid 0
         user = self.os_conf["user"]
         password = self.get_password(
-            ip="0.0.0.0", port=0, bk_cloud_id=self.payload["hosts"][0]["bk_cloud_id"], username=user
+            ip=DEFAULT_INSTANCE["ip"],
+            port=DEFAULT_INSTANCE["port"],
+            bk_cloud_id=DEFAULT_INSTANCE["bk_cloud_id"],
+            username=user,
         )
 
         return {

--- a/dbm-ui/backend/flow/utils/mongodb/mongodb_migrate_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mongodb/mongodb_migrate_dataclass.py
@@ -19,6 +19,7 @@ from backend.db_meta.enums.spec import SpecClusterType, SpecMachineType
 from backend.db_meta.models.spec import Spec
 from backend.flow.consts import (
     DEFAULT_DB_MODULE_ID,
+    DEFAULT_INSTANCE,
     ConfigFileEnum,
     ConfigTypeEnum,
     MongoDBActuatorActionEnum,
@@ -503,9 +504,12 @@ class MigrateActKwargs:
 
         user = self.os_conf["user"]
         file_path = self.os_conf["file_path"]
-        # 获取os user密码
+        # OS 用户配置与 Redis/MySQL 一致：各云区域统一读取 cloudid 0
         password = MongoDBPassword().get_password_from_db(
-            ip="0.0.0.0", port=0, bk_cloud_id=self.bk_cloud_id, username=user
+            ip=DEFAULT_INSTANCE["ip"],
+            port=DEFAULT_INSTANCE["port"],
+            bk_cloud_id=DEFAULT_INSTANCE["bk_cloud_id"],
+            username=user,
         )["password"]
         return {
             "init_flag": True,


### PR DESCRIPTION
close #20265

https://github.com/TencentBlueKing/blueking-dbm/issues/20265

## Summary
- MongoDB OS 初始化查询平台用户配置时，与 Redis/MySQL 对齐，统一使用 cloudid 0（`DEFAULT_INSTANCE`）
- 覆盖部署/扩容/替换等 `get_os_init_kwargs` 与迁移 `get_os_init_info`
- 作业执行目标仍使用主机真实 cloudid，仅配置查询改为 0

## Test plan
- [ ] cloudid 0 区域 MongoDB OS 初始化仍能读到平台用户配置
- [ ] 非 0 云区域不再依赖按 cloudid 单独配置 OS 用户
- [ ] 部署/替换/迁移流程作业仍打到正确云区域