### PR TITLE
fix(frontend): 部署提单自动带出业务时同步已有代号，避免误弹创建确认

### DIFF
--- a/dbm-ui/frontend/src/hooks/useApplyBase.ts
+++ b/dbm-ui/frontend/src/hooks/useApplyBase.ts
@@ -46,12 +46,24 @@ export const useApplyBase = () => {
   }
 
   /**
+   * 同步当前业务；仅在已有业务且 bk_biz_id 变化时返回 true（自动带出同一业务时不要清空规格 / IP）
+   */
+  function applyBizInfo(info: BizItem) {
+    const prevId = bizState.info.bk_biz_id;
+    const bizChanged = prevId !== undefined && prevId !== info.bk_biz_id;
+    bizState.info = info;
+    bizState.hasEnglishName = !!info.english_name;
+    return bizChanged;
+  }
+
+  /**
    * 创建业务英文缩写
    */
   function handleCreateAppAbbr(formdata: any) {
     const appAbbr = formdata.details.db_app_abbr;
+    const bizName = bizState.info.display_name || bizState.info.name || '';
     InfoBox({
-      content: t('业务Codexx将被保存到业务xx且保存后不允许修改', [appAbbr, bizState.info.display_name]),
+      content: t('业务Codexx将被保存到业务xx且保存后不允许修改', [appAbbr, bizName]),
       onCancel: () => {
         baseState.isSubmitting = false;
       },
@@ -99,6 +111,7 @@ export const useApplyBase = () => {
   }
 
   return {
+    applyBizInfo,
     baseState,
     bizState,
     handleCancel,

--- a/dbm-ui/frontend/src/views/db-manage/common/apply-items/BusinessItems.vue
+++ b/dbm-ui/frontend/src/views/db-manage/common/apply-items/BusinessItems.vue
@@ -144,8 +144,8 @@
       const englishName = currentBiz.value?.english_name;
       hasEnglishName.value = !!englishName;
       appAbbr.value = englishName ?? '';
-      // 从申请实例 跳转过来，或单据克隆，需要同步数据出去
-      if ((route.query.bizId || route.query.ticketType) && currentBiz.value) {
+      // 业务由页面自动带出时，也要把业务信息同步给提单页
+      if (currentBiz.value) {
         handleAppChange(currentBiz.value);
       }
     },

--- a/dbm-ui/frontend/src/views/db-manage/doris/DORIS_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/doris/DORIS_APPLY/Index.vue
@@ -812,19 +812,20 @@
 
   const getSmartActionOffsetTarget = () => document.querySelector('.bk-form-content');
 
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   // 切换业务，需要重置 IP 相关的选择
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     formData.details.nodes.hot = [];
     formData.details.nodes.warm = [];
     formData.details.nodes.observer = [];
     formData.details.nodes.follower = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   };
 
   /**

--- a/dbm-ui/frontend/src/views/db-manage/elastic-search/ES_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/elastic-search/ES_APPLY/Index.vue
@@ -631,19 +631,20 @@
 
   const getSmartActionOffsetTarget = () => document.querySelector('.bk-form-content');
 
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   // 切换业务，需要重置 IP 相关的选择
   function handleChangeBiz(info: BizItem) {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     formData.details.nodes.hot = [];
     formData.details.nodes.cold = [];
     formData.details.nodes.client = [];
     formData.details.nodes.master = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   }
 
   /**

--- a/dbm-ui/frontend/src/views/db-manage/hdfs/HDFS_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/hdfs/HDFS_APPLY/Index.vue
@@ -581,19 +581,20 @@
     { deep: true, flush: 'post' },
   );
 
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   // 切换业务，需要重置 IP 相关的选择
   function handleChangeBiz(info: BizItem) {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     nodeAndZookerperMergeList.value = [];
     formData.details.nodes.namenode = [];
     formData.details.nodes.zookeeper = [];
     formData.details.nodes.datanode = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   }
   /**
    * 变更所属管控区域

--- a/dbm-ui/frontend/src/views/db-manage/influxdb/INFLUXDB_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/influxdb/INFLUXDB_APPLY/Index.vue
@@ -241,7 +241,7 @@
   const router = useRouter();
   const { t } = useI18n();
 
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   useTicketDetail<Influxdb.Apply>(TicketTypes.INFLUXDB_APPLY, {
@@ -315,12 +315,13 @@
    * 切换业务，需要重置 IP 相关的选择
    */
   function handleChangeBiz(info: BizItem) {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     formData.details.group_id = '';
     formData.details.nodes.influxdb = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   }
   /**
    * 变更所属管控区域

--- a/dbm-ui/frontend/src/views/db-manage/kafka/KAFKA_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/kafka/KAFKA_APPLY/Index.vue
@@ -557,7 +557,7 @@
     { deep: true, flush: 'post' },
   );
 
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   const zookeeperDisableDialogSubmitMethod = (hostList: Array<any>) =>
@@ -585,12 +585,13 @@
 
   // 切换业务，需要重置 IP 相关的选择
   function handleChangeBiz(info: BizItem) {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     formData.details.nodes.zookeeper = [];
     formData.details.nodes.broker = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   }
   /**
    * 变更所属管控区域

--- a/dbm-ui/frontend/src/views/db-manage/mongodb/MONGODB_REPLICASET_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/mongodb/MONGODB_REPLICASET_APPLY/Index.vue
@@ -278,7 +278,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   useTicketDetail<Mongodb.ReplicasetApply>(TicketTypes.MONGODB_REPLICASET_APPLY, {
@@ -409,8 +409,7 @@
   );
 
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/mongodb/MONGODB_SHARD_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/mongodb/MONGODB_SHARD_APPLY/Index.vue
@@ -314,7 +314,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   useTicketDetail<Mongodb.ShardApply>(TicketTypes.MONGODB_SHARD_APPLY, {
@@ -490,8 +490,7 @@
   });
 
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/mysql/common/apply/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/mysql/common/apply/Index.vue
@@ -451,7 +451,7 @@
   });
 
   // 基础设置
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
 
   useTicketDetail<Mysql.SingleApply>(TicketTypes.MYSQL_SINGLE_APPLY, {
     onSuccess(ticketDetail) {
@@ -719,14 +719,12 @@
    * 变更业务选择
    */
   const handleChangeBiz = (info: BizItem) => {
-    // 仅当业务真的变化时才清空模块选择，避免单据回显阶段 BusinessItems 自动 emit changeBiz 误清空
-    if (info.bk_biz_id !== formData.bk_biz_id) {
-      formData.details.db_module_id = null;
-    }
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    const bizChanged = applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
-
+    if (!bizChanged) {
+      return;
+    }
+    formData.details.db_module_id = null;
     formData.details.nodes.backend = [];
     formData.details.nodes.proxy = [];
     moduleRef.value?.clearValidate();

--- a/dbm-ui/frontend/src/views/db-manage/pulsar/PULSAR_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/pulsar/PULSAR_APPLY/Index.vue
@@ -492,7 +492,7 @@
   const route = useRoute();
   const router = useRouter();
   const { t } = useI18n();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   useTicketDetail<Pulsar.Apply>(TicketTypes.PULSAR_APPLY, {
@@ -622,13 +622,14 @@
    * 切换业务，需要重置 IP 相关的选择
    */
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     formData.details.nodes.bookkeeper = [];
     formData.details.nodes.broker = [];
     formData.details.nodes.zookeeper = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   };
   /**
    * 变更所属管控区域

--- a/dbm-ui/frontend/src/views/db-manage/qdrant/K8S_QDRANT_HA_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/qdrant/K8S_QDRANT_HA_APPLY/Index.vue
@@ -143,7 +143,7 @@
   const route = useRoute();
   const router = useRouter();
   const { t } = useI18n();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
   const userProfile = useUserProfile();
   const bizStore = useGlobalBizs();
@@ -196,8 +196,7 @@
   const getSmartActionOffsetTarget = () => document.querySelector('.bk-form-content');
 
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/redis/REDIS_CLUSTER_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/redis/REDIS_CLUSTER_APPLY/Index.vue
@@ -458,7 +458,7 @@
   };
 
   // 基础设置
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
   const { t } = useI18n();
   const funControllerStore = useFunController();
@@ -812,14 +812,14 @@
    * 变更业务
    */
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-
-    // 清空 ip 选择器
+    const bizChanged = applyBizInfo(info);
+    serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
     formData.details.nodes.proxy = [];
     formData.details.nodes.master = [];
     formData.details.nodes.slave = [];
-    serviceApply?.changeBizId(info.bk_biz_id);
   };
 
   /**

--- a/dbm-ui/frontend/src/views/db-manage/redis/REDIS_INS_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/redis/REDIS_INS_APPLY/Index.vue
@@ -306,7 +306,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
 
   const serviceApply = inject(serviceApplyKey);
 
@@ -537,8 +537,7 @@
   const getSmartActionOffsetTarget = () => document.querySelector('.bk-form-content');
 
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/riak/RIAK_CLUSTER_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/riak/RIAK_CLUSTER_APPLY/Index.vue
@@ -269,7 +269,7 @@
   const route = useRoute();
   const router = useRouter();
   const { t } = useI18n();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   useTicketDetail<Riak.Apply>(TicketTypes.RIAK_CLUSTER_APPLY, {
@@ -361,8 +361,7 @@
 
   // 切换业务，需要重置 IP 相关的选择
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/sqlserver/common/apply/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/sqlserver/common/apply/Index.vue
@@ -264,7 +264,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
 
   const serviceApply = inject(serviceApplyKey);
 
@@ -663,14 +663,13 @@
    * 变更业务选择
    */
   const handleChangeBiz = (info: BizItem) => {
-    // 仅当业务真的变化时才清空模块选择，避免单据回显阶段 BusinessItems 自动 emit changeBiz 误清空
-    if (info.bk_biz_id !== formData.bk_biz_id) {
-      formData.details.db_module_id = null;
-    }
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
-    formData.details.nodes.backend = [];
+    const bizChanged = applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
+    formData.details.db_module_id = null;
+    formData.details.nodes.backend = [];
   };
 
   // 获取 DM模块

--- a/dbm-ui/frontend/src/views/db-manage/surrealdb/K8S_SURREALDB_HA_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/surrealdb/K8S_SURREALDB_HA_APPLY/Index.vue
@@ -162,7 +162,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
   const userProfile = useUserProfile();
   const bizStore = useGlobalBizs();
@@ -233,8 +233,7 @@
   const getSmartActionOffsetTarget = () => document.querySelector('.bk-form-content');
 
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/surrealdb/K8S_SURREALDB_SINGLE_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/surrealdb/K8S_SURREALDB_SINGLE_APPLY/Index.vue
@@ -154,7 +154,7 @@
   const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
   const userProfile = useUserProfile();
   const bizStore = useGlobalBizs();
@@ -208,8 +208,7 @@
   const getSmartActionOffsetTarget = () => document.querySelector('.bk-form-content');
 
   const handleChangeBiz = (info: BizItem) => {
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
   };
 

--- a/dbm-ui/frontend/src/views/db-manage/tendb-cluster/TENDBCLUSTER_APPLY/Index.vue
+++ b/dbm-ui/frontend/src/views/db-manage/tendb-cluster/TENDBCLUSTER_APPLY/Index.vue
@@ -236,7 +236,7 @@
   });
 
   // 基础设置
-  const { baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
+  const { applyBizInfo, baseState, bizState, handleCancel, handleCreateAppAbbr, handleCreateTicket } = useApplyBase();
   const serviceApply = inject(serviceApplyKey);
 
   useTicketDetail<TendbCluster.Apply>(TicketTypes.TENDBCLUSTER_APPLY, {
@@ -340,10 +340,12 @@
    * 变更业务
    */
   const handleChangeBiz = (info: BizItem) => {
-    formData.details.db_module_id = null;
-    bizState.info = info;
-    bizState.hasEnglishName = !!info.english_name;
+    const bizChanged = applyBizInfo(info);
     serviceApply?.changeBizId(info.bk_biz_id);
+    if (!bizChanged) {
+      return;
+    }
+    formData.details.db_module_id = null;
   };
 
   /** 重置表单 */


### PR DESCRIPTION
## Summary
- 业务由部署页自动带出时，把已有业务代号同步到提单页，不再只填输入框。
- 仅在所属业务真正切换时清空 IP / 规格；自动带出同一业务不清表。
- 覆盖各组件部署申请页（Redis / MySQL / Mongo 等共用逻辑）。

TAPD：https://tapd.woa.com/tapd_fe/20452995/bug/detail/1020452995163525058

## Test plan
- [ ] 打开部署页，业务自动带出且代号已填，不要再点所属业务，直接提交：不弹「确认创建业务 Code」
- [ ] 同一业务在下拉里再点一次后提交：同样不弹
- [ ] 选一个还没有业务代号的业务，手填代号后提交：仍弹出确认，且括号里有业务名


Made with [Cursor](https://cursor.com)