### PR TITLE
fix(redis): default empty AI queue username to DEFAULT_USERNAME #20291

### DIFF
--- a/dbm-ui/backend/dbm_aiagent/tasks/invoker.py
+++ b/dbm-ui/backend/dbm_aiagent/tasks/invoker.py
@@ -19,6 +19,7 @@ from backend.db_periodic_task.dispatch.outcomes import DispatchOutcomeType
 from backend.dbm_aiagent.agent.constants import DBMAgentCode
 from backend.dbm_aiagent.tasks.config import AGENT_RESPONSE_LOG_MAX_CHARS
 from backend.dbm_aiagent.tasks.outcomes import AgentOutcome
+from backend.env import DEFAULT_USERNAME
 
 logger = logging.getLogger("root")
 
@@ -104,19 +105,22 @@ class AgentInvoker:
         try:
             from backend.dbm_aiagent.agent.handlers import AgentHandler
 
+            # Handler defaults to DEFAULT_USERNAME. Passing None/"" overrides that
+            # and skips the PaaS sandbox virtual-user rewrite (executor whitelist).
+            username = request.username or DEFAULT_USERNAME
             if request.session_code:
                 ai_response, _ = AgentHandler.ask_agent_with_content_in_session(
                     agent_code=agent_code,
                     content=request.content,
                     session_code=request.session_code,
-                    username=request.username,
+                    username=username,
                     timeout=execution_timeout,
                 )
             else:
                 ai_response = AgentHandler.ask_agent_with_content(
                     agent_code=agent_code,
                     content=request.content,
-                    username=request.username,
+                    username=username,
                     timeout=execution_timeout,
                 )
             elapsed = time.monotonic() - invoke_started_at

--- a/dbm-ui/backend/tests/dbm_aiagent/tasks/test_ai_task_layer.py
+++ b/dbm-ui/backend/tests/dbm_aiagent/tasks/test_ai_task_layer.py
@@ -119,6 +119,50 @@ class TestAgentInvoker:
             )
         invoke.assert_called_once()
 
+    def test_missing_username_falls_back_to_default(self):
+        from backend.env import DEFAULT_USERNAME
+
+        for username in (None, ""):
+            with patch(
+                "backend.dbm_aiagent.agent.handlers.AgentHandler.ask_agent_with_content",
+                return_value="ok",
+            ) as invoke:
+                AgentInvoker.invoke(
+                    task_key="test.task",
+                    agent_code="ai-x",
+                    request=AgentRequest(content="hello", username=username),
+                    execution_timeout_seconds=30,
+                )
+            assert invoke.call_args.kwargs["username"] == DEFAULT_USERNAME
+
+    def test_explicit_username_is_preserved(self):
+        with patch(
+            "backend.dbm_aiagent.agent.handlers.AgentHandler.ask_agent_with_content",
+            return_value="ok",
+        ) as invoke:
+            AgentInvoker.invoke(
+                task_key="test.task",
+                agent_code="ai-x",
+                request=AgentRequest(content="hello", username="alice"),
+                execution_timeout_seconds=30,
+            )
+        assert invoke.call_args.kwargs["username"] == "alice"
+
+    def test_session_missing_username_falls_back_to_default(self):
+        from backend.env import DEFAULT_USERNAME
+
+        with patch(
+            "backend.dbm_aiagent.agent.handlers.AgentHandler.ask_agent_with_content_in_session",
+            return_value=("ok", "session-1"),
+        ) as invoke:
+            AgentInvoker.invoke(
+                task_key="test.task",
+                agent_code="ai-x",
+                request=AgentRequest(content="hello", session_code="session-1"),
+                execution_timeout_seconds=30,
+            )
+        assert invoke.call_args.kwargs["username"] == DEFAULT_USERNAME
+
 
 class TestAITaskQueue:
     def test_build_job_id_stable(self):


### PR DESCRIPTION
- AI 队列派发时 `AgentRequest.username` 为 `None`/`""`，PaaS 沙箱按空用户鉴权失败（「沙箱没有权限」），直接 ask 则正常

## 具体改动

- **空 username 覆盖 Handler 默认值**：`AgentInvoker` 把 `None`/`""` 回落为 `DEFAULT_USERNAME`（`admin`），不再把空用户显式传给 `ask_agent_with_content` → 沙箱走虚拟身份改写，和直接 ask 一致
- **显式用户保留**：请求里已有 username 时原样透传，不改成 `bk_dbm_paas`
- **session 与 content 两条路径对齐**：`ask_agent_with_content_in_session` 同样回落，避免会话调用再踩同一鉴权坑

## 测试 & 风险

- 单测已覆盖空/`None` 回落默认、显式 username 保留、session 路径回落
- 仅影响 AI 队列 `AgentInvoker` 调 Handler 的身份；无 API breaking change；空 username 后台任务会按 `admin` 开沙箱，属预期修复