### PR TITLE
fix(mysql): 优化mysql数据修复的逻辑 #20161

### DIFF
--- a/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/pt_table_sync.go
+++ b/dbm-services/mysql/db-tools/dbactuator/internal/subcmd/mysqlcmd/pt_table_sync.go
@@ -61,6 +61,14 @@ func (d *PtTableSyncAct) Run() (err error) {
 	// subcmd.Steps 顺序执行，某个步骤error，剩下步骤不执行
 	defer d.Service.DropSyncUser()
 	defer d.Service.DropTempTable()
+	// 最后声明的 defer 最先执行, 保证在清理账号/临时表之前通过 OutputCtx 输出修复报告
+	defer func() {
+		report, perr := d.Service.PrintRepairReport()
+		if perr != nil {
+			return
+		}
+		d.OutputCtx(report)
+	}()
 	steps := subcmd.Steps{
 		{
 			FunName: "初始化",

--- a/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/pt_table_sync.go
+++ b/dbm-services/mysql/db-tools/dbactuator/pkg/components/mysql/pt_table_sync.go
@@ -15,10 +15,14 @@
 package mysql
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"math/big"
+	"regexp"
 	"strings"
+	"time"
 
 	"dbm-services/common/go-pubpkg/logger"
 	"dbm-services/mysql/db-tools/dbactuator/pkg/components"
@@ -27,15 +31,31 @@ import (
 	"dbm-services/mysql/db-tools/dbactuator/pkg/util/osutil"
 )
 
+// dsnPassRe 匹配 pt-table-sync DSN 中的密码段.
+// pt-table-sync DSN 形如: h=1.1.1.1,P=3306,u=user,p=secret --execute
+// 密码前必然是 DSN 内分隔符 ',' 或 DSN 段起始处的空白, 密码值以下一个 ',' 或空白结束.
+// 通过锚定边界字符, 精确定位 DSN 中的密码字段, 避免:
+//  1. 密码明文作为子串意外出现在其它位置(如库表名)被误替换;
+//  2. 密码含 DSN 分隔符时无法完整匹配到真实边界.
+var dsnPassRe = regexp.MustCompile(`([,\s]p=)[^,\s]+`)
+
 const checkSumDB = native.INFODBA_SCHEMA
 const checkSumTable = "checksum"
 const checkSumHistoryTable = "checksum_history"
 const slaveBehindMasterLimit = 1800 // slave不能落后master 半小时以上
 const chunkSize = "10000"           // pt-table-sync每次修复的chunk单位,检验时候会用到
+const maxInconsistentChunk = 50     // 单表不一致 chunk 数阈值,超过则不进行修复,建议走重建 slave 流程
+
 // Charset TODO
 const Charset = "binary" // 目前统一使用binary字符集
-// SyncExitStatus2 TODO
-const SyncExitStatus2 = "exit status 2" // 如果执行信息返回状态为2，是代表真的有数据不一致的情况，视为程序执行正常
+
+// 修复结果状态枚举
+const (
+	repairStatusSuccess = "success" // 修复成功
+	repairStatusFailed  = "failed"  // 修复失败
+	repairStatusSkipped = "skipped" // 跳过修复(表不满足修复条件)
+	repairStatusNoDiff  = "no_diff" // 未发现不一致
+)
 
 // PtTableSyncComp TODO
 type PtTableSyncComp struct {
@@ -56,9 +76,12 @@ type PtTableSyncParam struct {
 	SyncUser            string `json:"sync_user" validate:"required"`
 	SyncPass            string `json:"sync_pass" validate:"required"`
 	CheckSumTable       string `json:"check_sum_table" validate:"required"`
-	StartTime           string `json:"start_time"`
-	EndTime             string `json:"end_time"`
-	IsRoutineTrigger    bool   `json:"is_routine_trigger"`
+	// StartTime/EndTime 会被拼接进 checksum 表 SQL 的 ts BETWEEN '...' AND '...' 条件,
+	// 通过严格白名单格式校验(允许为空; 非空必须匹配 YYYY-MM-DD 或 YYYY-MM-DD HH:MM:SS),
+	// 可彻底规避潜在的 SQL 拼接注入风险
+	StartTime        string `json:"start_time" validate:"omitempty,datetime=2006-01-02|datetime=2006-01-02 15:04:05"`
+	EndTime          string `json:"end_time" validate:"omitempty,datetime=2006-01-02|datetime=2006-01-02 15:04:05"`
+	IsRoutineTrigger bool   `json:"is_routine_trigger"`
 	// Synctables        []string `json:"sync_tables"`
 	// SyncDbs           []string `json:"SyncDbs"`
 }
@@ -69,12 +92,23 @@ type PtTableSyncCtx struct {
 	dbConn                *native.DbWorker
 	masterDbConn          *native.DbWorker
 	tempCheckSumTableName string
+	repairResults         []TableRepairResult // 每张表的修复结果,循环结束后统一输出 JSON 报告
 }
 
 // TableSyncInfo 定义待修复表的信息结构体
 type TableSyncInfo struct {
 	DbName    string `db:"DbName"`
 	TableName string `db:"TableName"`
+}
+
+// TableRepairResult 定义单张表的修复结果, 用于最终 JSON 报告输出
+type TableRepairResult struct {
+	DbName             string `json:"db_name"`
+	TableName          string `json:"table_name"`
+	Status             string `json:"status"`              // success/failed/skipped/no_diff
+	Reason             string `json:"reason"`              // 中文原因说明
+	InconsistentChunks int    `json:"inconsistent_chunks"` // checksum 表中该表不一致 chunk 数
+	ExitCode           int    `json:"exit_code"`           // pt-table-sync 退出码,仅实际执行时填充
 }
 
 // TableInfo TODO
@@ -105,6 +139,12 @@ func (c *PtTableSyncComp) Example() interface{} {
 // Init 定义act的初始化内容
 func (c *PtTableSyncComp) Init() (err error) {
 
+	// 参数硬校验: 把可能进入 SQL 的时间字符串锁死为严格白名单,
+	// 从入参源头一次性覆盖所有下游拼接点 (getTableSyncMap / countInconsistentChunks / CopyTableCheckSumReport)
+	if err = c.validateTimeParams(); err != nil {
+		return err
+	}
+
 	// 连接本地实例的db（其实是从实例）
 	c.dbConn, err = native.InsObject{
 		Host: c.Params.Host,
@@ -113,7 +153,7 @@ func (c *PtTableSyncComp) Init() (err error) {
 		Pwd:  c.GeneralParam.RuntimeAccountParam.AdminPwd,
 	}.Conn()
 	if err != nil {
-		logger.Error("Connect %d failed:%s", c.Params.Port, err.Error())
+		logger.Error("连接本地实例 %s:%d 失败: %s", c.Params.Host, c.Params.Port, err.Error())
 		return err
 	}
 	// 远程连接传入过来的master实例，用临时账号
@@ -124,7 +164,7 @@ func (c *PtTableSyncComp) Init() (err error) {
 		Pwd:  c.Params.SyncPass,
 	}.Conn()
 	if err != nil {
-		logger.Error("Connect %d failed:%s", c.Params.Port, err.Error())
+		logger.Error("连接主库实例 %s:%d 失败: %s", c.Params.MasterHost, c.Params.MasterPort, err.Error())
 		return err
 	}
 
@@ -140,6 +180,52 @@ func (c *PtTableSyncComp) Init() (err error) {
 	return nil
 }
 
+// validateTimeParams 校验 StartTime / EndTime 的合法性
+//
+// 业务约定:
+//  1. 手动触发场景 (is_routine_trigger=false): 允许 start_time / end_time 为空;
+//  2. 例行触发场景 (is_routine_trigger=true):  两个字段均必填;
+//  3. 非空时必须严格匹配 YYYY-MM-DD 或 YYYY-MM-DD HH:MM:SS 两种格式之一.
+//
+// 安全用途: 这两个字段会被拼接进 checksum 表 SQL 的 ts BETWEEN '...' AND '...' 条件,
+// 严格白名单校验后即可彻底规避潜在的 SQL 拼接注入面.
+// 该函数与 struct tag 上的 validate 规则等价, 作为兜底第二道防线,
+// 避免调用方绕过 validator 直接构造 struct 时校验缺失.
+func (c *PtTableSyncComp) validateTimeParams() error {
+	const dateLayout = "2006-01-02"
+	const dateTimeLayout = "2006-01-02 15:04:05"
+
+	check := func(field, val string) error {
+		if val == "" {
+			return nil
+		}
+		if _, err := time.ParseInLocation(dateLayout, val, time.Local); err == nil {
+			return nil
+		}
+		if _, err := time.ParseInLocation(dateTimeLayout, val, time.Local); err == nil {
+			return nil
+		}
+		return fmt.Errorf(
+			"%s 格式非法, 期望 %q 或 %q, 实际 %q",
+			field, dateLayout, dateTimeLayout, val,
+		)
+	}
+	if err := check("start_time", c.Params.StartTime); err != nil {
+		return err
+	}
+	if err := check("end_time", c.Params.EndTime); err != nil {
+		return err
+	}
+	// 例行触发场景下, 两个时间必须成对出现
+	if c.Params.IsRoutineTrigger &&
+		(c.Params.StartTime == "" || c.Params.EndTime == "") {
+		return fmt.Errorf(
+			"is_routine_trigger=true 时, start_time 和 end_time 均不能为空",
+		)
+	}
+	return nil
+}
+
 // Precheck 定义act的前置检测行为
 // 检测记录异常的表,现在是否存在；
 // 现在的节点的同步是否还是现在的主库，同步是否正常
@@ -147,7 +233,7 @@ func (c *PtTableSyncComp) Precheck() (err error) {
 
 	// 判断传入过来的checksum表是否存在
 	if !c.isExistCheckSumTable() {
-		return fmt.Errorf("the checksum table [%s.%s] maybe not exit ", checkSumDB, c.Params.CheckSumTable)
+		return fmt.Errorf("checksum 表 [%s.%s] 可能不存在", checkSumDB, c.Params.CheckSumTable)
 	}
 
 	slaveStatus, err := c.dbConn.ShowSlaveStatus()
@@ -156,36 +242,33 @@ func (c *PtTableSyncComp) Precheck() (err error) {
 	}
 	// 同步是否正常
 	if !slaveStatus.ReplSyncIsOk() {
-		errMsg := fmt.Sprintf(
-			"IOThread:%s,SQLThread:%s",
+		return fmt.Errorf(
+			"主从同步异常, IOThread=%s, SQLThread=%s",
 			slaveStatus.SlaveIORunning, slaveStatus.SlaveSQLRunning,
 		)
-		return fmt.Errorf(errMsg)
 	}
 	// 目前节点的master是否是参数传入的master
 	if slaveStatus.MasterHost != c.Params.MasterHost || slaveStatus.MasterPort != c.Params.MasterPort {
-		errMsg := fmt.Sprintf(
-			"The current node syncs this node[%s:%d], not this node[%s:%d]",
+		return fmt.Errorf(
+			"当前节点实际同步的主库为 [%s:%d], 与参数指定的主库 [%s:%d] 不一致",
 			slaveStatus.MasterHost, slaveStatus.MasterPort, c.Params.MasterHost, c.Params.MasterPort,
 		)
-		return fmt.Errorf(errMsg)
 	}
 	// 如果该节点如果了落后时间时间大于1800s ，则程序先异常退出，可等待主从复制同步后再重试任务
 	if slaveStatus.SecondsBehindMaster.Int64 >= slaveBehindMasterLimit {
-		errMsg := fmt.Sprintf(
-			"The slave node [%s:%d] data lags behind the master [%s:%d] by more than 1800s, so exit first",
-			c.Params.Host, c.Params.Port, c.Params.MasterHost, c.Params.MasterPort,
+		return fmt.Errorf(
+			"从库 [%s:%d] 落后主库 [%s:%d] 超过 %ds, 先退出, 待主从追平后重试",
+			c.Params.Host, c.Params.Port, c.Params.MasterHost, c.Params.MasterPort, slaveBehindMasterLimit,
 		)
-		return fmt.Errorf(errMsg)
 	}
 	// 判断最终待修复的表信息列表是否为空,后续引入忽略表的参数，最终可能会为空
 	if len(c.tableSyncMap) == 0 {
-		return fmt.Errorf("check that the list to be fixed is empty ")
+		return fmt.Errorf("待修复的表列表为空")
 	}
 	// 加载pt-table-sync 工具路径
 	c.tools, err = tools.NewToolSetWithPick(tools.ToolPtTableSync)
 	if err != nil {
-		logger.Error("init toolset failed: %s", err.Error())
+		logger.Error("初始化 pt-table-sync 工具集失败: %s", err.Error())
 		return err
 	}
 
@@ -197,84 +280,173 @@ func (c *PtTableSyncComp) Precheck() (err error) {
 // 如果其中某张表修复出现异常，db-act进程不中断，对下一张表进行修复。失败的表打印到日志上
 // 修复表之前看看表是否满足修复条件，如果不满足，则跳过对这个表的修复
 func (c *PtTableSyncComp) ExecPtTableSync() (err error) {
-	// 定义出现修复异常表的失败的表数量
-	var errTableCount int = 0
-	// 定义出现跳过表修复的数量
-	var skipTableCount int = 0
-
-	// 定义数据修复的checksum表名
+	// 数据修复的checksum表名(常规=Params.CheckSumTable, 例行=临时表)
 	var getChecksumName string
 
 	// 获取工具文件路径
 	PtTableSyncPath, err := c.tools.Get(tools.ToolPtTableSync)
 	if err != nil {
-		logger.Error("get %s failed: %s", tools.ToolPtTableSync, err.Error())
+		logger.Error("获取 %s 工具路径失败: %s", tools.ToolPtTableSync, err.Error())
 		return err
 	}
 
 	for _, syncTable := range c.tableSyncMap {
-		// 先在master实例判断表是否符合修复条件
-		isExist, tableCharSet := c.checkTable(syncTable.DbName, syncTable.TableName)
+		db, tbl := syncTable.DbName, syncTable.TableName
+
+		// 1) 主库校验表是否符合修复规格(存在、事务引擎)
+		isExist, tableCharSet := c.checkTable(db, tbl)
 		if !isExist {
-			skipTableCount++
-			logger.Warn(
-				fmt.Sprintf(
-					"The table [%s.%s] does not conform to the behavior of this data repair, skip sync",
-					syncTable.DbName, syncTable.TableName,
-				),
+			logger.Warn("表 [%s.%s] 不符合修复规格,跳过修复", db, tbl)
+			c.appendRepairResult(db, tbl, repairStatusSkipped, "表不存在或非事务引擎,跳过修复", 0, 0)
+			continue
+		}
+
+		// 2) 主库探测表是否存在唯一索引(PRIMARY 或 UNIQUE)
+		hasUniq, uErr := c.hasUniqueIndex(db, tbl)
+		if uErr != nil {
+			logger.Error("探测表 [%s.%s] 唯一索引失败: %s", db, tbl, uErr.Error())
+			c.appendRepairResult(
+				db, tbl, repairStatusFailed,
+				fmt.Sprintf("探测唯一索引出错: %s", uErr.Error()), 0, 0,
+			)
+			continue
+		}
+		if !hasUniq {
+			logger.Warn("表 [%s.%s] 没有唯一索引,不支持修复,跳过修复", db, tbl)
+			c.appendRepairResult(
+				db, tbl, repairStatusSkipped,
+				"该表没有唯一索引,pt-table-sync 无法进行行级修复,跳过修复", 0, 0,
 			)
 			continue
 		}
 
+		// 3) 确定实际使用的 checksum 表名
 		if c.Params.IsRoutineTrigger {
-			// 例行检查发起的数据修复，用临时表作为修复依据
+			// 例行检查发起的数据修复,用临时表作为修复依据
 			getChecksumName = c.PtTableSyncCtx.tempCheckSumTableName
-			if !c.CopyTableCheckSumReport(syncTable.DbName, syncTable.TableName, getChecksumName) {
-				return fmt.Errorf("copy table data error")
+			if !c.CopyTableCheckSumReport(db, tbl, getChecksumName) {
+				logger.Error("复制表 [%s.%s] 的 checksum 记录到临时表失败", db, tbl)
+				c.appendRepairResult(
+					db, tbl, repairStatusFailed,
+					"复制 checksum 记录到临时表失败", 0, 0,
+				)
+				continue
 			}
-
 		} else {
-			// 否则使用传入记录表
+			// 常规校验使用传入的 checksum 表
 			getChecksumName = c.Params.CheckSumTable
 		}
 
-		// 拼接pt-table-sync 的执行命令
+		// 4) 统计不一致 chunk 数,超过阈值则拦截
+		chunks, cErr := c.countInconsistentChunks(db, tbl, getChecksumName)
+		if cErr != nil {
+			logger.Error("统计表 [%s.%s] 不一致 chunk 数失败: %s", db, tbl, cErr.Error())
+			c.appendRepairResult(
+				db, tbl, repairStatusFailed,
+				fmt.Sprintf("统计不一致 chunk 数出错: %s", cErr.Error()), 0, 0,
+			)
+			continue
+		}
+		if chunks > maxInconsistentChunk {
+			logger.Warn(
+				"表 [%s.%s] 不一致 chunk 数=%d, 超过阈值(%d), 跳过修复", db, tbl, chunks, maxInconsistentChunk,
+			)
+			c.appendRepairResult(
+				db, tbl, repairStatusFailed,
+				fmt.Sprintf("不一致 chunk 数超过阈值(%d),修复时间过长, 会影响业务长时间抖动,建议走重建 slave 流程", maxInconsistentChunk),
+				chunks, 0,
+			)
+			continue
+		}
+
+		// 5) 拼接 pt-table-sync 命令
+		// 固定算法为 Nibble:
+		//   - 不指定时工具默认 Chunk 优先：字符列（如 varchar 存数字串/中文，
+		//     在差异范围内同首字符时，
+		//     Chunk 算法 prepare 阶段 die "Cannot chunk table ... same character"，
+		//     且 --algorithms 列表不会自动降级到下一算法，导致整表修复失败；
+		//   - Nibble 按索引序逐段推进、不依赖字符空间切分，天然适配同首字符列，
+		//     其中文边界双重编码问题已随 pt-table-sync 3.3.2-dbm-0.0.1 修复并实测通过；
+		//   - 本修复模式（--replicate --sync-to-master）要求表有唯一索引（行级
+		//     修复需唯一键定位行），有唯一索引则 Nibble 必可用，无需兜底算法。
 		syncCmd := fmt.Sprintf(
 			"%s --replicate=%s.%s --sync-to-master --no-buffer-to-client --no-check-child-tables "+
-				"--chunk-size=%s --databases=%s --tables=%s --charset=%s h=%s,P=%d,u=%s,p=%s --execute --algorithms=Nibble ",
-			PtTableSyncPath, checkSumDB, getChecksumName, chunkSize, syncTable.DbName,
-			syncTable.TableName, tableCharSet, c.Params.Host, c.Params.Port, c.Params.SyncUser, c.Params.SyncPass,
+				"--algorithms=Nibble --chunk-size=%s --databases=%s --tables=%s --charset=%s h=%s,P=%d,u=%s,p=%s --execute",
+			PtTableSyncPath, checkSumDB, getChecksumName, chunkSize, db,
+			tbl, tableCharSet, c.Params.Host, c.Params.Port, c.Params.SyncUser, c.Params.SyncPass,
 		)
 
-		logger.Info("executing %s", syncCmd)
-		output, exitCode, err := osutil.StandardShellCommandForExitCode(false, syncCmd)
+		logger.Info("开始修复表 [%s.%s], 执行命令: %s", db, tbl, maskPasswordInCmd(syncCmd, c.Params.SyncPass))
+		output, exitCode, execErr := osutil.StandardShellCommandForExitCode(false, syncCmd)
 
-		if exitCode != 0 && exitCode != 2 {
-			// 如果修复某张表时候进程查询异常，不中断，记录异常信息，执行下张表的修复
-			logger.Error("exec cmd get an error:%s,%s", output, err.Error())
-			errTableCount++
-			continue
-		} else {
-			// 打印输出日志
-			logger.Info("exitcode: %d", exitCode)
-			logger.Info("fix result : %s", output)
+		// 6) 精细化处理 exitCode
+		switch exitCode {
+		case 0:
+			// exitCode=0 表示 pt-table-sync 未发现实际不一致的行,
+			// 可能是 pt-table-sync 的已知 bug,也可能是差异已被人工修复。
+			// 但 checksum 表中差异记录仍然残留,DBHA 会依据这些记录判断主从数据一致性,
+			// 若不清理将持续影响主从切换判断,因此这里也需要清理 checksum 差异记录。
+			logger.Warn(
+				"表 [%s.%s] pt-table-sync 未发现不一致记录,建议重新执行数据校验单据再次确认。输出: %s",
+				db, tbl, output,
+			)
+			if uerr := c.UpdateOldRecords(db, tbl); uerr != nil {
+				logger.Error(
+					"表 [%s.%s] 未发现不一致但清理 checksum 差异记录失败: %s",
+					db, tbl, uerr.Error(),
+				)
+				c.appendRepairResult(
+					db, tbl, repairStatusFailed,
+					fmt.Sprintf("未发现不一致但清理 checksum 差异记录失败(会影响 DBHA 切换判断): %s", uerr.Error()),
+					chunks, 0,
+				)
+				continue
+			}
+			logger.Info(
+				"表 [%s.%s] 未发现实际不一致,已清理 checksum 差异记录,避免影响 DBHA 切换判断", db, tbl,
+			)
+			c.appendRepairResult(
+				db, tbl, repairStatusNoDiff,
+				"pt-table-sync 未发现不一致记录(可能为工具 bug 或已人工修复),已清理 checksum 差异记录,建议重新执行数据校验单据再次确认",
+				chunks, 0,
+			)
+		case 2:
+			// exitCode=2 表示已修复差异,更新历史记录
+			logger.Info("表 [%s.%s] pt-table-sync 修复完成, 输出: %s", db, tbl, output)
+			if uerr := c.UpdateOldRecords(db, tbl); uerr != nil {
+				logger.Error("表 [%s.%s] 更新 checksum 历史记录失败: %s", db, tbl, uerr.Error())
+				c.appendRepairResult(
+					db, tbl, repairStatusFailed,
+					fmt.Sprintf("修复完成但更新历史记录失败: %s", uerr.Error()),
+					chunks, 2,
+				)
+				continue
+			}
+			logger.Info("表 [%s.%s] 修复成功", db, tbl)
+			c.appendRepairResult(db, tbl, repairStatusSuccess, "修复成功", chunks, 2)
+		default:
+			// 其他退出码统一视为失败,不中断,继续处理下一张表
+			errMsg := ""
+			if execErr != nil {
+				errMsg = execErr.Error()
+			}
+			logger.Error(
+				"表 [%s.%s] pt-table-sync 执行失败, exitCode=%d, output=%s, err=%s",
+				db, tbl, exitCode, output, errMsg,
+			)
+			c.appendRepairResult(
+				db, tbl, repairStatusFailed,
+				fmt.Sprintf("pt-table-sync 执行失败, exitCode=%d, output=%s", exitCode, output),
+				chunks, exitCode,
+			)
 		}
-		// 更新历史记录
-		if err := c.UpdateOldRecords(syncTable.DbName, syncTable.TableName); err != nil {
-			logger.Error(err.Error())
-			errTableCount++
-			continue
-		}
-		logger.Info("syncing-table [%s.%s] has been executed successfully", syncTable.DbName, syncTable.TableName)
 	}
-	logger.Info(
-		"Number of successful fixes: %d ,Number of failed fixes: %d, Number of skip fixes: %d",
-		len(c.tableSyncMap)-errTableCount-skipTableCount, errTableCount, skipTableCount,
-	)
 
-	// 如果真的存在部分表修复异常，则返回失败
-	if errTableCount != 0 {
-		return fmt.Errorf("error")
+	// 存在失败表则返回错误(保持"单表失败不中断"语义,修复报告由上层 defer 输出)
+	for _, r := range c.repairResults {
+		if r.Status == repairStatusFailed {
+			return fmt.Errorf("存在修复失败的表,详见修复报告")
+		}
 	}
 	return nil
 }
@@ -300,7 +472,7 @@ func (c *PtTableSyncComp) getTableSyncMap() (err error) {
 	// 这里查询返回空的话，先不在这里报错退出
 	err = c.dbConn.Queryx(&c.tableSyncMap, checkSQL)
 	if err != nil && !c.dbConn.IsNotRowFound(err) {
-		logger.Error(err.Error())
+		logger.Error("查询 checksum 异常表信息失败: %s", err.Error())
 		return err
 	}
 
@@ -316,7 +488,7 @@ func (c *PtTableSyncComp) isExistCheckSumTable() bool {
 	)
 	_, err := c.dbConn.Query(checkSumSql)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("查询 checksum 表是否存在失败: %s", err.Error())
 		return false
 	}
 	return true
@@ -333,12 +505,12 @@ func (c *PtTableSyncComp) checkTable(dbName string, tableName string) (bool, str
 	)
 	err := c.masterDbConn.Queryx(&tableInfo, checkSumSql)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("查询表 [%s.%s] 元信息失败: %s", dbName, tableName, err.Error())
 		return false, ""
 	}
 	// 检测是否是非事务引擎表，目前事务引擎只有 innodb和tokudb
 	if !c.Params.IsSyncNonInnodbTbls && !(tableInfo[0].Engine == "InnoDB" || tableInfo[0].Engine == "TokuDB") {
-		logger.Error(fmt.Sprintf("The table [%s.%s] is not a transaction engine table", dbName, tableName))
+		logger.Error("表 [%s.%s] 非事务引擎表, 不支持修复", dbName, tableName)
 		return false, ""
 	}
 	return true, getFirstSubstring(tableInfo[0].Collation)
@@ -347,23 +519,24 @@ func (c *PtTableSyncComp) checkTable(dbName string, tableName string) (bool, str
 // DropSyncUser 修复后删除主从节点的临时数据修复账号
 func (c *PtTableSyncComp) DropSyncUser() (err error) {
 
-	logger.Info("droping sync user ....")
+	logger.Info("开始删除临时数据修复账号 ....")
 	userHost := fmt.Sprintf("%s@%s", c.Params.SyncUser, c.Params.Host)
 
 	// 在主节点删除
 	if _, err := c.masterDbConn.Exec(fmt.Sprintf("drop user %s;", userHost)); err != nil {
 		logger.Error(
-			"drop %s failed:%s in the instance [%s:%d]", userHost, err.Error(), c.Params.MasterHost,
-			c.Params.MasterPort,
+			"在主库 [%s:%d] 删除账号 %s 失败: %s", c.Params.MasterHost, c.Params.MasterPort, userHost, err.Error(),
 		)
 		return err
 	}
 	// 在本地节点删除
 	if _, err := c.dbConn.Exec(fmt.Sprintf("drop user %s;", userHost)); err != nil {
-		logger.Error("drop %s failed:%s in the instance [%s:%d]", userHost, err.Error(), c.Params.Host, c.Params.Port)
+		logger.Error(
+			"在本地实例 [%s:%d] 删除账号 %s 失败: %s", c.Params.Host, c.Params.Port, userHost, err.Error(),
+		)
 		return err
 	}
-	logger.Info("drop-user has been executed successfully")
+	logger.Info("临时数据修复账号删除完成")
 	return nil
 }
 
@@ -377,7 +550,7 @@ func (c *PtTableSyncComp) CopyTableCheckSumReport(DBName string, tableName strin
 	// 校验必要参数的逻辑
 	if !(c.Params.IsRoutineTrigger && len(c.Params.StartTime) != 0 && len(c.Params.EndTime) != 0) {
 		logger.Error(
-			"the required parameter is unreasonable,if is_routine_trigger is true, start_time and end_time is not null ",
+			"必要参数不合法: is_routine_trigger 为 true 时, start_time 和 end_time 不能为空",
 		)
 		return false
 	}
@@ -409,16 +582,16 @@ func (c *PtTableSyncComp) CopyTableCheckSumReport(DBName string, tableName strin
 
 	//  在主库执行
 	if _, err := c.masterDbConn.ExecMore(copySQLs); err != nil {
-		logger.Error("create table %s in master failed:[%s]", tempCheckSumTableName, err.Error())
+		logger.Error("在主库创建临时表 %s 失败: %s", tempCheckSumTableName, err.Error())
 		return false
 	}
-	logger.Info("create table %s in master successfully", tempCheckSumTableName)
+	logger.Info("在主库创建临时表 %s 成功", tempCheckSumTableName)
 	// 在从库执行
 	if _, err := c.dbConn.ExecMore(copySQLs); err != nil {
-		logger.Error("create table %s in local failed:[%s]", tempCheckSumTableName, err.Error())
+		logger.Error("在本地实例创建临时表 %s 失败: %s", tempCheckSumTableName, err.Error())
 		return false
 	}
-	logger.Info("create table %s in local successfully", tempCheckSumTableName)
+	logger.Info("在本地实例创建临时表 %s 成功", tempCheckSumTableName)
 
 	return true
 }
@@ -428,11 +601,11 @@ func (c *PtTableSyncComp) DropTempTable() (err error) {
 
 	if !c.Params.IsRoutineTrigger {
 		// 判断临时表没有创建过，则主动跳过
-		logger.Info("temp-table is null, skip")
+		logger.Info("未使用临时 checksum 表, 跳过删除")
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("droping Temp table :%s ....", c.PtTableSyncCtx.tempCheckSumTableName))
+	logger.Info("开始删除临时表: %s ....", c.PtTableSyncCtx.tempCheckSumTableName)
 	if _, err := c.masterDbConn.Exec(
 		fmt.Sprintf(
 			"drop table if exists %s.%s;",
@@ -440,10 +613,10 @@ func (c *PtTableSyncComp) DropTempTable() (err error) {
 			c.PtTableSyncCtx.tempCheckSumTableName,
 		),
 	); err != nil {
-		logger.Error("drop temp table failed")
+		logger.Error("删除临时表失败: %s", err.Error())
 		return err
 	}
-	logger.Info("drop-temp-table has been executed successfully")
+	logger.Info("临时表删除完成")
 	return nil
 }
 
@@ -477,10 +650,109 @@ func (c *PtTableSyncComp) UpdateOldRecords(dbName string, tableName string) (err
 	sqls = append(sqls, "set session sql_log_bin = 1 ;")
 
 	if _, err := c.dbConn.ExecMore(sqls); err != nil {
-		return fmt.Errorf("update-old-records %s.%s failed:[%s]", dbName, tableName, err.Error())
+		return fmt.Errorf("更新表 [%s.%s] 的 checksum 历史记录失败: %s", dbName, tableName, err.Error())
 	}
-	logger.Info("update-old-records [%s.%s] has been executed successfully", dbName, tableName)
+	logger.Info("表 [%s.%s] 的 checksum 历史记录更新完成", dbName, tableName)
 	return nil
+}
+
+// appendRepairResult 追加一条表级修复结果到上下文的结果集
+func (c *PtTableSyncComp) appendRepairResult(db, tbl, status, reason string, chunks, exitCode int) {
+	c.repairResults = append(c.repairResults, TableRepairResult{
+		DbName:             db,
+		TableName:          tbl,
+		Status:             status,
+		Reason:             reason,
+		InconsistentChunks: chunks,
+		ExitCode:           exitCode,
+	})
+}
+
+// PrintRepairReport 汇总修复结果并返回格式化 JSON 字符串,由上层通过 OutputCtx 包装输出
+func (c *PtTableSyncComp) PrintRepairReport() (string, error) {
+	// 分类计数
+	var successCnt, failedCnt, skippedCnt, noDiffCnt int
+	for _, r := range c.repairResults {
+		switch r.Status {
+		case repairStatusSuccess:
+			successCnt++
+		case repairStatusFailed:
+			failedCnt++
+		case repairStatusSkipped:
+			skippedCnt++
+		case repairStatusNoDiff:
+			noDiffCnt++
+		}
+	}
+
+	logger.Info(
+		"数据修复结果汇总: 成功=%d, 失败=%d, 跳过=%d, 无差异=%d, 总计=%d",
+		successCnt, failedCnt, skippedCnt, noDiffCnt, len(c.repairResults),
+	)
+
+	// 序列化为格式化 JSON, 供上层 OutputCtx 包装输出
+	// 使用 Encoder 并关闭 HTML 转义, 避免中文被转成 \uXXXX 形式, 保证可读性
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(c.repairResults); err != nil {
+		logger.Error("修复结果 JSON 序列化失败: %s", err.Error())
+		return "", err
+	}
+	// Encoder.Encode 会在末尾追加换行符, 去除以便 OutputCtx 输出紧凑
+	report := strings.TrimRight(buf.String(), "\n")
+	// 打印本地日志便于对比: 若日志里为原文中文, 而 <ctx> 展示端仍是 \uXXXX, 则是上游二次编码
+	logger.Info("数据修复结果报告(JSON,原文):\n%s", report)
+	return report, nil
+}
+
+// hasUniqueIndex 在主库探测表是否存在 PRIMARY 或 UNIQUE 索引(通过 Non_unique=0 判定)
+// 注意: DbWorker.Query 在查询结果为空行时,会返回一个字面值为 "not row found" 的 error,
+// 这不是真正的执行错误,而是"没有匹配到行"的业务语义,对于本函数就应当解释为"没有唯一索引",
+// 因此需要显式兼容,避免误报为"探测失败"。
+func (c *PtTableSyncComp) hasUniqueIndex(dbName, tableName string) (bool, error) {
+	sqlStr := fmt.Sprintf("SHOW INDEX FROM `%s`.`%s` WHERE Non_unique = 0", dbName, tableName)
+	rows, err := c.masterDbConn.Query(sqlStr)
+	if err != nil {
+		// 空结果集在 DbWorker 里被包装成 error, 这里等价于"无唯一索引"
+		if strings.Contains(err.Error(), native.NotRowFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(rows) > 0, nil
+}
+
+// countInconsistentChunks 统计指定 checksum 表中某张表不一致 chunk 记录数
+// 常规场景查 Params.CheckSumTable, 例行场景查临时表且按 ts BETWEEN StartTime AND EndTime 过滤
+func (c *PtTableSyncComp) countInconsistentChunks(dbName, tableName, checkSumName string) (int, error) {
+	var countSQL string
+	if c.Params.IsRoutineTrigger {
+		countSQL = fmt.Sprintf(
+			`select count(*) as cnt from %s.%s where db = '%s' and tbl = '%s' `+
+				`and (this_crc <> master_crc or this_cnt <> master_cnt) `+
+				`and (ts between '%s' and '%s')`,
+			checkSumDB, checkSumName, dbName, tableName, c.Params.StartTime, c.Params.EndTime,
+		)
+	} else {
+		countSQL = fmt.Sprintf(
+			`select count(*) as cnt from %s.%s where db = '%s' and tbl = '%s' `+
+				`and (this_crc <> master_crc or this_cnt <> master_cnt)`,
+			checkSumDB, checkSumName, dbName, tableName,
+		)
+	}
+
+	var result []struct {
+		Cnt int `db:"cnt"`
+	}
+	if err := c.dbConn.Queryx(&result, countSQL); err != nil {
+		return 0, err
+	}
+	if len(result) == 0 {
+		return 0, nil
+	}
+	return result[0].Cnt, nil
 }
 
 func getFirstSubstring(s string) string {
@@ -488,4 +760,16 @@ func getFirstSubstring(s string) string {
 		return s[:idx] // 找到第一个 _ 前的内容
 	}
 	return s // 未找到则返回原字符串
+}
+
+// maskPasswordInCmd 对命令行中的 pt-table-sync DSN 密码进行脱敏,避免明文密码泄露到日志。
+// pt-table-sync DSN 中密码通过 p=xxx 传递,通常形如: h=1.1.1.1,P=3306,u=user,p=secret --execute
+// 使用正则锚定 DSN 内边界字符(前置 ',' 或空白, 后置 ',' 或空白/行尾),
+// 将 p= 后的实际密码值统一替换为占位符 ***.
+// 相较于 strings.ReplaceAll(cmd, "p="+pass, "p=***") 的字面替换:
+//  1. 不会因为密码字面值恰好作为子串出现在其它位置(如库表名)而被误替换;
+//  2. 密码含 DSN 分隔符时仍能精确匹配到真实边界;
+//  3. 不再依赖 pass 明文入参, 传空也不影响功能.
+func maskPasswordInCmd(cmd, _ string) string {
+	return dsnPassRe.ReplaceAllString(cmd, "${1}***")
 }

--- a/dbm-services/mysql/db-tools/mysql-table-checksum/pt-table-sync
+++ b/dbm-services/mysql/db-tools/mysql-table-checksum/pt-table-sync
@@ -55,7 +55,20 @@ BEGIN {
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.3.2-dbm-0.0.1';
+# 版本号说明（bk-dbm 定制版）：
+#   格式 = <上游 percona-toolkit 基线版本>-dbm-<dbm 定制序号>
+#   - 3.3.2     ：上游 percona-toolkit 基线版本
+#   - dbm-0.0.1 ：bk-dbm 定制第 1 版
+# 本版定制内容（#20161）：修复中文 chunk 边界双重编码导致"假修复"——
+#   - 方案A：8 处 SQL 执行出口 utf8::downgrade 还原被隐式升级的字符串
+#     （sync_table / _take_action / make_row / make_UPDATE / Nibble 边界
+#      发现 / TableChunker MIN·MAX·EXPLAIN / get_first_valid_value）；
+#   - 方案B：TableParser::parse 入口将 DDL 还原为原始字节串，消除
+#     tbl_struct 全部派生字段的 UTF8 标志源头（pack/unpack 方式，
+#     兼容 DDL 含中文 COMMENT 的场景）。
+#   机理、验证与部署详见同目录 issue-20161-pt-table-sync-chinese-boundary-bug.md。
+# 后续 dbm 定制变更请递增 -dbm- 后序号（0.0.2、0.0.3 ...）并在此追加记录。
 
 use strict;
 use warnings FATAL => 'all';
@@ -2865,6 +2878,34 @@ sub parse {
    my ( $self, $ddl, $opts ) = @_;
    return unless $ddl;
 
+   # 修复 #20161（方案B，源头加固）：tbl_struct 的 UTF8 标志源头治理。
+   # mysql_enable_utf8=1 时（dbactuator 传 --charset=utf8 触发，见
+   # DSNParser 连接属性逻辑），SHOW CREATE TABLE 的 DDL 被 DBD 解码、
+   # 整串带 UTF8 标志（即使内容纯 ASCII）。本函数从 $ddl 正则派生的
+   # 全部结构字段（cols/type_for/engine/charset/is_numeric...）继承该
+   # 标志，并随列名/索引名进入所有 SQL 模板。带标志模板与不带标志的
+   # utf8 字节串值（如 checksum 表读回的中文边界值）拼接时，Perl 将
+   # 值的每个字节按 Latin-1 码点隐式 utf8::upgrade，DBD 发送时二次
+   # 编码为乱码（2026-09 插桩实测：P1 全字段 flag=1，P3 diff_where
+   # 产物即现 c3a7c294 双重编码）。在解析入口把 DDL 还原为字节串，
+   # 所有派生字段天然不带标志，任何模板插值（含未来新增 SQL 路径）
+   # 都不再触发升级——以一处源头修复替代在每个 SQL 出口逐点打补丁。
+   # 实现说明（修正版）：DDL 常含中文 COMMENT（如 COMMENT '用户名'），
+   # DBD 解码后这些字符是码点 >= 0x100 的真宽字符，utf8::downgrade
+   # 对此 no-op（2026-09 实测：含中文注释的表上 P1 仍全 flag=1）。
+   # 故改用 pack/unpack 把"解码形态"强制还原为"原始 utf8 字节串"：
+   #   - 宽字符 -> 其 UTF-8 字节（恰为服务器返回的原始字节；中文
+   #     COMMENT 以字节形态留存于 DDL，不参与列名/索引名/引擎等
+   #     结构字段的派生，派生字段全为 ASCII）；
+   #   - ASCII 部分（列名/类型/引擎/字符集）字节不变；
+   #   - 派生的结构字段从此不带 UTF8 标志，模板插值不再触发升级；
+   #   - flag=0 的字节串 DDL（未开 utf8 的连接）不进入该分支，原样。
+   # $ddl 为局部拷贝，不影响调用方；$src->{ddl} 等原文消费点经核查
+   # 仅作本函数入参，字节化无下游影响。与各 SQL 出口的
+   # utf8::downgrade（方案A）叠加构成纵深防御：本处消除污染的产生，
+   # 出口兜底本处前提之外的一切。
+   $ddl = pack 'C0 C*', unpack 'U0 C*', $ddl if utf8::is_utf8($ddl);
+
    if ( $ddl =~ m/CREATE (?:TEMPORARY )?TABLE "/ ) {
       $ddl = $self->ansi_to_legacy($ddl);
    }
@@ -3478,6 +3519,13 @@ sub dst {
 
 sub _take_action {
    my ( $self, $sql, $dbh ) = @_;
+   # 修复 #20161：所有修复语句（REPLACE/DELETE/UPDATE/INSERT）的统一出口。
+   # 行数据里的中文列值（如 xxx='/质量中心/...'）从 DBI 取回后
+   # 同样会被隐式 utf8::upgrade，生成的修复 SQL 被二次 UTF-8 编码——即使
+   # 比对阶段已修好，--execute 阶段也会把乱码写进表里，把好数据修坏。
+   # 此处统一还原为原始字节。机理与安全性详见 TableSyncer::sync_table
+   # 中的核心修复注释。
+   utf8::downgrade($sql, 1);
    PTDEBUG && _d('Calling subroutines on', $dbh, $sql);
    foreach my $action ( @{$self->{actions}} ) {
       $action->($sql, $dbh);
@@ -3581,6 +3629,8 @@ sub make_UPDATE {
    my @cols;
    if ( my $dbh = $self->{fetch_back} ) {
       my $sql = $self->make_fetch_back_query($where);
+      # 修复 #20161：同 make_row，防止 fetch_back 的 WHERE 中文键值被二次编码。
+      utf8::downgrade($sql, 1);
       PTDEBUG && _d('Fetching data on dbh', $dbh, 'for UPDATE:', $sql);
       my $res = $dbh->selectrow_hashref($sql);
       @{$row}{keys %$res} = values %$res;
@@ -3627,6 +3677,10 @@ sub make_row {
    if ( my $dbh = $self->{fetch_back} ) {
       my $where = $self->make_where_clause($row, $cols);
       my $sql   = $self->make_fetch_back_query($where);
+      # 修复 #20161：fetch_back 回查整行的 SELECT，其 WHERE 可能包含中文
+      # 键值（GroupBy 算法 key_cols 为全部列），不还原会被二次编码导致
+      # 回查不到行。详见 TableSyncer::sync_table 中的核心修复注释。
+      utf8::downgrade($sql, 1);
       PTDEBUG && _d('Fetching data on dbh', $dbh, 'for', $verb, ':', $sql);
       my $res = $dbh->selectrow_hashref($sql);
       @{$row}{keys %$res} = values %$res;
@@ -4290,6 +4344,13 @@ sub get_range_statistics {
       my $sql = "SELECT MIN($col), MAX($col) FROM $db_tbl"
               . ($args{index_hint} ? " $args{index_hint}" : "")
               . ($where ? " WHERE ($where)" : '');
+      # 修复 #20161（方案A-2）：MIN/MAX 范围统计 SQL 同样内插 diff WHERE
+      # 且在 TableChunker 内部执行，不经过 sync_table 的修复通道。不还原
+      # 时乱码边界使范围为空集、MIN/MAX 返回 NULL，TableSyncChunk 对
+      # NULL 的兜底是退化为单 chunk（1=1）——比对结果仍正确（比对 SQL
+      # 已修复），但 chunk 粒度退化：大表会被当成一整个 chunk 锁定和
+      # 比对，放大锁范围与内存开销。机理详见 sync_table 核心修复注释。
+      utf8::downgrade($sql, 1);
       PTDEBUG && _d($dbh, $sql);
       ($min, $max) = $dbh->selectrow_array($sql);
       PTDEBUG && _d("Actual end points:", $min, $max);
@@ -4313,6 +4374,9 @@ sub get_range_statistics {
    my $sql = "EXPLAIN SELECT * FROM $db_tbl"
            . ($args{index_hint} ? " $args{index_hint}" : "")
            . ($where ? " WHERE $where" : '');
+   # 修复 #20161（方案A-2）：EXPLAIN 行数估算 SQL，WHERE 同上，需还原，
+   # 否则 rows_in_range 估算失真。
+   utf8::downgrade($sql, 1);
    PTDEBUG && _d($sql);
    my $expl = $dbh->selectrow_hashref($sql);
 
@@ -4560,6 +4624,10 @@ sub get_first_valid_value {
            . "WHERE $col $cmp ? AND $col IS NOT NULL "
            . ($args{where} ? "AND ($args{where}) " : "")
            . "ORDER BY $col LIMIT 1";
+   # 修复 #20161（方案A-3，防御性）：该 SQL 也内插 diff WHERE。当前仅
+   # temporal 切分列（值为 ASCII）会走到此分支，实际无风险；为保持
+   # "所有内插 diff WHERE 的 SQL 出口统一还原"的不变式而修补。
+   utf8::downgrade($sql, 1);
    PTDEBUG && _d($dbh, $sql);
    my $sth = $dbh->prepare($sql);
 
@@ -5573,6 +5641,19 @@ sub __get_boundaries {
       my $sql;
       ($sql, $lb) = $self->__make_boundary_sql(%args);  # $lb from outer scope!
 
+      # 修复 #20161（方案A-1）：Nibble 的边界发现 SQL 在插件内部构建并
+      # 执行（EXPLAIN 索引校验 + selectrow_hashref 取下一边界行），不经
+      # 过 TableSyncer::sync_table 中已修复的 $src_sql/$dst_sql 通道。
+      # 该 SQL 内插了含非 ASCII 边界值的 diff WHERE（病态字符串形态），
+      # 若不在两个执行出口前还原为原始字节：
+      #   - 边界值被双重编码，叠加 utf8_general_ci 口音折叠，边界范围
+      #     成为空集（MySQL 视为 Impossible WHERE，EXPLAIN 无索引可用）；
+      #   - 第 0 个 nibble 的索引校验失败，die "Cannot nibble table ...
+      #     because MySQL chose no index instead of the `PRIMARY` index"，
+      #     整表修复直接失败（--algorithms 列表不会自动降级到下一算法）。
+      # 机理与安全性论证详见 TableSyncer::sync_table 中的核心修复注释。
+      utf8::downgrade($sql, 1);
+
       if ( $self->{nibble} == 0 && !$self->{small_table} ) {
          my $explain_index = $self->__get_explain_index($sql);
          if ( lc($explain_index || '') ne lc($s->{index}) ) {
@@ -6075,6 +6156,38 @@ sub sync_table {
             $dst_sql .= ' FOR UPDATE';
          }
       }
+      # 修复 #20161（核心修复）：解决 chunk 边界含非 ASCII 字符（如中文）时
+      # 主从差异永远无法被修复的问题。
+      #
+      # 故障机理（已在 5.7.20 环境实测复现）：
+      #   1. checksum 表里的 lower/upper_boundary 存的是正确的 utf8 字节串
+      #      （如 '用户' = E794A8 E688B7），经 DBI 读回后是【未置 UTF8 标志】
+      #      的原始字节字符串；
+      #   2. diff_where() 把边界值替换进 WHERE 模板时，Perl 对混合字符串做了
+      #      隐式 utf8::upgrade：把这些字节逐个当作 Latin-1 码点并置上 UTF8
+      #      标志，字符串内容变成 \x{e7}\x{94}\x{a8}\x{e6}\x{88}\x{b7}；
+      #   3. DBD::mysql（mysql_enable_utf8=1）在发送带 UTF8 标志的字符串前会
+      #      重新做 UTF-8 编码，于是服务器实际收到的是二次编码后的乱码字面量
+      #      （C3A7C294C2A8C3A6C288C2B7，即 6 个 Latin-1 字符，首字符 'ç'）；
+      #   4. utf8_general_ci 对 Latin-1 补充区字符做口音折叠（'ç' 的排序权重
+      #      等同 'c'），乱码上边界被排到下边界 'deanchi' 之前，比对范围
+      #      （user_name > 'deanchi' AND user_name < 乱码串）变成空集；
+      #   5. 主从两侧对空范围各算出 cnt=0, crc=0，same_row 误判“一致”，工具
+      #      静默 exit 0——差异永远修不上；且上层 dbactuator 会把 exit 0 当
+      #      修复成功并清空 checksum 差异标记，形成“假修复”闭环。
+      #
+      # 修复方式：SQL 交给 DBD 发送前，用 utf8::downgrade 把被误升级的字符串
+      # 无损还原为原始字节（码点 -> 字节，恰好是第 2 步的逆操作）。
+      #
+      # 安全性说明：
+      #   - utf8::downgrade($s, 1) 仅当字符串所有码点均 <256（即恰好处于
+      #     “字节被当作码点”的误升级形态）时才转换，正是本 bug 的形态；
+      #   - 若字符串含真正的宽字符（码点 >=0x100，即曾被正确解码过），带
+      #     fail_ok=1 的 downgrade 不做任何修改（no-op），而 DBD 对这种字符
+      #     串重编码的结果本来就是正确的 utf8 字节；
+      #   - 纯 ASCII 字符串两种形态等价，不受影响。三种情况均安全。
+      utf8::downgrade($src_sql, 1);
+      utf8::downgrade($dst_sql, 1);
       PTDEBUG && _d('src:', $src_sql);
       PTDEBUG && _d('dst:', $dst_sql);
 
@@ -13101,6 +13214,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-table-sync 3.4.0
+pt-table-sync 3.3.2-dbm-0.0.1
 
 =cut

--- a/dbm-ui/backend/flow/engine/bamboo/scene/common/builder.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/common/builder.py
@@ -266,7 +266,8 @@ class Builder(object):
                 type=Var.PLAIN, value=act_info.get("write_payload_var", False)
             )
 
-            self.rewritable_node_source_keys.append({"source_act": act.id, "source_key": "trans_data"})
+            if not act_info.get("is_remote_rewritable", False):
+                self.rewritable_node_source_keys.append({"source_act": act.id, "source_key": "trans_data"})
 
             flow_node_list.append(FlowNode(uid=self.data["uid"], root_id=self.root_id, node_id=act.id))
             acts.append(act)

--- a/dbm-ui/backend/flow/engine/bamboo/scene/mysql/pt_table_sync.py
+++ b/dbm-ui/backend/flow/engine/bamboo/scene/mysql/pt_table_sync.py
@@ -22,8 +22,10 @@ from backend.flow.consts import ACCOUNT_PREFIX
 from backend.flow.engine.bamboo.scene.common.builder import Builder, SubBuilder
 from backend.flow.engine.bamboo.scene.common.get_file_list import GetFileList
 from backend.flow.plugins.components.collections.mysql.pt_table_sync import PtTableSyncComponent
+from backend.flow.plugins.components.collections.mysql.pt_table_sync_summary import PtTableSyncSummaryComponent
 from backend.flow.plugins.components.collections.mysql.trans_flies import TransFileComponent
 from backend.flow.utils.mysql.mysql_act_dataclass import DownloadMediaKwargs, PtTableSyncKwargs
+from backend.flow.utils.mysql.mysql_context_dataclass import PtTableSyncContext
 
 logger = logging.getLogger("flow")
 
@@ -88,6 +90,7 @@ class PtTableSyncFlow(object):
                             file_list=GetFileList(db_type=DBType.MySQL).get_db_actuator_package(),
                         )
                     ),
+                    "is_remote_rewritable": True,
                 }
             )
         if not acts_list:
@@ -130,6 +133,15 @@ class PtTableSyncFlow(object):
                         )
                     ),
                 )
+                # 追加摘要写入节点：从 trans_data.result[slave_ip] 展平为 (集群, ip, 库, 表) 行，合并写入 FlowSummary
+                slave_sync_sub_pipeline.add_act(
+                    act_name=_("写入数据修复摘要"),
+                    act_component_code=PtTableSyncSummaryComponent.code,
+                    kwargs={
+                        "cluster_domain": cluster.immute_domain,
+                        "slave_ip": slave["ip"],
+                    },
+                )
                 cluster_sync_sub_list.append(
                     slave_sync_sub_pipeline.build_sub_process(
                         sub_name=_("{}:{}做数据修复").format(slave["ip"], slave["port"])
@@ -143,4 +155,4 @@ class PtTableSyncFlow(object):
             raise Exception(_("修复单据找不到可修复的集群"))
 
         table_sync_pipeline.add_parallel_sub_pipeline(sub_flow_list=sub_pipelines)
-        table_sync_pipeline.run_pipeline(is_drop_random_user=True)
+        table_sync_pipeline.run_pipeline(is_drop_random_user=True, init_trans_data_class=PtTableSyncContext())

--- a/dbm-ui/backend/flow/plugins/components/collections/common/base_service.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/base_service.py
@@ -35,7 +35,7 @@ from backend.utils.excel import ExcelHandler
 from backend.utils.redis import RedisConn
 
 logger = logging.getLogger("flow")
-cpl = re.compile("<ctx>(?P<context>.+?)</ctx>")  # 非贪婪模式，只匹配第一次出现的自定义tag
+cpl = re.compile(r"<ctx>(?P<context>[\s\S]+?)</ctx>")  # 非贪婪模式，只匹配第一次出现的自定义tag；[\s\S]+? 兼容跨行 JSON
 
 
 class ServiceLogMixin:
@@ -311,8 +311,17 @@ class BkJobService(BaseService, metaclass=ABCMeta):
             # 结果返回异常，则异常退出
             return False
         try:
+            # 先提取 <ctx> 段，命中不到时打明确日志；避免 .group() 抛 AttributeError 被通用 except 吞掉
+            match = re.search(cpl, resp["data"]["log_content"])
+            if not match:
+                self.log_error(
+                    _("[写入上下文结果失败] stdout 中未发现 <ctx>...</ctx> 结构化输出，log_content 长度={}").format(
+                        len(resp["data"].get("log_content") or "")
+                    )
+                )
+                return False
             # 以dict形式追加写入
-            result = json.loads(re.search(cpl, resp["data"]["log_content"]).group("context"))
+            result = json.loads(match.group("context"))
 
             if write_op == WriteContextOpType.APPEND.value:
                 context = copy.deepcopy(getattr(trans_data, write_payload_var))

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/exec_actuator_script.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/exec_actuator_script.py
@@ -31,7 +31,9 @@ from backend.flow.utils.script_template import actuator_template, fast_execute_s
 from backend.utils.string import base64_encode
 
 logger = logging.getLogger("json")
-cpl = re.compile("<ctx>(?P<context>.+?)</ctx>")  # 非贪婪模式，只匹配第一次出现的自定义tag
+# 非贪婪模式，只匹配第一次出现的自定义 tag
+# 使用 [\s\S]+? 而非 .+? ：db-actuator 侧若产出多行 JSON（含 \n），默认 `.` 不匹配换行会导致 re.search 返回 None
+cpl = re.compile(r"<ctx>(?P<context>[\s\S]+?)</ctx>")
 
 
 class ExecuteDBActuatorScriptService(BkJobService):

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/flow_output_summary.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/flow_output_summary.py
@@ -46,6 +46,7 @@ from backend.flow.utils.mysql.flow_output_presets import (
     InstanceChangeSummarySerializer,
     MessageSummarySerializer,
     PrecheckResultSummarySerializer,
+    PtTableSyncSummarySerializer,
     SqlExecResultSummarySerializer,
 )
 from backend.ticket.models import Flow
@@ -62,6 +63,7 @@ _PRESET_REGISTRY: Dict[str, Type[BaseFlowOutputSerializer]] = {
     "precheck": PrecheckResultSummarySerializer,
     "sql_exec": SqlExecResultSummarySerializer,
     "message": MessageSummarySerializer,
+    "pt_table_sync": PtTableSyncSummarySerializer,
 }
 
 

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/pt_table_sync.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/pt_table_sync.py
@@ -13,7 +13,7 @@ import logging
 from pipeline.component_framework.component import Component
 
 from backend.components import DBPrivManagerApi
-from backend.flow.consts import AUTH_ADDRESS_DIVIDER, LONG_JOB_TIMEOUT
+from backend.flow.consts import AUTH_ADDRESS_DIVIDER, LONG_JOB_TIMEOUT, WriteContextOpType
 from backend.flow.plugins.components.collections.mysql.exec_actuator_script import ExecuteDBActuatorScriptService
 from backend.flow.utils.mysql.mysql_act_playload import MysqlActPayload
 
@@ -78,6 +78,8 @@ class PtTableSyncService(ExecuteDBActuatorScriptService):
         data.get_one_of_inputs("kwargs")["get_trans_data_ip_var"] = None
         data.get_one_of_inputs("kwargs")["cluster"] = cluster_info
         data.get_one_of_inputs("kwargs")["job_timeout"] = LONG_JOB_TIMEOUT
+        data.get_one_of_inputs("kwargs")["write_op"] = WriteContextOpType.APPEND.value
+        data.inputs.write_payload_var = "result"  # 记录修复后结果的上下文地方
         return super()._execute(data, parent_data)
 
 

--- a/dbm-ui/backend/flow/plugins/components/collections/mysql/pt_table_sync_summary.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/mysql/pt_table_sync_summary.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+------------------------------------------------------------------------------
+
+mysql pt-table-sync 修复结果摘要组件（trans_data 展平版）。
+
+模块职责：
+  - 面向 pt-table-sync 数据修复子流程末尾节点：把 :class:`PtTableSyncContext.result`
+    （结构：{slave_ip: [{db_name, table_name, status, reason, ...}, ...]}）按
+    (集群, slave-ip, 库, 表) 四元组展平为一行行摘要，写入 FlowSummary.summary。
+
+设计要点 / 数据源 / 调用通道：
+  - 采用与 :class:`MysqlClusterApplySummaryComponent` 同款的\"继承 + 薄壳\"分层：
+    :class:`PtTableSyncSummaryService` 继承 :class:`MysqlFlowOutputSummaryService`，
+    `_execute` 只做一件事——从 trans_data 展平出 items → 塞回 kwargs
+    → 回调 super()._execute()，preset 校验 / Flow 兜底 / 幂等落库全部沿用通用底座，
+    避免逻辑重复。
+  - 单据侧调用极简：仅传 `cluster_domain + slave_ip` 两个静态定位字段；
+    业务字段（db_name / table_name / status / reason）从 trans_data 反查。
+
+边界：
+  - trans_data 无 result 或 result 中无对应 slave_ip -> items 为空，父类走 no-op 返回 True。
+  - 单行缺 db_name / table_name / status -> log_warning 跳过该行，不阻断其他行。
+  - kwargs 缺 cluster_domain / slave_ip -> log_error 返回 False（对齐父类"preset 非法"的显式失败语义）。
+  - 无关联 Flow / 反查结果为空等其他兜底路径 -> 沿用父类行为，不重复实现。
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from django.utils.translation import gettext as _
+from pipeline.component_framework.component import Component
+
+from backend.flow.plugins.components.collections.mysql.flow_output_summary import MysqlFlowOutputSummaryService
+
+logger = logging.getLogger("flow")
+
+#: 本组件固定服务的预设 key；对齐 flow_output_presets.PtTableSyncSummarySerializer。
+#: 调用方无需感知，Service 强制注入到 kwargs["preset"]。
+_FIXED_PRESET_KEY: str = "pt_table_sync"
+
+
+class PtTableSyncSummaryService(MysqlFlowOutputSummaryService):
+    """mysql pt-table-sync 数据修复摘要 Service（trans_data 展平装配）。
+
+    功能说明：
+      - 从 kwargs 读取集群/节点定位信息（`cluster_domain` + `slave_ip`），
+        从 :class:`PtTableSyncContext.result` 读取当前 slave 的修复结果列表，
+        按 (集群, ip, 库, 表) 四元组展平为对齐
+        :class:`PtTableSyncSummarySerializer` 契约的 items 后回调
+        :meth:`MysqlFlowOutputSummaryService._execute` 完成落库。
+      - 调用方**不再传业务字段**（db_name / table_name / status / reason），
+        全部由 Service 从 trans_data 展平产生。
+
+    输入参数（即 kwargs 字段结构）：
+      - cluster_domain (str, 必填, 非空): 集群主域名，前端展示第一列
+      - slave_ip (str, 必填, 非空): 修复目标 slave IP；用于从 trans_data.result 取子列表
+      - global_data (dict, 可选): 由 pipeline 框架传入，用于激活国际化
+
+    输出：
+      - 返回 bool；行为语义与父类一致：
+          * True: 写入成功 / no-op（trans_data 无结果、无关联 Flow 等）
+          * False: 定位字段缺失 / 父类落库失败
+
+    边界 / 异常：
+      - kwargs.cluster_domain / kwargs.slave_ip 缺失 -> log_error 返回 False。
+      - trans_data 无 result 属性或 result 中无对应 slave_ip -> items 为空，
+        父类走\"items 为空 no-op\"路径返回 True。
+      - 单行缺 db_name / table_name / status -> log_warning 跳过该行，
+        不中止其他行，也不阻断整体写入。
+      - 无关联 Flow 的临时 pipeline -> 沿用父类 Flow 兜底逻辑，不重复实现。
+    """
+
+    #: 必需的静态定位字段清单
+    _REQUIRED_KWARGS: List[str] = ["cluster_domain", "slave_ip"]
+
+    def _execute(self, data, parent_data) -> bool:
+        kwargs: Dict[str, Any] = data.get_one_of_inputs("kwargs") or {}
+
+        # 1) 静态入参校验：定位字段缺失直接失败，避免展平出无主键的脏行
+        for key in self._REQUIRED_KWARGS:
+            if not kwargs.get(key):
+                self.log_error(_("pt-table-sync 摘要写入缺少必填 kwargs 字段: {}").format(key))
+                return False
+        cluster_domain: str = kwargs["cluster_domain"]
+        slave_ip: str = kwargs["slave_ip"]
+
+        # 2) 从 trans_data 展平 items；无结果时 items=[]，交给父类走 no-op 分支
+        trans_data = data.get_one_of_inputs("trans_data")
+        items: List[Dict[str, Any]] = self._build_items_from_trans_data(trans_data, cluster_domain, slave_ip)
+
+        # 3) 将装配好的 items 与固定 preset 塞回 kwargs，交给父类完成 preset 校验 / Flow 兜底 / 落库
+        kwargs["preset"] = _FIXED_PRESET_KEY
+        kwargs["items"] = items
+        data.inputs.kwargs = kwargs
+        return super()._execute(data, parent_data)
+
+    def _build_items_from_trans_data(
+        self,
+        trans_data: Any,
+        cluster_domain: str,
+        slave_ip: str,
+    ) -> List[Dict[str, Any]]:
+        """按 trans_data.result[slave_ip] 展平为 :class:`PtTableSyncSummarySerializer` 契约的 items。
+
+        功能说明 / 怎么做：
+          - 从 trans_data.result 中取当前 slave_ip 对应的修复结果列表；
+          - 逐行装配 `(cluster_domain, ip, db_name.table_name, status, reason)`；
+          - unique_key 按预设 Serializer 约定拼接 `"{domain}|{ip}|{db}|{table}"` 作为主键单字段，
+            走 FlowOutputHandler.insert_data 主键合并分支实现同 (集群, ip, 库, 表) 的"后写覆盖前写"幂等；
+          - 缺关键字段的行跳过并 log_warning，避免脏行触发预设 Serializer 校验失败牵连整体写入。
+
+        :param trans_data: pipeline 运行期上下文对象；期望是 :class:`PtTableSyncContext`
+        :param cluster_domain: 集群主域名，摘要第一列
+        :param slave_ip: 修复目标 slave IP，摘要第二列 & unique_key 组成部分
+        :return: 已对齐预设 Serializer 字段契约的 items 列表；长度 ≤ 原始 rows 长度
+                 （无结果 / 脏行会被过滤掉）
+
+        边界 / 异常：
+          - trans_data 无 result 属性或 result 不含 slave_ip -> 返回 []，父类走 no-op；
+          - rows 单行缺 db_name / table_name / status -> log_warning 跳过；
+          - reason 缺失 -> 填空串，符合预设 Serializer 的 allow_blank 契约。
+        """
+        result_map: Optional[Dict[str, List[Dict[str, Any]]]] = getattr(trans_data, "result", None)
+        if not result_map or slave_ip not in result_map:
+            self.log_info(_("trans_data.result 无 slave_ip=[{}] 的修复结果，跳过摘要写入").format(slave_ip))
+            return []
+
+        rows: List[Dict[str, Any]] = result_map.get(slave_ip) or []
+        if not rows:
+            return []
+
+        items: List[Dict[str, Any]] = []
+        for row in rows:
+            row = row or {}
+            db_name: str = row.get("db_name") or ""
+            table_name: str = row.get("table_name") or ""
+            status: str = row.get("status") or ""
+            if not db_name or not table_name or not status:
+                # 脏行不产出，避免触发预设 Serializer allow_blank=False 校验失败牵连整体
+                self.log_warning(_("pt-table-sync 修复结果单行缺关键字段, 跳过: row={}").format(row))
+                continue
+            items.append(
+                {
+                    "cluster_domain": cluster_domain,
+                    "ip": slave_ip,
+                    "db_name_table_name": f"{db_name}.{table_name}",
+                    "status": status,
+                    "reason": row.get("reason") or "",
+                    # unique_key：与预设 Serializer 约定的四元组拼接串，作为主键做同行覆盖合并
+                    "unique_key": f"{cluster_domain}|{slave_ip}|{db_name}|{table_name}",
+                }
+            )
+        return items
+
+
+class PtTableSyncSummaryComponent(Component):
+    """pt-table-sync 修复结果摘要组件（薄壳）。
+
+    使用方式（在 pt-table-sync 修复子流程里，紧跟 PtTableSyncComponent 之后添加）：
+      slave_sync_sub_pipeline.add_act(
+          act_name=_("写入数据修复摘要"),
+          act_component_code=PtTableSyncSummaryComponent.code,
+          kwargs={
+              "cluster_domain": cluster.immute_domain,
+              "slave_ip": slave["ip"],
+          },
+      )
+
+    边界 / 备注：
+      - 本组件强制走 preset="pt_table_sync"（对齐 PtTableSyncSummarySerializer）；
+        单据侧无需感知 preset 短名。
+      - trans_data 必须使用 :class:`PtTableSyncContext`（其 result 字段承载 db-actuator 输出）。
+    """
+
+    name = __name__
+    code = "mysql_pt_table_sync_summary"
+    bound_service = PtTableSyncSummaryService

--- a/dbm-ui/backend/flow/utils/mysql/flow_output_presets/__init__.py
+++ b/dbm-ui/backend/flow/utils/mysql/flow_output_presets/__init__.py
@@ -38,6 +38,7 @@ from backend.flow.utils.mysql.flow_output_presets.instance_change import (
 )
 from backend.flow.utils.mysql.flow_output_presets.message import MessageSummarySerializer
 from backend.flow.utils.mysql.flow_output_presets.precheck import PrecheckResultSummarySerializer
+from backend.flow.utils.mysql.flow_output_presets.pt_table_sync import PtTableSyncSummarySerializer
 from backend.flow.utils.mysql.flow_output_presets.sql_exec import SqlExecResultSummarySerializer
 
 __all__ = [
@@ -47,5 +48,6 @@ __all__ = [
     "PrecheckResultSummarySerializer",
     "SqlExecResultSummarySerializer",
     "MessageSummarySerializer",
+    "PtTableSyncSummarySerializer",
     "InstanceChangeAction",
 ]

--- a/dbm-ui/backend/flow/utils/mysql/flow_output_presets/pt_table_sync.py
+++ b/dbm-ui/backend/flow/utils/mysql/flow_output_presets/pt_table_sync.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-DB管理系统(BlueKing-BK-DBM) available.
+Copyright (C) 2017-2023 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+------------------------------------------------------------------------------
+
+mysql/spider pt-table-sync 数据修复类摘要预设。
+
+职责：
+  - 描述"每(集群, slave-ip, 库, 表) 一行"的 pt-table-sync 修复结果摘要。
+  - 依托 table_primary_key = "unique_key" 走 FlowOutputHandler.insert_data 的主键合并分支，
+    实现节点重试 / 同表多次修复对同一 (集群, IP, 库, 表) 记录的"后写覆盖前写"幂等语义。
+
+数据源 / 调用通道：
+  - 由 mysql pt-table-sync 流程节点在采集完 PtTableSyncContext.result 后调用：
+    `FlowOutputHandler(PtTableSyncSummarySerializer).insert_data(root_id, data)`。
+  - PtTableSyncContext.result 结构：{slave_ip: [{db_name, table_name, status, reason, ...}, ...]}
+    需要由调用方按 (集群, ip, 库, 表) 展平为每行 dict 后交给本预设写入。
+
+边界：
+  - FlowOutputHandler.insert_data 只支持"单字段可 hash"主键，因此本预设不使用
+    (cluster_domain, ip, db_name, table_name) 组合主键，而是要求调用方将四元组拼成
+    单字段 unique_key（推荐格式："{cluster_domain}|{ip}|{db_name}|{table_name}"）。
+    与 ClusterApplySummarySerializer.cluster_domain_and_port 同款惯例：主键字段自身作为
+    一列参与前端展示，无需额外隐藏机制。
+  - status / reason 直接透传 db-actuator 侧输出（例如 ok / skipped / error），本预设不做
+    枚举强校验，避免与 Go 侧新增状态耦合。
+  - reason 允许为空串（例如 status=ok 时无需理由）。
+"""
+
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+
+from backend.flow.utils.base.flow_output import BaseFlowOutputSerializer
+
+
+class PtTableSyncSummarySerializer(BaseFlowOutputSerializer):
+    """mysql pt-table-sync 数据修复摘要（每 (集群, slave-ip, 库, 表) 一行）。
+
+    功能说明：
+      - 描述 pt-table-sync 对单个 (集群, slave-ip, 库, 表) 的一次修复结果，字段顺序即前端表头顺序。
+      - 主键 `unique_key` 由调用方按 "{cluster_domain}|{ip}|{db_name}|{table_name}" 拼接得到；
+        通过 `table_primary_key = "unique_key"` 走 FlowOutputHandler.insert_data 主键合并分支，
+        实现同 (集群, ip, 库, 表) 重复写入时的"后写覆盖前写"幂等。
+      - 主键字段沉在最后一列，与 ClusterApplySummarySerializer.cluster_domain_and_port
+        同款惯例（主键即业务列，无需额外隐藏机制）。
+
+    输入参数（即 data 每一行的字段结构）：
+      - cluster_domain (str, 必填, 非空): 集群主域名，例如 "c1.mysql.example.db"
+      - ip (str, 必填, 非空, IP): 执行修复的 slave 节点 IP，走基类 IpField 严格校验
+      - db_name_table_name (str, 必填, 非空): 库.表，格式 "db_name.table_name"
+      - status (str, 必填, 非空): 修复状态，透传 db-actuator 输出（ok / skipped / error 等）
+      - reason (str, 可空, 默认 ""): 修复结果说明；status=ok 场景允许为空串
+      - unique_key (str, 必填, 非空): 行标识，格式 "{cluster_domain}|{ip}|{db_name}|{table_name}"
+
+    输出：
+      - 写入 FlowSummary.summary 中 table_name = "mysql_pt_table_sync" 的表 values；
+        每次调用产出的 dict 会按 unique_key 主键合并进该表 values 数组。
+
+    边界：
+      - cluster_domain / ip / db_name_table_name / status / unique_key 任一为空 -> is_valid
+        抛 ValidationError。
+      - ip 非合法 IPv4/IPv6 字面量 -> IpField 校验失败抛 ValidationError。
+      - 相同 unique_key 的重复写入 -> 依赖 insert_data 主键合并分支覆盖旧行，`values` 长度不变。
+      - status / reason 不做枚举校验，避免与 db-actuator 侧新增状态耦合。
+    """
+
+    #: 表名（mysql/spider 命名空间下唯一，前缀 mysql_）
+    table_name: str = "mysql_pt_table_sync"
+    #: 前端表格展示名
+    table_display_name: str = _("数据修复结果")
+    #: 表主键：调用方需拼成 "{cluster_domain}|{ip}|{db_name}|{table_name}" 的单字段串
+    #: 与 ClusterApplySummarySerializer.cluster_domain_and_port 同款惯例——
+    #: 主键字段本身作为一列参与前端展示，用户可视化"这一行的唯一定位坐标"。
+    table_primary_key: str = "unique_key"
+
+    cluster_domain = serializers.CharField(help_text=_("集群主域名"), required=True, allow_blank=False)
+    ip = BaseFlowOutputSerializer.IpField(help_text=_("修复节点IP"), required=True)
+    db_name_table_name = serializers.CharField(help_text=_("库.表"), required=True, allow_blank=False)
+    status = serializers.CharField(help_text=_("修复状态"), required=True, allow_blank=False)
+    #: 修复结果说明；透传 db-actuator 的 reason 字段，前端按纯文本渲染
+    reason = serializers.CharField(help_text=_("修复结果"), required=False, allow_blank=True, default="")
+    #: 行唯一标识：格式 "{cluster_domain}|{ip}|{db_name}|{table_name}"；
+    #: 既作为 FlowOutputHandler 主键做同行覆盖合并，也作为前端末列展示（对齐
+    #: ClusterApplySummarySerializer.cluster_domain_and_port 的做法）。
+    unique_key = serializers.CharField(help_text=_("行标识"), required=True, allow_blank=False)

--- a/dbm-ui/backend/flow/utils/mysql/mysql_context_dataclass.py
+++ b/dbm-ui/backend/flow/utils/mysql/mysql_context_dataclass.py
@@ -430,3 +430,12 @@ class TendbClusterSpiderUpgradeContext:
     @staticmethod
     def get_alarm_shield_id_var_name() -> str:
         return "alarm_shield_id"
+
+
+@dataclass()
+class PtTableSyncContext:
+    """
+    定义数据修复的flow的上下文dataclass类
+    """
+
+    result: dict = field(default_factory=dict)


### PR DESCRIPTION
1：pt-table-sync 中文chunk边界双重编码导致“假修复”的问题
2：优化数据修复逻辑，明确一些边界不支持修复的问题
3：优化数据修复单据：增加单据摘要输出